### PR TITLE
fix: use per-run kubectl cache dir to avoid stale API discovery

### DIFF
--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -392,6 +392,7 @@ async function generateClientCert(
   const csrPath  = join(tmpDir, `${envName}-client.csr`)
   const certPath = join(tmpDir, `${envName}-client.crt`)
   const extPath  = join(tmpDir, `${envName}-client.ext`)
+  const srlPath  = join(tmpDir, 'ca.srl')   // serial file — must be writable, not next to the CA
 
   await writeFile(extPath, [
     '[req_ext]',
@@ -405,7 +406,7 @@ async function generateClientCert(
     ['openssl', ['req', '-new', '-key', keyPath, '-out', csrPath, '-subj', `/CN=eso-${envName}/O=ORION`]],
     ['openssl', ['x509', '-req', '-days', '3650',
       '-in', csrPath, '-CA', caCertPath, '-CAkey', caKeyPath,
-      '-CAcreateserial', '-out', certPath, '-extfile', extPath, '-extensions', 'req_ext']],
+      '-CAserial', srlPath, '-CAcreateserial', '-out', certPath, '-extfile', extPath, '-extensions', 'req_ext']],
   ]
 
   for (const [cmd, args] of steps) {

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -647,6 +647,19 @@ export async function bootstrapCluster(
         msg => emit({ type: 'log', message: msg }),
       )
 
+      // Wait for ESO CRDs to be established before applying ClusterSecretStore
+      emit({ type: 'log', message: 'Waiting for ESO CRDs to be established...' })
+      await runCommand(
+        'kubectl',
+        [
+          'wait', '--for=condition=established', '--timeout=120s',
+          'crd/clustersecretstores.external-secrets.io',
+          'crd/externalsecrets.external-secrets.io',
+        ],
+        kenv,
+        msg => emit({ type: 'log', message: msg }),
+      )
+
       // 10. Apply ClusterSecretStore + AppRole credentials Secret
       //     If vault-proxy certs exist: use HTTPS + mTLS. Otherwise fall back to HTTP.
       emit({ type: 'step', message: 'Configuring ClusterSecretStore → ORION Vault...' })

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -392,7 +392,9 @@ async function generateClientCert(
   const csrPath  = join(tmpDir, `${envName}-client.csr`)
   const certPath = join(tmpDir, `${envName}-client.crt`)
   const extPath  = join(tmpDir, `${envName}-client.ext`)
-  const srlPath  = join(tmpDir, 'ca.srl')   // serial file — must be writable, not next to the CA
+  // Use a random serial number rather than a serial file — avoids any writes to the
+  // read-only /vault-proxy-certs mount that holds the CA key/cert.
+  const serial   = randomBytes(8).toString('hex')
 
   await writeFile(extPath, [
     '[req_ext]',
@@ -406,7 +408,7 @@ async function generateClientCert(
     ['openssl', ['req', '-new', '-key', keyPath, '-out', csrPath, '-subj', `/CN=eso-${envName}/O=ORION`]],
     ['openssl', ['x509', '-req', '-days', '3650',
       '-in', csrPath, '-CA', caCertPath, '-CAkey', caKeyPath,
-      '-CAserial', srlPath, '-CAcreateserial', '-out', certPath, '-extfile', extPath, '-extensions', 'req_ext']],
+      '-set_serial', `0x${serial}`, '-out', certPath, '-extfile', extPath, '-extensions', 'req_ext']],
   ]
 
   for (const [cmd, args] of steps) {

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -443,7 +443,9 @@ export async function bootstrapCluster(
     emit({ type: 'step', message: 'Writing kubeconfig...' })
     const kubeconfigYaml = Buffer.from(env.kubeconfig, 'base64').toString('utf8')
     await writeFile(kubeconfigPath, kubeconfigYaml, { mode: 0o600 })
-    const kenv = { KUBECONFIG: kubeconfigPath }
+    // KUBECTL_CACHE_DIR: use a per-run temp dir so kubectl never reads a stale
+    // API discovery cache (e.g. one built before ESO CRDs were installed).
+    const kenv = { KUBECONFIG: kubeconfigPath, KUBECTL_CACHE_DIR: join(tmpDir, 'kubectl-cache') }
 
     // 2. Verify cluster connectivity
     emit({ type: 'step', message: 'Verifying cluster connectivity...' })

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -559,8 +559,8 @@ export async function bootstrapCluster(
 
     if (vaultInitSetting?.value && rawToken) {
       const rootToken  = decrypt(String(rawToken))
-      const policyName = `orion-cluster-${env.name}`
-      const roleName   = `orion-cluster-${env.name}`
+      const policyName = `orion-cluster-${toSlug(env.name)}`
+      const roleName   = `orion-cluster-${toSlug(env.name)}`
 
       emit({ type: 'step', message: 'Configuring Vault AppRole for this cluster...' })
 


### PR DESCRIPTION
## Summary
kubectl caches API group discovery at `~/.kube/cache/`. When ESO CRDs are installed during bootstrap, the existing cache doesn't know about `external-secrets.io/v1beta1`, so `ClusterSecretStore` apply fails with:

```
no matches for kind "ClusterSecretStore" in version "external-secrets.io/v1beta1"
ensure CRDs are installed first
```

This happens even after `kubectl wait --for=condition=established` succeeds — the CRDs are registered in the API server, but kubectl's local cache is stale.

Fix: set `KUBECTL_CACHE_DIR` to a path inside the per-run `tmpDir`, forcing fresh API discovery on every bootstrap.

## Test plan
- [ ] Bootstrap completes all 10 steps
- [ ] `kubectl get clustersecretstore orion-vault` shows `READY=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)