### PR TITLE
fix(m-001): replace raw SQL with Prisma ORM to prevent SQL injection (SOC2)

### DIFF
--- a/apps/web/src/lib/api-key.ts
+++ b/apps/web/src/lib/api-key.ts
@@ -47,13 +47,12 @@ function mapRow(r: ApiKeyRow): ApiKeyInfo {
 // Raw SQL queries for the api_keys table (managed by Prisma schema)
 // Column names are camelCase (Prisma default), table name is api_keys (via @@map)
 // PostgreSQL lowercases unquoted identifiers, so we use double-quoted mixed-case names
+// SOC2: [M-001] findByHash, listByUser, verifyByHash use parameterized queries ($1, $2)
+// updateLastUsed and deleteByKey use Prisma ORM instead of raw SQL to prevent SQL injection
 const sql = {
   findByHash: `SELECT "id", "hashPrefix", name, active, "expiresAt", "lastUsedAt", "createdAt" FROM api_keys WHERE "hashPrefix" = $1 AND hash = $2`,
   listByUser: `SELECT "id", "hashPrefix", name, active, "expiresAt", "lastUsedAt", "createdAt" FROM api_keys WHERE "userId" = $1 ORDER BY "createdAt" DESC`,
   verifyByHash: `SELECT "id", "userId", "expiresAt", "lastUsedAt", active FROM api_keys WHERE "hashPrefix" = $1 AND hash = $2`,
-  updateLastUsed: (h: string) => `UPDATE api_keys SET "lastUsedAt" = now() WHERE hash = '${h.replace(/'/g, "''")}'`,
-  deleteByKey: (keyId: string, userId: string) =>
-    `DELETE FROM api_keys WHERE id = '${keyId.replace(/'/g, "''")}' AND "userId" = '${userId.replace(/'/g, "''")}'`,
 } as const
 
 /**
@@ -115,8 +114,8 @@ export async function verifyApiKey(key: string): Promise<string | null> {
   const match = await compare(key, r.hash)
   if (!match) return null
 
-  // Update lastUsedAt
-  await prisma.$executeRawUnsafe(sql.updateLastUsed(r.hash))
+  // Update lastUsedAt (SOC2: [M-001] use Prisma ORM — not raw SQL)
+  await prisma.apiKey.updateMany({ where: { hash: r.hash, userId: r.userId }, data: { lastUsedAt: new Date() } })
 
   return r.userId
 }
@@ -126,6 +125,7 @@ export async function verifyApiKey(key: string): Promise<string | null> {
  * Only the owning user or an admin can revoke.
  */
 export async function revokeApiKey(keyId: string, userId: string): Promise<boolean> {
-  const count = await prisma.$executeRawUnsafe(sql.deleteByKey(keyId, userId))
+  // SOC2: [M-001] use Prisma ORM — not raw SQL (prevents SQL injection)
+  const count = await prisma.apiKey.deleteMany({ where: { id: keyId, userId } })
   return count > 0
 }


### PR DESCRIPTION
## Summary

**SOC2 [M-001]** — Convert raw SQL queries in `api-key.ts` to Prisma ORM to eliminate SQL injection vector.

The `updateLastUsed` and `deleteByKey` functions used string interpolation with manual single-quote escaping (`'.replace("'", "''")`) instead of parameterized queries. While the current data flow makes exploitation unlikely (hash values come from DB, not user input), the pattern is fragile and violates SOC 2 requirements.

## Changes

- `updateLastUsed` → `prisma.apiKey.updateMany({ where: { hash: r.hash, userId: r.userId }, data: { lastUsedAt: new Date() } })`
- `deleteByKey` → `prisma.apiKey.deleteMany({ where: { id: keyId, userId } })`
- Removed vulnerable SQL template functions from `sql` object

## Related Issue

[#97](https://github.com/richard-callis/orion-web/issues/97)

## Test Plan

- [x] Prisma schema valid (apiKey model exists with hash and userId fields)
- [x] No raw SQL in api-key.ts for UPDATE/DELETE operations
- [ ] Manual: verify API key creation, verification, and revocation still works

## SOC 2 Reference

- AICAA SOC 2 Type II — Security [M-001]
- Related: M-002, CR-001