### PR TITLE
feat: agent tool calling — create tasks, update tasks, create agents from chat

### DIFF
--- a/apps/web/src/components/tasks/TeamDetailPanel.tsx
+++ b/apps/web/src/components/tasks/TeamDetailPanel.tsx
@@ -33,10 +33,11 @@ interface AgentForm {
   persistent: boolean    // always-on watcher agent
   watchPrompt: string    // what to check/do on each watch cycle
   watchIntervalMin: number // how often to run (minutes)
+  tools: boolean         // enable ORION tool calling (create tasks, agents, etc.)
 }
 
 const DEFAULT_MODEL = 'claude:claude-sonnet-4-6'
-const emptyForm: AgentForm = { name: '', modelId: DEFAULT_MODEL, role: '', description: '', systemPrompt: '', persistent: false, watchPrompt: '', watchIntervalMin: 60 }
+const emptyForm: AgentForm = { name: '', modelId: DEFAULT_MODEL, role: '', description: '', systemPrompt: '', persistent: false, watchPrompt: '', watchIntervalMin: 60, tools: false }
 
 function modelIdToType(modelId: string): string {
   if (modelId === 'human')             return 'human'
@@ -107,6 +108,7 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
       persistent:       (contextConfig?.persistent as boolean) ?? false,
       watchPrompt:      (contextConfig?.watchPrompt as string) ?? '',
       watchIntervalMin: (contextConfig?.watchIntervalMin as number) ?? 60,
+      tools:            (contextConfig?.tools as boolean) ?? false,
     })
     setConfirmDelete(false)
     setModalAgent(agent)
@@ -287,7 +289,10 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
           description: form.description || null,
           metadata: !isHuman ? {
             systemPrompt: form.systemPrompt || undefined,
-            contextConfig: { llm: form.modelId },
+            contextConfig: {
+              llm: form.modelId,
+              ...(form.tools && { tools: true }),
+            },
           } : undefined,
         }),
       })
@@ -326,6 +331,7 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
             watchPrompt: editForm.watchPrompt,
             watchIntervalMin: editForm.watchIntervalMin,
           }),
+          ...(editForm.tools && { tools: true }),
         },
       } : null,
     }
@@ -448,12 +454,21 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
                   className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary resize-none focus:outline-none focus:border-accent" />
               </div>
               {form.modelId !== 'human' && (
-                <div>
-                  <label className="block text-xs text-text-muted mb-1">System Prompt</label>
-                  <textarea value={form.systemPrompt} onChange={e => setForm(f => ({ ...f, systemPrompt: e.target.value }))}
-                    rows={4} placeholder="How this agent should behave, its persona, constraints..."
-                    className="w-full px-3 py-2 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary resize-none focus:outline-none focus:border-accent" />
-                </div>
+                <>
+                  <div>
+                    <label className="block text-xs text-text-muted mb-1">System Prompt</label>
+                    <textarea value={form.systemPrompt} onChange={e => setForm(f => ({ ...f, systemPrompt: e.target.value }))}
+                      rows={4} placeholder="How this agent should behave, its persona, constraints..."
+                      className="w-full px-3 py-2 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary resize-none focus:outline-none focus:border-accent" />
+                  </div>
+                  <label className="flex items-center gap-2.5 cursor-pointer">
+                    <input type="checkbox" checked={form.tools}
+                      onChange={e => setForm(f => ({ ...f, tools: e.target.checked }))}
+                      className="w-3.5 h-3.5 accent-accent" />
+                    <span className="text-xs font-medium text-text-primary">ORION tools</span>
+                    <span className="text-[10px] text-text-muted">— can create tasks, agents, and more in chat</span>
+                  </label>
+                </>
               )}
             </div>
             <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-border-subtle">
@@ -622,6 +637,13 @@ export function TeamDetailPanel({ initialAgents, agents: agentsProp, onCreate, o
                       className={`${modalInputCls} resize-none border-accent/30 bg-accent/5`} />
                   </div>
                   <div className="rounded-lg border border-border-subtle p-3 space-y-3">
+                    <label className="flex items-center gap-2.5 cursor-pointer">
+                      <input type="checkbox" checked={editForm.tools}
+                        onChange={e => setEditForm(f => ({ ...f, tools: e.target.checked }))}
+                        className="w-3.5 h-3.5 accent-accent" />
+                      <span className="text-xs font-medium text-text-primary">ORION tools</span>
+                      <span className="text-[10px] text-text-muted">— can create tasks, agents, and more in chat</span>
+                    </label>
                     <label className="flex items-center gap-2.5 cursor-pointer">
                       <input type="checkbox" checked={editForm.persistent}
                         onChange={e => setEditForm(f => ({ ...f, persistent: e.target.checked }))}

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -1,0 +1,173 @@
+/**
+ * ORION tool definitions and execution for room agents.
+ *
+ * Tools are passed as OpenAI function-call schemas to the LLM.
+ * When the model calls a tool, executeTool() runs the corresponding
+ * Prisma operation and returns a result string the model can act on.
+ *
+ * Available tools:
+ *   create_task         — create a new task
+ *   update_task         — update status/title/description of an existing task
+ *   create_agent        — create a new agent and invite it to the current room
+ */
+
+import { prisma } from './db'
+
+// ── Tool definitions (OpenAI function-call format) ────────────────────────────
+
+export const ORION_TOOL_DEFINITIONS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'create_task',
+      description: 'Create a new task in ORION. Use this when a user asks you to log, track, or create a task.',
+      parameters: {
+        type: 'object',
+        properties: {
+          title:       { type: 'string', description: 'Short task title' },
+          description: { type: 'string', description: 'Detailed description of what needs to be done' },
+          priority:    { type: 'string', enum: ['low', 'medium', 'high'], description: 'Task priority (default: medium)' },
+          status:      { type: 'string', enum: ['pending', 'in_progress', 'done', 'blocked'], description: 'Initial status (default: pending)' },
+        },
+        required: ['title'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'update_task',
+      description: 'Update an existing task. Use this to change status, title, or description.',
+      parameters: {
+        type: 'object',
+        properties: {
+          taskId:      { type: 'string', description: 'The ID of the task to update' },
+          title:       { type: 'string', description: 'New title (optional)' },
+          description: { type: 'string', description: 'New description (optional)' },
+          status:      { type: 'string', enum: ['pending', 'in_progress', 'done', 'blocked'], description: 'New status (optional)' },
+          priority:    { type: 'string', enum: ['low', 'medium', 'high'], description: 'New priority (optional)' },
+        },
+        required: ['taskId'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'create_agent',
+      description: 'Create a new AI agent and automatically invite it to the current chat room. Use this when asked to spin up, create, or add a new agent.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name:        { type: 'string', description: 'Unique name for the agent' },
+          role:        { type: 'string', description: 'Role or job title (e.g. "Creative Writer", "QA Engineer")' },
+          systemPrompt:{ type: 'string', description: 'Full system prompt defining the agent\'s personality and behavior' },
+          llm:         { type: 'string', description: 'LLM identifier to use. Leave blank to use the same model as you.' },
+        },
+        required: ['name', 'systemPrompt'],
+      },
+    },
+  },
+] as const
+
+// ── Tool execution ────────────────────────────────────────────────────────────
+
+type ToolArgs = Record<string, unknown>
+
+export async function executeTool(
+  toolName: string,
+  args: ToolArgs,
+  context: { roomId: string; callerAgentId: string; callerLlm: string },
+): Promise<string> {
+  try {
+    switch (toolName) {
+      case 'create_task': {
+        const task = await prisma.task.create({
+          data: {
+            title:       String(args.title ?? 'Untitled Task'),
+            description: args.description ? String(args.description) : undefined,
+            priority:    String(args.priority ?? 'medium'),
+            status:      String(args.status ?? 'pending'),
+            createdBy:   context.callerAgentId,
+            assignedAgent: context.callerAgentId,
+          },
+        })
+        return `Task created: "${task.title}" (id: ${task.id}, status: ${task.status}, priority: ${task.priority})`
+      }
+
+      case 'update_task': {
+        const taskId = String(args.taskId ?? '')
+        if (!taskId) return 'Error: taskId is required'
+        const existing = await prisma.task.findUnique({ where: { id: taskId } })
+        if (!existing) return `Error: task ${taskId} not found`
+        const updated = await prisma.task.update({
+          where: { id: taskId },
+          data: {
+            title:       args.title       ? String(args.title)       : undefined,
+            description: args.description ? String(args.description) : undefined,
+            status:      args.status      ? String(args.status)      : undefined,
+            priority:    args.priority    ? String(args.priority)    : undefined,
+          },
+        })
+        return `Task updated: "${updated.title}" (id: ${updated.id}, status: ${updated.status})`
+      }
+
+      case 'create_agent': {
+        const name = String(args.name ?? '').trim()
+        if (!name) return 'Error: name is required'
+
+        // Check for name collision
+        const existing = await prisma.agent.findUnique({ where: { name } })
+        if (existing) return `Error: an agent named "${name}" already exists (id: ${existing.id})`
+
+        const llm = args.llm ? String(args.llm) : context.callerLlm
+
+        const agent = await prisma.agent.create({
+          data: {
+            name,
+            role:   args.role ? String(args.role) : undefined,
+            type:   'custom',
+            status: 'online',
+            metadata: {
+              systemPrompt: String(args.systemPrompt ?? ''),
+              contextConfig: { llm },
+            },
+          },
+        })
+
+        // Auto-invite to the current room
+        await prisma.chatRoomMember.create({
+          data: { roomId: context.roomId, agentId: agent.id, role: 'member' },
+        })
+
+        // Post a system message so participants see it arrive
+        await prisma.chatMessage.create({
+          data: {
+            roomId: context.roomId,
+            senderType: 'system',
+            content: `${agent.name} has joined the room.`,
+          },
+        })
+
+        return `Agent created and invited: "${agent.name}" (id: ${agent.id}, llm: ${llm})`
+      }
+
+      default:
+        return `Error: unknown tool "${toolName}"`
+    }
+  } catch (e) {
+    return `Error executing ${toolName}: ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
+// ── System prompt addendum ────────────────────────────────────────────────────
+
+export const TOOLS_SYSTEM_ADDENDUM = `
+You have access to the following ORION tools. Use them when asked — do not pretend to perform an action when you can call a tool instead.
+
+Tools available:
+- create_task: Log a new task (title, description, priority, status)
+- update_task: Update an existing task by ID (status, title, description, priority)
+- create_agent: Create a new AI agent and invite it to this chat room (name, role, systemPrompt, llm)
+
+When you use a tool, report the result back to the user clearly (e.g. "Done — I've created task #abc123 titled 'LOTR Writer'").`

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -18,6 +18,7 @@ import fs from 'fs'
 import path from 'path'
 import { prisma } from './db'
 import { setTyping, clearTyping } from './typing-state'
+import { ORION_TOOL_DEFINITIONS, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agent-tools'
 
 // ── Mention parsing ───────────────────────────────────────────────────────────
 
@@ -49,7 +50,7 @@ type ChatMsg = { role: 'system' | 'user' | 'assistant'; content: string }
  * otherParticipants lists the names of other agents/users in the room so the
  * model knows who it can @mention to continue the conversation.
  */
-function buildSystemPrompt(agentName: string, agentBasePrompt: string, otherParticipants: string[]): string {
+function buildSystemPrompt(agentName: string, agentBasePrompt: string, otherParticipants: string[], hasTools = false): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
     : 'You are the only agent in this chat.'
@@ -70,7 +71,7 @@ Rules you must follow without exception:
 7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT
 
 ---
-${agentBasePrompt}`
+${agentBasePrompt}${hasTools ? TOOLS_SYSTEM_ADDENDUM : ''}`
 }
 
 /**
@@ -161,7 +162,10 @@ async function callOllamaChat(
   return data.message?.content?.trim() || null
 }
 
-/** OpenAI-compatible /v1/chat/completions endpoint */
+type OpenAIMessage = { role: string; content: string | null; tool_calls?: ToolCall[]; tool_call_id?: string; name?: string }
+type ToolCall = { id: string; type: 'function'; function: { name: string; arguments: string } }
+
+/** OpenAI-compatible /v1/chat/completions endpoint — supports tool calling */
 async function callOpenAIChat(
   agentName: string,
   agentBasePrompt: string,
@@ -171,27 +175,62 @@ async function callOpenAIChat(
   model: string,
   baseUrl: string,
   apiKey?: string | null,
+  toolContext?: { roomId: string; agentId: string; llm: string },
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants)
+  const hasTools = !!toolContext
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
-  const res = await fetch(`${baseUrl}/v1/chat/completions`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      model,
-      stream: false,
-      messages: [{ role: 'system', content: sys }, ...chatMsgs],
-    }),
-    signal: AbortSignal.timeout(120_000),
-  })
-  if (!res.ok) {
-    console.error(`[room-agents] OpenAI-compat ${baseUrl} returned HTTP ${res.status}`)
-    return null
+
+  const messages: OpenAIMessage[] = [{ role: 'system', content: sys }, ...chatMsgs]
+
+  // Tool-call loop — keep going until the model produces a text reply
+  const MAX_TOOL_ROUNDS = 5
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+    const body: Record<string, unknown> = { model, stream: false, messages }
+    if (hasTools) body.tools = ORION_TOOL_DEFINITIONS
+
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(120_000),
+    })
+    if (!res.ok) {
+      console.error(`[room-agents] OpenAI-compat ${baseUrl} returned HTTP ${res.status}`)
+      return null
+    }
+
+    type Choice = { finish_reason: string; message: { role: string; content: string | null; tool_calls?: ToolCall[] } }
+    const data = await res.json() as { choices?: Choice[] }
+    const choice = data.choices?.[0]
+    if (!choice) return null
+
+    // Plain text reply — done
+    if (choice.finish_reason !== 'tool_calls' || !choice.message.tool_calls?.length) {
+      return choice.message.content?.trim() || null
+    }
+
+    // Tool calls — execute each and feed results back
+    messages.push({ role: 'assistant', content: choice.message.content, tool_calls: choice.message.tool_calls })
+
+    for (const tc of choice.message.tool_calls) {
+      let args: Record<string, unknown> = {}
+      try { args = JSON.parse(tc.function.arguments) } catch { /* ignore */ }
+      console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
+      const result = await executeTool(tc.function.name, args, {
+        roomId:        toolContext!.roomId,
+        callerAgentId: toolContext!.agentId,
+        callerLlm:     toolContext!.llm,
+      })
+      console.log(`[room-agents] tool result: ${result}`)
+      messages.push({ role: 'tool', content: result, tool_call_id: tc.id, name: tc.function.name })
+    }
   }
-  const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> }
-  return data.choices?.[0]?.message?.content?.trim() || null
+
+  console.warn(`[room-agents] ${agentName} hit MAX_TOOL_ROUNDS without a text reply`)
+  return null
 }
 
 /** Resolve a fallback Ollama base URL from configured ExternalModels */
@@ -294,6 +333,7 @@ export async function triggerRoomAgentReplies(
       const contextConfig = (meta.contextConfig ?? {}) as Record<string, unknown>
       const rawPrompt     = meta.systemPrompt as string | undefined
       const llm           = (contextConfig.llm as string | undefined) ?? 'claude:claude-haiku-4-5-20251001'
+      const toolsEnabled  = !!(contextConfig.tools)
 
       // Base persona description — identity constraint is added by buildSystemPrompt()
       const agentBasePrompt = rawPrompt
@@ -305,7 +345,12 @@ export async function triggerRoomAgentReplies(
         .filter(a => a.id !== agent.id)
         .map(a => a.name)
 
-      console.log(`[room-agents] ${agent.name} (${llm}) → replying to room ${roomId}`)
+      // Tool context passed to OpenAI-compatible calls when tools are enabled
+      const toolContext = toolsEnabled
+        ? { roomId, agentId: agent.id, llm }
+        : undefined
+
+      console.log(`[room-agents] ${agent.name} (${llm}${toolsEnabled ? ', tools' : ''}) → replying to room ${roomId}`)
 
       let reply: string | null = null
 
@@ -322,8 +367,8 @@ export async function triggerRoomAgentReplies(
           if (extModel.provider === 'ollama') {
             reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl)
           } else {
-            // openai / custom — OpenAI-compatible
-            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey)
+            // openai / custom — OpenAI-compatible (supports tool calling)
+            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext)
           }
         } else if (llm.startsWith('ollama:')) {
           const model   = llm.slice('ollama:'.length)


### PR DESCRIPTION
## Summary
Agents were hallucinating actions (claiming to create tasks/agents without actually doing it). This gives them real tool access backed by Prisma, and adds a UI toggle to enable it per agent.

## Changes

### `agent-tools.ts` (new)
- OpenAI function-call schemas for `create_task`, `update_task`, `create_agent`
- `executeTool()` runs each via Prisma directly
- `create_agent` auto-invites the new agent to the current room + posts a system message
- `TOOLS_SYSTEM_ADDENDUM` explains available tools in the system prompt

### `room-agents.ts`
- `callOpenAIChat` runs a tool-call loop (up to 5 rounds): `finish_reason: tool_calls` → execute → append `role: tool` result → repeat until text reply
- Reads `contextConfig.tools` to decide whether to pass tool definitions
- System prompt gains the tools addendum when enabled

### `TeamDetailPanel.tsx`
- "ORION tools" checkbox added to both the create and edit agent modals
- Persists as `contextConfig.tools: true` in agent metadata

## Enabling for Alpha
Open Alpha's agent settings → check "ORION tools" → Save.

## Test plan
- [ ] Enable tools on Alpha, ask it to create a task → appears in task list
- [ ] Ask Alpha to create a new agent → agent appears and joins the room
- [ ] Ask Alpha to update a task status → DB updated
- [ ] Agent without tools → behavior unchanged, no tool schemas sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)