### PR TITLE
feat: ORION-aware agent creation planning prompt

### DIFF
--- a/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { streamClaudeResponse, streamAgentChat, streamOllamaChat, streamGeminiChat, streamOpenAIChat, type AgentContextConfig } from '@/lib/claude'
 import { prisma } from '@/lib/db'
+import { getPrompt } from '@/lib/system-prompts'
 import { getToken } from 'next-auth/jwt'
 
 export const dynamic = 'force-dynamic'
@@ -71,8 +72,9 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       ollamaModel = rawModel.startsWith('ollama:') ? rawModel.slice('ollama:'.length) : rawModel
     }
   }
-  const planTarget = meta?.planTarget as { type: string; id: string } | undefined
-  const agentChat  = meta?.agentChat  as { id: string; name: string } | undefined
+  const planTarget  = meta?.planTarget  as { type: string; id: string } | undefined
+  const agentChat   = meta?.agentChat   as { id: string; name: string } | undefined
+  const agentDraft  = meta?.agentDraft  as boolean | undefined
 
   // If this is an agent chat, load the agent's system prompt and context config
   let agentSystemPrompt: string | undefined
@@ -115,6 +117,10 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   return createSSEStream((send, close) => {
     ;(async () => {
+      const agentCreationPrompt = agentDraft && !agentSystemPrompt
+        ? await getPrompt('system.agent-creation')
+        : undefined
+
       const generator = agentSystemPrompt
         ? streamAgentChat(prompt, conversationId, agentSystemPrompt, history, agentContextConfig, agentChat?.id, userId, targetEnvironmentId)
         : openaiModel && openaiBaseUrl
@@ -123,7 +129,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
         ? streamOllamaChat(prompt, conversationId, history, ollamaModel, ollamaBaseUrl, abortCtrl.signal, userId, targetEnvironmentId)
         : geminiModel
         ? streamGeminiChat(prompt, conversationId, history, geminiModel, abortCtrl.signal)
-        : streamClaudeResponse(prompt, conversationId, history, planTarget, undefined, undefined, abortCtrl.signal)
+        : streamClaudeResponse(prompt, conversationId, history, planTarget, agentCreationPrompt, undefined, abortCtrl.signal)
       for await (const chunk of generator) {
         send(chunk.type, chunk)
         if (chunk.type === 'done' || chunk.type === 'error') {

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -257,11 +257,84 @@ Help me break this down into a clear implementation plan.`,
   },
 
   {
+    key: 'system.agent-creation',
+    name: 'Agent Creation Planning System Prompt',
+    category: 'system',
+    description: 'System prompt used during the "Plan with AI" agent creation flow from the Team panel. No dynamic variables.',
+    content: `You are an ORION agent designer. Your job is to help the user define and create a new AI agent for their ORION team.
+
+## ORION Agent Model
+
+Every agent has these fields:
+- **name** — short, role-based (e.g. "Kira", "DevBot", "SecurityScanner")
+- **type** — always \`claude\` for AI agents
+- **role** — one-line description of what the agent handles (shown in the UI roster)
+- **metadata.systemPrompt** — the full system prompt that defines the agent's behavior and knowledge
+- **metadata.persistent** — \`true\` if this agent stays in the roster permanently; \`false\` for one-off work
+- **metadata.transient** — \`true\` if Alpha should archive this agent after its task completes
+
+## The Team Today
+
+**Alpha** (Team Leader, watcher agent) — runs every 60 seconds, reviews the task backlog, assigns tasks to agents and humans, and creates new agents when needed. Alpha coordinates but never executes.
+
+**gmacro** — the one human on the team. Escalation target for anything requiring judgment, credentials, or external action.
+
+Any new agent you help define will join this team. Alpha will automatically assign tasks to them based on their role.
+
+## Persistent vs Transient
+
+**Persistent agents** are standing specialists — they stay in the roster and Alpha reuses them across many tasks.
+Examples: a DevOps engineer, a backend developer, a security auditor, a documentation writer.
+
+**Transient agents** are scoped to a single task — created by Alpha when needed, archived (not deleted) when the task completes. Good for one-off work that doesn't warrant a standing specialist.
+
+## What Makes a Good ORION System Prompt
+
+A strong agent system prompt includes:
+1. A clear identity statement (who they are, their domain)
+2. What they are responsible for — specific, not vague
+3. What tools or capabilities they use (kubectl, docker, code, research, etc.)
+4. What they should NOT do (out-of-scope guard rails)
+5. How they should report their work (format, detail level)
+6. Any standing rules for this homelab (e.g. never modify production secrets, always specify namespaces)
+
+Avoid generic instructions that apply to every agent. Tailor the prompt to the specific role.
+
+## Your Goal
+
+Through conversation, help the user define:
+1. What this agent's role is and whether it should be persistent or transient
+2. A specific, focused system prompt for the agent
+3. A clear one-line role description
+
+Ask targeted questions. Don't ask everything at once — start with what the agent needs to DO, then refine capabilities, then write the system prompt together.
+
+When you have enough information, produce a complete agent spec in this format:
+
+\`\`\`json
+{
+  "name": "AgentName",
+  "type": "claude",
+  "role": "one-line description",
+  "metadata": {
+    "systemPrompt": "full system prompt here",
+    "persistent": true,
+    "transient": false
+  }
+}
+\`\`\`
+
+The user can use this spec to fill out the agent creation form.`,
+  },
+
+  {
     key: 'context.agent-create',
     name: 'New Agent Creation Context',
     category: 'context',
-    description: 'Sent when a user starts the "Create Agent" flow from the Team panel. No dynamic variables.',
-    content: `I want to create a new agent for my homelab team. Help me define what this agent should do. Ask me what kind of agent I need, its responsibilities, and if it's an AI agent, help me write a good system prompt for it.`,
+    description: 'Auto-sent as the first message when a user starts the "Plan with AI" agent creation flow. No dynamic variables.',
+    content: `I want to add a new agent to the ORION team. Help me figure out what this agent should do and write a good system prompt for it.
+
+The team currently has Alpha (Team Leader) who handles task assignment, and gmacro (the human admin). What questions do you need answered to help me design the right agent?`,
   },
 ]
 


### PR DESCRIPTION
## Summary

- Adds `system.agent-creation` — replaces the generic ORION assistant for the "Plan with AI" agent creation flow with a context-rich agent designer that knows the team (Alpha, gmacro), the Agent data model, and the persistent/transient pattern. Guides the conversation toward producing a ready-to-paste JSON agent spec.
- Updates `context.agent-create` (auto-sent first message) to reference the current team instead of being completely generic.
- Wires `agentDraft` conversations in the stream route to use `system.agent-creation` instead of falling through to the no-gateway placeholder.

## Test plan

- [ ] Click "Plan with AI" on the Team panel — verify the assistant introduces itself as an ORION agent designer (not as generic ORION infra assistant)
- [ ] Have a short conversation about creating a DevOps agent — verify it asks targeted questions about role and scope
- [ ] Verify it produces a valid JSON agent spec at the end that can be pasted into the creation form
- [ ] Verify non-agentDraft chats (regular, planTarget, agentChat) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)