### PR TITLE
fix(c-003): encrypt upsert create/update fields

### DIFF
--- a/apps/web/src/lib/encryption-middleware.ts
+++ b/apps/web/src/lib/encryption-middleware.ts
@@ -106,24 +106,40 @@ export function registerEncryptionMiddleware(prisma: PrismaClient): void {
     // Encrypt before writes (POST = create, PUT/PATCH = update)
     const isWrite = ['create', 'connectOrCreate', 'upsert', 'update', 'updateMany'].includes(params.action)
     if (isWrite && params.args) {
-      // Handle upsert/create data
-      if (params.args.data) {
-        const data = params.args.data
-        if (isRecord(data)) {
-          const processed = preProcess(data, params.model)
-          if (processed !== data) {
-            params = { ...params, args: { ...params.args, data: processed } }
-          }
-        } else if (Array.isArray(data)) {
-          // upsert takes { where, create, update }
-          params = {
-            ...params,
-            args: {
-              ...params.args,
-              data: data.map((item) => isRecord(item) ? preProcess(item, params.model) : item),
-            },
-          }
+      let newArgs = { ...params.args }
+
+      // Handle standard data field (create, update, updateMany)
+      if (newArgs.data && isRecord(newArgs.data)) {
+        const processed = preProcess(newArgs.data, params.model)
+        if (processed !== newArgs.data) {
+          newArgs = { ...newArgs, data: processed }
         }
+      }
+
+      // Handle upsert's create and update fields
+      if (newArgs.create && isRecord(newArgs.create)) {
+        const processed = preProcess(newArgs.create, params.model)
+        if (processed !== newArgs.create) {
+          newArgs = { ...newArgs, create: processed }
+        }
+      }
+      if (newArgs.update && isRecord(newArgs.update)) {
+        const processed = preProcess(newArgs.update, params.model)
+        if (processed !== newArgs.update) {
+          newArgs = { ...newArgs, update: processed }
+        }
+      }
+
+      // Handle connectOrCreate's create field
+      if (newArgs.connectOrCreate && isRecord(newArgs.connectOrCreate) && isRecord(newArgs.connectOrCreate.create)) {
+        const processed = preProcess(newArgs.connectOrCreate.create as Record<string, unknown>, params.model)
+        if (processed !== newArgs.connectOrCreate.create) {
+          newArgs = { ...newArgs, connectOrCreate: { ...newArgs.connectOrCreate, create: processed } }
+        }
+      }
+
+      if (newArgs !== params.args) {
+        params = { ...params, args: newArgs }
       }
     }
 

--- a/apps/web/src/lib/encryption-middleware.ts
+++ b/apps/web/src/lib/encryption-middleware.ts
@@ -9,7 +9,7 @@
  */
 
 import { PrismaClient } from '@prisma/client'
-import { decrypt } from './encryption'
+import { decrypt, encrypt } from './encryption'
 
 const ENCRYPTED_ENV_FIELDS = ['gatewayToken', 'kubeconfig']
 const ENCRYPTED_EXT_FIELDS = ['apiKey']
@@ -61,10 +61,70 @@ function processResult(result: unknown, model?: string): unknown {
   return isRecord(result) ? processRow(result, model) : result
 }
 
+/**
+ * Encrypt sensitive fields BEFORE write operations (SOC2: [C-003]).
+ * Only encrypts fields that are still plaintext (not already starting with 'enc:v1:').
+ * This is idempotent — encrypting an already-encrypted value is safe (decrypt passes it through).
+ */
+function preProcess(obj: unknown, model?: string): unknown {
+  if (!isRecord(obj)) return obj
+
+  const copy = { ...obj }
+  let changed = false
+
+  // Encrypt Environment fields on write
+  if (model === 'Environment') {
+    for (const field of ENCRYPTED_ENV_FIELDS) {
+      const raw = copy[field]
+      if (typeof raw === 'string' && !raw.startsWith('enc:v1:')) {
+        copy[field] = encrypt(raw)
+        changed = true
+      }
+    }
+  }
+
+  // Encrypt ExternalModel fields on write
+  if (model === 'ExternalModel') {
+    for (const field of ENCRYPTED_EXT_FIELDS) {
+      const raw = copy[field]
+      if (typeof raw === 'string' && !raw.startsWith('enc:v1:')) {
+        copy[field] = encrypt(raw)
+        changed = true
+      }
+    }
+  }
+
+  return changed ? copy : obj
+}
+
 export function registerEncryptionMiddleware(prisma: PrismaClient): void {
   prisma.$use(async (params, next) => {
     if (params.model !== 'Environment' && params.model !== 'ExternalModel') {
       return next(params)
+    }
+
+    // Encrypt before writes (POST = create, PUT/PATCH = update)
+    const isWrite = ['create', 'connectOrCreate', 'upsert', 'update', 'updateMany'].includes(params.action)
+    if (isWrite && params.args) {
+      // Handle upsert/create data
+      if (params.args.data) {
+        const data = params.args.data
+        if (isRecord(data)) {
+          const processed = preProcess(data, params.model)
+          if (processed !== data) {
+            params = { ...params, args: { ...params.args, data: processed } }
+          }
+        } else if (Array.isArray(data)) {
+          // upsert takes { where, create, update }
+          params = {
+            ...params,
+            args: {
+              ...params.args,
+              data: data.map((item) => isRecord(item) ? preProcess(item, params.model) : item),
+            },
+          }
+        }
+      }
     }
 
     const result = await next(params)


### PR DESCRIPTION
## Fix for PR #100

**Issue:** Upsert operations bypass encryption middleware

Prisma upsert puts sensitive fields in `params.args.create` and `params.args.update`, not `params.args.data`. The middleware only encrypted the `data` field, leaving upsert data as plaintext.

**Fix:** Handle create/update fields separately, plus connectOrCreate.

**Testing:**
- Manual: Create environment with upsert (ensure kubeconfig/gatewayToken are encrypted)
- Verify encrypted values start with 'enc:v1:' in database
- Verify decryption works on read