### PR TITLE
fix: harden LLM tool generation endpoint (CR-005)

### DIFF
--- a/apps/web/src/app/api/tools/generate/route.ts
+++ b/apps/web/src/app/api/tools/generate/route.ts
@@ -69,12 +69,8 @@ function sanitizeCommand(command: string, envType: string): string {
   const firstWord = trimmed.split(/\s+/)[0] ?? ''
   const allowed = ALLOWED_COMMAND_PREFIXES[envType as keyof typeof ALLOWED_COMMAND_PREFIXES]
   if (allowed && !allowed.some(prefix => firstWord.startsWith(prefix))) {
-    // Allow if it's a relative path or the command starts with a known-safe utility
-    const safePrefixes = ['sh', 'bash', 'curl', 'wget', 'jq']
-    if (!safePrefixes.includes(firstWord) && !allowed.includes(firstWord)) {
-      // Log warning but allow — the command validation above should catch most issues
-      console.warn(`[tools/generate] Unusual command prefix: ${firstWord} for env ${envType}`)
-    }
+    // Enforce: reject commands not on the allowlist for this environment
+    throw new Error(`Command '${firstWord}' not allowed in '${envType}' environment. Allowed: ${allowed.join(', ')}`)
   }
 
   return trimmed
@@ -118,8 +114,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Description too long (max 500 characters)' }, { status: 400 })
   }
 
-  // Validate description content (block obvious injection attempts)
-  if (/^(create|add|install|execute|run|delete|exfil|download|upload|reverse\s|bind|shell)\b/i.test(description.trim())) {
+  // Validate description content (block obvious attack keywords)
+  // Note: We rely on the command sanitization in sanitizeCommand() for the real defense
+  if (/\b(exfil|reverse\s+shell|bind\s+shell|payload|backdoor)\b/i.test(description.trim())) {
     return NextResponse.json({ error: 'Description contains suspicious keywords' }, { status: 400 })
   }
 

--- a/apps/web/src/app/api/tools/generate/route.ts
+++ b/apps/web/src/app/api/tools/generate/route.ts
@@ -1,5 +1,103 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
+
+// Allowed shell commands per environment type (allowlist)
+const ALLOWED_COMMAND_PREFIXES = {
+  cluster: [
+    'kubectl', 'helm', 'kubectl-kustomize', 'kubens', 'kubectx',
+  ],
+  docker: [
+    'docker', 'docker-compose', 'docker compose', 'ctr', 'nerdctl',
+  ],
+  localhost: [
+    'kubectl', 'helm', 'docker', 'docker-compose', 'docker compose',
+    'sh', 'bash', 'curl', 'wget', 'jq', 'yq', 'tar', 'gzip', 'gunzip',
+    'grep', 'sed', 'awk', 'sort', 'uniq', 'wc', 'head', 'tail', 'cat',
+    'ls', 'find', 'df', 'du', 'free', 'top', 'ps', 'uptime', 'hostname',
+    'ip', 'ifconfig', 'ss', 'nc', 'ncat', 'nmap', 'ping', 'traceroute',
+    'dig', 'nslookup', 'host', 'systemctl', 'journalctl', 'chmod', 'chown',
+    'mkdir', 'rm', 'cp', 'mv', 'ln', 'touch', 'zip', 'unzip', 'rsync',
+    'apt-get', 'apk', 'yum', 'dnf', 'pip', 'npm', 'yarn', 'pnpm',
+  ],
+  generic: [
+    'sh', 'bash', 'curl', 'wget', 'jq', 'yq', 'grep', 'sed', 'awk',
+    'ls', 'find', 'cat', 'echo', 'test', '[', 'true', 'false',
+  ],
+}
+
+/**
+ * Sanitize a generated shell command — strip dangerous patterns.
+ * Returns sanitized command or throws if it contains untrusted patterns.
+ */
+function sanitizeCommand(command: string, envType: string): string {
+  const trimmed = command.trim()
+
+  // Block common injection patterns even if individual chars are "safe"
+  const dangerousPatterns = [
+    /\|\|/,    // OR chain
+    /&&/,      // AND chain
+    /\$\(/,    // command substitution
+    /`[^`]*`/, // backtick substitution
+    /;[ \t]*\w/, // semicolon + command
+    />[ \t]*/, // output redirect (allowed in some contexts)
+    /<([ \t]|&)/, // input redirect
+    /\/etc\//,  // reading system files
+    /\/proc\//, // proc filesystem
+    /\/dev\//,  // device files
+    /rm\s+-rf/, // mass deletion
+    /dd\s+/,    // disk operations
+    /mknod/,   // device creation
+    /mkfifo/,  // named pipe creation
+    /socat/,   // network utility (common in reverse shells)
+    /nc\s+(-[elp]|-[lv]|-[c])/, // netcat patterns
+    /python.*-c/, // python -c code execution
+    /perl.*-e/,  // perl -e code execution
+    /ruby.*-e/,  // ruby -e code execution
+    /node.*-e/,  // node -e code execution
+    /base64\s+-d/, // base64 decode
+    /\bxargs\b/, // xargs (often used in chains)
+  ]
+
+  for (const pattern of dangerousPatterns) {
+    if (pattern.test(trimmed)) {
+      throw new Error(`Generated command contains unsafe pattern: ${trimmed.slice(0, 80)}`)
+    }
+  }
+
+  // If command has a prefix, verify it's allowed for this environment type
+  const firstWord = trimmed.split(/\s+/)[0] ?? ''
+  const allowed = ALLOWED_COMMAND_PREFIXES[envType as keyof typeof ALLOWED_COMMAND_PREFIXES]
+  if (allowed && !allowed.some(prefix => firstWord.startsWith(prefix))) {
+    // Allow if it's a relative path or the command starts with a known-safe utility
+    const safePrefixes = ['sh', 'bash', 'curl', 'wget', 'jq']
+    if (!safePrefixes.includes(firstWord) && !allowed.includes(firstWord)) {
+      // Log warning but allow — the command validation above should catch most issues
+      console.warn(`[tools/generate] Unusual command prefix: ${firstWord} for env ${envType}`)
+    }
+  }
+
+  return trimmed
+}
+
+/**
+ * Validate and sanitize package names from LLM output.
+ * Returns sanitized package list or throws.
+ */
+function sanitizePackages(packages: string[]): string[] {
+  const validPkgRegex = /^[a-zA-Z0-9][a-zA-Z0-9.+\-]*$/
+  const sanitized: string[] = []
+  for (const pkg of packages) {
+    if (!validPkgRegex.test(pkg)) {
+      throw new Error(`Invalid package name: ${pkg.slice(0, 50)}`)
+    }
+    if (pkg.length > 100) {
+      throw new Error(`Package name too long: ${pkg.slice(0, 50)}`)
+    }
+    sanitized.push(pkg)
+  }
+  return sanitized
+}
 
 /**
  * POST /api/tools/generate
@@ -7,9 +105,23 @@ import { prisma } from '@/lib/db'
  * Returns { name, description, command, inputSchema, execType }
  */
 export async function POST(req: NextRequest) {
+  // SOC2: CR-005 — require authentication (LLM calls cost money, tools execute on gateway)
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const body = await req.json()
   const { description, environmentType } = body as { description?: string; environmentType?: string }
+
+  // Validate description length
   if (!description?.trim()) return NextResponse.json({ error: 'description is required' }, { status: 400 })
+  if (description.length > 500) {
+    return NextResponse.json({ error: 'Description too long (max 500 characters)' }, { status: 400 })
+  }
+
+  // Validate description content (block obvious injection attempts)
+  if (/^(create|add|install|execute|run|delete|exfil|download|upload|reverse\s|bind|shell)\b/i.test(description.trim())) {
+    return NextResponse.json({ error: 'Description contains suspicious keywords' }, { status: 400 })
+  }
 
   // Find an Ollama model to use
   const extModel = await prisma.externalModel.findFirst({
@@ -26,7 +138,16 @@ export async function POST(req: NextRequest) {
     ? 'This is a Kubernetes cluster environment. Tools run kubectl commands.'
     : 'This is a generic remote environment.'
 
+  // Hardened system prompt with explicit security instructions
   const systemPrompt = `You are a tool definition assistant for an infrastructure management platform. ${envContext}
+
+SECURITY RULES:
+- NEVER generate commands that read /etc/shadow, /etc/passwd, or any sensitive files
+- NEVER generate commands that make outbound network requests to unknown hosts
+- NEVER generate commands that use reverse shells, base64 encoding, or obfuscation
+- NEVER generate commands that modify system configuration or install packages unnecessarily
+- ONLY generate commands appropriate for the stated environment
+- Commands should be read-only or safe read/write operations only
 Respond ONLY with a valid JSON object — no markdown, no explanation, no code fences.`
 
   const userPrompt = `Generate a tool definition for: "${description.trim()}"
@@ -47,8 +168,9 @@ Rules:
 - command must be a real, safe shell command appropriate for the environment
 - Use {param} placeholders for any variable inputs
 - Only include parameters that the command actually uses
-- packages: list any Alpine Linux (apk) packages needed that may not be pre-installed. Use exact Alpine package names (e.g. "nmap", "curl", "jq", "bind-tools", "iputils"). Leave empty array [] if only standard tools are used (kubectl, docker, sh, grep, etc.)
-- Keep it simple and focused on exactly what was asked`
+- packages: list any Alpine Linux (apk) packages needed that may not be pre-installed. Use exact Alpine package names. Leave empty array [] if only standard tools are used.
+- Keep it simple and focused on exactly what was asked
+- IMPORTANT: Only generate safe, read-only commands. No file system traversal, no outbound connections.`
 
   try {
     const res = await fetch(`${extModel.baseUrl}/api/chat`, {
@@ -80,6 +202,26 @@ Rules:
       parameters?: Record<string, { type?: string; description?: string; required?: boolean }>
     }
 
+    // Validate name (snake_case, alphanumeric + underscores, max 64 chars)
+    const toolNameRegex = /^[a-z][a-z0-9_]*$/
+    if (!toolNameRegex.test(parsed.name)) {
+      throw new Error(`Invalid tool name: ${parsed.name.slice(0, 50)}`)
+    }
+    if (parsed.name.length > 64) {
+      throw new Error('Tool name too long (max 64 characters)')
+    }
+    // Validate description length
+    if (parsed.description.length > 200) {
+      throw new Error('Description too long (max 200 characters)')
+    }
+
+    // Validate and sanitize the command
+    const safeEnvType = (environmentType ?? 'generic') as string
+    const sanitizedCommand = sanitizeCommand(parsed.command, safeEnvType)
+
+    // Validate and sanitize package names
+    const sanitizedPackages = parsed.packages?.length ? sanitizePackages(parsed.packages) : []
+
     // Build JSON Schema from parameters
     const params = parsed.parameters ?? {}
     const properties: Record<string, { type: string; description?: string }> = {}
@@ -90,14 +232,14 @@ Rules:
     }
     const inputSchema = { type: 'object', properties, required }
 
-    const execConfig: Record<string, unknown> = { command: parsed.command }
-    if (parsed.packages?.length) execConfig.packages = parsed.packages
+    const execConfig: Record<string, unknown> = { command: sanitizedCommand }
+    if (sanitizedPackages.length) execConfig.packages = sanitizedPackages
 
     return NextResponse.json({
       name:        parsed.name,
       description: parsed.description,
-      command:     parsed.command,
-      packages:    parsed.packages ?? [],
+      command:     sanitizedCommand,
+      packages:    sanitizedPackages,
       inputSchema,
       execType:    'shell',
       execConfig,


### PR DESCRIPTION
## CR-005: LLM tool generation hardening

**Fixes:** https://github.com/richard-callis/orion-web/issues/72 (SOC 2 CR-005)

### The Vulnerability
The tool generation endpoint was completely open (no auth). An attacker could:
1. Call the LLM with a crafted description to generate a malicious tool definition
2. The generated command would be returned to the attacker
3. When stored and executed by the gateway, it would run arbitrary shell commands

### Defense Layers

**1. Authentication** — requires authenticated user (was completely open)

**2. Input validation**
- Max 500 character limit on description
- Block suspicious keywords (exfil, reverse, bind, shell, etc.)

**3. LLM prompt hardening**
- System prompt explicitly forbids: /etc/shadow, outbound requests, reverse shells
- Reinforced with "safe, read-only commands only" in user prompt

**4. Post-LLM command sanitization** (most important)
- Blocks dangerous patterns: `||`, `&&`, `$()`, backticks, semicolons
- Blocks file system access: `/etc/`, `/proc/`, `/dev/`
- Blocks destructive commands: `rm -rf`, `dd`, `mknod`, `mkfifo`, `socat`
- Blocks reverse shells: `nc -elp`, `python -c`, `perl -e`, `node -e`
- Command prefix allowlist per environment type (cluster, docker, localhost, generic)

**5. Package name validation** — regex: `^[a-zA-Z0-9][a-zA-Z0-9.+-]*$`

**6. Tool name validation** — snake_case, alphanumeric + underscores, max 64 chars
