### PR TITLE
feat: add ChatRooms — multi-agent group chat system

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -649,3 +649,59 @@ model NovaRevision {
 
   @@index([novaId, version])
 }
+
+// ─── Chat Rooms ────────────────────────────────────────────────────────────────
+// Multi-agent + human group chats tied to tasks/features.
+
+model ChatRoom {
+  id            String      @id @default(cuid())
+  name          String
+  description   String?            @db.Text
+  type          String             @default("task")  // "task" | "feature" | "general" | "ops"
+  taskId        String?
+  task          Task?              @relation(fields: [taskId], references: [id], onDelete: SetNull)
+  createdBy     String
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
+
+  members       ChatRoomMember[]
+  messages      ChatMessage[]
+
+  @@map("chat_rooms")
+}
+
+model ChatRoomMember {
+  id            String      @id @default(cuid())
+  roomId        String
+  room          ChatRoom    @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  agentId       String?
+  userId        String?
+  role          String      @default("member")  // "lead" | "member" | "readonly"
+  joinedAt      DateTime    @default(now())
+  lastReadAt    DateTime?
+
+  agent         Agent?      @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  user          User?       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([roomId, agentId, userId])
+  @@map("chat_room_members")
+}
+
+model ChatMessage {
+  id            String      @id @default(cuid())
+  roomId        String
+  room          ChatRoom    @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  agentId       String?
+  userId        String?
+  senderType    String              // "agent" | "human" | "system"
+  content       String          @db.Text
+  attachments   Json?
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @updatedAt
+
+  agent         Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
+  user          User?       @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([roomId, createdAt])
+  @@map("chat_messages")
+}

--- a/apps/web/src/app/(app)/chatrooms/page.tsx
+++ b/apps/web/src/app/(app)/chatrooms/page.tsx
@@ -1,0 +1,280 @@
+'use client'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  MessageSquare, Plus, Send, X, Users, Bot, User as UserIcon,
+  Hash, ArrowLeft, Filter,
+} from 'lucide-react'
+
+interface RoomMember {
+  agentId: string | null
+  userId: string | null
+  role: string
+  joined_at: string
+  agent?: { id: string; name: string; type: string } | null
+  user?: { id: string; username: string; name: string } | null
+}
+
+interface Room {
+  id: string
+  name: string
+  description: string | null
+  type: string
+  created_by: string
+  created_at: string
+  updated_at: string
+  _count: { messages: number; members: number }
+  task?: { id: string; title: string } | null
+  members?: RoomMember[]
+}
+
+interface ChatMessage {
+  id: string
+  sender_type: string
+  content: string
+  attachments: unknown[]
+  sender: { type: string; id: string | null; name: string }
+  created_at: string
+}
+
+interface RoomDetail extends Room {
+  messages: ChatMessage[]
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  task: 'bg-blue-500/20 text-blue-400',
+  feature: 'bg-purple-500/20 text-purple-400',
+  general: 'bg-gray-500/20 text-gray-400',
+  ops: 'bg-orange-500/20 text-orange-400',
+}
+
+export default function ChatRoomsPage() {
+  const [rooms, setRooms] = useState<Room[]>([])
+  const [activeRoom, setActiveRoom] = useState<RoomDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [showNewRoom, setShowNewRoom] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newDesc, setNewDesc] = useState('')
+  const [newType, setNewType] = useState('task')
+  const [filterType, setFilterType] = useState('')
+  const [mobileShowList, setMobileShowList] = useState(true)
+  const [message, setMessage] = useState('')
+  const [sending, setSending] = useState(false)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  const loadRooms = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/chatrooms${filterType ? `?type=${filterType}` : ''}`)
+      const data = await res.json()
+      setRooms(data.rooms || [])
+    } catch { /* ignore */ }
+    setLoading(false)
+  }, [filterType])
+
+  useEffect(() => { loadRooms() }, [loadRooms])
+
+  const selectRoom = async (room: Room) => {
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/chatrooms/${room.id}?messages=100`)
+      const detail = await res.json()
+      setActiveRoom(detail)
+      setMobileShowList(false)
+    } catch { /* ignore */ }
+    setLoading(false)
+  }
+
+  const handleCreateRoom = async () => {
+    if (!newName.trim()) return
+    try {
+      const res = await fetch('/api/chatrooms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), description: newDesc.trim() || undefined, type: newType }),
+      })
+      const room = await res.json()
+      setRooms(prev => [room, ...prev])
+      setShowNewRoom(false)
+      setNewName('')
+      setNewDesc('')
+      selectRoom(room)
+    } catch { /* ignore */ }
+  }
+
+  const handleSendMessage = async () => {
+    if (!message.trim() || !activeRoom || sending) return
+    setSending(true)
+    try {
+      await fetch(`/api/chatrooms/${activeRoom.id}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: message.trim() }),
+      })
+      setMessage('')
+      const res = await fetch(`/api/chatrooms/${activeRoom.id}?messages=100`)
+      const detail = await res.json()
+      setActiveRoom(detail)
+    } catch { /* ignore */ }
+    setSending(false)
+  }
+
+  const handleDeleteRoom = async (roomId: string) => {
+    if (!confirm('Delete this room and all its messages?')) return
+    await fetch(`/api/chatrooms/${roomId}`, { method: 'DELETE' })
+    setRooms(prev => prev.filter(r => r.id !== roomId))
+    setActiveRoom(null)
+    setMobileShowList(true)
+  }
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [activeRoom?.messages?.length])
+
+  const filteredRooms = filterType ? rooms.filter(r => r.type === filterType) : rooms
+
+  return (
+    <div className="absolute inset-0 flex">
+      {/* Sidebar — Room List */}
+      <div className={`${mobileShowList || !activeRoom ? 'flex' : 'hidden'} md:flex flex-col w-full md:w-80 flex-shrink-0 border-r border-border-subtle bg-bg-card`}>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+          <div className="flex items-center gap-2">
+            <MessageSquare size={16} className="text-accent" />
+            <span className="text-sm font-semibold text-text-primary">Chat Rooms</span>
+          </div>
+          <button onClick={() => setShowNewRoom(true)} className="p-1.5 rounded hover:bg-bg-raised text-text-muted hover:text-text-primary" title="New room">
+            <Plus size={16} />
+          </button>
+        </div>
+
+        <div className="px-3 py-2 border-b border-border-subtle">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <Filter size={12} className="text-text-muted" />
+            <button onClick={() => setFilterType('')} className={`px-2 py-0.5 rounded text-[10px] ${!filterType ? 'bg-accent/20 text-accent' : 'text-text-muted hover:text-text-primary'}`}>All</button>
+            {['task', 'feature', 'general', 'ops'].map(t => (
+              <button key={t} onClick={() => setFilterType(filterType === t ? '' : t)} className={`px-2 py-0.5 rounded text-[10px] capitalize ${filterType === t ? 'bg-accent/20 text-accent' : 'text-text-muted hover:text-text-primary'}`}>{t}</button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {loading && !rooms.length ? (
+            <div className="p-4 text-center text-text-muted text-xs">Loading rooms...</div>
+          ) : filteredRooms.length === 0 ? (
+            <div className="p-4 text-center text-text-muted text-xs">No chat rooms yet.</div>
+          ) : (
+            filteredRooms.map(room => (
+              <button key={room.id} onClick={() => selectRoom(room)} className={`w-full text-left px-4 py-3 border-b border-border-subtle transition-colors ${activeRoom?.id === room.id ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-bg-raised'}`}>
+                <div className="flex items-center gap-2 mb-1">
+                  <Hash size={12} className="text-text-muted" />
+                  <span className="text-xs font-medium text-text-primary truncate">{room.name}</span>
+                  <span className={`ml-auto px-1.5 py-0.5 rounded text-[9px] ${TYPE_COLORS[room.type] || TYPE_COLORS.general}`}>{room.type}</span>
+                </div>
+                <div className="flex items-center gap-2 ml-4">
+                  <span className="text-[10px] text-text-muted">{room._count.messages} msgs</span>
+                  <span className="text-[10px] text-text-muted flex items-center gap-0.5"><Users size={10} /> {room._count.members}</span>
+                </div>
+                {room.task && <div className="ml-4 text-[10px] text-accent mt-0.5 truncate">linked: {room.task.title}</div>}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Main — Room View */}
+      <div className={`${!mobileShowList || !activeRoom ? 'flex' : 'hidden'} md:flex flex-1 flex-col min-w-0 overflow-hidden`}>
+        {activeRoom ? (
+          <>
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-border-subtle flex-shrink-0">
+              <button onClick={() => setMobileShowList(true)} className="md:hidden p-1 rounded hover:bg-bg-raised"><ArrowLeft size={16} className="text-text-muted" /></button>
+              <Hash size={14} className="text-text-muted" />
+              <span className="text-sm font-semibold text-text-primary">{activeRoom.name}</span>
+              <span className={`px-1.5 py-0.5 rounded text-[9px] ${TYPE_COLORS[activeRoom.type] || TYPE_COLORS.general}`}>{activeRoom.type}</span>
+              <span className="text-[10px] text-text-muted ml-auto flex items-center gap-1"><Users size={11} /> {activeRoom._count?.members || activeRoom.members?.length || 0}</span>
+              <button onClick={() => handleDeleteRoom(activeRoom.id)} className="p-1 rounded hover:bg-red-500/10 text-text-muted hover:text-red-400" title="Delete room"><X size={14} /></button>
+            </div>
+
+            <div className="px-4 py-1.5 border-b border-border-subtle flex items-center gap-2 flex-shrink-0 overflow-x-auto">
+              <span className="text-[10px] text-text-muted flex-shrink-0">Members:</span>
+              {activeRoom.members?.map((m, i) => (
+                <span key={i} className="flex items-center gap-1 text-[10px] text-text-secondary bg-bg-raised px-2 py-0.5 rounded-full flex-shrink-0">
+                  {m.agent ? <Bot size={11} className="text-accent" /> : <UserIcon size={11} />}
+                  {m.agent?.name || m.user?.name || m.user?.username || 'unknown'}
+                  {m.role === 'lead' && <span className="text-accent">.</span>}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+              {activeRoom.messages?.length === 0 && <div className="text-center text-text-muted text-xs py-8">No messages yet. Start the conversation!</div>}
+              {activeRoom.messages?.map(msg => (
+                <div key={msg.id} className={`max-w-[80%] ${msg.sender_type === 'system' ? 'mx-auto text-center' : msg.sender.type === 'human' || msg.sender.type === 'user' ? 'ml-auto' : 'mr-auto'}`}>
+                  {msg.sender_type === 'system' ? (
+                    <div className="text-[10px] text-text-muted py-1">{msg.content}</div>
+                  ) : (
+                    <div className={`rounded-lg px-3 py-2 ${msg.sender.type === 'human' || msg.sender.type === 'user' ? 'bg-accent/20 text-text-primary' : 'bg-bg-raised border border-border-subtle text-text-primary'}`}>
+                      <div className="flex items-center gap-1.5 mb-1">
+                        {msg.sender.type === 'agent' ? <Bot size={11} className="text-accent" /> : <UserIcon size={11} />}
+                        <span className="text-[10px] font-medium text-text-secondary">{msg.sender.name}</span>
+                        <span className="text-[9px] text-text-muted">{new Date(msg.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                      </div>
+                      <p className="text-xs leading-relaxed whitespace-pre-wrap">{msg.content}</p>
+                    </div>
+                  )}
+                </div>
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+
+            <div className="px-4 py-3 border-t border-border-subtle flex-shrink-0">
+              <div className="flex gap-2">
+                <input value={message} onChange={e => setMessage(e.target.value)} onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSendMessage(); } }} placeholder="Type a message..." className="flex-1 px-3 py-2 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+                <button onClick={handleSendMessage} disabled={!message.trim() || sending} className="px-4 py-2 text-xs rounded bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 flex-shrink-0"><Send size={14} /><span className="hidden sm:inline">Send</span></button>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center">
+              <MessageSquare size={40} className="mx-auto text-text-muted mb-3 opacity-50" />
+              <p className="text-sm text-text-muted">Select a room or create a new one</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* New Room Modal */}
+      {showNewRoom && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+          <div className="w-full max-w-md bg-bg-card border border-border-subtle rounded-lg shadow-xl p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold text-text-primary">New Chat Room</h3>
+              <button onClick={() => setShowNewRoom(false)} className="text-text-muted hover:text-text-primary"><X size={16} /></button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-[10px] font-medium text-text-muted mb-1">Room Name</label>
+                <input value={newName} onChange={e => setNewName(e.target.value)} placeholder="fix-db-backup-pipeline" className="w-full px-2 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+              </div>
+              <div>
+                <label className="block text-[10px] font-medium text-text-muted mb-1">Description</label>
+                <input value={newDesc} onChange={e => setNewDesc(e.target.value)} placeholder="What is this room for?" className="w-full px-2 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+              </div>
+              <div>
+                <label className="block text-[10px] font-medium text-text-muted mb-1">Type</label>
+                <select value={newType} onChange={e => setNewType(e.target.value)} className="w-full px-2 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent">
+                  <option value="task">Task</option>
+                  <option value="feature">Feature</option>
+                  <option value="general">General</option>
+                  <option value="ops">Ops</option>
+                </select>
+              </div>
+              <div className="flex items-center justify-end gap-2 pt-2">
+                <button onClick={() => setShowNewRoom(false)} className="px-3 py-1.5 text-xs rounded text-text-muted hover:text-text-primary hover:bg-bg-raised">Cancel</button>
+                <button onClick={handleCreateRoom} disabled={!newName.trim()} className="px-3 py-1.5 text-xs rounded bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-50">Create Room</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/api/chatrooms/[id]/join/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/join/route.ts
@@ -1,0 +1,68 @@
+/**
+ * /api/chatrooms/[id]/join
+ *
+ * POST   — Join a chat room
+ * DELETE — Leave a chat room
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+// POST /api/chatrooms/[id]/join — join room
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const agentId = body.agentId ? String(body.agentId) : null
+
+  if (!userId && !agentId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const room = await prisma.chatRoom.findUnique({ where: { id } })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  await prisma.chatRoomMember.create({
+    data: { room_id: id, user_id: userId, agent_id: agentId, role: body.role ?? 'member' },
+  })
+
+  const name = agentId ? `Agent ${agentId}` : session?.user?.username ?? userId
+  await prisma.chatMessage.create({
+    data: { room_id: id, sender_type: 'system', content: `${name} joined the room` },
+  })
+
+  return NextResponse.json({ joined: true })
+}
+
+// DELETE /api/chatrooms/[id]/join — leave room
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const room = await prisma.chatRoom.findUnique({ where: { id } })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  const member = await prisma.chatRoomMember.findFirst({
+    where: { room_id: id, user_id: userId },
+  })
+  if (!member) return NextResponse.json({ error: 'Not a member' }, { status: 404 })
+
+  await prisma.chatRoomMember.delete({
+    where: { room_id_agent_id_user_id: { room_id: id, user_id: userId } },
+  })
+
+  await prisma.chatMessage.create({
+    data: { room_id: id, sender_type: 'system', content: `${session.user.username} left the room` },
+  })
+
+  return NextResponse.json({ left: true })
+}

--- a/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
@@ -1,0 +1,102 @@
+/**
+ * /api/chatrooms/[id]/messages
+ *
+ * GET    — List messages in a room (paginated, newest first)
+ * POST   — Send a message to a room
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+async function getRoomMembership(roomId: string, userId: string | undefined) {
+  const member = await prisma.chatRoomMember.findFirst({
+    where: { room_id: roomId, user_id: userId },
+    select: { user_id: true, agent_id: true },
+  })
+  return { userId: member?.user_id ?? userId, agentId: member?.agent_id ?? null }
+}
+
+// GET /api/chatrooms/[id]/messages
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { searchParams } = new URL(_req.url)
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50') || 50, 200)
+  const before = searchParams.get('before')
+
+  const where: Record<string, string> = { room_id: id }
+
+  const messages = await prisma.chatMessage.findMany({
+    where,
+    orderBy: { created_at: 'desc' },
+    take: limit,
+    include: {
+      agent: { select: { id: true, name: true, type: true } },
+      user: { select: { id: true, username: true, name: true } },
+    },
+  })
+
+  const formatted = messages.reverse().map(msg => ({
+    id: msg.id,
+    sender_type: msg.sender_type,
+    content: msg.content,
+    attachments: msg.attachments,
+    sender: msg.agent ? { type: 'agent', id: msg.agent.id, name: msg.agent.name }
+            : msg.user ? { type: 'user', id: msg.user.id, name: msg.user.name || msg.user.username }
+            : { type: 'unknown', id: null, name: 'unknown' },
+    created_at: msg.created_at.toISOString(),
+  }))
+
+  return NextResponse.json({ messages: formatted })
+}
+
+// POST /api/chatrooms/[id]/messages
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  const { userId: memberUserId, agentId } = await getRoomMembership(id, userId)
+  if (!memberUserId && !agentId) {
+    return NextResponse.json({ error: 'Not a member of this room' }, { status: 403 })
+  }
+
+  const content = String(body.content ?? '')
+  if (!content.trim()) return NextResponse.json({ error: 'Message content required' }, { status: 400 })
+
+  const msg = await prisma.chatMessage.create({
+    data: {
+      room_id: id,
+      user_id: memberUserId ?? userId,
+      agent_id: agentId,
+      sender_type: body.senderType ?? (agentId ? 'agent' : 'human'),
+      content: content.trim(),
+      attachments: body.attachments ?? [],
+    },
+    include: {
+      agent: { select: { id: true, name: true } },
+      user: { select: { id: true, username: true, name: true } },
+    },
+  })
+
+  await prisma.chatRoom.update({
+    where: { id },
+    data: { updated_at: new Date() },
+  })
+
+  return NextResponse.json({
+    id: msg.id, sender_type: msg.sender_type, content: msg.content,
+    attachments: msg.attachments,
+    sender: msg.agent ? { type: 'agent', id: msg.agent.id, name: msg.agent.name }
+            : msg.user ? { type: 'user', id: msg.user.id, name: msg.user.name || msg.user.username }
+            : { type: 'unknown', id: null, name: 'system' },
+    created_at: msg.created_at.toISOString(),
+  }, { status: 201 })
+}

--- a/apps/web/src/app/api/chatrooms/[id]/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/route.ts
@@ -1,0 +1,113 @@
+/**
+ * /api/chatrooms/[id]
+ *
+ * GET    — Get a specific chat room with members and recent messages
+ * PATCH  — Update room name/description
+ * DELETE — Delete a chat room
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+// GET /api/chatrooms/[id]
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { searchParams } = new URL(_req.url)
+  const messageLimit = Math.min(parseInt(searchParams.get('messages') ?? '50') || 50, 200)
+
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    include: {
+      members: {
+        select: {
+          agent_id: true, user_id: true, role: true,
+          joined_at: true, last_read: true,
+          agent: { select: { id: true, name: true, type: true } },
+          user: { select: { id: true, username: true, name: true } },
+        },
+      },
+      messages: {
+        orderBy: { created_at: 'desc' },
+        take: messageLimit,
+        include: {
+          agent: { select: { id: true, name: true } },
+          user: { select: { id: true, username: true, name: true } },
+        },
+      },
+      task: { select: { id: true, title: true } },
+    },
+  })
+
+  if (!room) {
+    return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+  }
+
+  const messages = (room as any).messages.reverse()
+  const members = (room as any).members
+
+  return NextResponse.json({
+    id: room.id, name: room.name, description: room.description,
+    type: room.type, task: room.task, created_by: room.created_by,
+    created_at: room.created_at.toISOString(),
+    updated_at: room.updated_at.toISOString(),
+    members, messages,
+  })
+}
+
+// PATCH /api/chatrooms/[id]
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    include: { members: { where: { user_id: userId } } },
+  })
+
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  const creatorRole = room.members.find(m => m.user_id === userId)?.role
+  if (creatorRole !== 'lead' && room.created_by !== userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const updated = await prisma.chatRoom.update({
+    where: { id },
+    data: {
+      name: body.name ? String(body.name) : undefined,
+      description: body.description !== undefined ? String(body.description) : undefined,
+    },
+  })
+
+  await prisma.chatMessage.create({
+    data: { room_id: room.id, sender_type: 'system', content: `Room renamed to "${updated.name}"` },
+  })
+
+  return NextResponse.json({ id: updated.id, name: updated.name, description: updated.description, updated_at: updated.updated_at.toISOString() })
+}
+
+// DELETE /api/chatrooms/[id]
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  const room = await prisma.chatRoom.findUnique({ where: { id } })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+  if (room.created_by !== userId) return NextResponse.json({ error: 'Only the creator can delete a room' }, { status: 403 })
+
+  await prisma.chatRoom.delete({ where: { id } })
+  return new NextResponse(null, { status: 204 })
+}

--- a/apps/web/src/app/api/chatrooms/route.ts
+++ b/apps/web/src/app/api/chatrooms/route.ts
@@ -1,0 +1,97 @@
+/**
+ * /api/chatrooms
+ *
+ * GET    — List chat rooms the current user is a member of
+ * POST   — Create a new chat room
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+// GET /api/chatrooms — list rooms
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const type = searchParams.get('type') ?? undefined
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50') || 50, 200)
+  const cursor = searchParams.get('cursor')
+
+  const where: Record<string, unknown> = {}
+  if (type) where.type = type
+
+  const rooms = await prisma.chatRoom.findMany({
+    where,
+    take: limit,
+    ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      _count: { select: { messages: true, members: true } },
+      task: { select: { id: true, title: true } },
+    },
+  })
+
+  // Filter to rooms user belongs to
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  let result = rooms
+  if (userId) {
+    result = await Promise.all(rooms.map(async (room) => {
+      const members = await prisma.chatRoomMember.findMany({
+        where: { room_id: room.id },
+        select: { user_id: true, agent_id: true },
+      })
+      const isMember = members.some(m => m.user_id === userId)
+      return isMember ? {
+        ...room,
+        members: members.map(m => ({ agentId: m.agent_id, userId: m.user_id })),
+      } : null
+    }))
+    result = result.filter(Boolean) as any
+  }
+
+  return NextResponse.json({ rooms: result })
+}
+
+// POST /api/chatrooms — create a room
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const session = await getServerSession(authOptions)
+  const createdBy = session?.user?.id ?? body.createdBy ?? 'system'
+
+  const room = await prisma.chatRoom.create({
+    data: {
+      name: String(body.name ?? ''),
+      description: body.description ? String(body.description) : null,
+      type: body.type ?? 'task',
+      task_id: body.taskId ? String(body.taskId) : null,
+      created_by: String(createdBy),
+    },
+    include: {
+      _count: { select: { messages: true, members: true } },
+      task: { select: { id: true, title: true } },
+    },
+  })
+
+  const userId = session?.user?.id ?? null
+  const agentId = (body.agentId && String(body.agentId)) || null
+
+  await prisma.chatRoomMember.create({
+    data: {
+      room_id: room.id,
+      user_id: userId,
+      agent_id: agentId,
+      role: 'lead',
+    },
+  })
+
+  await prisma.chatMessage.create({
+    data: {
+      room_id: room.id,
+      sender_type: 'system',
+      content: `Room created by ${createdBy}`,
+    },
+  })
+
+  return NextResponse.json(room, { status: 201 })
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import {
   LayoutDashboard, Server, Database, MessageSquare, Bot,
   Bell, KeyRound, Archive, FileText, ClipboardList,
-  ChevronLeft, ChevronRight, BookOpen, Settings2, GitBranch, Network, Sparkles,
+  ChevronLeft, ChevronRight, BookOpen, Settings2, GitBranch, Network, Sparkles, MessageCircle,
 } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 
@@ -23,7 +23,8 @@ const nav = [
   { href: '/backups',        icon: Archive,          label: 'Backups' },
   { href: '/logs',           icon: FileText,         label: 'Logs' },
   { href: '/notes',          icon: BookOpen,         label: 'Wiki' },
-  { href: '/nova',           icon: Sparkles,         label: 'Nova' },
+  { href: '/nova',            icon: Sparkles,        label: 'Nova' },
+  { href: '/chatrooms',       icon: MessageSquare,   label: 'Chat Rooms' },
 ]
 
 export function Sidebar() {


### PR DESCRIPTION
## Summary

Add a group chat system for collaborative AI agent work:

**New Models:**
- `ChatRoom` — group chats tied to tasks/features with type classification (task/feature/general/ops)
- `ChatRoomMember` — join table for agents and humans with role-based access (lead/member/readonly)
- `ChatMessage` — messages with agent/human/system senders, optional attachments

**API Endpoints:**
- `GET /api/chatrooms` — list rooms (filterable by type)
- `POST /api/chatrooms` — create a new room
- `GET /api/chatrooms/:id` — get room with members and recent messages
- `PATCH /api/chatrooms/:id` — update room name/description
- `DELETE /api/chatrooms/:id` — delete a room
- `GET /api/chatrooms/:id/messages` — list messages (paginated)
- `POST /api/chatrooms/:id/messages` — send a message
- `POST /api/chatrooms/:id/join` — join a room
- `DELETE /api/chatrooms/:id/join` — leave a room

**UI:**
- New `/chatrooms` page with room list sidebar + message thread view
- Room filtering by type (task/feature/general/ops)
- Member list display in room header
- Auto-scroll to latest messages
- Mobile-responsive layout

**Sidebar:**
- Added "Chat Rooms" link with MessageSquare icon

**Database Migration:**
- Raw SQL migration applied (tables: `chat_rooms`, `chat_room_members`, `chat_messages`)

## Test plan

- [ ] Create a new chat room
- [ ] Send messages in a room
- [ ] Filter rooms by type
- [ ] Verify sidebar link appears