### PR TITLE
fix: raise agent chain depth limit from 3 to 20

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -207,8 +207,10 @@ async function resolveOllamaBaseUrl(): Promise<string> {
 /**
  * Max rounds of agent-to-agent chaining after the initial human trigger.
  * depth=0 → human triggered, depth=1..MAX → agent reply triggered by prior agent reply.
+ * Agents are expected to reply SILENT when the conversation winds down naturally.
+ * Hard cap is just a safety net against infinite loops.
  */
-const MAX_AGENT_CHAIN_DEPTH = 3
+const MAX_AGENT_CHAIN_DEPTH = 20
 
 /**
  * Trigger agent replies for a chat room message (fire-and-forget from POST handler).


### PR DESCRIPTION
## Summary
- Conversation was cutting off after 3 exchanges (Alpha → Orion → Alpha → stop)
- The depth cap of 3 was too conservative — it existed to prevent infinite loops, but agents are already instructed to reply `SILENT` when the conversation winds down naturally

## Changes
- `MAX_AGENT_CHAIN_DEPTH`: 3 → 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)