### PR TITLE
fix: resolve knowledge graph build errors

### DIFF
--- a/apps/web/src/app/(app)/notes/graph/page.tsx
+++ b/apps/web/src/app/(app)/notes/graph/page.tsx
@@ -1,8 +1,8 @@
 import type { ComponentType } from 'react'
-import dynamic from 'next/dynamic'
+import nextDynamic from 'next/dynamic'
 
 // Force-graph-2d (Three.js) is browser-only — disable SSR
-const GraphViewClient = dynamic<{ }>(
+const GraphViewClient = nextDynamic<{ }>(
   async () => {
     const mod = await import('@/components/notes/GraphView')
     return mod.GraphView as ComponentType
@@ -16,6 +16,10 @@ const GraphViewClient = dynamic<{ }>(
     ),
   },
 )
+
+// Force dynamic rendering — prevents Next.js from prerendering
+// which crashes on react-force-graph-2d's window access
+export const dynamic = 'force-dynamic'
 
 export default function GraphPage() {
   return <GraphViewClient />


### PR DESCRIPTION
PR #13 merged the knowledge graph feature but the build had errors that prevent the graph from rendering. This PR fixes all of them.

## Changes

- **GraphView.tsx**: Remove unsupported `linkDirectionalDashArray` prop (react-force-graph-2d@1.29.1 doesn't support it)
- **infrastructure/route.ts**: Fix TypeScript error with `Promise.allSettled` discriminated union
- **notes/[id]/route.ts**: Remove duplicate `DELETE` export
- **embed/rebuild/route.ts**: Fix `next-auth` import (use `getServerSession`)
- **package-lock.json**: Regenerated to include workspace dependencies
- **notes/graph/page.tsx**: Prevent prerender crash — `react-force-graph-2d` accesses `window` which fails during static generation. Set `export const dynamic = 'force-dynamic'` to force server-side rendering.

## Verification

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npx next build` succeeds — `/notes/graph` renders as dynamic (ƒ)
- [ ] Deploy and verify graph renders in `/notes/graph`