### PR TITLE
feat: typing indicator for agent replies in chat rooms

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/typing/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/typing/route.ts
@@ -1,0 +1,16 @@
+/**
+ * GET /api/chatrooms/[id]/typing
+ *
+ * Returns the names of agents currently generating a reply in this room.
+ * Polled by the frontend every 2s to show a typing indicator.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getTyping } from '@/lib/typing-state'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  return NextResponse.json({ typing: getTyping(id) })
+}

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -86,6 +86,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
   const [mentionSearch, setMentionSearch] = useState<string | null>(null)
   const [messageLimit, setMessageLimit] = useState(100)
+  const [typingAgents, setTypingAgents] = useState<string[]>([])
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -142,6 +143,25 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [room?.messages?.length])
+
+  // Poll typing state and reload messages while agents are active
+  useEffect(() => {
+    let active = true
+    const poll = async () => {
+      if (!active) return
+      try {
+        const res = await fetch(`/api/chatrooms/${roomId}/typing`)
+        if (res.ok) {
+          const data = await res.json() as { typing: string[] }
+          setTypingAgents(data.typing)
+          // Reload messages while any agent is typing so replies appear promptly
+          if (data.typing.length > 0) loadRoom()
+        }
+      } catch { /* ignore */ }
+    }
+    const id = setInterval(poll, 2000)
+    return () => { active = false; clearInterval(id) }
+  }, [roomId, loadRoom])
 
   const handleSendMessage = async () => {
     if (!message.trim() || !room || sending) return
@@ -299,6 +319,22 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           </>
         )}
       </div>
+
+      {/* Typing indicator */}
+      {typingAgents.length > 0 && (
+        <div className="px-4 py-1 flex items-center gap-1.5 flex-shrink-0">
+          <span className="flex gap-0.5 items-end">
+            <span className="w-1 h-1 rounded-full bg-accent animate-bounce" style={{ animationDelay: '0ms' }} />
+            <span className="w-1 h-1 rounded-full bg-accent animate-bounce" style={{ animationDelay: '150ms' }} />
+            <span className="w-1 h-1 rounded-full bg-accent animate-bounce" style={{ animationDelay: '300ms' }} />
+          </span>
+          <span className="text-[10px] text-text-muted italic">
+            {typingAgents.length === 1
+              ? `${typingAgents[0]} is typing…`
+              : `${typingAgents.slice(0, -1).join(', ')} and ${typingAgents[typingAgents.length - 1]} are typing…`}
+          </span>
+        </div>
+      )}
 
       {/* Input */}
       <div className="px-4 py-3 border-t border-border-subtle flex-shrink-0 relative">

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -17,6 +17,7 @@
 import fs from 'fs'
 import path from 'path'
 import { prisma } from './db'
+import { setTyping, clearTyping } from './typing-state'
 
 // ── Mention parsing ───────────────────────────────────────────────────────────
 
@@ -308,28 +309,33 @@ export async function triggerRoomAgentReplies(
 
       let reply: string | null = null
 
-      if (llm.startsWith('ext:')) {
-        const extId  = llm.slice('ext:'.length)
-        const extModel = await prisma.externalModel.findUnique({ where: { id: extId } })
-        if (!extModel) {
-          console.error(`[room-agents] ext model ${extId} not found`)
-          continue
-        }
-        const baseUrl = extModel.baseUrl ?? 'http://localhost:11434'
-        if (extModel.provider === 'ollama') {
-          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl)
+      setTyping(roomId, agent.name)
+      try {
+        if (llm.startsWith('ext:')) {
+          const extId  = llm.slice('ext:'.length)
+          const extModel = await prisma.externalModel.findUnique({ where: { id: extId } })
+          if (!extModel) {
+            console.error(`[room-agents] ext model ${extId} not found`)
+            continue
+          }
+          const baseUrl = extModel.baseUrl ?? 'http://localhost:11434'
+          if (extModel.provider === 'ollama') {
+            reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl)
+          } else {
+            // openai / custom — OpenAI-compatible
+            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey)
+          }
+        } else if (llm.startsWith('ollama:')) {
+          const model   = llm.slice('ollama:'.length)
+          const baseUrl = await resolveOllamaBaseUrl()
+          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl)
         } else {
-          // openai / custom — OpenAI-compatible
-          reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey)
+          // claude / claude:<model>
+          const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
+          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel)
         }
-      } else if (llm.startsWith('ollama:')) {
-        const model   = llm.slice('ollama:'.length)
-        const baseUrl = await resolveOllamaBaseUrl()
-        reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl)
-      } else {
-        // claude / claude:<model>
-        const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-        reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel)
+      } finally {
+        clearTyping(roomId, agent.name)
       }
 
       if (!reply) {

--- a/apps/web/src/lib/typing-state.ts
+++ b/apps/web/src/lib/typing-state.ts
@@ -1,0 +1,22 @@
+/**
+ * Server-side in-memory typing state for chat rooms.
+ *
+ * Tracks which agents are currently generating a reply so the frontend can
+ * show a "{Name} is typing..." indicator. Module-level singleton — safe for
+ * a single Node.js process (Next.js production build).
+ */
+
+const typingMap = new Map<string, Set<string>>() // roomId → Set<agentName>
+
+export function setTyping(roomId: string, agentName: string): void {
+  if (!typingMap.has(roomId)) typingMap.set(roomId, new Set())
+  typingMap.get(roomId)!.add(agentName)
+}
+
+export function clearTyping(roomId: string, agentName: string): void {
+  typingMap.get(roomId)?.delete(agentName)
+}
+
+export function getTyping(roomId: string): string[] {
+  return Array.from(typingMap.get(roomId) ?? [])
+}


### PR DESCRIPTION
## Summary
Shows animated "Alpha is typing…" dots above the input while agents are generating replies.

## Changes
- **`typing-state.ts`** — module-level `Map<roomId, Set<agentName>>` singleton with `setTyping` / `clearTyping` / `getTyping`
- **`GET /api/chatrooms/[id]/typing`** — lightweight endpoint returning `{ typing: string[] }`
- **`room-agents.ts`** — `setTyping` before each LLM call, `clearTyping` in `finally` so it always clears on success or error
- **`RoomChat.tsx`** — polls `/typing` every 2s; shows animated bounce dots + italic text; also triggers a `loadRoom()` while any agent is typing so replies appear immediately instead of waiting for the old fixed 3s/7s timeouts

## Test plan
- [ ] Send a message — see "Alpha is typing…" appear with bouncing dots
- [ ] When reply arrives, indicator disappears
- [ ] Two agents typing at once → "Alpha and Orion are typing…"
- [ ] Error in LLM call → indicator still clears (finally block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)