### PR TITLE
fix: consolidate sidebar navigation and improve infrastructure tabs

### DIFF
--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -377,7 +377,7 @@ export function InfrastructureTabs() {
     }`
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {/* Toolbar — only show on overview tab */}
       {activeTab === 'overview' && (
         <>
@@ -427,7 +427,7 @@ export function InfrastructureTabs() {
       )}
 
       {/* Tab bar */}
-      <div className="flex gap-1 flex-wrap px-1">
+      <div className="flex gap-1 flex-wrap border-b border-border-subtle pb-2">
         {tabs.map(t => (
           <button key={t.key} className={tabCls(t.key)} onClick={() => { setActiveTab(t.key); setLoading(false); setError(null) }}>
             <t.icon size={11} className="inline mr-1" />
@@ -437,7 +437,7 @@ export function InfrastructureTabs() {
       </div>
 
       {/* Tab content */}
-      <div className="min-h-[400px]">
+      <div className="space-y-6">
         {activeTab === 'overview' && (
           <>
             {nodes.length > 0 && (

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -3,26 +3,20 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
 import {
-  Server, Database, MessageSquare, Bot,
-  Bell, KeyRound, Archive, FileText, ClipboardList,
-  ChevronLeft, ChevronRight, BookOpen, Settings2, GitBranch, Network, Sparkles, MessageCircle,
+  Server, MessageSquare, Bot,
+  Bell, ClipboardList,
+  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles,
 } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 
 const nav = [
-  { href: '/infrastructure', icon: Server,           label: 'Infrastructure' },
-  { href: '/gitops',         icon: GitBranch,        label: 'GitOps' },
-  { href: '/storage',        icon: Database,         label: 'Storage' },
-  { href: '/messages',        icon: MessageSquare,   label: 'Messages' },
-  { href: '/tasks',          icon: ClipboardList,    label: 'Tasks' },
-  { href: '/agents',         icon: Bot,              label: 'Agents' },
-  { href: '/ingress',        icon: Network,          label: 'Ingress' },
-  { href: '/alerts',         icon: Bell,             label: 'Alerts' },
-  { href: '/secrets',        icon: KeyRound,         label: 'Secrets' },
-  { href: '/backups',        icon: Archive,          label: 'Backups' },
-  { href: '/logs',           icon: FileText,         label: 'Logs' },
-  { href: '/notes',          icon: BookOpen,         label: 'Wiki' },
-  { href: '/nova',            icon: Sparkles,        label: 'Nova' },
+  { href: '/infrastructure', icon: Server,  label: 'Infrastructure' },
+  { href: '/messages',       icon: MessageSquare, label: 'Messages' },
+  { href: '/tasks',          icon: ClipboardList, label: 'Tasks' },
+  { href: '/agents',         icon: Bot,    label: 'Agents' },
+  { href: '/alerts',         icon: Bell,   label: 'Alerts' },
+  { href: '/notes',          icon: BookOpen, label: 'Wiki' },
+  { href: '/nova',           icon: Sparkles, label: 'Nova' },
 ]
 
 export function Sidebar() {


### PR DESCRIPTION
## Changes

- **Sidebar**: Remove duplicate nav links (GitOps, Storage, Ingress, Secrets, Backups, Logs) now consolidated under the Infrastructure tabbed interface
- **InfrastructureTabs**: Improve visual spacing - add tab bar bottom border separator, `space-y-6` content spacing, remove cramped `min-h-[400px]` constraint

## Sidebar Before/After

**Before**: 13 nav items including individual links for gitops, storage, ingress, secrets, backups, logs
**After**: 7 nav items with Infrastructure as the consolidated parent

## Test plan

- [ ] Navigate to Infrastructure page — sidebar only shows Infrastructure (no duplicate links)
- [ ] Tab bar has clear bottom border separator
- [ ] Overview tab has proper spacing between environment selector, tabs, and content
- [ ] NodeGrid and PodTable are not cramped
- [ ] All tabs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)