### PR TITLE
fix: add error handling to agent creation and ChatWindow

### DIFF
--- a/apps/web/src/components/tasks/TeamDetailPanel.tsx
+++ b/apps/web/src/components/tasks/TeamDetailPanel.tsx
@@ -141,27 +141,37 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
   const create = async () => {
     if (!form.name.trim()) return
     setSaving(true)
-    const isHuman = form.modelId === 'human'
-    const r = await fetch('/api/agents', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: form.name,
-        type: modelIdToType(form.modelId),
-        role: form.role || null,
-        description: form.description || null,
-        metadata: !isHuman ? {
-          systemPrompt: form.systemPrompt || undefined,
-          contextConfig: { llm: form.modelId },
-        } : undefined,
-      }),
-    })
-    const agent: Agent = await r.json()
-    if (onCreate) onCreate(agent)
-    else setLocalAgents(prev => [...prev, agent])
-    setCreateModal(false)
-    setForm(emptyForm)
-    setSaving(false)
+    try {
+      const isHuman = form.modelId === 'human'
+      const r = await fetch('/api/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          type: modelIdToType(form.modelId),
+          role: form.role || null,
+          description: form.description || null,
+          metadata: !isHuman ? {
+            systemPrompt: form.systemPrompt || undefined,
+            contextConfig: { llm: form.modelId },
+          } : undefined,
+        }),
+      })
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({}))
+        throw new Error(err.error ?? 'Failed to create agent')
+      }
+      const agent: Agent = await r.json()
+      if (onCreate) onCreate(agent)
+      else setLocalAgents(prev => [...prev, agent])
+      setCreateModal(false)
+      setForm(emptyForm)
+    } catch (err) {
+      console.error('Failed to create agent:', err)
+      alert(`Failed to create agent: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    } finally {
+      setSaving(false)
+    }
   }
 
   const saveEdit = async () => {


### PR DESCRIPTION
## Summary
- Wrap agent creation in error handling to prevent crashes on failure
- Add error handling to ChatWindow component

## Test plan
- [ ] `npm run build` passes without TypeScript errors
- [ ] Agent creation handles API failures gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)