### PR TITLE
fix: chain agent replies on bare name mention, not just @mention

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -339,9 +339,18 @@ export async function triggerRoomAgentReplies(
     }
   }
 
-  // Chain: if the last reply @mentions another agent, trigger the next round
-  if (lastSavedReply && parseMentions(lastSavedReply).length > 0) {
-    console.log(`[room-agents] depth=${depth} — chaining reply with @mentions`)
-    await triggerRoomAgentReplies(roomId, lastSavedReply, depth + 1)
+  // Chain: if the last reply names another agent (with or without @), trigger them.
+  // Models often write "Hey Orion" instead of "@Orion", so we check bare names too.
+  if (lastSavedReply) {
+    const addressed = agentMembers.filter(a => {
+      const pattern = new RegExp(`(?:^|\\s|@)${a.name}\\b`, 'i')
+      return pattern.test(lastSavedReply!)
+    })
+    if (addressed.length > 0) {
+      // Build a synthetic trigger with @mentions so the next round routes correctly
+      const syntheticTrigger = addressed.map(a => `@${a.name}`).join(' ')
+      console.log(`[room-agents] depth=${depth} — chaining to: ${addressed.map(a => a.name).join(', ')}`)
+      await triggerRoomAgentReplies(roomId, syntheticTrigger, depth + 1)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Agents were writing each other's names ("Hey Orion, what do you think?") but not using `@Orion`, so the chaining from #46 never triggered

## Changes
Replaced the `parseMentions` check in the chain logic with a word-boundary regex scan against all known agent names. If any agent's name appears in the last reply (with or without `@`), a synthetic `@mention` trigger is built and passed to the next `triggerRoomAgentReplies` call so routing works correctly. Cap at `MAX_AGENT_CHAIN_DEPTH = 3` is unchanged.

## Test plan
- [ ] Agent writes "Hey Alpha, ..." → Alpha gets triggered for the next round
- [ ] Agent writes "@Alpha ..." → still works as before
- [ ] Neither name appears in reply → chain stops naturally
- [ ] Still caps at depth 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)