### PR TITLE
fix: inject active task list into agent system prompts

### DIFF
--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -4,6 +4,20 @@ import { prisma } from './db'
 import { getPrompt, interpolate } from './system-prompts'
 import type { SDKAssistantMessage, SDKResultMessage } from '@anthropic-ai/claude-code'
 
+async function getActiveTasksSection(): Promise<string> {
+  const tasks = await prisma.task.findMany({
+    where: { status: { in: ['pending', 'running'] } },
+    select: { id: true, title: true, description: true, plan: true, priority: true, status: true },
+    orderBy: { priority: 'desc' },
+    take: 20,
+  })
+  if (!tasks.length) return ''
+  const lines = tasks.map(t =>
+    `  • [${t.status}] ${t.title}${t.priority ? ` (priority: ${t.priority})` : ''}${t.description ? `\n    ${t.description.slice(0, 200)}` : ''}`
+  )
+  return `\nYou have a task board with active work items:\n${lines.join('\n')}\nUse these as guidance for what work is expected. Do not claim to have completed tasks you haven't verified.\n`
+}
+
 // Tool allowlist — read-only kubectl only
 export const ALLOWED_TOOLS = [
   'Bash(kubectl get:*)',
@@ -528,21 +542,23 @@ export async function* streamAgentChat(
     const noGwSuffix = '\n\nNo MCP gateway is connected right now. You cannot run tools or commands. Be honest about this limitation.'
 
     if (provider === 'ollama') {
+      const activeTasks = await getActiveTasksSection()
       if (gw) {
-        const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt, conversationId)
+        const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt + activeTasks, conversationId)
         yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId)
       } else {
-        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + noGwSuffix, trimmedHistory, model, baseUrl, timeoutSecs)
+        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix, trimmedHistory, model, baseUrl, timeoutSecs)
       }
     } else {
       // OpenAI-compatible endpoint (custom / openai / llama.cpp / etc.)
       // Don't use getSystemPrompt — its ORION template would conflict with the agent's persona.
       // agentSystemPrompt is already the raw agent identity prompt.
+      const activeTasks = await getActiveTasksSection()
       let openAISystemPrompt: string
       if (gw) {
-        // Build system prompt: persona + tool definitions + cluster context
+        // Build system prompt: persona + tasks + tool definitions + cluster context
         const toolDefs = gw.tools.map(t => `  - ${t.name}: ${t.description || 'No description'}`).join('\n')
-        openAISystemPrompt = `${agentSystemPrompt}
+        openAISystemPrompt = `${agentSystemPrompt}${activeTasks}
 
 You have the following MCP tools available:
 ${toolDefs}
@@ -553,7 +569,7 @@ Tool usage rules:
 
 ${readClusterContext()}`
       } else {
-        openAISystemPrompt = agentSystemPrompt + noGwSuffix
+        openAISystemPrompt = agentSystemPrompt + activeTasks + noGwSuffix
       }
       yield* streamOpenAIChatCore(
         prompt, conversationId, openAISystemPrompt, trimmedHistory,


### PR DESCRIPTION
## Summary
- **Problem**: Agents using external models (llama.cpp/Ollama) had no awareness of the task board during interactive chat — they couldn't see any tasks.
- **Fix**: Added `getActiveTasksSection()` helper that fetches pending/running tasks from the database and appends them to the agent's system prompt, between the persona and tool definitions.
- **Scope**: Both Ollama and OpenAI-compatible (llama.cpp) agent backends. Only 20 highest-priority active tasks are included to avoid prompt bloat.
- **Verified**: TypeScript compiles clean, previous CodeQL checks passed for PR #31 on the same file.

## Test plan
- [ ] Create tasks in pending/running state
- [ ] Chat with agent Alpha (external model) — should mention active tasks
- [ ] Chat with Ollama agent — should mention active tasks
- [ ] Chat when no tasks are active — should work normally (no task section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)