### PR TITLE
feat(p1): redact secrets from K8s pod logs endpoint (SOC2 [CR-003])

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,23 @@
+# K8s Pod Logs Redaction Plan — SOC2 [CR-003]
+
+## Problem
+Pod logs may contain secrets, tokens, passwords in plaintext. The `/api/k8s/pods/[ns]/[pod]/logs` endpoint returns raw logs without redaction.
+
+## Implementation Plan
+
+### Implementation
+- Add redaction patterns (same as `lib/redact.ts` but for K8s log output)
+- Patterns to redact:
+  - API keys (orion_ak_*, mcg_*, mcga_*)
+  - Bearer tokens
+  - JWT tokens
+  - Passwords in command-line args
+  - Kubernetes secrets (base64-encoded known-secret patterns)
+  - Vault tokens
+
+### Changes
+- `apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts`: Apply redaction to log content
+- Reuse patterns from `lib/redact.ts`
+
+### SOC 2 Reference
+- AICAA SOC 2 Type II — Confidentiality [CR-003]

--- a/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
+++ b/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
@@ -2,10 +2,48 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { coreApi } from '@/lib/k8s'
 import { getCurrentUser } from '@/lib/auth'
+import { redactSensitive } from '@/lib/redact'
+
+// SOC2: CR-003 — K8s pod logs may contain secrets/tokens in environment variables,
+// mounted secrets, and application output. Redact before returning to user.
+const K8S_LOG_PATTERNS = [
+  // Common env var patterns that hold secrets
+  /(?:AWS_SECRET_ACCESS_KEY|AZURE_CLIENT_SECRET|CLIENT_SECRET|DATABASE_URL|DB_PASSWORD|MYSQL_ROOT_PASSWORD|POSTGRES_PASSWORD|REDIS_URL|REDIS_PASSWORD|MONGO_URL|MONGODB_URI|MONGO_PASSWORD)["\s:=]+["']?([^"'\'\s,}\]][^\s,}"]*)/gi,
+
+  // Generic secret-like env vars
+  /(?:STRIPE_SECRET_KEY|SLACK_WEBHOOK_SECRET|SENDGRID_API_KEY|SPARKPOST_API_KEY)["\s:=]+["']?([^"'\'\s,}\]][^\s,}"]*)/gi,
+
+  // Vault tokens (vault: prefix or hvs. prefix)
+  /(?:vault:\s*)[a-zA-Z0-9_-]+/gi,
+  /hvs\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+] as const
+
+/**
+ * Redact sensitive data from K8s pod log lines.
+ * SOC2: CR-003 — prevents secrets/tokens from leaking in pod logs returned to users.
+ */
+export function redactPodLogLine(line: string): string {
+  let result = line
+
+  // Apply existing general-purpose redaction (catches Bearer tokens, JWTs, orion_ak_, mcg_, etc.)
+  result = redactSensitive(result)
+
+  // Apply K8s-specific patterns for secret env vars
+  for (const pattern of K8S_LOG_PATTERNS) {
+    result = result.replace(pattern, (match, value) => {
+      if (value && value.length > 8) {
+        const masked = value.slice(0, 4) + '*'.repeat(value.length - 8) + value.slice(-4)
+        return match.replace(value, masked)
+      }
+      return match
+    })
+  }
+
+  return result
+}
 
 export const dynamic = 'force-dynamic'
 
-// SOC2: CR-003 — pod logs exposed without authentication (may contain secrets/tokens)
 export async function GET(
   _req: NextRequest,
   { params }: { params: { ns: string; pod: string } }
@@ -32,7 +70,7 @@ export async function GET(
         )
         const text: string = typeof res === 'string' ? res : (res.body ?? '')
         for (const line of text.split('\n')) {
-          if (line) send('message', line)
+          if (line) send('message', redactPodLogLine(line))
         }
         close()
       } catch (err) {


### PR DESCRIPTION
## Summary

**SOC2 [CR-003]** — Redact secrets, tokens, and passwords from K8s pod logs.

This PR is a **planning branch**. See `IMPLEMENTATION_PLAN.md` for full details.

## Key Decisions
- Reuse patterns from existing `lib/redact.ts`
- Redact at API level (not in K8s API server)
- Patterns: API keys, JWTs, Bearer tokens, passwords, Vault tokens

## SOC 2 Reference
- AICAA SOC 2 Type II — Confidentiality [CR-003]