### PR TITLE
fix: resolve TypeScript build error in infrastructure route

### DIFF
--- a/apps/web/src/app/api/environments/[id]/infrastructure/route.ts
+++ b/apps/web/src/app/api/environments/[id]/infrastructure/route.ts
@@ -131,10 +131,13 @@ export async function GET(
     ])
 
     // Nodes always required; pods are best-effort
-    const nodesJsonResult = nodesJson.value
-    if (!nodesJsonResult) {
+    if (nodesJson.status === 'rejected') {
       const reason = nodesJson.reason instanceof Error ? nodesJson.reason.message : String(nodesJson.reason)
       return NextResponse.json({ error: reason }, { status: 502 })
+    }
+    const nodesJsonResult = nodesJson.status === 'fulfilled' ? nodesJson.value : null
+    if (!nodesJsonResult) {
+      return NextResponse.json({ error: 'nodes query returned no data' }, { status: 502 })
     }
 
     const nodeList = JSON.parse(nodesJsonResult)


### PR DESCRIPTION
## Summary
- Fixes `Promise.allSettled` result type narrowing for `nodesJson.value` and `nodesJson.reason`
- Required for CI/CD pipeline to pass after v0.2.0 merge

## Test plan
- [ ] `npm run build` passes without TypeScript errors
- [ ] CI/CD "Build & Deploy ORION Web" workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)