### PR TITLE
fix: restore spacing between overview sections

### DIFF
--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -437,7 +437,7 @@ export function InfrastructureTabs() {
       )}
 
       {/* Tab content */}
-      <div>
+      <div className="space-y-5">
         {activeTab === 'overview' && (
           <>
             {nodes.length > 0 && (


### PR DESCRIPTION
- Re-add  to tab content wrapper — was lost when moving tab bar above environment selector\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)