### PR TITLE
fix: encrypt Environment/ExternalModel secrets at rest (H-001)

### DIFF
--- a/apps/web/src/app/api/internal/encryption/rotate/route.ts
+++ b/apps/web/src/app/api/internal/encryption/rotate/route.ts
@@ -6,7 +6,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { encrypt, decrypt } from '@/lib/encryption'
+import { encrypt, decrypt, encryptWithKey } from '@/lib/encryption'
 
 export async function POST(req: NextRequest) {
   const auth = req.headers.get('authorization')
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
     if (env.gatewayToken) {
       try {
         const plaintext = decrypt(env.gatewayToken)
-        updates.gatewayToken = encrypt(plaintext)
+        updates.gatewayToken = encryptWithKey(plaintext, newKeyBase64)
         migrated++
       } catch (e) {
         errors.push({ model: 'Environment', id: env.id, field: 'gatewayToken', error: String(e) })
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest) {
     if (env.kubeconfig) {
       try {
         const plaintext = decrypt(env.kubeconfig)
-        updates.kubeconfig = encrypt(plaintext)
+        updates.kubeconfig = encryptWithKey(plaintext, newKeyBase64)
         migrated++
       } catch (e) {
         errors.push({ model: 'Environment', id: env.id, field: 'kubeconfig', error: String(e) })
@@ -80,7 +80,7 @@ export async function POST(req: NextRequest) {
     if (ext.apiKey) {
       try {
         const plaintext = decrypt(ext.apiKey)
-        const encrypted = encrypt(plaintext)
+        const encrypted = encryptWithKey(plaintext, newKeyBase64)
         await prisma.externalModel.update({ where: { id: ext.id }, data: { apiKey: encrypted } })
         migrated++
       } catch (e) {

--- a/apps/web/src/lib/encryption-middleware.ts
+++ b/apps/web/src/lib/encryption-middleware.ts
@@ -29,26 +29,36 @@ function decryptField(raw: unknown): unknown {
   }
 }
 
-function processRow(obj: unknown): unknown {
+function processRow(obj: unknown, model?: string): unknown {
   if (!isRecord(obj)) return obj
 
   const copy = { ...obj }
 
+  // Decrypt Environment fields
   for (const field of ENCRYPTED_ENV_FIELDS) {
     if (Object.prototype.hasOwnProperty.call(copy, field)) {
       copy[field] = decryptField(copy[field])
     }
   }
 
+  // Decrypt ExternalModel fields
+  if (model === 'ExternalModel') {
+    for (const field of ENCRYPTED_EXT_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(copy, field)) {
+        copy[field] = decryptField(copy[field])
+      }
+    }
+  }
+
   return copy
 }
 
-function processResult(result: unknown): unknown {
+function processResult(result: unknown, model?: string): unknown {
   if (Array.isArray(result)) {
-    return result.map((r) => (isRecord(r) ? processRow(r) : r))
+    return result.map((r) => (isRecord(r) ? processRow(r, model) : r))
   }
 
-  return isRecord(result) ? processRow(result) : result
+  return isRecord(result) ? processRow(result, model) : result
 }
 
 export function registerEncryptionMiddleware(prisma: PrismaClient): void {
@@ -58,6 +68,6 @@ export function registerEncryptionMiddleware(prisma: PrismaClient): void {
     }
 
     const result = await next(params)
-    return processResult(result)
+    return processResult(result, params.model)
   })
 }

--- a/apps/web/src/lib/encryption-migrate.ts
+++ b/apps/web/src/lib/encryption-migrate.ts
@@ -38,7 +38,8 @@ async function migrate() {
 
     if (env.gatewayToken) {
       const plaintext = decrypt(env.gatewayToken)
-      if (plaintext !== env.gatewayToken) {
+      // If decrypt() returns the same value, it was plaintext (no enc:v1: prefix) — needs encryption
+      if (plaintext === env.gatewayToken) {
         updates.gatewayToken = encrypt(plaintext)
         envMigrated++
         console.log(`  encrypted gatewayToken for "${env.name}"`)
@@ -49,7 +50,8 @@ async function migrate() {
 
     if (env.kubeconfig) {
       const plaintext = decrypt(env.kubeconfig)
-      if (plaintext !== env.kubeconfig) {
+      // If decrypt() returns the same value, it was plaintext (no enc:v1: prefix) — needs encryption
+      if (plaintext === env.kubeconfig) {
         updates.kubeconfig = encrypt(plaintext)
         envMigrated++
         console.log(`  encrypted kubeconfig for "${env.name}"`)
@@ -76,7 +78,8 @@ async function migrate() {
   for (const ext of extModels) {
     if (ext.apiKey) {
       const plaintext = decrypt(ext.apiKey)
-      if (plaintext !== ext.apiKey) {
+      // If decrypt() returns the same value, it was plaintext (no enc:v1: prefix) — needs encryption
+      if (plaintext === ext.apiKey) {
         const encrypted = encrypt(plaintext)
         await prisma.externalModel.update({
           where: { id: ext.id },

--- a/apps/web/src/lib/encryption.ts
+++ b/apps/web/src/lib/encryption.ts
@@ -56,3 +56,34 @@ export function decryptJson<T>(value: unknown): T {
   }
   return value as T   // legacy: value is already the parsed object
 }
+
+/**
+ * Encrypt with a custom key (for key rotation).
+ * keyBase64: 32-byte key in base64 format
+ */
+export function encryptWithKey(plaintext: string, keyBase64: string): string {
+  const key = Buffer.from(keyBase64, 'base64')
+  if (key.byteLength !== 32) throw new Error(`Key must be 32 bytes (got ${key.byteLength})`)
+  const iv  = randomBytes(IV_BYTES)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+  const body = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag  = cipher.getAuthTag()
+  return PREFIX + Buffer.concat([iv, tag, body]).toString('base64')
+}
+
+/**
+ * Decrypt with a custom key (for key rotation).
+ * keyBase64: 32-byte key in base64 format
+ */
+export function decryptWithKey(value: string, keyBase64: string): string {
+  if (!value.startsWith(PREFIX)) return value   // plaintext passthrough
+  const key = Buffer.from(keyBase64, 'base64')
+  if (key.byteLength !== 32) throw new Error(`Key must be 32 bytes (got ${key.byteLength})`)
+  const packed = Buffer.from(value.slice(PREFIX.length), 'base64')
+  const iv         = packed.subarray(0, IV_BYTES)
+  const tag        = packed.subarray(IV_BYTES, IV_BYTES + TAG_BYTES)
+  const ciphertext = packed.subarray(IV_BYTES + TAG_BYTES)
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+  return decipher.update(ciphertext).toString('utf8') + decipher.final('utf8')
+}


### PR DESCRIPTION
## Summary

Encrypts `gatewayToken`, `kubeconfig` (Environment) and `apiKey` (ExternalModel) secrets stored in plaintext in PostgreSQL.

Uses Prisma `$use` middleware for **bulletproof decryption** — no call site can forget to decrypt. 50+ read sites covered automatically.

### Approach

| Component | File | Purpose |
|-----------|------|---------|
| Middleware | `encryption-middleware.ts` | `$use` hook auto-decrypts encrypted fields on every DB read |
| Migration | `encryption-migrate.ts` | One-time CLI script to encrypt existing plaintext values |
| Rotate endpoint | `internal/encryption/rotate/route.ts` | Key rotation (Bearer `ORION_ENCRYPTION_KEY`) |
| Wiring | `db.ts` | Registers middleware when `ORION_ENCRYPTION_KEY` is set |

### Safety guarantees

- **Plaintext passthrough**: `decrypt()` returns plaintext as-is if no `enc:v1:` prefix — deploy without key still works
- **Fail safe**: corrupt data → decrypt throws → field becomes `null` → auth fails (401), not crash
- **Abort/resume**: migration is idempotent — safe to retry, partial runs are fine
- **No downtime**: backward-compatible — old plaintext values decrypt transparently

### Threat model

Protects against direct database access (backup leak, SQLi in DB client). Does **not** replace Vault — defense in depth.

### Key rotation

```bash
# Generate new key
node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

# Rotate
curl -X POST /api/internal/encryption/rotate \
  -H "Authorization: Bearer $ORION_ENCRYPTION_KEY" \
  -H "Content-Type: application/json" \
  -d "{\"key\": \"<new-key-base64>\"}"

# Re-migrate existing plaintext values
npx tsx apps/web/src/lib/encryption-migrate.ts
```

## Test plan

- [ ] Deploy without `ORION_ENCRYPTION_KEY` → app starts, plaintext values work (passthrough)
- [ ] Deploy with key set → app starts, existing plaintext values decrypted correctly
- [ ] Run migration script → all values re-encrypted
- [ ] Gateway heartbeat still works (auth comparison with decrypted token)
- [ ] LLM calls still work (`apiKey` decrypted for OpenAI/Anthropic Bearer header)
- [ ] Key rotation endpoint → all values re-encrypted with new key
- [ ] Corrupted field → middleware returns `null`, auth fails 401 (not crash)
