### PR TITLE
fix: run cluster bootstrap as BackgroundJob instead of SSE stream

### DIFF
--- a/apps/web/src/app/api/environments/[id]/bootstrap/route.ts
+++ b/apps/web/src/app/api/environments/[id]/bootstrap/route.ts
@@ -1,42 +1,38 @@
 /**
  * POST /api/environments/:id/bootstrap
  *
- * Triggers cluster bootstrap: Gitea repo + ArgoCD + Gateway.
- * Returns a Server-Sent Events stream so the UI can show live progress.
+ * Creates a BackgroundJob and runs cluster bootstrap asynchronously.
+ * Returns {jobId} immediately — client polls GET /api/jobs/:id for progress.
+ *
+ * Using BackgroundJob instead of SSE avoids Cloudflare's ~100s proxy timeout
+ * killing long-running bootstraps. The job completes regardless of whether
+ * the client stays connected.
  */
-import { NextRequest } from 'next/server'
-import { bootstrapCluster, type BootstrapEvent } from '@/lib/cluster-bootstrap'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { startJob } from '@/lib/job-runner'
+import { bootstrapCluster } from '@/lib/cluster-bootstrap'
 
 export async function POST(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  const encoder = new TextEncoder()
+  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
 
-  const stream = new ReadableStream({
-    async start(controller) {
-      function send(event: BootstrapEvent) {
-        const data = `data: ${JSON.stringify(event)}\n\n`
-        controller.enqueue(encoder.encode(data))
-      }
-
-      try {
-        await bootstrapCluster(params.id, send)
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        console.error(`[bootstrap] ${params.id} failed:`, err)
-        send({ type: 'error', message: msg })
-      } finally {
-        controller.close()
-      }
+  const jobId = await startJob(
+    'cluster-bootstrap',
+    `Bootstrap: ${env.name}`,
+    { environmentId: params.id },
+    async (log) => {
+      await bootstrapCluster(params.id, (event) => {
+        const prefix = event.type === 'step'  ? '▶' :
+                       event.type === 'error' ? '✗' :
+                       event.type === 'done'  ? '✓' : ' '
+        log(`${prefix} ${event.message}`)
+      })
     },
-  })
+  )
 
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-    },
-  })
+  return NextResponse.json({ jobId }, { status: 202 })
 }


### PR DESCRIPTION
## Summary

- Bootstrap was using SSE streaming which Cloudflare kills after ~100s — long bootstraps (ArgoCD install takes 2-3+ minutes) always failed with a network error on the client
- Switched to `startJob()` (already exists in `lib/job-runner.ts`) — returns `{jobId}` with 202 immediately, runs async in Node.js event loop
- Client polls `GET /api/jobs/:id` for progress — disconnect has zero effect on the job

## Test plan

- [ ] Trigger bootstrap from UI — should get jobId back immediately, no network error
- [ ] Check `GET /api/jobs/:id` shows running status and log lines appending
- [ ] Bootstrap completes (status: completed) even after closing the browser tab
- [ ] Failed steps show status: failed with error in logs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)