### PR TITLE
fix: guard msg.sender access with optional chaining in RoomChat

### DIFF
--- a/apps/web/src/app/(app)/messages/page.tsx
+++ b/apps/web/src/app/(app)/messages/page.tsx
@@ -104,6 +104,10 @@ export default function MessagesPage() {
     }
   }
 
+  const handleRename = (id: string, title: string) => {
+    setConvos(prev => prev.map(c => c.id === id ? { ...c, title: title || null } : c))
+  }
+
   const handleNewRoom = async () => {
     try {
       const res = await fetch('/api/chatrooms', {
@@ -152,6 +156,8 @@ export default function MessagesPage() {
           activeId={activeId ?? undefined}
           onMobileSelect={() => setMobileShowList(false)}
           onCreateNew={view === 'rooms' ? handleNewRoom : handleCreateNew}
+          onDelete={handleDelete}
+          onRename={handleRename}
           convos={regularConvos}
           planningConvos={planningConvos}
           agentConvos={agentConvos}
@@ -170,6 +176,7 @@ export default function MessagesPage() {
           activeId={activeId}
           onMobileBack={() => setMobileShowList(true)}
           onConversationCreated={handleConversationCreated}
+          onDelete={handleDelete}
           view={view}
         />
       </div>

--- a/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { streamClaudeResponse, streamAgentChat, streamOllamaChat, streamGeminiChat, streamOpenAIChat, type AgentContextConfig } from '@/lib/claude'
+import { retrieveKnowledgeContext } from '@/lib/embeddings'
 import { prisma } from '@/lib/db'
 import { getPrompt } from '@/lib/system-prompts'
 import { getToken } from 'next-auth/jwt'
@@ -113,6 +114,10 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       : m.content,
   }))
 
+  // RAG: embed the user's query and retrieve the top-3 most relevant notes.
+  // Runs in parallel with other setup — fails silently if no provider configured.
+  const knowledgeContext = await retrieveKnowledgeContext(prompt)
+
   const abortCtrl = new AbortController()
 
   return createSSEStream((send, close) => {
@@ -122,14 +127,14 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
         : undefined
 
       const generator = agentSystemPrompt
-        ? streamAgentChat(prompt, conversationId, agentSystemPrompt, history, agentContextConfig, agentChat?.id, userId, targetEnvironmentId)
+        ? streamAgentChat(prompt, conversationId, agentSystemPrompt, history, agentContextConfig, agentChat?.id, userId, targetEnvironmentId, knowledgeContext)
         : openaiModel && openaiBaseUrl
-        ? streamOpenAIChat(prompt, conversationId, history, openaiModel, openaiBaseUrl, openaiApiKey, abortCtrl.signal, userId, targetEnvironmentId, agentCreationPrompt)
+        ? streamOpenAIChat(prompt, conversationId, history, openaiModel, openaiBaseUrl, openaiApiKey, abortCtrl.signal, userId, targetEnvironmentId, agentCreationPrompt, knowledgeContext)
         : ollamaModel
-        ? streamOllamaChat(prompt, conversationId, history, ollamaModel, ollamaBaseUrl, abortCtrl.signal, userId, targetEnvironmentId, agentCreationPrompt)
+        ? streamOllamaChat(prompt, conversationId, history, ollamaModel, ollamaBaseUrl, abortCtrl.signal, userId, targetEnvironmentId, agentCreationPrompt, knowledgeContext)
         : geminiModel
-        ? streamGeminiChat(prompt, conversationId, history, geminiModel, abortCtrl.signal)
-        : streamClaudeResponse(prompt, conversationId, history, planTarget, agentCreationPrompt, undefined, abortCtrl.signal)
+        ? streamGeminiChat(prompt, conversationId, history, geminiModel, abortCtrl.signal, knowledgeContext)
+        : streamClaudeResponse(prompt, conversationId, history, planTarget, agentCreationPrompt, undefined, abortCtrl.signal, knowledgeContext)
       for await (const chunk of generator) {
         send(chunk.type, chunk)
         if (chunk.type === 'done' || chunk.type === 'error') {

--- a/apps/web/src/app/api/chatrooms/[id]/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/route.ts
@@ -46,7 +46,18 @@ export async function GET(
     return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
   }
 
-  const messages = (room as any).messages.reverse()
+  const messages = (room as any).messages.reverse().map((msg: any) => ({
+    id: msg.id,
+    senderType: msg.senderType,
+    content: msg.content,
+    attachments: msg.attachments,
+    sender: msg.agent
+      ? { type: 'agent', id: msg.agent.id, name: msg.agent.name }
+      : msg.user
+      ? { type: 'user', id: msg.user.id, name: msg.user.name || msg.user.username }
+      : { type: msg.senderType ?? 'unknown', id: null, name: 'System' },
+    createdAt: msg.createdAt instanceof Date ? msg.createdAt.toISOString() : msg.createdAt,
+  }))
   const members = (room as any).members
 
   return NextResponse.json({

--- a/apps/web/src/components/messages/ChatContainer.tsx
+++ b/apps/web/src/components/messages/ChatContainer.tsx
@@ -13,10 +13,11 @@ interface Props {
   activeId: string | null
   onMobileBack: () => void
   onConversationCreated: (convo: Conversation) => void
+  onDelete?: (prefixedId: string) => void
   view: 'ai' | 'rooms'
 }
 
-export function ChatContainer({ activeId, onMobileBack, onConversationCreated, view }: Props) {
+export function ChatContainer({ activeId, onMobileBack, onConversationCreated, onDelete, view }: Props) {
   if (!activeId) {
     return (
       <div className="flex-1 flex items-center justify-center bg-bg-card">
@@ -31,7 +32,7 @@ export function ChatContainer({ activeId, onMobileBack, onConversationCreated, v
 
   if (activeId.startsWith('r_')) {
     const roomId = activeId.slice(2)
-    return <RoomChat roomId={roomId} onMobileBack={onMobileBack} />
+    return <RoomChat roomId={roomId} onMobileBack={onMobileBack} onLeave={() => onDelete?.(`r_${roomId}`)} />
   }
 
   const conversationId = activeId.startsWith('c_') ? activeId.slice(2) : activeId

--- a/apps/web/src/components/messages/MessageList.tsx
+++ b/apps/web/src/components/messages/MessageList.tsx
@@ -45,6 +45,8 @@ interface Props {
   activeId?: string
   onMobileSelect?: () => void
   onCreateNew?: () => void
+  onDelete?: (prefixedId: string) => void
+  onRename?: (id: string, title: string) => void
   // AI data
   convos?: Conversation[]
   planningConvos?: PlanningConvo[]
@@ -66,7 +68,7 @@ const TYPE_COLORS: Record<string, string> = {
 }
 
 export function MessageList({
-  view, onSelect, activeId, onMobileSelect, onCreateNew,
+  view, onSelect, activeId, onMobileSelect, onCreateNew, onDelete, onRename,
   convos = [], planningConvos = [], agentConvos = [], debugConvos = [],
   epics = [], agents = [],
   rooms = [], roomFilter, onRoomFilterChange,
@@ -113,6 +115,7 @@ export function MessageList({
   const removeConvo = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation()
     await fetch(`/api/chat/conversations/${id}`, { method: 'DELETE' })
+    onDelete?.(`c_${id}`)
   }
 
   const startEdit = (e: React.MouseEvent, convo: Conversation) => {
@@ -129,6 +132,7 @@ export function MessageList({
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ title }),
     })
+    onRename?.(id, title ?? '')
     setEditingId(null)
   }
 
@@ -148,7 +152,7 @@ export function MessageList({
   const renderConversation = (c: Conversation) => (
     <div
       key={c.id}
-      className={`group w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${activeId === c.id ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-bg-raised'}`}
+      className={`group w-full text-left px-3 py-2 flex items-start gap-2 transition-colors ${activeId === `c_${c.id}` ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-bg-raised'}`}
       onClick={() => { if (editingId !== c.id) { onSelect(`c_${c.id}`); onMobileSelect?.() } }}
     >
       <MessageSquare size={14} className="flex-shrink-0 mt-0.5 text-text-muted" />
@@ -267,7 +271,7 @@ export function MessageList({
                   )
                 })}
                 {orphanConvos.map(c => (
-                  <div key={c.id} onClick={() => onSelect(`c_${c.id}`)} className={`${rowBase} gap-1.5 ml-2 ${activeId === `c_${c.id}` ? activeRow : idleRow}`}>
+                  <div key={c.id} onClick={() => { onSelect(`c_${c.id}`); onMobileSelect?.() }} className={`${rowBase} gap-1.5 ml-2 ${activeId === `c_${c.id}` ? activeRow : idleRow}`}>
                     <MessageSquare size={10} className="flex-shrink-0" />
                     <span className="flex-1 truncate text-[10px]">{c.title ?? 'Planning chat'}</span>
                   </div>
@@ -333,7 +337,7 @@ export function MessageList({
                     )
                   })}
                   {orphans.map(c => (
-                    <div key={c.id} onClick={() => onSelect(`c_${c.id}`)} className={`group ${rowBase} gap-1.5 ml-2 ${activeId === `c_${c.id}` ? activeRow : idleRow}`}>
+                    <div key={c.id} onClick={() => { onSelect(`c_${c.id}`); onMobileSelect?.() }} className={`group ${rowBase} gap-1.5 ml-2 ${activeId === `c_${c.id}` ? activeRow : idleRow}`}>
                       <MessageSquare size={10} className="flex-shrink-0" />
                       <span className="flex-1 truncate text-[10px]">{c.title ?? 'Chat'}</span>
                     </div>

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -213,14 +213,14 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               <div className="text-center text-text-muted text-xs py-8">No messages yet. Start the conversation!</div>
             )}
             {room?.messages?.map(msg => (
-              <div key={msg.id} className={`max-w-[80%] ${msg.senderType === 'system' ? 'mx-auto text-center' : msg.sender.type === 'human' || msg.sender.type === 'user' ? 'ml-auto' : 'mr-auto'}`}>
+              <div key={msg.id} className={`max-w-[80%] ${msg.senderType === 'system' ? 'mx-auto text-center' : msg.sender?.type === 'human' || msg.sender?.type === 'user' ? 'ml-auto' : 'mr-auto'}`}>
                 {msg.senderType === 'system' ? (
                   <div className="text-[10px] text-text-muted py-1">{msg.content}</div>
                 ) : (
-                  <div className={`rounded-lg px-3 py-2 ${msg.sender.type === 'human' || msg.sender.type === 'user' ? 'bg-accent/20 text-text-primary' : 'bg-bg-raised border border-border-subtle text-text-primary'}`}>
+                  <div className={`rounded-lg px-3 py-2 ${msg.sender?.type === 'human' || msg.sender?.type === 'user' ? 'bg-accent/20 text-text-primary' : 'bg-bg-raised border border-border-subtle text-text-primary'}`}>
                     <div className="flex items-center gap-1.5 mb-1">
-                      {msg.sender.type === 'agent' ? <Bot size={11} className="text-accent" /> : <UserIcon size={11} />}
-                      <span className="text-[10px] font-medium text-text-secondary">{msg.sender.name}</span>
+                      {msg.sender?.type === 'agent' ? <Bot size={11} className="text-accent" /> : <UserIcon size={11} />}
+                      <span className="text-[10px] font-medium text-text-secondary">{msg.sender?.name}</span>
                       <span className="text-[9px] text-text-muted">{new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
                     </div>
                     <p className="text-xs leading-relaxed whitespace-pre-wrap">{msg.content}</p>

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -45,6 +45,7 @@ interface InviteOption {
 interface Props {
   roomId: string
   onMobileBack: () => void
+  onLeave?: () => void
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -54,7 +55,7 @@ const TYPE_COLORS: Record<string, string> = {
   ops: 'bg-orange-500/20 text-orange-400',
 }
 
-export function RoomChat({ roomId, onMobileBack }: Props) {
+export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   const [room, setRoom] = useState<RoomDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [message, setMessage] = useState('')
@@ -89,11 +90,12 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
     if (!message.trim() || !room || sending) return
     setSending(true)
     try {
-      await fetch(`/api/chatrooms/${room.id}/messages`, {
+      const res = await fetch(`/api/chatrooms/${room.id}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: message.trim() }),
       })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
       setMessage('')
       await loadRoom()
     } catch { /* ignore */ }
@@ -147,8 +149,9 @@ export function RoomChat({ roomId, onMobileBack }: Props) {
       await fetch(`/api/chatrooms/${roomId}/join`, { method: 'DELETE' })
     } catch { /* ignore */ }
     setShowLeaveConfirm(false)
-    loadRoom()
-  }, [roomId, loadRoom])
+    if (onLeave) onLeave()
+    else onMobileBack()
+  }, [roomId, onLeave, onMobileBack])
 
   // Filter invite list by search
   const filteredUsers = inviteUsers.filter(u =>

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -120,7 +120,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
     setInviteError(null)
     setIsInviting(option.id)
     try {
-      const isAgent = option.type === 'agent'
+      const isAgent = inviteTab === 'agents'
       const body: Record<string, string> = {}
       body[isAgent ? 'agentId' : 'userId'] = option.id
       const res = await fetch(`/api/chatrooms/${roomId}/invite`, {
@@ -142,7 +142,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
       setInviteError(e instanceof Error ? e.message : 'Unknown error')
     }
     setIsInviting(null)
-  }, [roomId, isInviting, loadRoom])
+  }, [roomId, isInviting, inviteTab, loadRoom])
 
   const handleLeave = useCallback(async () => {
     try {

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { prisma } from './db'
 import { getPrompt, interpolate } from './system-prompts'
+import { generateEmbedding, vectorSearch } from './embeddings'
 import type { SDKAssistantMessage, SDKResultMessage } from '@anthropic-ai/claude-code'
 
 async function getActiveTasksSection(): Promise<string> {
@@ -35,6 +36,7 @@ async function getSystemPrompt(
   toolNames: string[] = [],
   basePrompt?: string,
   conversationId?: string,  // Optional: inject conversation memories
+  knowledgeContext?: string, // Optional: pre-fetched RAG context to inject
 ): Promise<string> {
   const clusterContext = readClusterContext()
   const persona = basePrompt ?? 'You are ORION, an AI assistant for homelab infrastructure management.'
@@ -53,9 +55,13 @@ async function getSystemPrompt(
     }
   }
 
+  const kcSection = knowledgeContext
+    ? '\n\n---\n## Relevant Knowledge Base\n\nThe following notes are semantically relevant to this query. Reference them when helpful:\n\n' + knowledgeContext + '\n---'
+    : ''
+
   if (toolNames.length === 0) {
     const template = await getPrompt('system.main.no-gateway')
-    return interpolate(template, { persona }) + memorySection
+    return interpolate(template, { persona }) + memorySection + kcSection
   }
 
   const template = await getPrompt('system.main')
@@ -63,7 +69,7 @@ async function getSystemPrompt(
     toolCount:      String(toolNames.length),
     toolList:       toolNames.join(', '),
     clusterContext,
-  }) + memorySection
+  }) + memorySection + kcSection
 }
 
 async function getPlanningSystemPrompt(targetType: string): Promise<string> {
@@ -247,6 +253,7 @@ export async function* streamOllamaChat(
   userId?: string,
   targetEnvironmentId?: string,
   systemPromptOverride?: string,
+  knowledgeContext?: string,
 ): AsyncGenerator<StreamChunk> {
   // Load tools from the specified (or first connected) gateway
   const { GatewayClient } = await import('./agent-runner/gateway-client')
@@ -272,13 +279,13 @@ export async function* streamOllamaChat(
 
   // No gateway — fall through to regular streaming chat with an honest system prompt
   if (!gatewayTools.length || !gatewayClient) {
-    const sp = systemPromptOverride ?? await getSystemPrompt([])
+    const sp = systemPromptOverride ?? await getSystemPrompt([], undefined, undefined, knowledgeContext)
     yield* streamOllamaAgentChat(prompt, conversationId, sp, history, model, baseUrl, undefined, abortSignal)
     return
   }
 
   // Tools available — run agentic loop (non-streaming turns with tool execution)
-  const systemPrompt = await getSystemPrompt(gatewayTools.map(t => t.name))
+  const systemPrompt = await getSystemPrompt(gatewayTools.map(t => t.name), undefined, undefined, knowledgeContext)
   yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, history, model, baseUrl, gatewayTools, gatewayClient, connectedEnv!.id, abortSignal, userId)
 }
 
@@ -314,32 +321,64 @@ async function* streamOllamaToolLoop(
     timeoutSecs = extModel.timeoutSecs ?? 120
   }
 
-  // Synthetic propose_tool — handled locally, never forwarded to the gateway
-  const proposeToolDef = {
-    type: 'function',
-    function: {
-      name: 'propose_tool',
-      description: 'Propose a new tool to be added to this environment\'s gateway. Use this when you need a command that isn\'t available. A human must approve it before you can use it.',
-      parameters: {
-        type: 'object',
-        properties: {
-          name:        { type: 'string', description: 'snake_case tool name, e.g. kubectl_get_pods' },
-          description: { type: 'string', description: 'What the tool does' },
-          command:     { type: 'string', description: 'Shell command with {param} placeholders, e.g. kubectl get pods -n {namespace}' },
-          parameters:  { type: 'object', description: 'Parameter definitions — keys are param names, values have type and description' },
-          reason:      { type: 'string', description: 'Why this tool is needed right now' },
+  // Synthetic management tools — handled locally, never forwarded to the gateway
+  const localToolDefs = [
+    {
+      type: 'function',
+      function: {
+        name: 'propose_tool',
+        description: 'Propose a new tool to be added to this environment\'s gateway. Use this when you need a command that isn\'t available. A human must approve it before you can use it.',
+        parameters: {
+          type: 'object',
+          properties: {
+            name:        { type: 'string', description: 'snake_case tool name, e.g. kubectl_get_pods' },
+            description: { type: 'string', description: 'What the tool does' },
+            command:     { type: 'string', description: 'Shell command with {param} placeholders, e.g. kubectl get pods -n {namespace}' },
+            parameters:  { type: 'object', description: 'Parameter definitions — keys are param names, values have type and description' },
+            reason:      { type: 'string', description: 'Why this tool is needed right now' },
+          },
+          required: ['name', 'description', 'command'],
         },
-        required: ['name', 'description', 'command'],
       },
     },
-  }
+    {
+      type: 'function',
+      function: {
+        name: 'knowledge_search',
+        description: 'Semantically search the knowledge base (notes, runbooks, wiki pages) for content relevant to a query.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query:          { type: 'string',  description: 'Natural language search query' },
+            limit:          { type: 'number',  description: 'Max results (1-20, default 5)' },
+            includeContent: { type: 'boolean', description: 'Include note content (default true)' },
+          },
+          required: ['query'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'knowledge_graph',
+        description: 'Get the full knowledge graph — all notes with wikilink dependencies and semantic connections.',
+        parameters: {
+          type: 'object',
+          properties: {
+            threshold:      { type: 'number',  description: 'Min similarity for semantic edges (default 0.5)' },
+            includeContent: { type: 'boolean', description: 'Include content snippet per note (default false)' },
+          },
+        },
+      },
+    },
+  ]
 
   const ollamaToolDefs = [
     ...tools.map(t => ({
       type: 'function',
       function: { name: t.name, description: t.description, parameters: t.inputSchema },
     })),
-    proposeToolDef,
+    ...localToolDefs,
   ]
 
   const messages: OllamaMsg[] = [
@@ -413,6 +452,24 @@ async function* streamOllamaToolLoop(
             continue
           }
 
+          // Knowledge tools — handled server-side
+          if (fn.name === 'knowledge_search') {
+            const argsStr = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments)
+            yield { type: 'tool_call', tool: fn.name, input: argsStr }
+            const result = await handleKnowledgeSearch(argsStr)
+            yield { type: 'tool_result', tool: fn.name, output: result }
+            messages.push({ role: 'tool', content: result })
+            continue
+          }
+          if (fn.name === 'knowledge_graph') {
+            const argsStr = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments)
+            yield { type: 'tool_call', tool: fn.name, input: argsStr }
+            const result = await handleKnowledgeGraph(argsStr)
+            yield { type: 'tool_result', tool: fn.name, output: result }
+            messages.push({ role: 'tool', content: result })
+            continue
+          }
+
           yield { type: 'tool_call', tool: fn.name, input: typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments) }
 
           // Permission check — must happen before forwarding to gateway
@@ -466,6 +523,7 @@ export async function* streamAgentChat(
   agentId?: string,
   userId?: string,
   targetEnvironmentId?: string,
+  knowledgeContext?: string,
 ): AsyncGenerator<StreamChunk> {
   const historyLimit   = contextConfig.historyMessages ?? 6
   const summarizeAfter = contextConfig.summarizeAfter  ?? 20
@@ -543,13 +601,17 @@ export async function* streamAgentChat(
     const gw = await loadAgentGateway()
     const noGwSuffix = '\n\nNo MCP gateway is connected right now. You cannot run tools or commands. Be honest about this limitation.'
 
+    const kcSection = knowledgeContext
+      ? '\n\n---\n## Relevant Knowledge Base\n\n' + knowledgeContext + '\n---'
+      : ''
+
     if (provider === 'ollama') {
       const activeTasks = await getActiveTasksSection()
       if (gw) {
-        const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt + activeTasks, conversationId)
+        const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt + activeTasks, conversationId, knowledgeContext)
         yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId)
       } else {
-        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix, trimmedHistory, model, baseUrl, timeoutSecs)
+        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix + kcSection, trimmedHistory, model, baseUrl, timeoutSecs)
       }
     } else {
       // OpenAI-compatible endpoint (custom / openai / llama.cpp / etc.)
@@ -569,9 +631,9 @@ Tool usage rules:
 - Call tools immediately when you need real data. Do not ask permission first.
 - NEVER make up or hallucinate tool output. Always use a tool and return its real result.
 
-${readClusterContext()}`
+${readClusterContext()}${kcSection}`
       } else {
-        openAISystemPrompt = agentSystemPrompt + activeTasks + noGwSuffix
+        openAISystemPrompt = agentSystemPrompt + activeTasks + noGwSuffix + kcSection
       }
       yield* streamOpenAIChatCore(
         prompt, conversationId, openAISystemPrompt, trimmedHistory,
@@ -594,11 +656,15 @@ ${readClusterContext()}`
   const maxTurns     = contextConfig.maxTurns    ?? 6
   const allowedTools = contextConfig.allowedTools ?? []
 
+  const kcSectionClaude = knowledgeContext
+    ? '\n\n---\n## Relevant Knowledge Base\n\n' + knowledgeContext + '\n---'
+    : ''
+
   const overridePrompt = `You are NOT Claude Code and NOT the Claude CLI. Do not mention or reference Claude Code, Anthropic's CLI, or any developer tooling.
 
 ${agentSystemPrompt}
 
-Respond only in the persona described above. Never break character or refer to yourself as Claude Code.`
+Respond only in the persona described above. Never break character or refer to yourself as Claude Code.${kcSectionClaude}`
 
   yield* streamClaudeResponse(prompt, conversationId, trimmedHistory, null, overridePrompt, {
     maxTurns,
@@ -712,6 +778,7 @@ export async function* streamOpenAIChat(
   userId?: string,
   targetEnvironmentId?: string,
   systemPromptOverride?: string,
+  knowledgeContext?: string,
 ): AsyncGenerator<StreamChunk> {
   // Load gateway tools from specified or first connected environment
   const { GatewayClient } = await import('./agent-runner/gateway-client')
@@ -731,7 +798,7 @@ export async function* streamOpenAIChat(
     try { gatewayTools = await gatewayClient.listTools() } catch { /* proceed without tools */ }
   }
 
-  const systemPrompt = systemPromptOverride ?? await getSystemPrompt(gatewayTools.map(t => t.name), undefined, conversationId)
+  const systemPrompt = systemPromptOverride ?? await getSystemPrompt(gatewayTools.map(t => t.name), undefined, conversationId, knowledgeContext)
   yield* streamOpenAIChatCore(
     prompt, conversationId, systemPrompt, history,
     model, baseUrl, apiKey,
@@ -934,6 +1001,94 @@ async function handleGitopsPropose(argsRaw: string, conversationId: string): Pro
   }
 }
 
+// ── Knowledge graph management tool handlers ─────────────────────────────────
+
+async function handleKnowledgeSearch(argsRaw: string): Promise<string> {
+  try {
+    const { query, limit = 5, includeContent = true } = JSON.parse(argsRaw || '{}') as {
+      query?: string; limit?: number; includeContent?: boolean
+    }
+    if (!query) return 'Error: query is required'
+
+    const embedding = await generateEmbedding(query.slice(0, 2000))
+    if (!embedding) return 'No embedding provider configured. Add an embedding model in Admin → Models to enable semantic search.'
+
+    const results = await vectorSearch(embedding.vector, Math.min(limit, 20))
+    if (!results.length) return 'No relevant notes found for this query.'
+
+    return JSON.stringify(
+      results.map(r => ({
+        title:  r.title,
+        type:   r.type,
+        folder: r.folder,
+        score:  parseFloat(r.score.toFixed(3)),
+        ...(includeContent && { content: r.content.slice(0, 2000) }),
+      })),
+      null, 2
+    )
+  } catch (e) {
+    return `Error: ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
+async function handleKnowledgeGraph(argsRaw: string): Promise<string> {
+  try {
+    const { threshold = 0.5, includeContent = false } = JSON.parse(argsRaw || '{}') as {
+      threshold?: number; includeContent?: boolean
+    }
+
+    const [notes, semanticEdges] = await Promise.all([
+      prisma.note.findMany({
+        select: { id: true, title: true, type: true, folder: true, content: true },
+        orderBy: { title: 'asc' },
+      }),
+      prisma.semanticConnection.findMany({
+        where: { score: { gte: threshold } },
+        select: { sourceNoteId: true, targetNoteId: true, score: true },
+        orderBy: { score: 'desc' },
+        take: 200,
+      }),
+    ])
+
+    const noteById = new Map(notes.map(n => [n.id, n]))
+
+    // Parse wikilinks from note content
+    const wikilinkEdges: Array<{ from: string; to: string }> = []
+    const noteByTitle = new Map(notes.map(n => [n.title.toLowerCase(), n.title]))
+    const wikilinkRegex = /\[\[([^\]|#]+)(?:[|#][^\]]+)?\]\]/g
+    for (const note of notes) {
+      for (const match of note.content.matchAll(wikilinkRegex)) {
+        const target = match[1].trim()
+        if (noteByTitle.has(target.toLowerCase()) && target.toLowerCase() !== note.title.toLowerCase()) {
+          wikilinkEdges.push({ from: note.title, to: target })
+        }
+      }
+    }
+
+    const nodeLines = notes.map(n => {
+      const tag = n.type !== 'note' ? ` [${n.type}]` : ''
+      const folder = n.folder ? ` (${n.folder})` : ''
+      const snippet = includeContent ? `\n  ${n.content.slice(0, 200).replace(/\n/g, ' ')}` : ''
+      return `- ${n.title}${tag}${folder}${snippet}`
+    })
+
+    const wikiLines = wikilinkEdges.map(e => `  ${e.from} → ${e.to}`)
+    const semLines = semanticEdges
+      .map(e => {
+        const src = noteById.get(e.sourceNoteId)?.title ?? e.sourceNoteId
+        const tgt = noteById.get(e.targetNoteId)?.title ?? e.targetNoteId
+        return `  ${src} ↔ ${tgt} (${(e.score * 100).toFixed(0)}%)`
+      })
+
+    let output = `Knowledge Graph — ${notes.length} notes\n\n## Notes\n${nodeLines.join('\n')}`
+    if (wikiLines.length) output += `\n\n## Wikilink Dependencies\n${wikiLines.join('\n')}`
+    if (semLines.length)  output += `\n\n## Semantic Connections (≥${(threshold * 100).toFixed(0)}% similar)\n${semLines.join('\n')}`
+    return output
+  } catch (e) {
+    return `Error: ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
 async function* streamOpenAIChatCore(
   prompt: string,
   conversationId: string,
@@ -1015,6 +1170,36 @@ async function* streamOpenAIChatCore(
             environment_id: { type: 'string', description: 'Environment ID' },
           },
           required: ['environment_id'],
+        },
+      },
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'knowledge_search',
+        description: 'Semantically search the knowledge base (notes, runbooks, wiki pages) for content relevant to a query. Returns notes ranked by similarity.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query:          { type: 'string',  description: 'Natural language search query' },
+            limit:          { type: 'number',  description: 'Max results to return (1-20, default 5)' },
+            includeContent: { type: 'boolean', description: 'Whether to include full note content (default true)' },
+          },
+          required: ['query'],
+        },
+      },
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'knowledge_graph',
+        description: 'Get the full knowledge graph — all notes with their types, wikilink dependencies, and semantic connections. Use this to understand what documentation exists and how topics relate to each other.',
+        parameters: {
+          type: 'object',
+          properties: {
+            threshold:      { type: 'number',  description: 'Minimum similarity score for semantic edges (0.0-1.0, default 0.5)' },
+            includeContent: { type: 'boolean', description: 'Include a short content snippet per note (default false)' },
+          },
         },
       },
     },
@@ -1175,6 +1360,10 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
           result = await handleOrionBootstrapEnvironment(tc.argsRaw)
         } else if (tc.name === 'gitops_propose') {
           result = await handleGitopsPropose(tc.argsRaw, conversationId)
+        } else if (tc.name === 'knowledge_search') {
+          result = await handleKnowledgeSearch(tc.argsRaw)
+        } else if (tc.name === 'knowledge_graph') {
+          result = await handleKnowledgeGraph(tc.argsRaw)
         } else if (gateway && environmentId) {
           // ── Gateway tools ─────────────────────────────────────────────────
           try {
@@ -1233,8 +1422,10 @@ export async function* streamGeminiChat(
   history: Array<{ role: string; content: string }>,
   model: string,
   abortSignal?: AbortSignal,
+  knowledgeContext?: string,
 ): AsyncGenerator<StreamChunk> {
-  yield* streamGeminiAgentChat(prompt, conversationId, await getSystemPrompt(), history, model, abortSignal)
+  const sp = await getSystemPrompt([], undefined, undefined, knowledgeContext)
+  yield* streamGeminiAgentChat(prompt, conversationId, sp, history, model, abortSignal)
 }
 
 async function* streamGeminiAgentChat(
@@ -1461,6 +1652,7 @@ export async function* streamClaudeResponse(
   agentSystemPrompt?: string,
   overrides?: { maxTurns?: number; allowedTools?: string[]; model?: string },
   abortSignal?: AbortSignal,
+  knowledgeContext?: string,
 ): AsyncGenerator<StreamChunk> {
   const start = Date.now()
   const toolsUsed: string[] = []
@@ -1481,9 +1673,12 @@ export async function* streamClaudeResponse(
       process.env.HOME = claudeHome
     }
 
-    const systemPrompt = agentSystemPrompt ?? (planTarget
+    const baseSystemPrompt = agentSystemPrompt ?? (planTarget
       ? await getPlanningSystemPrompt(planTarget.type)
-      : await getSystemPrompt([], undefined, conversationId))
+      : await getSystemPrompt([], undefined, conversationId, knowledgeContext))
+    const systemPrompt = agentSystemPrompt && knowledgeContext
+      ? agentSystemPrompt + '\n\n---\n## Relevant Knowledge Base\n\n' + knowledgeContext + '\n---'
+      : baseSystemPrompt
 
     const fullPrompt = previousMessages.length > 0
       ? previousMessages.map(m => `${m.role}: ${m.content}`).join('\n\n') + `\n\nuser: ${prompt}`

--- a/apps/web/src/lib/embeddings.ts
+++ b/apps/web/src/lib/embeddings.ts
@@ -272,6 +272,41 @@ export async function computeSemanticEdges(
   }
 }
 
+// ── RAG Context Retrieval ─────────────────────────────────────────────────────
+
+/**
+ * Retrieve the most semantically relevant notes for a query.
+ * Returns a formatted markdown block ready to append to a system prompt.
+ * Returns empty string silently on any error (no embedding provider, pgvector
+ * not installed, no notes embedded, etc.) so it never blocks an LLM call.
+ */
+export async function retrieveKnowledgeContext(
+  query: string,
+  topK = 3,
+  minScore = 0.4,
+): Promise<string> {
+  try {
+    const result = await generateEmbedding(query.slice(0, 2000))
+    if (!result) return ''
+
+    const hits = await vectorSearch(result.vector, topK)
+    const relevant = hits.filter(h => h.score >= minScore)
+    if (relevant.length === 0) return ''
+
+    return relevant
+      .map(h => {
+        const typeTag = h.type !== 'note' ? ` [${h.type}]` : ''
+        const body = h.content.length > 1500
+          ? h.content.slice(0, 1500) + '\n[…]'
+          : h.content
+        return `### ${h.title}${typeTag}\n${body}`
+      })
+      .join('\n\n')
+  } catch {
+    return ''
+  }
+}
+
 /**
  * Compute semantic edges for ALL notes. For initial backfill.
  */


### PR DESCRIPTION
## Summary

- `msg.sender` can be undefined when `senderType` is `'system'` (no agent or user linked) or from stale data
- All four `msg.sender.type` / `msg.sender.name` accesses in the message render map were unchecked
- Result: `TypeError: Cannot read properties of undefined (reading 'type')` crash when rendering after sending a message
- Fix: replace `msg.sender.X` with `msg.sender?.X` throughout the message render

Companion to #38 which fixed the API — this makes the client defensively safe regardless of data shape.

## Test plan

- [ ] Send a message to a chat room — no crash, message appears
- [ ] Room with system messages (e.g. "X was added") renders without crash
- [ ] Agent and user messages display correct styling/icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)