### PR TITLE
fix(m-005): fix getClientIp and integrate logAudit

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -251,17 +251,20 @@ model TaskEvent {
 }
 
 model AuditLog {
-  id        String   @id @default(cuid())
-  userId    String
-  action    String
-  target    String
-  detail    Json?
-  createdAt DateTime @default(now())
+  id         String   @id @default(cuid())
+  userId     String
+  action     String
+  target     String
+  detail     Json?
+  ipAddress  String?  // SOC2: [M-005] Source IP for audit trail
+  userAgent  String?  // SOC2: [M-005] Client user-agent for audit trail
+  createdAt  DateTime @default(now())
 
   // SOC2: [M-005, L-001] Indexes for user-specific queries and date range filters
   @@index([userId])
   @@index([createdAt])
   @@index([userId, createdAt])
+  @@index([ipAddress])
 }
 
 model SavedView {

--- a/apps/web/src/app/api/api-keys/[id]/route.ts
+++ b/apps/web/src/app/api/api-keys/[id]/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { revokeApiKey, verifyApiKey } from '@/lib/api-key'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 type User = { id: string }
 
@@ -38,6 +39,15 @@ export async function DELETE(
     if (!ok) {
       return NextResponse.json({ error: 'API key not found or unauthorized' }, { status: 404 })
     }
+
+    // SOC2: [M-005] Audit API key revocation (non-blocking)
+    logAudit({
+      userId: result.user!.id,
+      action: 'api_key_revoke',
+      target: `api_key:${id}`,
+      ipAddress: getClientIp(req),
+      userAgent: getUserAgent(req.headers),
+    }).catch(() => {})
 
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/apps/web/src/app/api/api-keys/route.ts
+++ b/apps/web/src/app/api/api-keys/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { createApiKey, listUserKeys, verifyApiKey } from '@/lib/api-key'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 type User = { id: string }
 
@@ -70,6 +71,16 @@ export async function POST(req: NextRequest) {
     const { name, expiresInDays } = body as { name?: string; expiresInDays?: number }
 
     const apiKeyResult = await createApiKey(result.user!.id, name || 'Default', expiresInDays)
+
+    // SOC2: [M-005] Audit API key creation (non-blocking)
+    logAudit({
+      userId: result.user!.id,
+      action: 'api_key_create',
+      target: `api_key:${apiKeyResult.info.id}`,
+      detail: { name: apiKeyResult.info.name, expiresInDays },
+      ipAddress: getClientIp(req),
+      userAgent: getUserAgent(req.headers),
+    }).catch(() => {})
 
     return NextResponse.json({
       key: apiKeyResult.key, // Shown ONCE — can't be retrieved again

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { Prisma } from '@prisma/client'
 import { getDefaultTools } from '@/lib/default-tools'
 import { getCurrentUser, requireAdmin } from '@/lib/auth'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 export async function GET() {
   // SOC2: CR-002 — require authentication to list environments
@@ -72,6 +73,16 @@ export async function POST(req: NextRequest) {
     where: { id: env.id },
     include: { tools: true, agents: { include: { agent: true } } },
   })
+
+  // SOC2: [M-005] Audit environment creation (non-blocking)
+  logAudit({
+    userId: user.id,
+    action: 'environment_create',
+    target: `environment:${env.id}`,
+    detail: { name: env.name, type: env.type },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
 
   return NextResponse.json(
     { ...envWithTools, gatewayToken: envWithTools?.gatewayToken ? '••••' : null, kubeconfig: envWithTools?.kubeconfig ? '••••' : null },

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -1,0 +1,94 @@
+/**
+ * Audit logging utility for SOC2 [M-005] compliance.
+ *
+ * Creates audit log entries with IP address and user-agent tracking.
+ * Non-blocking — failures are silently logged to prevent impact on request processing.
+ */
+
+import { prisma } from './db'
+
+export type AuditAction =
+  | 'user_login'
+  | 'user_logout'
+  | 'user_create'
+  | 'user_update'
+  | 'user_delete'
+  | 'user_role_change'
+  | 'api_key_create'
+  | 'api_key_revoke'
+  | 'environment_create'
+  | 'environment_update'
+  | 'environment_delete'
+  | 'task_create'
+  | 'task_update'
+  | 'task_assign'
+  | 'task_complete'
+  | 'task_fail'
+  | 'note_create'
+  | 'note_update'
+  | 'note_delete'
+  | 'agent_create'
+  | 'agent_update'
+  | 'agent_delete'
+  | 'model_create'
+  | 'model_update'
+  | 'model_delete'
+  | 'tool_execute'
+  | 'tool_approve'
+  | 'tool_revoke'
+  | 'sso_config_update'
+  | 'admin_action'
+  | 'settings_update'
+  | 'vault_unseal'
+  | 'vault_reseal'
+
+/**
+ * Log an audit event. Non-blocking — never throws.
+ */
+export async function logAudit(params: {
+  userId: string
+  action: AuditAction
+  target: string
+  detail?: Record<string, unknown>
+  ipAddress?: string | null
+  userAgent?: string | null
+}): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId: params.userId,
+        action: params.action,
+        target: params.target,
+        detail: params.detail ?? {},
+        ipAddress: params.ipAddress ?? undefined,
+        userAgent: params.userAgent ?? undefined,
+      },
+    })
+  } catch {
+    // Non-blocking — audit logging failures must not impact normal operations
+    // SOC2: If audit logging is consistently failing, this is an alerting condition
+  }
+}
+
+/**
+ * Extract IP address from a Next.js request (respects X-Forwarded-For).
+ */
+export function getClientIp(req: { ip?: string; socket?: { remoteAddress?: string } }): string | undefined {
+  const forwarded = req.ip
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return req.socket?.remoteAddress
+    ? req.socket.remoteAddress.replace(/^::ffff:/, '')
+    : undefined
+}
+
+/**
+ * Extract user-agent from request headers.
+ */
+export function getUserAgent(headers: Headers | Record<string, string | null | string[]>): string | undefined {
+  const val = typeof headers.get === 'function'
+    ? headers.get('user-agent')
+    : typeof headers === 'object' && 'user-agent' in headers
+    ? headers['user-agent']
+    : null
+  return val ? (typeof val === 'string' ? val : val.join(', ')) : undefined
+}

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -6,6 +6,7 @@
  */
 
 import { prisma } from './db'
+import type { NextRequest } from 'next/server'
 
 export type AuditAction =
   | 'user_login'
@@ -72,13 +73,15 @@ export async function logAudit(params: {
 
 /**
  * Extract IP address from a Next.js request (respects X-Forwarded-For).
+ * Works with NextRequest and other request objects.
  */
-export function getClientIp(req: { ip?: string; socket?: { remoteAddress?: string } }): string | undefined {
-  const forwarded = req.ip
+export function getClientIp(req: NextRequest | { headers: Headers; ip?: string }): string | undefined {
+  // Next.js App Router: check x-forwarded-for header (set by Traefik/reverse proxy)
+  const forwarded = req.headers.get('x-forwarded-for')
   if (forwarded) return forwarded.split(',')[0].trim()
-  return req.socket?.remoteAddress
-    ? req.socket.remoteAddress.replace(/^::ffff:/, '')
-    : undefined
+  // Fallback: NextRequest.ip (available in some deployments)
+  if ('ip' in req && req.ip) return req.ip
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## Fix for PR #104

**Issues Fixed:**
1. `getClientIp()` broken for Next.js App Router — doesn't work with NextRequest
2. `logAudit()` never called anywhere — dead code

**Solution:**

### getClientIp Fix
- Now reads `x-forwarded-for` header (set by Traefik reverse proxy)
- Works with Next.js NextRequest and other request objects
- Added NextRequest type import

### logAudit Integration
Added audit logging to critical security operations:
- `POST /api/api-keys` → api_key_create
- `DELETE /api/api-keys/[id]` → api_key_revoke  
- `POST /api/environments` → environment_create

Each call captures:
- userId, action, target
- IP address (from x-forwarded-for)
- User-agent (from headers)
- Timestamp (from DB)

All calls are non-blocking (use .catch(() => {})) to prevent request failures.

**Testing:**
- Manual: Create API key, check audit log
- Manual: Revoke API key, check audit log
- Manual: Create environment, check audit log
- Verify IP address is captured correctly from x-forwarded-for header
- Verify user-agent is captured from request headers