### PR TITLE
feat: add member invite and leave room for chat rooms

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
@@ -1,0 +1,58 @@
+/**
+ * /api/chatrooms/[id]/invite
+ *
+ * POST — Invite a user or agent to a chat room (lead-only)
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const userId = body.userId ? String(body.userId) : null
+  const agentId = body.agentId ? String(body.agentId) : null
+
+  if (!userId && !agentId) return NextResponse.json({ error: 'Provide userId or agentId' }, { status: 400 })
+
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    include: { members: { select: { userId: true, agentId: true, role: true } } },
+  })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  // Check if already a member
+  const already = room.members.find(m =>
+    (userId && m.userId === userId) || (agentId && m.agentId === agentId)
+  )
+  if (already) return NextResponse.json({ error: 'Already a member' }, { status: 409 })
+
+  // Lead-only: must be a lead member or the room creator
+  const isLead = room.members.some(m => m.userId === session.user.id && m.role === 'lead')
+  if (!isLead && room.createdBy !== session.user.id) {
+    return NextResponse.json({ error: 'Only room leads or the creator can invite members' }, { status: 403 })
+  }
+
+  const roleValue = typeof body.role === 'string' ? body.role : 'member'
+
+  await prisma.chatRoomMember.create({
+    data: { roomId: id, userId, agentId, role: roleValue },
+  })
+
+  const name = agentId
+    ? (await prisma.agent.findUnique({ where: { id: agentId! }, select: { name: true } }))?.name || `Agent ${agentId}`
+    : (await prisma.user.findUnique({ where: { id: userId! }, select: { username: true } }))?.username || userId
+
+  await prisma.chatMessage.create({
+    data: { roomId: id, senderType: 'system', content: `${name} was added to the room` },
+  })
+
+  return NextResponse.json({ added: true })
+}

--- a/apps/web/src/app/api/chatrooms/[id]/members/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/members/route.ts
@@ -1,0 +1,42 @@
+/**
+ * /api/chatrooms/[id]/members
+ *
+ * GET — List available users/agents that are NOT yet members (for invite dropdown)
+ */
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await params
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    include: { members: { select: { userId: true, agentId: true } } },
+  })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  // Get all users except the current user
+  const allUsers = await prisma.user.findMany({
+    select: { id: true, username: true, name: true },
+    orderBy: { username: 'asc' },
+  })
+  const allAgents = await prisma.agent.findMany({
+    select: { id: true, name: true, type: true },
+    orderBy: { name: 'asc' },
+  })
+
+  const memberUserIds = room.members.map(m => m.userId).filter(Boolean) as string[]
+  const memberAgentIds = room.members.map(m => m.agentId).filter(Boolean) as string[]
+
+  const availableUsers = allUsers.filter(u => u.id !== session.user.id && !memberUserIds.includes(u.id))
+  const availableAgents = allAgents.filter(a => !memberAgentIds.includes(a.id))
+
+  return NextResponse.json({ users: availableUsers, agents: availableAgents })
+}

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   Users, Bot, User as UserIcon,
-  Hash, Send, X, Loader2,
+  Hash, Send, X, Loader2, Plus, LogOut,
 } from 'lucide-react'
 
 interface RoomMember {
@@ -35,6 +35,13 @@ interface RoomDetail {
   messages?: RoomMessage[]
 }
 
+interface InviteOption {
+  id: string
+  name: string
+  type: string
+  username?: string
+}
+
 interface Props {
   roomId: string
   onMobileBack: () => void
@@ -52,6 +59,14 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
   const [loading, setLoading] = useState(true)
   const [message, setMessage] = useState('')
   const [sending, setSending] = useState(false)
+  const [showInvite, setShowInvite] = useState(false)
+  const [inviteUsers, setInviteUsers] = useState<InviteOption[]>([])
+  const [inviteAgents, setInviteAgents] = useState<InviteOption[]>([])
+  const [inviteLoading, setInviteLoading] = useState(false)
+  const [inviteSearch, setInviteSearch] = useState('')
+  const [inviteTab, setInviteTab] = useState<'agents' | 'users'>('agents')
+  const [isInviting, setIsInviting] = useState<string | null>(null)
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   const loadRoom = useCallback(async () => {
@@ -84,6 +99,55 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
     setSending(false)
   }
 
+  const loadInviteOptions = useCallback(async () => {
+    setInviteLoading(true)
+    try {
+      const res = await fetch(`/api/chatrooms/${roomId}/members`)
+      if (res.ok) {
+        const data = await res.json()
+        setInviteUsers(data.users || [])
+        setInviteAgents(data.agents || [])
+      }
+    } catch { /* ignore */ }
+    setInviteLoading(false)
+  }, [roomId])
+
+  const handleInvite = useCallback(async (option: InviteOption) => {
+    if (isInviting) return
+    setIsInviting(option.id)
+    try {
+      const isAgent = option.type === 'agent'
+      const body: Record<string, string> = {}
+      body[isAgent ? 'agentId' : 'userId'] = option.id
+      await fetch(`/api/chatrooms/${roomId}/invite`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      setShowInvite(false)
+      setInviteSearch('')
+      setInviteTab('agents')
+      await loadRoom()
+    } catch { /* ignore */ }
+    setIsInviting(null)
+  }, [roomId, isInviting, loadRoom])
+
+  const handleLeave = useCallback(async () => {
+    try {
+      await fetch(`/api/chatrooms/${roomId}/join`, { method: 'DELETE' })
+    } catch { /* ignore */ }
+    setShowLeaveConfirm(false)
+    loadRoom()
+  }, [roomId, loadRoom])
+
+  // Filter invite list by search
+  const filteredUsers = inviteUsers.filter(u =>
+    !inviteSearch || (u.name || u.username || '').toLowerCase().includes(inviteSearch.toLowerCase())
+  )
+  const filteredAgents = inviteAgents.filter(a =>
+    !inviteSearch || a.name.toLowerCase().includes(inviteSearch.toLowerCase())
+  )
+
   return (
     <>
       {/* Header */}
@@ -92,7 +156,24 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
         <Hash size={14} className="text-text-muted flex-shrink-0" />
         <span className="text-sm font-semibold text-text-primary truncate">{room?.name}</span>
         {room && <span className={`px-1.5 py-0.5 rounded text-[9px] flex-shrink-0 ${TYPE_COLORS[room.type] || TYPE_COLORS.general}`}>{room.type}</span>}
-        <span className="text-[10px] text-text-muted ml-auto flex items-center gap-1 flex-shrink-0"><Users size={11} /> {room?._count?.members || room?.members?.length || 0}</span>
+        <div className="flex items-center gap-1 ml-auto flex-shrink-0">
+          {/* Invite button */}
+          <button
+            onClick={() => { setShowInvite(true); loadInviteOptions() }}
+            className="p-1.5 rounded hover:bg-bg-raised text-text-muted hover:text-accent transition-colors"
+            title="Add member"
+          >
+            <Plus size={14} />
+          </button>
+          {/* Leave room button */}
+          <button
+            onClick={() => setShowLeaveConfirm(true)}
+            className="p-1.5 rounded hover:bg-bg-raised text-text-muted hover:text-status-error transition-colors"
+            title="Leave room"
+          >
+            <LogOut size={14} />
+          </button>
+        </div>
       </div>
 
       {/* Members bar */}
@@ -143,9 +224,102 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
       <div className="px-4 py-3 border-t border-border-subtle flex-shrink-0">
         <div className="flex gap-2">
           <input value={message} onChange={e => setMessage(e.target.value)} onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSendMessage(); } }} placeholder="Type a message..." className="flex-1 px-3 py-2 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
-          <button onClick={handleSendMessage} disabled={!message.trim() || sending} className="px-4 py-2 text-xs rounded bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 flex-shrink-0"><Send size={14} /><span className="hidden sm:inline">Send</span></button>
+          <button onClick={() => { if (message.trim()) handleSendMessage(); }} disabled={!message.trim() || sending} className="px-4 py-2 text-xs rounded bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 flex-shrink-0"><Send size={14} /><span className="hidden sm:inline">Send</span></button>
         </div>
       </div>
+
+      {/* Invite Modal */}
+      {showInvite && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={() => setShowInvite(false)}>
+          <div className="w-full max-w-md bg-bg-sidebar border border-border-subtle rounded-xl shadow-2xl overflow-hidden flex flex-col" style={{ maxHeight: 'min(60vh, 450px)' }} onClick={e => e.stopPropagation()}>
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+              <span className="text-sm font-semibold text-text-primary">Add Member</span>
+              <button onClick={() => setShowInvite(false)} className="p-1 rounded text-text-muted hover:text-text-primary"><X size={16} /></button>
+            </div>
+
+            {/* Search */}
+            <div className="px-3 py-2 border-b border-border-subtle flex-shrink-0">
+              <input
+                value={inviteSearch}
+                onChange={e => setInviteSearch(e.target.value)}
+                placeholder="Search..."
+                className="w-full px-3 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              />
+            </div>
+
+            {/* Tabs */}
+            <div className="flex border-b border-border-subtle flex-shrink-0">
+              <button
+                onClick={() => setInviteTab('agents')}
+                className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${inviteTab === 'agents' ? 'text-accent border-b-2 border-accent' : 'text-text-muted hover:text-text-primary'}`}
+              >
+                Agents ({inviteAgents.length})
+              </button>
+              <button
+                onClick={() => setInviteTab('users')}
+                className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${inviteTab === 'users' ? 'text-accent border-b-2 border-accent' : 'text-text-muted hover:text-text-primary'}`}
+              >
+                Users ({inviteUsers.length})
+              </button>
+            </div>
+
+            {/* List */}
+            <div className="flex-1 overflow-y-auto">
+              {inviteLoading ? (
+                <div className="flex items-center justify-center py-8"><Loader2 size={16} className="animate-spin text-text-muted" /></div>
+              ) : (inviteTab === 'agents' ? filteredAgents : filteredUsers).length === 0 ? (
+                <div className="text-center text-text-muted text-xs py-8">
+                  {inviteSearch ? 'No results' : 'No available options'}
+                </div>
+              ) : (
+                (inviteTab === 'agents' ? filteredAgents : filteredUsers).map(option => (
+                  <button
+                    key={option.id}
+                    onClick={() => handleInvite(option)}
+                    disabled={isInviting === option.id}
+                    className="w-full flex items-center gap-2 px-4 py-2 text-xs text-left text-text-secondary hover:bg-bg-raised hover:text-text-primary transition-colors disabled:opacity-50"
+                  >
+                    {inviteTab === 'agents' ? (
+                      <Bot size={13} className="text-accent flex-shrink-0" />
+                    ) : (
+                      <UserIcon size={13} className="text-text-muted flex-shrink-0" />
+                    )}
+                    <span className="flex-1 truncate">
+                      {option.name}{option.username ? ` (${option.username})` : ''}
+                    </span>
+                    {isInviting === option.id ? (
+                      <Loader2 size={12} className="animate-spin text-text-muted" />
+                    ) : (
+                      <Plus size={12} className="text-text-muted" />
+                    )}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Leave Room Confirmation */}
+      {showLeaveConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={() => setShowLeaveConfirm(false)}>
+          <div className="w-full max-w-sm bg-bg-sidebar border border-border-subtle rounded-xl shadow-2xl overflow-hidden" onClick={e => e.stopPropagation()}>
+            <div className="p-4">
+              <h3 className="text-sm font-semibold text-text-primary mb-2">Leave Room</h3>
+              <p className="text-xs text-text-muted mb-4">You will leave this chat room. You can rejoin later if invited.</p>
+              <div className="flex justify-end gap-2">
+                <button onClick={() => setShowLeaveConfirm(false)} className="px-3 py-1.5 text-xs rounded border border-border-subtle text-text-muted hover:text-text-primary transition-colors">
+                  Cancel
+                </button>
+                <button onClick={handleLeave} className="px-3 py-1.5 text-xs rounded bg-status-error text-white hover:bg-status-error/80 transition-colors">
+                  Leave
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Added **invite** button (+ icon) in chat room header — opens a modal to search and add users or agents
- Added **leave room** button (log out icon) with confirmation dialog
- New endpoints:
  - `POST /api/chatrooms/[id]/invite` — lead/creator-only, accepts `userId` or `agentId`
  - `GET /api/chatrooms/[id]/members` — lists available users/agents not yet in the room
- Invite modal has tabs for agents/users and a search box
- Invite flow: only leads or the room creator can add members (enforced server-side)

## How to use
1. Open a chat room
2. Click the **+** icon in the header to add agents/users
3. Click the **log out** icon to leave the room

## Test plan
- [ ] Click + in a chat room header → invite modal opens
- [ ] Search for an agent → click to add → member appears in bar
- [ ] Click log out → confirmation dialog → leave room works
- [ ] Try inviting as non-lead → should get error

🤖 Generated with [Claude Code](https://claude.com/claude-code)