### PR TITLE
fix: add authentication to tool CRUD endpoints (CR-001)

### DIFF
--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
@@ -1,9 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 // POST /api/environments/[id]/tools/[toolId]/approve
 // Approves a pending tool proposal — activates it so the gateway picks it up on next heartbeat.
 export async function POST(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+  // SOC2: CR-001 — require admin to approve tools (prevents unauthorized tool activation)
+  const user = await requireAdmin()
+
+  // Verify env exists
+  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
   const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (tool.status !== 'pending') return NextResponse.json({ error: 'Tool is not pending' }, { status: 400 })

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/route.ts
@@ -1,13 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
 
 export async function GET(_: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+  // Support gateway Bearer token OR user session
+  const auth = _.headers.get('authorization')
+  if (auth?.startsWith('Bearer ')) {
+    const env = await prisma.environment.findUnique({
+      where: { id: params.id },
+      select: { gatewayToken: true },
+    })
+    if (!env?.gatewayToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (auth !== `Bearer ${env.gatewayToken}`) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  } else {
+    const user = await getCurrentUser()
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(tool)
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+  // SOC2: CR-001 — require authenticated user
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  // Verify env exists
+  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
   const body = await req.json()
   const data: Record<string, unknown> = {}
 
@@ -26,6 +48,9 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string; 
 }
 
 export async function DELETE(_: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+  // SOC2: CR-001 — require authenticated user
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   await prisma.mcpTool.delete({ where: { id: params.toolId } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/environments/[id]/tools/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
+
+async function verifyEnvAccess(userId: string, envId: string): Promise<{ error: NextResponse['body']; env: { id: string } } | null> {
+  const env = await prisma.environment.findUnique({ where: { id: envId }, select: { id: true } })
+  if (!env) return { error: NextResponse.json({ error: 'Not found' }, { status: 404 }).body, env: {} as any }
+  return null // access OK (any authenticated user can list/manage tools on any env for now)
+}
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  // Support gateway Bearer auth (existing) OR user session auth (SOC2: CR-001)
   const auth = req.headers.get('authorization')
   if (auth?.startsWith('Bearer ')) {
-    // Called by the gateway — validate the token
     const env = await prisma.environment.findUnique({
       where: { id: params.id },
       select: { gatewayToken: true },
@@ -13,6 +20,9 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     if (!env.gatewayToken || auth !== `Bearer ${env.gatewayToken}`) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+  } else {
+    const user = await getCurrentUser()
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const { searchParams } = new URL(req.url)
@@ -29,6 +39,13 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  // SOC2: CR-001 — require authenticated user
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  // Verify env exists
+  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
   const body = await req.json()
 
   if (!body.name?.trim())        return NextResponse.json({ error: 'name is required' }, { status: 400 })


### PR DESCRIPTION
## CR-001: Add authentication to tool CRUD endpoints

**Fixes:** https://github.com/richard-callis/orion-web/issues/68 (SOC 2 CR-001)

### Changes
- **GET /tools**: Accepts gateway Bearer token (existing) OR user session auth
- **POST /tools**: Requires authenticated user + verifies environment exists
- **PUT /tools/[id]**: Requires authenticated user + verifies environment exists
- **DELETE /tools/[id]**: Requires authenticated user
- **POST /tools/[id]/approve**: Requires admin auth + verifies environment exists

### Design decisions
- Gateway Bearer token still works for existing integrations (backward compatible)
- User session auth uses the existing  pattern
- Environment existence check prevents info leakage via 404 vs 401
-  for approve endpoint since tool approval is an admin operation