### PR TITLE
fix: add auth to environments and K8s endpoints (CR-002, CR-003)

### DIFF
--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { Prisma } from '@prisma/client'
 import { getDefaultTools } from '@/lib/default-tools'
+import { getCurrentUser, requireAdmin } from '@/lib/auth'
 
 export async function GET() {
+  // SOC2: CR-002 — require authentication to list environments
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const environments = await prisma.environment.findMany({
     orderBy: { name: 'asc' },
     include: {
@@ -16,6 +21,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  // SOC2: CR-002 — require admin to create environments
+  const user = await requireAdmin()
+
   const body = await req.json()
   if (!body.name?.trim()) return NextResponse.json({ error: 'name is required' }, { status: 400 })
 

--- a/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
+++ b/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
@@ -1,13 +1,17 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { coreApi } from '@/lib/k8s'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
+// SOC2: CR-003 — pod logs exposed without authentication (may contain secrets/tokens)
 export async function GET(
   _req: NextRequest,
   { params }: { params: { ns: string; pod: string } }
 ) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   return createSSEStream((send, close) => {
     ;(async () => {
       try {

--- a/apps/web/src/app/api/k8s/stream/route.ts
+++ b/apps/web/src/app/api/k8s/stream/route.ts
@@ -1,9 +1,16 @@
+import { NextResponse } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { addSseClient, removeSseClient, getCache, startWatchers } from '@/lib/k8s'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
+// SOC2: CR-003 — K8s events exposed real-time without authentication
 export async function GET() {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  await startWatchers()
   await startWatchers()
 
   return createSSEStream((send, close) => {


### PR DESCRIPTION
## CR-002 + CR-003: Add authentication to unprotected endpoints

**Fixes:** https://github.com/richard-callis/orion-web/issues/69 (SOC 2 CR-002) and https://github.com/richard-callis/orion-web/issues/70 (SOC 2 CR-003)

### CR-002: Environments CRUD auth
- **GET /environments**: now requires authenticated user (was completely open)
- **POST /environments**: now requires admin user (was completely open)

### CR-003: K8s stream/logs auth
- **GET /k8s/stream**: now requires authenticated user (was unauthenticated SSE exposing real-time K8s events)
- **GET /k8s/pods/[ns]/[pod]/logs**: now requires authenticated user (was unauthenticated, exposing any pod logs including secrets)

### Design
- Uses existing  and  patterns
- Returns 401 with JSON error message for consistency