### PR TITLE
fix: restore embed rebuild token bypass

### DIFF
--- a/apps/web/src/app/api/notes/embed/rebuild/route.ts
+++ b/apps/web/src/app/api/notes/embed/rebuild/route.ts
@@ -13,9 +13,12 @@ import { getServerSession } from 'next-auth'
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
-  // Auth check — session required
+  // Auth check — allow session, OR an embed trigger token set via env
   const session = await getServerSession()
-  if (!session) {
+  const embedToken = process.env.EMBED_TRIGGER_TOKEN
+  const headers = req.headers
+  const hasToken = embedToken && headers.get('x-embed-token') === embedToken
+  if (!session && !hasToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 


### PR DESCRIPTION
## Summary
Re-adds the `EMBED_TRIGGER_TOKEN` bypass that was lost during a merge. The route handler was checking only `getServerSession()` and rejecting the token-based auth.

## Impact
- Without this fix, the embedding rebuild endpoint (`/api/notes/embed/rebuild`) returns 401 for non-session auth (e.g., MCP gateway)
- With this fix, both session auth and `x-embed-token` header are accepted

## Verification
- Embedding rebuild already deployed successfully with `x-embed-token` bypass
- 11 notes embedded, 55 semantic connections computed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>