### PR TITLE
feat: add note tabs support and Infrastructure overview

### DIFF
--- a/apps/web/src/app/(app)/notes/page.tsx
+++ b/apps/web/src/app/(app)/notes/page.tsx
@@ -7,7 +7,9 @@ import remarkEmoji from 'remark-emoji'
 import rehypeHighlight from 'rehype-highlight'
 import 'highlight.js/styles/atom-one-dark.css'
 import { CodeBlock } from '@/components/notes/CodeBlock'
+import { Tabs } from '@/components/notes/Tabs'
 import { findBacklinks } from '@/lib/wiki-links'
+import { remarkTabs } from '@/lib/tabs-remark'
 import {
   Plus, Search, ChevronRight, ChevronDown, Trash2, FileText,
   Pin, Pencil, Eye, ArrowLeft, GitGraph,
@@ -476,8 +478,9 @@ export default function NotesPage() {
               <div className="h-full overflow-y-auto px-6 py-4">
                 {localContent ? (
                   <div className="max-w-3xl notes-prose">
+                    <Tabs>
                     <ReactMarkdown
-                      remarkPlugins={[remarkGfm, remarkCallouts, [remarkEmoji, { accessible: true }]]}
+                      remarkPlugins={[remarkGfm, remarkTabs, remarkCallouts, [remarkEmoji, { accessible: true }]]}
                       rehypePlugins={[rehypeHighlight]}
                       components={{
                         h1: ({ children }) => (
@@ -593,6 +596,7 @@ export default function NotesPage() {
                         </div>
                       )
                     })()}
+                    </Tabs>
                   </div>
                 ) : (
                   <p className="text-text-muted text-sm italic">Nothing to preview yet.</p>

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+// Root route — redirect to infrastructure as the default dashboard
+export default function RootPage() {
+  redirect('/infrastructure')
+}

--- a/apps/web/src/components/notes/Tabs.tsx
+++ b/apps/web/src/components/notes/Tabs.tsx
@@ -1,0 +1,100 @@
+'use client'
+import { useEffect } from 'react'
+
+/**
+ * Converts consecutive <div data-tab-group="tg-N"> blocks into interactive tab UI.
+ * The parent page preprocesses > [!TAB label]...[/TABS] blocks into these divs.
+ */
+export function Tabs({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const container = document.querySelector('.notes-prose')
+    if (!container) return
+
+    const allDivs = container.querySelectorAll<HTMLDivElement>('div[data-tab-group]')
+    if (allDivs.length === 0) return
+
+    // Group consecutive divs by their group ID
+    const groups: HTMLDivElement[][] = []
+    let current: HTMLDivElement[] = []
+    let currentGid = ''
+
+    for (const div of allDivs) {
+      const gid = div.getAttribute('data-tab-group') || ''
+      if (gid === currentGid && current.length > 0) {
+        current.push(div)
+      } else {
+        if (current.length > 1) groups.push(current)
+        current = [div]
+        currentGid = gid
+      }
+    }
+    if (current.length > 1) groups.push(current)
+
+    // Render each group as tabs
+    for (const divs of groups) {
+      const gid = divs[0].getAttribute('data-tab-group') || ''
+      const win = window as unknown as { _activeTab?: Record<string, number> }
+      if (!win._activeTab) win._activeTab = {}
+      const activeIdx = win._activeTab[gid] ?? 0
+
+      // Build tab bar
+      const tabBar = document.createElement('div')
+      tabBar.className = 'flex gap-0.5 mb-3 border-b border-border-subtle flex-wrap'
+
+      divs.forEach((div, i) => {
+        const btn = document.createElement('button')
+        btn.className = `px-3 py-1.5 text-xs font-medium rounded-t border-b-2 transition-colors whitespace-nowrap ${
+          i === activeIdx
+            ? 'text-accent border-accent bg-accent/5'
+            : 'text-text-muted border-transparent hover:text-text-secondary hover:border-border-subtle'
+        }`
+        // Get label from first heading or first line of text
+        const h = div.querySelector('h2, h3, h4, strong')
+        btn.textContent = h?.textContent?.trim() || div.textContent?.split('\n')[0]?.trim() || `Tab ${i + 1}`
+        btn.addEventListener('click', () => switchTab(i))
+        tabBar.appendChild(btn)
+      })
+
+      // Build content panels
+      const contentWrapper = document.createElement('div')
+      contentWrapper.className = 'note-tab-content-wrapper'
+
+      divs.forEach((div, i) => {
+        const panel = document.createElement('div')
+        panel.className = 'note-tab-panel'
+        panel.style.display = i === activeIdx ? '' : 'none'
+        panel.innerHTML = div.innerHTML
+        contentWrapper.appendChild(panel)
+      })
+
+      const switchTab = (idx: number) => {
+        if (idx === activeIdx) return
+        win._activeTab![gid] = idx
+        const buttons = tabBar.querySelectorAll('button')
+        buttons.forEach((b, bi) => {
+          b.className = `px-3 py-1.5 text-xs font-medium rounded-t border-b-2 transition-colors whitespace-nowrap ${
+            bi === idx
+              ? 'text-accent border-accent bg-accent/5'
+              : 'text-text-muted border-transparent hover:text-text-secondary hover:border-border-subtle'
+          }`
+        })
+        const panels = contentWrapper.querySelectorAll('.note-tab-panel')
+        panels.forEach((p, pi) => {
+          ;(p as HTMLElement).style.display = pi === idx ? '' : 'none'
+        })
+      }
+
+      // Build wrapper and replace
+      const wrapper = document.createElement('div')
+      wrapper.className = 'note-tabs-wrapper mb-4'
+      wrapper.appendChild(tabBar)
+      wrapper.appendChild(contentWrapper)
+
+      // Insert wrapper before first div, remove all divs
+      divs[0].parentNode?.insertBefore(wrapper, divs[0])
+      divs.forEach(d => d.remove())
+    }
+  }, [children])
+
+  return <>{children}</>
+}

--- a/apps/web/src/lib/tabs-remark.ts
+++ b/apps/web/src/lib/tabs-remark.ts
@@ -1,0 +1,83 @@
+/**
+ * Remark plugin: converts consecutive > [!TAB label] blockquotes into
+ * <div data-tab-group> elements. Consecutive tabs get the same group ID.
+ * Must run BEFORE remarkCallouts.
+ */
+export function remarkTabs() {
+  return (tree: { children: unknown[] }) => {
+    // First pass: collect all tab blockquotes and group them
+    const tabIndices: number[] = []
+
+    function findTabs(nodes: unknown[]) {
+      if (!Array.isArray(nodes)) return
+      for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i] as { type: string; children?: unknown[] }
+        if (n?.type === 'blockquote' && n.children?.length) {
+          const first = n.children[0] as { type: string; children?: Array<{ value?: string }> }
+          if (first?.type === 'paragraph' && first.children?.length) {
+            const text = (first.children[0] as { value?: string })?.value ?? ''
+            if (/^\[!TAB\s/.test(text)) {
+              tabIndices.push(i)
+            }
+          }
+        }
+        if (n?.children) findTabs(n.children)
+      }
+    }
+    findTabs(tree.children)
+
+    // Second pass: assign group IDs to consecutive tabs
+    const groups: number[][] = []
+    if (tabIndices.length === 0) return
+
+    let currentGroup = [tabIndices[0]]
+    for (let i = 1; i < tabIndices.length; i++) {
+      currentGroup.push(tabIndices[i])
+    }
+    groups.push(currentGroup)
+
+    // Third pass: transform blockquotes
+    function transform(nodes: unknown[]) {
+      if (!Array.isArray(nodes)) return
+      for (let g = 0; g < groups.length; g++) {
+        const group = groups[g]
+        for (const idx of group) {
+          const n = nodes[idx] as { type: string; children?: unknown[] }
+          if (n?.type === 'blockquote') {
+            const first = n.children?.[0] as { type: string; children?: Array<{ value?: string }> }
+            const firstText = first?.children?.[0] as { value?: string }
+            const raw = firstText?.value ?? ''
+            const label = /^\[!TAB\s+([^\]]+)\]/.exec(raw)?.[1]?.trim() || `Tab ${g + 1}`
+
+            // Children after the first paragraph
+            const content = n.children?.slice(1) ?? []
+
+            // The first paragraph might have text after [!TAB ...] — keep it
+            const afterText = /^\[!TAB\s+[^\]]+\]\s*(.*)/.exec(raw)?.[1]?.trim()
+            const firstPara = firstText ? {
+              type: 'paragraph',
+              children: [{ type: 'text', value: afterText || '' }],
+            } : null
+
+            nodes[idx] = {
+              type: 'element',
+              tagName: 'div',
+              properties: {
+                className: ['tab-content'],
+                'data-tab-group': `tg-${g}`,
+                'data-tab-label': label,
+              },
+              children: [firstPara, ...(content || [])].filter(Boolean),
+            } as unknown
+          }
+        }
+      }
+      // Recurse into nested structures
+      for (const node of nodes) {
+        const n = node as { children?: unknown[] }
+        if (n?.children) transform(n.children)
+      }
+    }
+    transform(tree.children)
+  }
+}


### PR DESCRIPTION
## Summary

- **Tabs component** — DOM-based tab UI for note preview rendering
- **remarkTabs plugin** — Converts `> [!TAB label]` markdown into interactive tabs (runs before callout plugin)
- **Root route** — Redirects `/` → `/infrastructure` as default dashboard
- **Infrastructure note** — 6 tabbed sections: Ingress, Storage, Secrets, Backups, Logs, GitOps

## Files Changed

| File | Change |
|------|--------|
| `apps/web/src/lib/tabs-remark.ts` | **New** — remark plugin for tab syntax parsing |
| `apps/web/src/components/notes/Tabs.tsx` | **New** — DOM-based tab UI component |
| `apps/web/src/app/(app)/page.tsx` | **New** — Root redirect to /infrastructure |
| `apps/web/src/app/(app)/notes/page.tsx` | Modified — Integrate Tabs wrapper + remarkTabs plugin |

## Usage

Notes can use tab syntax:
```markdown
> [!TAB Ingress]

### Traefik
Content here...

> [!TAB Storage]

### Longhorn
Content here...
```

## Test plan

- [ ] Open Infrastructure note — verify 6 tabs render and switch correctly
- [ ] Click tab labels — verify smooth switching without page reload
- [ ] Verify regular notes (no tabs) still render normally
- [ ] Verify callouts ([!NOTE], [!WARNING]) still work in non-tab notes
- [ ] Verify `/` route redirects to `/infrastructure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)