### PR TITLE
fix: remove inconsistent pt-2 wrapper from ingress tab

### DIFF
--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -460,11 +460,7 @@ export function InfrastructureTabs() {
           </>
         )}
 
-        {activeTab === 'ingress' && (
-          <div className="pt-2">
-            <IngressPage />
-          </div>
-        )}
+        {activeTab === 'ingress' && <IngressPage />}
 
         {activeTab === 'storage' && (
           <StorageTab

--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -437,7 +437,7 @@ export function InfrastructureTabs() {
       )}
 
       {/* Tab content */}
-      <div>
+      <div className="space-y-5">
         {activeTab === 'overview' && (
           <>
             {nodes.length > 0 && (


### PR DESCRIPTION
- Remove unnecessary pt-2 wrapper around IngressPage
- Makes ingress tab padding consistent with other tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)