### PR TITLE
fix: semantic edges vector cast, pgvector image, middleware

### DIFF
--- a/apps/web/src/lib/embeddings.ts
+++ b/apps/web/src/lib/embeddings.ts
@@ -238,7 +238,8 @@ export async function computeSemanticEdges(
   const target = await prisma.noteEmbedding.findUnique({ where: { noteId } })
   if (!target) return
 
-  const vecStr = `[${target.embedding}]`
+  // target.embedding is already stored as a JSON array string like [-0.1, 0.5, ...]
+  const vecStr = target.embedding
 
   const similar = await prisma.$queryRaw<
     Array<{ targetNoteId: string; score: number }>
@@ -289,7 +290,9 @@ export async function computeAllSemanticEdges(topN: number = 5): Promise<{
     try {
       await computeSemanticEdges(emb.noteId, topN)
       computed++
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`computeSemanticEdges(${emb.noteId}) failed: ${msg}`)
       failed++
     }
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,6 +7,7 @@ const PUBLIC_PATHS = [
   '/api/setup',
   '/api/auth',
   '/api/health',
+  '/api/notes/embed',       // embed rebuild — bypassed via x-embed-token header
   '/api/environments/join', // gateway registration — no session, token IS the auth
   '/api/webhooks',          // git provider webhooks — HMAC signature is the auth
   '/_next',

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       ORION_CALLBACK_URL: ${ORION_CALLBACK_URL:-http://${MANAGEMENT_IP:-localhost}:3000}
       COREDNS_DIR: /etc/coredns-managed
       LOCALHOST_JOIN_TOKEN: ${LOCALHOST_JOIN_TOKEN}
+      EMBED_TRIGGER_TOKEN: ${EMBED_TRIGGER_TOKEN:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - orion-claude-creds:/claude-creds
@@ -98,7 +99,7 @@ services:
 
   # ── PostgreSQL ─────────────────────────────────────────────────────────────
   postgres:
-    image: postgres:16
+    image: pgvector/pgvector:pg16
     restart: unless-stopped
     environment:
       POSTGRES_DB: orion


### PR DESCRIPTION
## Fixes

**Root cause 1: Missing pgvector shared library** — `postgres:16` image doesn't include pgvector, so `::vector` cast fails at runtime. Switched to `pgvector/pgvector:pg16`.

**Root cause 2: Double-bracket vector string** — `computeSemanticEdges` wrapped `target.embedding` (already `[x,y,z]`) in brackets again: `[[x,y,z]]`, which fails the `::vector` cast. This caused all 11 semantic edge computations to fail silently.

**Root cause 3: Middleware blocking embed endpoint** — `/api/notes/embed` was not in `PUBLIC_PATHS`, so the token-bypass endpoint was blocked by session auth.

## Changes
- `apps/web/src/lib/embeddings.ts` — fix vecStr, add error logging to catch block
- `deploy/docker-compose.yml` — pgvector/pgvector:pg16 image, EMBED_TRIGGER_TOKEN env
- `apps/web/src/middleware.ts` — add /api/notes/embed to PUBLIC_PATHS

## Verification
- pgvector SQL tested locally: `SELECT (1 - embedding::vector <-> embedding::vector) FROM note_embeddings` returns score 1.0
- All 11 notes have embeddings; semantic edges should now compute correctly