### PR TITLE
fix: agent system prompt for external models

### DIFF
--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ChatWindow } from '@/components/chat/ChatWindow'
+
+interface Conversation {
+  id: string
+  title: string | null
+  createdAt: string
+  _count: { messages: number }
+}
+
+function ChatContent() {
+  const searchParams = useSearchParams()
+  const conversationId = searchParams.get('conversation') as string | null
+  const taskId = searchParams.get('task')
+  const context = searchParams.get('context')
+
+  const handleConversationCreated = (convo: Conversation) => {
+    const url = new URL(window.location.href)
+    url.searchParams.set('conversation', convo.id)
+    if (taskId) url.searchParams.set('task', taskId)
+    if (context) url.searchParams.set('context', context)
+    window.history.replaceState(null, '', url.toString())
+  }
+
+  return (
+    <div className="absolute inset-0 flex overflow-hidden">
+      <ChatWindow
+        conversationId={conversationId}
+        onConversationCreated={handleConversationCreated}
+      />
+    </div>
+  )
+}
+
+export default function ChatPage() {
+  return (
+    <Suspense fallback={<div className="absolute inset-0 flex items-center justify-center text-text-muted text-sm">Loading chat…</div>}>
+      <ChatContent />
+    </Suspense>
+  )
+}

--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { ChatWindow } from '@/components/chat/ChatWindow'
 
+export const dynamic = 'force-dynamic'
+
 interface Conversation {
   id: string
   title: string | null

--- a/apps/web/src/app/api/tasks/[id]/chat/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/chat/route.ts
@@ -1,0 +1,59 @@
+/**
+ * /api/tasks/[id]/chat
+ *
+ * GET — Fetch chat rooms and messages for a task
+ */
+import { NextResponse } from 'next/server'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { prisma } = await import('@/lib/db')
+
+  const rooms = await prisma.chatRoom.findMany({
+    where: { taskId: params.id },
+    orderBy: { createdAt: 'asc' },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+        include: {
+          agent: { select: { id: true, name: true, type: true } },
+          user: { select: { id: true, username: true, name: true } },
+        },
+      },
+      members: {
+        include: {
+          agent: { select: { id: true, name: true } },
+          user: { select: { id: true, username: true, name: true } },
+        },
+      },
+    },
+  })
+
+  const formatted = rooms.map(room => ({
+    id: room.id,
+    name: room.name,
+    type: room.type,
+    messages: room.messages.map(msg => ({
+      id: msg.id,
+      senderType: msg.senderType,
+      content: msg.content,
+      attachments: msg.attachments,
+      sender: msg.agent
+        ? { type: 'agent' as const, id: msg.agent.id, name: msg.agent.name }
+        : msg.user
+          ? { type: 'user' as const, id: msg.user.id, name: msg.user.name || msg.user.username }
+          : { type: 'system' as const, id: null, name: 'system' },
+      createdAt: msg.createdAt.toISOString(),
+    })),
+    members: room.members.map(m => ({
+      agentId: m.agentId,
+      userId: m.userId,
+      agent: m.agent ? { id: m.agent.id, name: m.agent.name } : null,
+      user: m.user ? { id: m.user.id, name: m.user.name || m.user.username } : null,
+    })),
+  }))
+
+  return NextResponse.json({ rooms: formatted })
+}

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Plus, X, Trash2, ChevronRight, Flag, Menu, Terminal, CheckCircle2, XCircle, Play, MessageSquare, ChevronDown, ChevronUp } from 'lucide-react'
+import { Plus, X, Trash2, ChevronRight, Flag, Menu, Terminal, CheckCircle2, XCircle, Play, MessageSquare, ChevronDown, ChevronUp, Send, Loader2 } from 'lucide-react'
 import type { Agent, Task, Feature, Epic, SelectionState, PlanTarget, Bug } from '@/types/tasks'
 import { BugManager } from './BugManager'
 
@@ -123,10 +123,32 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
   const titleRef = useRef<HTMLInputElement>(null)
 
   // Task log tab
-  const [taskTab, setTaskTab]           = useState<'details' | 'log'>('details')
+  const [taskTab, setTaskTab]           = useState<'details' | 'log' | 'chat'>('details')
   const [taskEvents, setTaskEvents]     = useState<TaskEvent[]>([])
   const [eventsLoading, setEventsLoading] = useState(false)
   const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set())
+
+  // Task chat tab
+  interface ChatMsg {
+    id: string
+    senderType: string
+    content: string
+    sender: { type: string; id: string | null; name: string }
+    createdAt: string
+  }
+  interface ChatRoom {
+    id: string
+    name: string
+    type: string
+    messages: ChatMsg[]
+    members: Array<{ agentId: string | null; userId: string | null; agent: { id: string; name: string } | null; user: { id: string; name: string } | null }>
+  }
+  const [taskChatRooms, setTaskChatRooms]   = useState<ChatRoom[]>([])
+  const [chatLoading, setChatLoading]       = useState(false)
+  const [chatInput, setChatInput]           = useState('')
+  const [chatSending, setChatSending]       = useState(false)
+  const [activeChatRoom, setActiveChatRoom] = useState<string | null>(null)
+  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const loadEvents = useCallback(async (taskId: string) => {
     setEventsLoading(true)
@@ -137,6 +159,48 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
       setEventsLoading(false)
     }
   }, [])
+
+  const loadChat = useCallback(async (taskId: string) => {
+    setChatLoading(true)
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/chat`)
+      if (res.ok) {
+        const data = await res.json()
+        setTaskChatRooms(data.rooms || [])
+        if (data.rooms?.length && !activeChatRoom) {
+          setActiveChatRoom(data.rooms[0].id)
+        }
+      }
+    } finally {
+      setChatLoading(false)
+    }
+  }, [activeChatRoom])
+
+  const sendChatMessage = async () => {
+    const content = chatInput.trim()
+    if (!content || chatSending || !activeChatRoom || panel?.kind !== 'task') return
+    setChatSending(true)
+    setChatInput('')
+    try {
+      const res = await fetch(`/api/chatrooms/${activeChatRoom}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      })
+      if (res.ok) {
+        // Refresh room messages
+        const roomRes = await fetch(`/api/tasks/${panel.task.id}/chat`)
+        if (roomRes.ok) {
+          const data = await roomRes.json()
+          setTaskChatRooms(data.rooms || [])
+        }
+      }
+    } catch (e) {
+      console.error('Failed to send message:', e)
+    } finally {
+      setChatSending(false)
+    }
+  }
 
 
   // Sync task detail panel when task changes
@@ -149,6 +213,9 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
       setTaskTab('details')
       setTaskEvents([])
       setExpandedEvents(new Set())
+      setTaskChatRooms([])
+      setActiveChatRoom(null)
+      setChatInput('')
     }
   }, [panel?.kind === 'task' ? panel.task.id : null])
 
@@ -635,6 +702,10 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
               className={`px-3 py-2 text-[11px] font-medium border-b-2 transition-colors ${taskTab === 'log' ? 'border-accent text-accent' : 'border-transparent text-text-muted hover:text-text-secondary'}`}>
               Run Log
             </button>
+            <button onClick={() => { setTaskTab('chat'); loadChat(panel.task.id) }}
+              className={`px-3 py-2 text-[11px] font-medium border-b-2 transition-colors ${taskTab === 'chat' ? 'border-accent text-accent' : 'border-transparent text-text-muted hover:text-text-secondary'}`}>
+              Chat
+            </button>
           </div>
           <div className="flex-1 overflow-y-auto p-4 space-y-4">
             {taskTab === 'details' && (<>
@@ -718,6 +789,12 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                   return next
                 })}
                 onRefresh={() => loadEvents(panel.task.id)} />
+            )}
+
+            {taskTab === 'chat' && (
+              <TaskChat rooms={taskChatRooms} loading={chatLoading} activeRoom={activeChatRoom}
+                onRoomChange={setActiveChatRoom} onSend={sendChatMessage} sending={chatSending}
+                inputRef={chatInputRef} onInput={setChatInput} input={chatInput} />
             )}
           </div>
           {taskTab === 'details' && (
@@ -974,6 +1051,126 @@ function TaskRunLog({
             )
           })}
         </div>
+      </div>
+    </div>
+  )
+}
+
+// ── TaskChat ───────────────────────────────────────────────────────────────────
+
+const SENDER_BG: Record<string, string> = {
+  agent: 'bg-accent/15 text-accent border-accent/20',
+  user: 'bg-bg-raised text-text-secondary border-border-subtle',
+  system: 'bg-bg-raised text-text-muted border-border-subtle italic',
+}
+
+function TaskChat({
+  rooms, loading, activeRoom, onRoomChange, onSend, sending, inputRef, onInput, input
+}: {
+  rooms: Array<{id:string;name:string;type:string;messages:Array<{id:string;senderType:string;content:string;sender:{type:string;id:string|null;name:string};createdAt:string}>}>
+  loading: boolean
+  activeRoom: string | null
+  onRoomChange: (id: string) => void
+  onSend: () => void
+  sending: boolean
+  inputRef: React.RefObject<HTMLInputElement | null>
+  onInput: (v: string) => void
+  input: string
+}) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [rooms, activeRoom])
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-12 text-text-muted text-xs">Loading chat…</div>
+  )
+
+  const allRooms = rooms.length > 0 ? rooms : [{
+    id: '', name: 'Task Chat', type: 'task', messages: [] as Array<{id:string;senderType:string;content:string;sender:{type:string;id:string|null;name:string};createdAt:string}>,
+  }]
+
+  const currentRoom = activeRoom
+    ? allRooms.find(r => r.id === activeRoom)
+    : allRooms[0]
+
+  if (!currentRoom) return null
+
+  const messages = currentRoom.messages.length > 0 ? currentRoom.messages : []
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Room selector */}
+      {rooms.length > 1 && (
+        <div className="flex gap-1.5 mb-3 overflow-x-auto pb-1">
+          {rooms.map(room => (
+            <button
+              key={room.id}
+              onClick={() => onRoomChange(room.id)}
+              className={`flex-shrink-0 px-2.5 py-1 rounded text-[10px] border transition-colors ${
+                activeRoom === room.id
+                  ? 'bg-accent/15 border-accent/40 text-accent'
+                  : 'bg-bg-raised border-border-subtle text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              {room.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto space-y-3 pr-1">
+        {!messages.length ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center text-text-muted">
+            <div className="w-12 h-12 rounded-full bg-accent/20 flex items-center justify-center mb-3">
+              <MessageSquare size={22} className="text-accent" />
+            </div>
+            <p className="text-xs">No messages yet</p>
+            <p className="text-[10px] mt-1 opacity-60">Bot conversations for this task appear here.</p>
+          </div>
+        ) : (
+          messages.map(msg => {
+            const isAgent = msg.senderType === 'agent'
+            const isSystem = msg.senderType === 'system'
+            return (
+              <div key={msg.id} className={`rounded-lg border px-3 py-2 text-xs ${SENDER_BG[msg.senderType] ?? SENDER_BG.system}`}>
+                <div className="flex items-center gap-1.5 mb-1">
+                  <span className="text-[9px] font-semibold text-text-secondary">
+                    {isAgent ? msg.sender.name : msg.sender.name || 'system'}
+                  </span>
+                  <span className="text-[8px] text-text-muted flex-shrink-0">
+                    {new Date(msg.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <pre className="whitespace-pre-wrap break-words leading-relaxed font-mono text-[11px]">{msg.content}</pre>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-border-subtle p-2.5 flex gap-2 flex-shrink-0 mt-2">
+        <input
+          ref={inputRef as any}
+          value={input}
+          onChange={e => onInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSend() }}}
+          placeholder="Send a message…"
+          disabled={sending}
+          className="flex-1 px-3 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+        />
+        <button
+          onClick={onSend}
+          disabled={!input.trim() || sending}
+          className="p-1.5 rounded-lg bg-accent text-white hover:bg-accent/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex-shrink-0"
+        >
+          {sending ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+        </button>
       </div>
     </div>
   )

--- a/apps/web/src/components/tasks/TeamDetailPanel.tsx
+++ b/apps/web/src/components/tasks/TeamDetailPanel.tsx
@@ -86,6 +86,7 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
   const [planningInput, setPlanningInput] = useState('')
   const [draftForm, setDraftForm] = useState({ name: '', role: '', type: 'claude' })
   const [draftCreating, setDraftCreating] = useState(false)
+  const initialContextRef = useRef<string | null>(null)
   const planningAbortRef = useRef<AbortController | null>(null)
   const planningBottomRef = useRef<HTMLDivElement>(null)
   const planningInputRef = useRef<HTMLInputElement>(null)
@@ -142,16 +143,19 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
     setPlanningInput('')
     try {
       const tmplRes = await fetch('/api/admin/prompts/context.agent-create')
-      const initialContext = tmplRes.ok
+      const ctx = tmplRes.ok
         ? ((await tmplRes.json() as { content: string }).content)
         : "I want to create a new agent for my homelab team. Help me define what this agent should do. Ask me what kind of agent I need, its responsibilities, and if it's an AI agent, help me write a good system prompt for it."
+      initialContextRef.current = ctx
       const r = await fetch('/api/chat/conversations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: `Plan: ${form.name || 'New Agent'}`, agentDraft: true, initialContext }),
+        body: JSON.stringify({ title: `Plan: ${form.name || 'New Agent'}`, agentDraft: true, initialContext: ctx }),
       })
       const convo = await r.json()
       setPlanningConvId(convo.id)
+      // Auto-send the initial context so Claude gets its planning instructions
+      sendToPlanning(ctx)
     } catch (err) {
       console.error('Failed to start planning:', err)
       setPlanningMode(false)

--- a/apps/web/src/components/tasks/TeamDetailPanel.tsx
+++ b/apps/web/src/components/tasks/TeamDetailPanel.tsx
@@ -1,8 +1,8 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
-import { X, Plus, Trash2, Bot, User, Cpu, MessageSquarePlus, MessageSquare, Rocket } from 'lucide-react'
+import { X, Plus, Trash2, Bot, User, Cpu, MessageSquarePlus, MessageSquare, Rocket, Loader2, Check, Send, Square } from 'lucide-react'
 import type { Agent } from '@/types/tasks'
 import { NovaBrowser } from '@/components/nova/NovaBrowser'
 
@@ -77,6 +77,18 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
   const [showNovaBrowser, setShowNovaBrowser] = useState(false)
   const [saving, setSaving]             = useState(false)
   const [availableModels, setAvailableModels] = useState<Array<{id: string; name: string; provider: string; builtIn: boolean}>>([])
+
+  // Planning mode state
+  const [planningMode, setPlanningMode] = useState(false)
+  const [planningConvId, setPlanningConvId] = useState('')
+  const [planningMessages, setPlanningMessages] = useState<Array<{role: string; content: string; toolCalls?: Array<{tool: string; input: string; output?: string}>; streaming?: boolean}>>([])
+  const [planningStreaming, setPlanningStreaming] = useState(false)
+  const [planningInput, setPlanningInput] = useState('')
+  const [draftForm, setDraftForm] = useState({ name: '', role: '', type: 'claude' })
+  const [draftCreating, setDraftCreating] = useState(false)
+  const planningAbortRef = useRef<AbortController | null>(null)
+  const planningBottomRef = useRef<HTMLDivElement>(null)
+  const planningInputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
 
   useEffect(() => { fetch('/api/models').then(r => r.json()).then(setAvailableModels).catch(() => {}) }, [])
@@ -123,18 +135,128 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
     router.push(`/chat?conversation=${convo.id}`)
   }
 
-  const createWithClaude = async () => {
-    const tmplRes = await fetch('/api/admin/prompts/context.agent-create')
-    const initialContext = tmplRes.ok
-      ? ((await tmplRes.json() as { content: string }).content)
-      : "I want to create a new agent for my homelab team. Help me define what this agent should do. Ask me what kind of agent I need, its responsibilities, and if it's an AI agent, help me write a good system prompt for it."
-    const r = await fetch('/api/chat/conversations', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'New Agent', agentDraft: true, initialContext }),
-    })
-    const convo = await r.json()
-    router.push(`/chat?conversation=${convo.id}`)
+   const startPlanning = async () => {
+    setPlanningMode(true)
+    setPlanningMessages([])
+    setDraftForm({ name: '', role: '', type: 'claude' })
+    setPlanningInput('')
+    try {
+      const tmplRes = await fetch('/api/admin/prompts/context.agent-create')
+      const initialContext = tmplRes.ok
+        ? ((await tmplRes.json() as { content: string }).content)
+        : "I want to create a new agent for my homelab team. Help me define what this agent should do. Ask me what kind of agent I need, its responsibilities, and if it's an AI agent, help me write a good system prompt for it."
+      const r = await fetch('/api/chat/conversations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: `Plan: ${form.name || 'New Agent'}`, agentDraft: true, initialContext }),
+      })
+      const convo = await r.json()
+      setPlanningConvId(convo.id)
+    } catch (err) {
+      console.error('Failed to start planning:', err)
+      setPlanningMode(false)
+    }
+  }
+
+  const sendToPlanning = async (promptOverride?: string) => {
+    const prompt = (promptOverride ?? planningInput).trim()
+    if (!prompt || planningStreaming || !planningConvId) return
+    setPlanningInput('')
+    setPlanningStreaming(true)
+
+    const abort = new AbortController()
+    planningAbortRef.current = abort
+
+    const userMsg = { role: 'user' as const, content: prompt, toolCalls: [] as Array<{tool: string; input: string; output?: string}> }
+    const assistantMsg = { role: 'assistant' as const, content: '', toolCalls: [], streaming: true }
+    setPlanningMessages(prev => [...prev, userMsg, assistantMsg])
+
+    try {
+      const resp = await fetch(`/api/chat/conversations/${planningConvId}/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+        signal: abort.signal,
+      })
+      const reader = resp.body!.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n\n')
+        buffer = lines.pop() ?? ''
+        for (const block of lines) {
+          const eventLine = block.split('\n').find(l => l.startsWith('event:'))
+          const dataLine  = block.split('\n').find(l => l.startsWith('data:'))
+          if (!eventLine || !dataLine) continue
+          const event = eventLine.replace('event: ', '').trim()
+          const data = JSON.parse(dataLine.replace('data: ', ''))
+          setPlanningMessages(prev => {
+            const msgs = [...prev]
+            const last = msgs[msgs.length - 1]
+            if (!last || last.role !== 'assistant') return prev
+            if (event === 'text' && data.content) last.content += data.content
+            else if (event === 'tool_call') last.toolCalls = [...(last.toolCalls ?? []), { tool: data.tool!, input: data.input! }]
+            else if (event === 'tool_result') { const tc = last.toolCalls?.[last.toolCalls.length - 1]; if (tc) tc.output = data.output }
+            else if (event === 'done' || event === 'error') {
+              last.streaming = false
+              if (event === 'error') last.content += `\n\n⚠ ${data.error ?? 'Error'}`
+            }
+            return msgs
+          })
+        }
+      }
+    } catch (err) {
+      if (!(err instanceof Error && err.name === 'AbortError')) {
+        setPlanningMessages(prev => {
+          const msgs = [...prev]
+          const last = msgs[msgs.length - 1]
+          if (last?.role === 'assistant') { last.streaming = false; last.content += `\n\n⚠ Error: ${err}` }
+          return msgs
+        })
+      }
+    } finally {
+      planningAbortRef.current = null
+      setPlanningStreaming(false)
+      setPlanningMessages(prev => {
+        const msgs = [...prev]
+        const last = msgs[msgs.length - 1]
+        if (last?.role === 'assistant') last.streaming = false
+        return msgs
+      })
+    }
+  }
+
+  const createFromDraft = async () => {
+    if (!draftForm.name.trim()) return
+    setDraftCreating(true)
+    try {
+      const lastAssistant = [...planningMessages].reverse().find(m => m.role === 'assistant')
+      const agentRes = await fetch('/api/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: draftForm.name,
+          type: (draftForm.type === 'custom' ? 'claude' : draftForm.type),
+          role: draftForm.role || null,
+          metadata: lastAssistant?.content?.trim() ? { systemPrompt: lastAssistant.content.trim() } : undefined,
+        }),
+      })
+      if (!agentRes.ok) { const err = await agentRes.json().catch(() => ({})); throw new Error(err.error ?? 'Failed to create agent') }
+      const agent = await agentRes.json()
+      if (onCreate) onCreate(agent)
+      else setLocalAgents(prev => [...prev, agent])
+      setPlanningMode(false)
+      setPlanningConvId('')
+      setPlanningMessages([])
+      setDraftForm({ name: '', role: '', type: 'claude' })
+    } catch (err) {
+      console.error('Failed to create agent:', err)
+      alert(`Failed to create agent: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      setDraftCreating(false)
+    }
   }
 
   const handleNovaImport = (novaName: string) => {
@@ -279,11 +401,6 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
             className="flex-1 flex items-center gap-2 px-4 py-2.5 text-xs text-text-muted hover:text-accent hover:bg-bg-raised transition-colors">
             <Plus size={13} /> Add Agent
           </button>
-          <button onClick={createWithClaude}
-            className="flex items-center gap-2 px-4 py-2.5 text-xs text-text-muted hover:text-accent hover:bg-bg-raised transition-colors border-l border-border-subtle"
-            title="Start a conversation to plan the agent with Claude">
-            <MessageSquarePlus size={13} /> Create with Claude
-          </button>
           <button onClick={() => setShowNovaBrowser(true)}
             className="flex items-center gap-2 px-4 py-2.5 text-xs text-text-muted hover:text-accent hover:bg-bg-raised transition-colors border-l border-border-subtle"
             title="Browse Nebula service catalog to import agents">
@@ -339,10 +456,98 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
               <button onClick={closeCreate} className="px-3 py-1.5 text-xs rounded border border-border-subtle text-text-muted hover:text-text-primary transition-colors">
                 Cancel
               </button>
+              <button onClick={() => { setCreateModal(false); startPlanning(); }}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded bg-accent/15 text-accent hover:bg-accent/25 transition-colors">
+                <MessageSquarePlus size={11} /> Plan with AI
+              </button>
               <button onClick={create} disabled={!form.name.trim() || saving}
                 className="px-4 py-1.5 text-xs rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 transition-colors">
                 {saving ? 'Adding…' : 'Add Agent'}
               </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {/* Planning mode — inline chat with Claude for agent creation */}
+      {planningMode && planningConvId && createPortal(
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={() => setPlanningMode(false)}>
+          <div className="w-full max-w-2xl bg-bg-sidebar border border-border-subtle rounded-xl shadow-2xl overflow-hidden flex flex-col"
+               style={{ maxHeight: 'min(70vh, 700px)' }} onClick={e => e.stopPropagation()}>
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+              <div className="flex items-center gap-2">
+                <Bot size={14} className="text-accent" />
+                <span className="text-xs font-semibold text-text-primary">Plan with AI</span>
+              </div>
+              <button onClick={() => setPlanningMode(false)} className="p-1 rounded text-text-muted hover:text-text-primary"><X size={14} /></button>
+            </div>
+            {/* Agent creation banner — shown after Claude responds */}
+            {planningMessages.some(m => m.role === 'assistant') && (
+              <>
+                <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle bg-accent/5 flex-shrink-0">
+                  <Bot size={13} className="text-accent flex-shrink-0" />
+                  <span className="text-xs text-accent flex-1">Agent creation mode — chat with Claude to define your agent</span>
+                </div>
+                <div className="flex items-center gap-2 px-4 pb-2.5 flex-shrink-0">
+                  <input value={draftForm.name} onChange={e => setDraftForm(f => ({ ...f, name: e.target.value }))}
+                    placeholder="Agent name *"
+                    className="flex-1 min-w-0 px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+                  <input value={draftForm.role} onChange={e => setDraftForm(f => ({ ...f, role: e.target.value }))}
+                    placeholder="Role (e.g. DevOps)"
+                    className="flex-1 min-w-0 px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+                  <select value={draftForm.type} onChange={e => setDraftForm(f => ({ ...f, type: e.target.value }))}
+                    className="px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent">
+                    <option value="claude">Claude</option>
+                    <option value="human">Human</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                  <button onClick={createFromDraft} disabled={!draftForm.name.trim() || draftCreating}
+                    className="flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium bg-accent/15 text-accent hover:bg-accent/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors whitespace-nowrap">
+                    {draftCreating ? <><Loader2 size={11} className="animate-spin" /> Creating…</> : <><Check size={11} /> Create Agent</>}
+                  </button>
+                </div>
+              </>
+            )}
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+              {!planningMessages.length ? (
+                <div className="flex flex-col items-center justify-center h-full text-center text-text-muted">
+                  <div className="w-12 h-12 rounded-full bg-accent/20 flex items-center justify-center mb-4"><Bot size={22} className="text-accent" /></div>
+                  <p className="text-sm">Creating a new agent</p>
+                  <p className="text-xs mt-1 opacity-60">Describe what you need — Claude will help define the role, responsibilities, and system prompt.</p>
+                </div>
+              ) : (
+                planningMessages.map((msg, i) => (
+                  <div key={i} className={msg.role === 'user' ? 'text-right' : ''}>
+                    <div className={`inline-block max-w-[85%] rounded-lg px-3 py-2 text-xs whitespace-pre-wrap ${
+                      msg.role === 'user' ? 'bg-accent/20 text-accent' : 'bg-bg-raised text-text-secondary border border-border-subtle'
+                    }`}>
+                      {msg.content}
+                      {msg.toolCalls?.map((tc, j) => (
+                        <div key={j} className="mt-1 text-[10px] text-text-muted">Tool: {tc.tool}</div>
+                      ))}
+                    </div>
+                  </div>
+                ))
+              )}
+              <div ref={planningBottomRef} />
+            </div>
+            {/* Input */}
+            <div className="border-t border-border-subtle p-3 flex-shrink-0">
+              <div className="flex gap-2">
+                <input ref={planningInputRef} value={planningInput} onChange={e => setPlanningInput(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendToPlanning() }}}
+                  placeholder={planningMessages.length === 0 ? "Describe what kind of agent you need…" : "Type your message…"}
+                  disabled={planningStreaming}
+                  className="flex-1 px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+                {planningStreaming ? (
+                  <button onClick={() => planningAbortRef.current?.abort()} className="p-2.5 rounded-lg bg-status-error/15 text-status-error hover:bg-status-error/30"><Square size={16} /></button>
+                ) : (
+                  <button onClick={() => sendToPlanning()} disabled={!planningInput.trim()} className="p-2.5 rounded-lg bg-accent text-white hover:bg-accent/80 disabled:opacity-40"><Send size={16} /></button>
+                )}
+              </div>
             </div>
           </div>
         </div>,

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -504,7 +504,7 @@ export async function* streamAgentChat(
 
   if (llm.startsWith('ollama:') || llm.startsWith('ext:')) {
     // Resolve model + baseUrl + provider
-    let model: string
+    let model: string = ''
     let baseUrl: string | undefined
     let timeoutSecs = 120
     let provider = 'ollama'
@@ -514,7 +514,7 @@ export async function* streamAgentChat(
       const extId = llm.slice('ext:'.length)
       const extModel = await prisma.externalModel.findUnique({ where: { id: extId } })
       if (!extModel) { yield { type: 'error', error: `External model not found: ${extId}` }; return }
-      model = extModel.modelId
+      model = extModel.modelId || 'default'
       baseUrl = extModel.baseUrl ?? undefined
       timeoutSecs = extModel.timeoutSecs ?? 120
       provider = extModel.provider   // 'ollama' | 'openai' | 'custom' | etc.
@@ -536,13 +536,28 @@ export async function* streamAgentChat(
       }
     } else {
       // OpenAI-compatible endpoint (custom / openai / llama.cpp / etc.)
-      if (!baseUrl) { yield { type: 'error', error: `No baseUrl configured for model ${model}` }; return }
-      const systemPrompt = gw
-        ? await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt, conversationId)
-        : agentSystemPrompt + noGwSuffix
+      // Don't use getSystemPrompt — its ORION template would conflict with the agent's persona.
+      // agentSystemPrompt is already the raw agent identity prompt.
+      let openAISystemPrompt: string
+      if (gw) {
+        // Build system prompt: persona + tool definitions + cluster context
+        const toolDefs = gw.tools.map(t => `  - ${t.name}: ${t.description || 'No description'}`).join('\n')
+        openAISystemPrompt = `${agentSystemPrompt}
+
+You have the following MCP tools available:
+${toolDefs}
+
+Tool usage rules:
+- Call tools immediately when you need real data. Do not ask permission first.
+- NEVER make up or hallucinate tool output. Always use a tool and return its real result.
+
+${readClusterContext()}`
+      } else {
+        openAISystemPrompt = agentSystemPrompt + noGwSuffix
+      }
       yield* streamOpenAIChatCore(
-        prompt, conversationId, systemPrompt, trimmedHistory,
-        model, baseUrl, apiKey,
+        prompt, conversationId, openAISystemPrompt, trimmedHistory,
+        model!, baseUrl!, apiKey,
         gw?.tools ?? [], gw?.gc ?? null, gw?.environmentId,
         undefined, userId,
       )


### PR DESCRIPTION
## Summary

Fixes agents using external models (llama.cpp, OpenAI-compatible) responding as "ORION" instead of their own persona.

**Root cause:** The code passed the agent's system prompt through `getSystemPrompt()` which loaded the ORION template. This resulted in a system prompt containing both "You are ORION, an AI assistant..." and the agent's persona — for external models that may partially ignore the system prompt, ORION's identity won.

**Fix:** For non-Ollama providers (llama.cpp, OpenAI-compatible), skip `getSystemPrompt()` entirely and pass the raw agent system prompt directly.

## Changes

- **`apps/web/src/lib/claude.ts`** — For external model providers, build system prompt manually: raw agent persona + gateway tool definitions + cluster context (no ORION template)

## Verification

1. Chat with an agent using an external model (e.g., Alpha with Qwen3.6)
2. Agent should respond in its own persona, not as ORION

🤖 Generated with [Claude Code](https://claude.com/claude-code)