### PR TITLE
fix: slugify environment name for ArgoCD AppProject and Application names

### DIFF
--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -87,11 +87,16 @@ function runCommand(
 
 // ── ArgoCD manifests ──────────────────────────────────────────────────────────
 
+function toSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '')
+}
+
 function argoCdAppProject(envName: string, repoUrl: string): string {
+  const slug = toSlug(envName)
   return `apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
-  name: ${envName}
+  name: ${slug}
   namespace: argocd
 spec:
   description: ORION-managed environment ${envName}
@@ -107,15 +112,16 @@ spec:
 }
 
 function argoCdApplication(envName: string, repoUrl: string): string {
+  const slug = toSlug(envName)
   return `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${envName}
+  name: ${slug}
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  project: ${envName}
+  project: ${slug}
   source:
     repoURL: ${repoUrl}
     targetRevision: main


### PR DESCRIPTION
## Summary

- ArgoCD AppProject and Application metadata.name fields were using the raw environment name (e.g. "Talos Cluster") which is invalid — K8s resource names must be lowercase RFC 1123 subdomain format
- `kubectl apply` was rejecting the manifest with: `metadata.name: Invalid value: "Talos Cluster"`
- Fix: `toSlug()` converts to lowercase and replaces non-alphanumeric characters with hyphens ("Talos Cluster" → "talos-cluster")
- Human-readable name preserved in spec.description

## Test plan

- [ ] Bootstrap environment named "Talos Cluster" — AppProject and Application apply without error
- [ ] ArgoCD shows project named `talos-cluster`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)