### PR TITLE
fix: slug env name for Vault AppRole policy and role names

### DIFF
--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -559,8 +559,8 @@ export async function bootstrapCluster(
 
     if (vaultInitSetting?.value && rawToken) {
       const rootToken  = decrypt(String(rawToken))
-      const policyName = `orion-cluster-${env.name}`
-      const roleName   = `orion-cluster-${env.name}`
+      const policyName = `orion-cluster-${toSlug(env.name)}`
+      const roleName   = `orion-cluster-${toSlug(env.name)}`
 
       emit({ type: 'step', message: 'Configuring Vault AppRole for this cluster...' })
 


### PR DESCRIPTION
## Summary
- Vault rejects URL path segments containing spaces with 404
- `orion-cluster-Talos Cluster` → should be `orion-cluster-talos-cluster`
- Applied `toSlug()` (already used for ArgoCD resource names) to the Vault policy name and AppRole role name

## Root cause
The same env name slugification issue as #57 (ArgoCD AppProject) — `env.name` can contain spaces and uppercase, neither of which are valid in Vault API paths.

## Test plan
- [ ] Bootstrap completes past "Configuring Vault AppRole" step
- [ ] `vault list auth/approle/role` shows `orion-cluster-talos-cluster`

🤖 Generated with [Claude Code](https://claude.com/claude-code)