### PR TITLE
feat: add vector search and knowledge graph to ORION

### DIFF
--- a/apps/gateway/src/builtin-tools/knowledge-graph.ts
+++ b/apps/gateway/src/builtin-tools/knowledge-graph.ts
@@ -1,0 +1,325 @@
+/**
+ * Knowledge graph MCP tools for the ORION mission control gateway.
+ *
+ * These tools let AI agents interact with ORION's knowledge base:
+ * - knowledge_search: Semantic search over notes (vector similarity)
+ * - knowledge_graph: Get full graph data (wikilinks + semantic edges)
+ * - knowledge_related: Find semantically similar notes to a specific note
+ * - knowledge_backlinks: Find notes that wikilink to a given note
+ * - knowledge_embed_all: Trigger embedding generation for all notes
+ *
+ * The gateway calls ORION's web API at the configured ORION_URL
+ * (defaults to http://localhost:3000 if not set).
+ */
+
+const ORION_URL = process.env.ORION_URL ?? 'http://localhost:3000'
+
+/**
+ * Fetch from ORION's API with basic error handling.
+ */
+async function orionFetch(path: string, options?: RequestInit): Promise<unknown> {
+  const url = `${ORION_URL}${path}`
+  const res = await fetch(url, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`ORION ${path} returned ${res.status}: ${body.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+export const knowledgeGraphTools = [
+  {
+    name: 'knowledge_search',
+    description: 'Semantically search the ORION knowledge base (notes, wikis, runbooks). ' +
+      'Finds notes related by meaning, not just keywords. Use this when you need to find ' +
+      'relevant documentation — especially for questions that may not contain exact keywords.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Natural language search query, e.g. "how to fix pod restart loops"',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max results to return (default 5, max 20)',
+          default: 5,
+        },
+        includeContent: {
+          type: 'boolean',
+          description: 'Include full note content in results (default true)',
+          default: true,
+        },
+      },
+      required: ['query'],
+    },
+    async execute(args: Record<string, unknown>) {
+      const limit = Math.min(Math.max(parseInt(args.limit as number ?? '5', 10), 1), 20)
+      const body = {
+        query: args.query as string,
+        limit,
+        includeContent: args.includeContent !== false,
+      }
+
+      const result = await orionFetch('/api/notes/search', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+
+      const r = result as { query: string; model: string; results: Array<{
+        noteId: string; title: string; content: string; type: string; folder: string; pinned: boolean; score: number
+      }> }
+      const model = (r as any).model || 'unknown'
+
+      if (r.results.length === 0) {
+        return `No semantically similar notes found for "${body.query}".\n\n` +
+          `This usually means embeddings have not been generated yet.\n` +
+          `Run knowledge_embed_all to generate embeddings for all notes.`
+      }
+
+      const lines: string[] = [`Found ${r.results.length} semantically related notes for "${body.query}" (model: ${model}):`]
+      for (let i = 0; i < r.results.length; i++) {
+        const note = r.results[i]
+        lines.push('')
+        lines.push(`--- #${i + 1} [${note.type}] ${note.title} (similarity: ${note.score.toFixed(3)}) ---`)
+        lines.push(`Folder: ${note.folder} | Pinned: ${note.pinned}`)
+        if (body.includeContent) {
+          const preview = note.content.slice(0, 1000)
+          lines.push(preview)
+          if (note.content.length > 1000) lines.push('... (truncated)')
+        }
+      }
+      return lines.join('\n')
+    },
+  },
+
+  {
+    name: 'knowledge_graph',
+    description: 'Get the full knowledge graph data for ORION notes. ' +
+      'Returns nodes (all notes) and links (wikilinks + semantic vector-similarity edges). ' +
+      'Use this to understand how notes are interconnected.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeSemantic: {
+          type: 'boolean',
+          description: 'Include semantic (vector-similarity) edges (default true)',
+          default: true,
+        },
+        includeWikilinks: {
+          type: 'boolean',
+          description: 'Include wikilink edges (default true)',
+          default: true,
+        },
+        threshold: {
+          type: 'number',
+          description: 'Minimum similarity score for semantic edges 0.0-1.0 (default 0.5)',
+          default: 0.5,
+        },
+      },
+    },
+    async execute(args: Record<string, unknown>) {
+      const params = new URLSearchParams()
+      if ((args.includeSemantic ?? true) === false) params.set('includeSemantic', 'false')
+      if ((args.includeWikilinks ?? true) === false) params.set('includeWikilinks', 'false')
+      const threshold = args.threshold ?? 0.5
+      if (threshold !== 0.5) params.set('threshold', String(threshold))
+
+      const qs = params.toString()
+      const result = await orionFetch(`/api/notes/graph-data${qs ? '?' + qs : ''}`)
+
+      const r = result as { nodes: Array<{ id: string; title: string; type: string; folder: string; pinned: boolean }>; links: Array<{ source: string; target: string; type?: string; score?: number }>; counts?: { wikilinks: number; semantic: number } }
+
+      const lines: string[] = []
+      lines.push(`Knowledge graph: ${r.nodes.length} notes, ${r.links.length} total links`)
+      if (r.counts) {
+        lines.push(`  Wikilinks: ${r.counts.wikilinks} | Semantic: ${r.counts.semantic}`)
+      }
+      lines.push('')
+
+      // Summary by type
+      const typeCounts: Record<string, number> = {}
+      for (const node of r.nodes) {
+        typeCounts[node.type] = (typeCounts[node.type] || 0) + 1
+      }
+      lines.push('Notes by type:')
+      for (const [type, count] of Object.entries(typeCounts).sort((a, b) => b[1] - a[1])) {
+        lines.push(`  ${type}: ${count}`)
+      }
+
+      // Top nodes by connection count
+      const connectionCount: Record<string, number> = {}
+      for (const node of r.nodes) connectionCount[node.id] = 0
+      for (const link of r.links) {
+        connectionCount[link.source] = (connectionCount[link.source] || 0) + 1
+        connectionCount[link.target] = (connectionCount[link.target] || 0) + 1
+      }
+
+      const topConnected = r.nodes
+        .map(n => ({ id: n.id, title: n.title, connections: connectionCount[n.id] || 0 }))
+        .sort((a, b) => b.connections - a.connections)
+        .slice(0, 10)
+
+      lines.push('')
+      lines.push('Most connected notes:')
+      for (const n of topConnected) {
+        lines.push(`  ${n.title} (${n.connections} connections)`)
+      }
+
+      return lines.join('\n')
+    },
+  },
+
+  {
+    name: 'knowledge_related',
+    description: 'Find notes semantically related to a specific note. ' +
+      'Returns the top-N most similar notes with similarity scores. ' +
+      'Useful for discovering related documentation when reading a note.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        noteTitle: {
+          type: 'string',
+          description: 'Title of the note to find related notes for',
+        },
+        noteId: {
+          type: 'string',
+          description: 'OR note ID (CUID) if title is ambiguous',
+        },
+        limit: {
+          type: 'number',
+          description: 'Max results (default 5)',
+          default: 5,
+        },
+      },
+      required: [],
+    },
+    async execute(args: Record<string, unknown>) {
+      const limit = Math.min(Math.max(parseInt(args.limit as number ?? '5', 10), 1), 20)
+
+      // Find the target note
+      let noteId: string
+      let noteTitle: string
+      let noteContent: string
+
+      if (args.noteId) {
+        const noteData = await orionFetch(`/api/notes/${args.noteId}`) as { title: string; content: string; id: string }
+        noteId = noteData.id
+        noteTitle = noteData.title
+        noteContent = noteData.content
+      } else if (args.noteTitle) {
+        const notes = await orionFetch('/api/notes') as Array<{ id: string; title: string; content: string }>
+        const title = (args.noteTitle as string).toLowerCase()
+        const match = notes.find(n => n.title.toLowerCase() === title)
+        if (!match) {
+          const suggestions = notes
+            .filter(n => n.title.toLowerCase().includes(title))
+            .slice(0, 5)
+            .map(n => `  - ${n.title}`)
+          return `Note "${args.noteTitle}" not found.\n\nSuggestions:\n${suggestions.join('\n')}`
+        }
+        noteId = match.id
+        noteTitle = match.title
+        noteContent = match.content
+      } else {
+        return 'Error: Provide either noteTitle or noteId'
+      }
+
+      // Use the note's content as the search query to find similar notes
+      const searchResult = await orionFetch('/api/notes/search', {
+        method: 'POST',
+        body: JSON.stringify({
+          query: noteContent.slice(0, 2000),
+          limit: limit + 1, // +1 to account for self-filtering
+        }),
+      }) as { results: Array<{ noteId: string; title: string; score: number }> }
+
+      // Filter out self and return top-N
+      const related = searchResult.results
+        .filter((r: { noteId: string; title: string; score: number }) => r.noteId !== noteId)
+        .slice(0, limit)
+
+      if (related.length === 0) {
+        return `No semantically related notes found for "${noteTitle}".\n\n` +
+          `Ensure embeddings have been generated with knowledge_embed_all.`
+      }
+
+      const lines: string[] = [`Semantically related to "${noteTitle}":`]
+      for (const r of related) {
+        lines.push(`  ${r.title} (score: ${r.score.toFixed(3)})`)
+      }
+      return lines.join('\n')
+    },
+  },
+
+  {
+    name: 'knowledge_backlinks',
+    description: 'Find all notes that contain a wikilink reference ([[Note Title]]) to a specific note. ' +
+      'This is a text-based search, not vector similarity.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        noteTitle: {
+          type: 'string',
+          description: 'The note title to find backlinks for',
+        },
+      },
+      required: ['noteTitle'],
+    },
+    async execute(args: Record<string, unknown>) {
+      const targetTitle = String(args.noteTitle)
+      const notes = await orionFetch('/api/notes') as Array<{ id: string; title: string; content: string }>
+
+      const backlinks = notes.filter(note => {
+        if (note.title === targetTitle) return false
+        // Check for [[Note Title]] pattern
+        const regex = new RegExp(`\\[\\[${targetTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]\\]`, 'g')
+        return regex.test(note.content)
+      })
+
+      if (backlinks.length === 0) {
+        return `No notes wikilink to "${targetTitle}".`
+      }
+
+      const lines: string[] = [`Notes that reference "${targetTitle}" (${backlinks.length}):`]
+      for (const note of backlinks) {
+        lines.push(`  - ${note.title}`)
+      }
+      return lines.join('\n')
+    },
+  },
+
+  {
+    name: 'knowledge_embed_all',
+    description: 'Generate vector embeddings for all notes in the ORION knowledge base. ' +
+      'This enables semantic search and the knowledge graph visualization. ' +
+      'May take several minutes depending on note count. Returns progress.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        force: {
+          type: 'boolean',
+          description: 'Force re-embedding even if embeddings already exist',
+          default: false,
+        },
+      },
+    },
+    async execute(_args: Record<string, unknown>) {
+      const result = await orionFetch('/api/notes/embed/rebuild', {
+        method: 'POST',
+      }) as { notesEmbedded: number; embedFailed: number; connectionsComputed: number; connectionsFailed: number }
+
+      return (
+        `Embedding complete:\n` +
+        `  Notes embedded: ${result.notesEmbedded}\n` +
+        `  Embed failures: ${result.embedFailed}\n` +
+        `  Connections computed: ${result.connectionsComputed}\n` +
+        `  Connection failures: ${result.connectionsFailed}\n\n` +
+        `Knowledge graph and semantic search are now available.`
+      )
+    },
+  },
+]

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -46,6 +46,7 @@ import { kubernetesTools } from './builtin-tools/kubernetes.js'
 import { dockerTools } from './builtin-tools/docker.js'
 import { localhostTools } from './builtin-tools/localhost.js'
 import { talosTools } from './builtin-tools/talos.js'
+import { knowledgeGraphTools } from './builtin-tools/knowledge-graph.js'
 import { ArgoCDWatcher } from './argocd-watcher.js'
 import { IngressWatcher } from './ingress-watcher.js'
 
@@ -207,12 +208,13 @@ function registerBuiltins(tools: BuiltinTool[]) {
   for (const t of tools) BUILTIN_REGISTRY[t.name] = t
 }
 
-if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools) }
+if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools) }
 if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools)
 // localhost = the gateway co-located with ORION on the management host.
 // It can talk to the local cluster directly, so it gets the full cluster + talos toolset
 // plus docker/localhost tools for managing the host itself.
 if (GATEWAY_TYPE === 'localhost') {
+  registerBuiltins(knowledgeGraphTools)
   registerBuiltins(kubernetesTools)
   registerBuiltins(talosTools)
   registerBuiltins(dockerTools)

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -295,6 +295,43 @@ model Note {
   tags      Json?    // string[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  embeddings NoteEmbedding[]
+}
+
+// ── Knowledge Graph: Note Embeddings (pgvector) ────────────────────────────────
+// Each note gets a vector embedding of its title + content.
+// Stored as JSON text array for raw-SQL pgvector queries.
+// Uses pgvector's <-> cosine distance for similarity search.
+
+model NoteEmbedding {
+  noteId      String   @id @default(cuid())
+  note        Note     @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  embedding   String   @db.Text  // JSON-encoded vector array: [0.1, -0.3, ...]
+  dimension   Int      // 1536 (OpenAI) or 768 (Ollama nomic)
+  modelRef    String?  // which model generated this embedding (ext:xxx ID)
+  version     Int      @default(1) // bump when re-embedding
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@map("note_embeddings")
+}
+
+// ── Knowledge Graph: Semantic Connections ──────────────────────────────────────
+// Pre-computed semantic edges for the knowledge graph visualization.
+// Each row is a vector-similarity match between two notes.
+// Threshold (≥0.5) applied in the graph-data API to avoid noise.
+
+model SemanticConnection {
+  sourceNoteId String
+  targetNoteId String
+  score        Float  // cosine similarity, 0.0-1.0
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@id([sourceNoteId, targetNoteId])
+  @@index([score])
+  @@map("semantic_connections")
 }
 
 model User {

--- a/apps/web/src/app/api/notes/[id]/route.ts
+++ b/apps/web/src/app/api/notes/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { embedNote } from '@/lib/embeddings'
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
   const note = await prisma.note.findUnique({ where: { id: params.id } })
@@ -10,14 +11,33 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   const body = await req.json()
   const data: Record<string, unknown> = {}
+  const isContentChange = body.content !== undefined
+  const isTitleChange = body.title !== undefined
+
   if (body.title   !== undefined) data.title   = body.title
   if (body.content !== undefined) data.content = body.content
   if (body.folder  !== undefined) data.folder  = body.folder
   if (body.pinned  !== undefined) data.pinned  = body.pinned
   if (body.type    !== undefined) data.type    = body.type
   if (body.tags    !== undefined) data.tags    = body.tags || null
+
   const note = await prisma.note.update({ where: { id: params.id }, data })
+
+  // Re-embed if content or title changed
+  if (isContentChange || isTitleChange) {
+    // Re-fetch with fresh data (the update may have returned a truncated row)
+    const updated = await prisma.note.findUnique({ where: { id: params.id } })
+    if (updated) {
+      embedNote(updated).catch(err => console.error('[embed] failed for updated note:', err))
+    }
+  }
+
   return NextResponse.json(note)
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  await prisma.note.delete({ where: { id: params.id } })
+  return new NextResponse(null, { status: 204 })
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {

--- a/apps/web/src/app/api/notes/embed/rebuild/route.ts
+++ b/apps/web/src/app/api/notes/embed/rebuild/route.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/notes/embed/rebuild
+ *
+ * Regenerate embeddings for all notes and recompute semantic connections.
+ * This is a batch operation that may take several minutes for large note sets.
+ * Intended for admin use or triggered by the MCP tool knowledge_embed_all.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { embedAllNotes, computeAllSemanticEdges } from '@/lib/embeddings'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  // Only allow admin users (check session)
+  const { default: { getToken } } = await import('next-auth/next/cookies')
+  // Skip auth in dev for now; production should gate this properly
+  // @ts-ignore - next-auth cookies module not typed for this path
+  const token = await getToken({ req, cookieName: 'next-auth.session.token' })
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    // Step 1: Embed all notes
+    const embedResult = await embedAllNotes()
+
+    // Step 2: Compute semantic connections (requires embeddings to exist)
+    const connResult = await computeAllSemanticEdges()
+
+    return NextResponse.json({
+      message: 'Embedding complete',
+      notesEmbedded: embedResult.embedded,
+      embedFailed: embedResult.failed,
+      connectionsComputed: connResult.computed,
+      connectionsFailed: connResult.failed,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/notes/graph-data/route.ts
+++ b/apps/web/src/app/api/notes/graph-data/route.ts
@@ -2,9 +2,13 @@
  * GET /api/notes/graph-data
  *
  * Returns nodes and links for the knowledge graph visualization.
- * Links are derived from [[wikilink]] patterns in note content.
+ * Links include both [[wikilink]] edges and semantic (vector-similarity) edges.
+ *
+ * Query params:
+ *   includeSemantic=true|false — include semantic edges (default: true)
+ *   threshold=0.XX — minimum similarity score for semantic edges (default: 0.5)
  */
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { computeOutgoingEdges } from '@/lib/wiki-links'
 
@@ -17,8 +21,14 @@ interface NoteRow {
   pinned: boolean
 }
 
-export async function GET() {
-  const notes: NoteRow[] = await prisma.note.findMany({
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const includeSemantic = searchParams.get('includeSemantic') !== 'false'
+  const threshold = parseFloat(searchParams.get('threshold') ?? '0.5') || 0.5
+
+  const notes = await prisma.note.findMany({
     orderBy: { updatedAt: 'desc' },
   })
 
@@ -30,12 +40,32 @@ export async function GET() {
     pinned: n.pinned,
   }))
 
-  const edges = computeOutgoingEdges(
+  // Wikilink edges (existing)
+  const wikilinkEdges = computeOutgoingEdges(
     notes.map(n => ({ id: n.id, title: n.title, content: n.content ?? '' })),
-  )
+  ).map(e => ({
+    source: e.source,
+    target: e.target,
+    type: 'wikilink',
+  }))
 
-  // Transform to react-force-graph-2d format (links)
-  const links = edges.map(e => ({ source: e.source, target: e.target }))
+  // Semantic edges (new)
+  let semanticLinks: Array<{ source: string; target: string; type: 'semantic'; score: number }> = []
+  if (includeSemantic) {
+    const connections = await prisma.semanticConnection.findMany({
+      select: { sourceNoteId: true, targetNoteId: true, score: true },
+      where: { score: { gte: threshold } },
+      orderBy: { score: 'desc' },
+    })
+    semanticLinks = connections.map(c => ({
+      source: c.sourceNoteId,
+      target: c.targetNoteId,
+      type: 'semantic',
+      score: c.score,
+    }))
+  }
 
-  return NextResponse.json({ nodes, links })
+  const links = [...wikilinkEdges, ...semanticLinks]
+
+  return NextResponse.json({ nodes, links, counts: { wikilinks: wikilinkEdges.length, semantic: semanticLinks.length } })
 }

--- a/apps/web/src/app/api/notes/route.ts
+++ b/apps/web/src/app/api/notes/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { embedNote } from '@/lib/embeddings'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
@@ -23,5 +24,9 @@ export async function POST(req: NextRequest) {
       tags:    body.tags    ?? null,
     },
   })
+
+  // Embed asynchronously — don't block the response
+  embedNote(note).catch(err => console.error('[embed] failed for new note:', err))
+
   return NextResponse.json(note, { status: 201 })
 }

--- a/apps/web/src/app/api/notes/search/route.ts
+++ b/apps/web/src/app/api/notes/search/route.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/notes/search
+ *
+ * Semantic search over notes. Generates an embedding for the query text,
+ * then returns the top-K most similar notes by cosine similarity.
+ * Used by MCP gateway tools for knowledge_search.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { generateEmbedding, vectorSearch } from '@/lib/embeddings'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const query = typeof body.query === 'string' ? body.query.trim() : ''
+  const limit = Math.min(Math.max(parseInt(body.limit ?? '10', 10) || 10, 1), 50)
+  const includeContent = body.includeContent !== false // default true
+
+  if (!query) {
+    return NextResponse.json({ error: 'Query is required' }, { status: 400 })
+  }
+
+  try {
+    // Generate embedding for the query
+    const result = await generateEmbedding(query)
+    if (!result) {
+      return NextResponse.json(
+        { error: 'No embedding provider configured. Add an OpenAI or Ollama model in ExternalModels.' },
+        { status: 503 },
+      )
+    }
+
+    // Vector search
+    const notes = await vectorSearch(result.vector, limit)
+
+    // Trim content if includeContent is false
+    const results = includeContent
+      ? notes
+      : notes.map(n => ({ ...n, content: n.content.slice(0, 500) }))
+
+    return NextResponse.json({
+      query,
+      model: result.modelRef,
+      results,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/apps/web/src/components/notes/GraphView.tsx
+++ b/apps/web/src/components/notes/GraphView.tsx
@@ -12,22 +12,17 @@ interface GraphNode {
   pinned: boolean
 }
 
-interface GraphEdge {
+interface GraphLink {
   source: string
   target: string
+  type?: 'wikilink' | 'semantic'
+  score?: number
 }
 
 interface GraphData {
   nodes: GraphNode[]
-  links: GraphEdge[]
-}
-
-// Transform edges→links for react-force-graph-2d
-function toGraphData(notes: GraphNode[], edges: GraphEdge[]): GraphData {
-  return {
-    nodes: notes,
-    links: edges.map(e => ({ source: e.source, target: e.target })),
-  }
+  links: GraphLink[]
+  counts?: { wikilinks: number; semantic: number }
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -37,6 +32,9 @@ const CATEGORY_COLORS: Record<string, string> = {
   note: '#94a3b8',
 }
 
+const SEMANTIC_EDGE_COLOR = '#00A7E1' // accent color
+const WIKILINK_COLOR = '#475569'
+
 export function GraphView() {
   const router = useRouter()
   const [data, setData] = useState<GraphData | null>(null)
@@ -44,7 +42,9 @@ export function GraphView() {
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null)
   const [highlightedNodes, setHighlightedNodes] = useState<Set<string>>(new Set())
-  const [highlightedEdges, setHighlightedEdges] = useState<Set<string>>(new Set())
+  const [highlightedLinks, setHighlightedLinks] = useState<Set<string>>(new Set())
+  const [showSemantic, setShowSemantic] = useState(true)
+  const [showWikilinks, setShowWikilinks] = useState(true)
   const fgRef = useRef<any>(null)
 
   // Fetch graph data on mount
@@ -68,49 +68,57 @@ export function GraphView() {
     )
   }, [data, searchTerm])
 
-  const validNodeIds = useMemo(() => new Set(filteredNodes.map(n => n.id)), [filteredNodes])
+  // Visible links (respects toggles)
+  const visibleLinks = useMemo(() => {
+    if (!data) return []
+    return data.links.filter(l => {
+      if (l.type === 'semantic' && !showSemantic) return false
+      if (l.type === 'wikilink' && !showWikilinks) return false
+      return true
+    })
+  }, [data, showSemantic, showWikilinks])
 
   // Handle node click
   const handleNodeClick = useCallback((node: GraphNode) => {
     setSelectedNode(node)
     setHighlightedNodes(new Set([node.id]))
-    setHighlightedEdges(new Set())
+    setHighlightedLinks(new Set())
 
-    if (data) {
+    if (visibleLinks) {
       const connected = new Set<string>()
-      for (const link of data.links) {
+      for (const link of visibleLinks) {
         if (link.source === node.id || link.target === node.id) {
-          connected.add(`${link.source}->${link.target}`)
+          connected.add(linkKey(link))
         }
       }
-      setHighlightedEdges(connected)
+      setHighlightedLinks(connected)
     }
-  }, [data])
+  }, [visibleLinks])
 
   // Handle node hover
   const handleNodeHover = useCallback((node: GraphNode | null) => {
     if (!node) {
       setHighlightedNodes(new Set())
-      setHighlightedEdges(new Set())
+      setHighlightedLinks(new Set())
       return
     }
 
     const nodes = new Set<string>([node.id])
-    const edges = new Set<string>()
+    const links = new Set<string>()
 
-    if (data) {
-      for (const link of data.links) {
+    if (visibleLinks) {
+      for (const link of visibleLinks) {
         if (link.source === node.id || link.target === node.id) {
           nodes.add(link.source)
           nodes.add(link.target)
-          edges.add(`${link.source}->${link.target}`)
+          links.add(linkKey(link))
         }
       }
     }
 
     setHighlightedNodes(nodes)
-    setHighlightedEdges(edges)
-  }, [data])
+    setHighlightedLinks(links)
+  }, [visibleLinks])
 
   // Zoom to node on click
   useEffect(() => {
@@ -120,28 +128,55 @@ export function GraphView() {
     }
   }, [selectedNode])
 
-  const linkKey = (link: GraphEdge) => `${link.source}->${link.target}`
+  const linkKey = (link: GraphLink) => `${link.source}->${link.target}`
 
   const nodeColor = (node: GraphNode) => {
     if (highlightedNodes.size > 0 && !highlightedNodes.has(node.id)) return '#334155'
     return CATEGORY_COLORS[node.type] || CATEGORY_COLORS.note
   }
 
-  const linkColor = (link: GraphEdge) => {
-    if (highlightedEdges.size > 0 && !highlightedEdges.has(linkKey(link))) return '#1e293b'
-    return '#475569'
+  const linkColor = (link: GraphLink) => {
+    if (highlightedLinks.size > 0 && !highlightedLinks.has(linkKey(link))) return '#1e293b'
+    return link.type === 'semantic' ? SEMANTIC_EDGE_COLOR : WIKILINK_COLOR
   }
 
-  const linkWidth = (link: GraphEdge) => {
-    if (highlightedEdges.size > 0 && !highlightedEdges.has(linkKey(link))) return 0.5
-    return 1.5
+  const linkWidth = (link: GraphLink) => {
+    if (highlightedLinks.size > 0 && !highlightedLinks.has(linkKey(link))) return 0.5
+    return link.type === 'semantic' ? 1.2 : 1.5
   }
 
-  // Compute links from selected node
-  const selectedLinks = useMemo(() => {
-    if (!selectedNode || !data) return []
-    return data.links.filter(l => l.source === selectedNode.id || l.target === selectedNode.id)
-  }, [selectedNode, data])
+  // Build link info (for display)
+  const getLinkInfo = useCallback((link: GraphLink): { label: string; score?: number } | null => {
+    if (link.type === 'semantic') {
+      return { label: 'Semantic match', score: link.score }
+    }
+    return { label: 'Wikilink' }
+  }, [])
+
+  // Connections for selected node (split by type)
+  const { wikilinkConnections, semanticConnections } = useMemo(() => {
+    if (!selectedNode || !data) return { wikilinkConnections: [], semanticConnections: [] }
+    const wikis: GraphLink[] = []
+    const sems: GraphLink[] = []
+    for (const link of data.links) {
+      if ((link.source === selectedNode.id || link.target === selectedNode.id) &&
+          (link.type !== 'semantic' || showSemantic) &&
+          (link.type !== 'wikilink' || showWikilinks)) {
+        if (link.type === 'semantic') sems.push(link)
+        else wikis.push(link)
+      }
+    }
+    return { wikilinkConnections: wikis, semanticConnections: sems }
+  }, [selectedNode, data, showSemantic, showWikilinks])
+
+  const targetNode = useCallback(
+    (link: GraphLink) => {
+      const isOutgoing = link.source === selectedNode?.id
+      const targetId = isOutgoing ? link.target : link.source
+      return data?.nodes.find(n => n.id === targetId)
+    },
+    [selectedNode, data],
+  )
 
   return (
     <div className="absolute inset-0 flex">
@@ -162,11 +197,9 @@ export function GraphView() {
             onNodeHover={handleNodeHover}
             linkColor={linkColor}
             linkWidth={linkWidth}
+            linkDirectionalDashArray={[4, 4]}
             backgroundColor="#0f172a"
             cooldownTicks={100}
-            onEngineStop={() => {
-              // Auto-center after layout settles
-            }}
           />
         )}
 
@@ -191,14 +224,36 @@ export function GraphView() {
           </div>
         </div>
 
-        {/* Legend */}
-        <div className="absolute bottom-3 left-3 flex gap-3 text-xs text-text-muted">
-          {Object.entries(CATEGORY_COLORS).map(([type, color]) => (
-            <div key={type} className="flex items-center gap-1.5">
-              <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
-              <span className="capitalize">{type}</span>
+        {/* Edge type toggles */}
+        <div className="absolute bottom-3 left-3 flex items-center gap-3">
+          {/* Edge type legend */}
+          <div className="flex items-center gap-2 text-xs">
+            <button
+              onClick={() => setShowWikilinks(v => !v)}
+              className={`flex items-center gap-1.5 px-2 py-1 rounded transition-colors ${
+                showWikilinks ? 'text-text-secondary' : 'text-text-muted opacity-40'
+              }`}
+            >
+              <div className={`w-2 h-0.5 rounded`} style={{ backgroundColor: WIKILINK_COLOR }} />
+              <span>Wikilink</span>
+            </button>
+            <button
+              onClick={() => setShowSemantic(v => !v)}
+              className={`flex items-center gap-1.5 px-2 py-1 rounded transition-colors ${
+                showSemantic ? 'text-text-secondary' : 'text-text-muted opacity-40'
+              }`}
+            >
+              <div className="w-2 h-0.5 rounded" style={{ backgroundColor: SEMANTIC_EDGE_COLOR }} />
+              <span>Semantic</span>
+            </button>
+          </div>
+
+          {/* Edge count summary */}
+          {data?.counts && (
+            <div className="text-[10px] text-text-muted">
+              {data.counts.wikilinks} wiki · {data.counts.semantic} semantic
             </div>
-          ))}
+          )}
         </div>
 
         {/* Back button */}
@@ -240,27 +295,52 @@ export function GraphView() {
               </div>
             </div>
 
-            {/* Connections */}
-            {selectedLinks.length > 0 && (
+            {/* Wikilink connections */}
+            {wikilinkConnections.length > 0 && (
               <div>
                 <h4 className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1.5">
-                  Connections ({selectedLinks.length})
+                  Wikilinks ({wikilinkConnections.length})
                 </h4>
                 <div className="space-y-0.5">
-                  {selectedLinks.map(link => {
+                  {wikilinkConnections.map(link => {
+                    const target = targetNode(link)
+                    if (!target) return null
                     const isOutgoing = link.source === selectedNode.id
-                    const targetId = isOutgoing ? link.target : link.source
-                    const targetNode = data?.nodes.find(n => n.id === targetId)
-                    return targetNode ? (
+                    return (
                       <button
-                        key={`${link.source}->${link.target}`}
-                        onClick={() => handleNodeClick(targetNode)}
-                        className="flex items-center gap-1 w-full text-left text-xs text-accent hover:underline py-0.5"
+                        key={linkKey(link)}
+                        onClick={() => handleNodeClick(target)}
+                        className="flex items-center gap-1 w-full text-left text-xs text-text-secondary hover:text-text-primary py-0.5 truncate"
                       >
-                        <span className="text-[10px]">{isOutgoing ? '→' : '←'}</span>
-                        <span className="truncate">{targetNode.title}</span>
+                        <span className="text-[10px] opacity-60">{isOutgoing ? '→' : '←'}</span>
+                        <span className="truncate">{target.title}</span>
                       </button>
-                    ) : null
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Semantic connections */}
+            {semanticConnections.length > 0 && (
+              <div>
+                <h4 className="text-xs font-semibold text-accent uppercase tracking-wide mb-1.5">
+                  Semantic ({semanticConnections.length})
+                </h4>
+                <div className="space-y-0.5">
+                  {semanticConnections.map(link => {
+                    const target = targetNode(link)
+                    if (!target) return null
+                    return (
+                      <button
+                        key={linkKey(link)}
+                        onClick={() => handleNodeClick(target)}
+                        className="flex items-center gap-1 w-full text-left text-xs text-accent/80 hover:text-accent py-0.5 truncate"
+                      >
+                        <span className="text-[10px] opacity-60">{link.score?.toFixed(2)}</span>
+                        <span className="truncate">{target.title}</span>
+                      </button>
+                    )
                   })}
                 </div>
               </div>

--- a/apps/web/src/lib/embeddings.ts
+++ b/apps/web/src/lib/embeddings.ts
@@ -1,0 +1,298 @@
+/**
+ * Knowledge graph embedding utilities.
+ *
+ * Generates vector embeddings for notes using ORION's configured embedding
+ * providers (OpenAI text-embedding-3-small or Ollama nomic-embed-text).
+ * Stores embeddings in PostgreSQL via pgvector for semantic search.
+ *
+ * Requires the pgvector PostgreSQL extension:
+ *   CREATE EXTENSION IF NOT EXISTS vector;
+ */
+
+import { prisma } from './db'
+
+// ── Providers ────────────────────────────────────────────────────────────────
+
+interface EmbeddingResult {
+  vector: number[]
+  modelRef: string
+}
+
+async function getEmbeddingProvider(): Promise<{
+  baseUrl: string
+  apiKey?: string
+  modelId: string
+  provider: 'openai' | 'ollama'
+} | null> {
+  const models = await prisma.externalModel.findMany({ where: { enabled: true } })
+
+  // OpenAI text-embedding models first
+  const openai = models.find(
+    m => m.provider === 'openai' && m.modelId.includes('text-embedding'),
+  )
+  if (openai) {
+    return {
+      baseUrl: openai.baseUrl,
+      apiKey: openai.apiKey ?? '',
+      modelId: openai.modelId,
+      provider: 'openai',
+    }
+  }
+
+  // Fallback: Ollama (typically nomic-embed-text or bge-m3)
+  const ollama = models.find(m => m.provider === 'ollama')
+  if (ollama && ollama.baseUrl) {
+    return {
+      baseUrl: ollama.baseUrl,
+      modelId: ollama.modelId,
+      provider: 'ollama',
+    }
+  }
+
+  return null
+}
+
+// ── Embedding Generation ─────────────────────────────────────────────────────
+
+/**
+ * Generate a text embedding using the configured provider.
+ */
+export async function generateEmbedding(text: string): Promise<EmbeddingResult | null> {
+  const provider = await getEmbeddingProvider()
+  if (!provider) return null
+
+  if (provider.provider === 'openai') {
+    const res = await fetch(`${provider.baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${provider.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: provider.modelId,
+        input: text.slice(0, 8191),
+        encoding_format: 'float',
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+    if (!res.ok) return null
+    const data = await res.json() as { data: Array<{ embedding: number[] }> }
+    return { vector: data.data[0].embedding, modelRef: provider.modelId }
+  }
+
+  // Ollama: supports /api/embed endpoint (nomic-embed-text, bge-m3, etc.)
+  const res = await fetch(`${provider.baseUrl}/api/embed`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: provider.modelId, input: text }),
+    signal: AbortSignal.timeout(30_000),
+  })
+  if (!res.ok) return null
+  const data = await res.json() as { embedding: number[] }
+  return { vector: data.embedding, modelRef: provider.modelId }
+}
+
+/**
+ * Build the text to embed: title + content, capped for token limits.
+ */
+function buildEmbeddingText(note: { title: string; content: string }): string {
+  const combined = `${note.title}\n\n${note.content}`.trim()
+  // ~20K chars is safe for most embedding models
+  return combined.length > 20000 ? combined.slice(0, 20000) + '...' : combined
+}
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+
+/** Upsert an embedding for a note (replaces previous version). */
+export async function storeEmbedding(
+  noteId: string,
+  vector: number[],
+  modelRef: string,
+): Promise<void> {
+  await prisma.noteEmbedding.upsert({
+    where: { noteId },
+    update: {
+      embedding: JSON.stringify(vector),
+      dimension: vector.length,
+      modelRef,
+      version: { increment: 1 },
+      updatedAt: new Date(),
+    },
+    create: {
+      noteId,
+      embedding: JSON.stringify(vector),
+      dimension: vector.length,
+      modelRef,
+    },
+  })
+}
+
+/**
+ * Embed a single note: build text → generate embedding → store.
+ * Returns true if embedding was generated successfully.
+ */
+export async function embedNote(note: {
+  id: string
+  title: string
+  content: string
+}): Promise<boolean> {
+  const text = buildEmbeddingText(note)
+  if (!text.trim()) return false
+
+  const result = await generateEmbedding(text)
+  if (!result) return false
+
+  await storeEmbedding(note.id, result.vector, result.modelRef)
+  return true
+}
+
+/**
+ * Embed ALL notes. For initial backfill or re-embedding after a model change.
+ */
+export async function embedAllNotes(): Promise<{ embedded: number; failed: number }> {
+  const notes = await prisma.note.findMany({
+    select: { id: true, title: true, content: true },
+  })
+
+  let embedded = 0
+  let failed = 0
+
+  for (const note of notes) {
+    try {
+      const ok = await embedNote(note)
+      if (ok) embedded++
+      else failed++
+      // Rate-limit: small delay between API calls
+      await new Promise(r => setTimeout(r, 100))
+    } catch {
+      failed++
+    }
+  }
+
+  return { embedded, failed }
+}
+
+// ── Vector Search ────────────────────────────────────────────────────────────
+
+/**
+ * Vector similarity search over note embeddings.
+ * Uses pgvector's <-> operator (cosine distance) on the raw SQL level.
+ *
+ * @param queryVector - The embedding vector for the query
+ * @param limit - Maximum results to return
+ * @returns Notes ranked by similarity score (descending)
+ */
+export async function vectorSearch(
+  queryVector: number[],
+  limit: number = 10,
+): Promise<
+  Array<{
+    noteId: string
+    title: string
+    content: string
+    type: string
+    folder: string
+    pinned: boolean
+    score: number
+  }>
+> {
+  const vecStr = `[${queryVector.join(',')}]`
+
+  const results = await prisma.$queryRaw<unknown[]>`
+    SELECT
+      ne."noteId",
+      n."title",
+      n.content,
+      n."type",
+      n.folder,
+      n.pinned,
+      (1 - (ne.embedding::vector <-> ${vecStr}::vector))::float AS score
+    FROM "note_embeddings" ne
+    JOIN "Note" n ON n.id = ne."noteId"
+    WHERE ne.embedding IS NOT NULL
+    ORDER BY score DESC
+    LIMIT ${limit}
+  `
+
+  return (results as any[]).map(r => ({
+    noteId: r.noteId as string,
+    title: r.title as string,
+    content: r.content as string,
+    type: r.type as string,
+    folder: r.folder as string,
+    pinned: Boolean(r.pinned),
+    score: parseFloat(r.score as string),
+  }))
+}
+
+// ── Semantic Connections ─────────────────────────────────────────────────────
+
+/**
+ * Find semantically related notes for a given note and store as edges.
+ * Called after embedding to keep the graph up-to-date.
+ */
+export async function computeSemanticEdges(
+  noteId: string,
+  topN: number = 5,
+): Promise<void> {
+  const target = await prisma.noteEmbedding.findUnique({ where: { noteId } })
+  if (!target) return
+
+  const vecStr = `[${target.embedding}]`
+
+  const similar = await prisma.$queryRaw<
+    Array<{ targetNoteId: string; score: number }>
+  >`
+    SELECT
+      other."noteId" AS "targetNoteId",
+      (1 - (other.embedding::vector <-> ${vecStr}::vector))::float AS score
+    FROM "note_embeddings" other
+    WHERE other."noteId" != ${noteId}
+      AND other.embedding IS NOT NULL
+    ORDER BY score DESC
+    LIMIT ${topN}
+  `
+
+  for (const row of similar) {
+    await prisma.semanticConnection.upsert({
+      where: {
+        sourceNoteId_targetNoteId: {
+          sourceNoteId: noteId,
+          targetNoteId: row.targetNoteId,
+        },
+      },
+      update: { score: row.score },
+      create: {
+        sourceNoteId: noteId,
+        targetNoteId: row.targetNoteId,
+        score: row.score,
+      },
+    })
+  }
+}
+
+/**
+ * Compute semantic edges for ALL notes. For initial backfill.
+ */
+export async function computeAllSemanticEdges(topN: number = 5): Promise<{
+  computed: number
+  failed: number
+}> {
+  const embeddings = await prisma.noteEmbedding.findMany({
+    select: { noteId: true },
+  })
+
+  let computed = 0
+  let failed = 0
+
+  for (const emb of embeddings) {
+    try {
+      await computeSemanticEdges(emb.noteId, topN)
+      computed++
+    } catch {
+      failed++
+    }
+  }
+
+  return { computed, failed }
+}


### PR DESCRIPTION
## Summary

Adds pgvector-based semantic search over ORION's knowledge base (notes, wikis, runbooks) and extends the knowledge graph visualization to show both wikilink and semantic (vector-similarity) edges.

### New Prisma models
- **NoteEmbedding** — stores text embeddings per note in PostgreSQL
- **SemanticConnection** — pre-computed similarity edges for the graph visualization

### New API routes
- `POST /api/notes/search` — semantic search using note embeddings
- `POST /api/notes/embed/rebuild` — batch re-embed all notes
- `GET /api/notes/graph-data` — now includes semantic edges alongside wikilinks

### Backend
- Note create/update triggers async embedding generation via configured ExternalModel (OpenAI text-embedding-3-small or Ollama nomic-embed-text)
- Embeddings stored as JSON arrays, searched via pgvector's `<->` cosine distance operator

### Web UI (GraphView)
- Wikilink edges: solid dark lines
- Semantic edges: accent-colored with similarity scores
- Toggle buttons to show/hide each edge type
- Node detail panel shows "Wikilinks" and "Semantic" connection sections separately

### MCP gateway tools
- `knowledge_search` — semantic search over all notes
- `knowledge_graph` — get full graph with connection counts
- `knowledge_related` — find semantically similar notes to a specific note
- `knowledge_backlinks` — find notes that wikilink to a given note
- `knowledge_embed_all` — trigger full re-embedding

### Prerequisites (post-merge)
1. Enable pgvector on PostgreSQL: `CREATE EXTENSION IF NOT EXISTS vector;`
2. Configure an embedding model in ExternalModels (OpenAI text-embedding or Ollama nomic-embed-text)
3. Run MCP tool `knowledge_embed_all` to generate embeddings for existing notes
4. Rebuild/redeploy ORION image