### PR TITLE
fix: consistent padding for ingress and gitops tabs

### DIFF
--- a/apps/web/src/app/(app)/gitops/page.tsx
+++ b/apps/web/src/app/(app)/gitops/page.tsx
@@ -1,5 +1,9 @@
 import { GitOpsPage } from '@/components/gitops/GitOpsPage'
 
 export default function Page() {
-  return <GitOpsPage />
+  return (
+    <div className="p-4 lg:p-6">
+      <GitOpsPage />
+    </div>
+  )
 }

--- a/apps/web/src/app/(app)/ingress/page.tsx
+++ b/apps/web/src/app/(app)/ingress/page.tsx
@@ -3,5 +3,9 @@ import { IngressPage } from '@/components/ingress/IngressPage'
 export const dynamic = 'force-dynamic'
 
 export default function IngressRoutePage() {
-  return <IngressPage />
+  return (
+    <div className="p-4 lg:p-6">
+      <IngressPage />
+    </div>
+  )
 }

--- a/apps/web/src/components/gitops/GitOpsPage.tsx
+++ b/apps/web/src/components/gitops/GitOpsPage.tsx
@@ -682,7 +682,7 @@ export function GitOpsPage() {
   }
 
   return (
-    <div className="p-4 lg:p-6 space-y-6">
+    <div className="space-y-6">
       {/* Page header */}
       <div className="flex items-center justify-between">
         <div>

--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -437,7 +437,7 @@ export function InfrastructureTabs() {
       )}
 
       {/* Tab content */}
-      <div className="space-y-5">
+      <div className="p-4 lg:p-6 space-y-5">
         {activeTab === 'overview' && (
           <>
             {nodes.length > 0 && (

--- a/apps/web/src/components/ingress/IngressPage.tsx
+++ b/apps/web/src/components/ingress/IngressPage.tsx
@@ -1820,7 +1820,7 @@ export function IngressPage() {
   const disabledRoutes = domains.reduce((s, d) => s + d.ingressPoints.reduce((ss, p) => ss + p.routes.filter(r => !r.enabled).length, 0), 0)
 
   return (
-    <div className="p-4 lg:p-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-lg font-semibold text-text-primary">Ingress</h1>


### PR DESCRIPTION
- Strip p-4 lg:p-6 from IngressPage and GitOpsPage (was causing double padding inside InfrastructureTabs)
- InfrastructureTabs tab content now handles page-level padding
- Standalone ingress and gitops pages retain padding via wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)