### PR TITLE
fix: resolve TypeScript build errors in CI/CD pipeline

### DIFF
--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -54,7 +54,7 @@ export async function PUT(
   if (body.tags !== undefined) data.tags = body.tags
 
   // Save revision before updating
-  const prevConfig = { ...nova.config }
+  const prevConfig = nova.config ? { ...(nova.config as Record<string, unknown>) } : {}
   const newConfig = data.config || prevConfig
 
   const updatedNova = await prisma.nova.update({


### PR DESCRIPTION
## Summary
- Fix TypeScript build errors caused by spread on `Json` type
- Use `Array.from` where array methods are needed

## Test plan
- [ ] `npm run build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)