### PR TITLE
fix: resolve TypeScript spread errors in Nova engine

### DIFF
--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -54,7 +54,7 @@ export async function PUT(
   if (body.tags !== undefined) data.tags = body.tags
 
   // Save revision before updating
-  const prevConfig = { ...nova.config }
+  const prevConfig = nova.config ? { ...(nova.config as Record<string, unknown>) } : {}
   const newConfig = data.config || prevConfig
 
   const updatedNova = await prisma.nova.update({

--- a/apps/web/src/lib/nebula.ts
+++ b/apps/web/src/lib/nebula.ts
@@ -171,7 +171,8 @@ export async function loadRemoteNovae(): Promise<Map<string, Nova>> {
 /** Reload all remote Nova definitions from the manifest (e.g. after cache invalidation). */
 export async function reloadRemoteNovae(): Promise<string[]> {
   _remoteNovae.clear()
-  return (await loadRemoteNovae()).keys()
+  const m = await loadRemoteNovae()
+  return Array.from(m.keys())
 }
 
 // ── Nova registry (merged from all sources) ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `MapIterator` spread error in `reloadRemoteNovae` by wrapping with `Array.from`
- Fix TypeScript spread error in Nova route handler

## Test plan
- [ ] `npm run build` passes without TypeScript errors
- [ ] `nova_list` and `nova_deploy` tools work in agent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)