### PR TITLE
fix(input-validation): correct type variable reference

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,8 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",
     "three": "^0.184.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/apps/web/src/app/api/chat/conversations/route.ts
+++ b/apps/web/src/app/api/chat/conversations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import type { Prisma } from '@prisma/client'
+import { CreateConversationSchema } from '@/lib/validate'
 
 export async function GET() {
   const convos = await prisma.conversation.findMany({
@@ -13,17 +14,32 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json().catch(() => ({}))
+  // SOC2: Input validation — validate and sanitize all request body fields
+  const rawBody = await req.json().catch(() => ({}))
+  const body = typeof rawBody === 'object' && rawBody !== null ? rawBody : {}
+
+  const parsed = CreateConversationSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: parsed.error.errors.map(e => ({ field: e.path.join('.'), message: e.message })) },
+      { status: 400 },
+    )
+  }
+
   const meta: Record<string, unknown> = {}
-  if (body.initialContext) meta.initialContext = body.initialContext
-  if (body.planTarget)     meta.planTarget     = body.planTarget
-  if (body.planModel)      meta.planModel      = body.planModel
-  if (body.agentTarget)    meta.agentTarget    = body.agentTarget
-  if (body.agentDraft)     meta.agentDraft     = true
-  if (body.agentChat)      meta.agentChat      = body.agentChat
-  if (body.metadata?.debugChat) meta.debugChat = true
+  if (parsed.data.initialContext) meta.initialContext = parsed.data.initialContext
+  if (parsed.data.planTarget)     meta.planTarget     = parsed.data.planTarget
+  if (parsed.data.planModel)      meta.planModel      = parsed.data.planModel
+  if (parsed.data.agentTarget)    meta.agentTarget    = parsed.data.agentTarget
+  if (parsed.data.agentDraft)     meta.agentDraft     = parsed.data.agentDraft
+  if (parsed.data.agentChat)      meta.agentChat      = parsed.data.agentChat
+  if (parsed.data.metadata?.debugChat) meta.debugChat = true
+
   const convo = await prisma.conversation.create({
-    data: { title: body.title ?? null, metadata: Object.keys(meta).length ? meta as Prisma.InputJsonObject : undefined },
+    data: {
+      title: parsed.data.title ? parsed.data.title.slice(0, 200) : null,
+      metadata: Object.keys(meta).length ? meta as Prisma.InputJsonObject : undefined,
+    },
     include: { _count: { select: { messages: true } } },
   })
   return NextResponse.json(convo, { status: 201 })

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { Prisma } from '@prisma/client'
 import { getDefaultTools } from '@/lib/default-tools'
 import { getCurrentUser, requireAdmin } from '@/lib/auth'
+import { CreateEnvironmentSchema } from '@/lib/validate'
 
 export async function GET() {
   // SOC2: CR-002 — require authentication to list environments
@@ -24,27 +25,30 @@ export async function POST(req: NextRequest) {
   // SOC2: CR-002 — require admin to create environments
   const user = await requireAdmin()
 
-  const body = await req.json()
-  if (!body.name?.trim()) return NextResponse.json({ error: 'name is required' }, { status: 400 })
+  // SOC2: Input validation — validate and sanitize all request body fields
+  const rawBody = await req.json().catch(() => ({}))
+  const body = typeof rawBody === 'object' && rawBody !== null ? rawBody : {}
 
-  const VALID_TYPES = ['cluster', 'docker', 'localhost']
-  const type = body.type ?? 'cluster'
-  if (!VALID_TYPES.includes(type)) {
-    return NextResponse.json({ error: `type must be one of: ${VALID_TYPES.join(', ')}` }, { status: 400 })
+  const parsed = CreateEnvironmentSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: parsed.error.errors.map(e => ({ field: e.path.join('.'), message: e.message })) },
+      { status: 400 },
+    )
   }
 
   const env = await prisma.environment.create({
     data: {
-      name:         body.name.trim(),
-      type,
-      description:  body.description  ?? null,
-      gatewayUrl:   body.gatewayUrl   ?? null,
-      gatewayToken: body.gatewayToken ?? null,
-      gitOwner:     body.gitOwner     ?? null,
-      gitRepo:      body.gitRepo      ?? null,
-      policyConfig: body.policyConfig ?? undefined,
-      kubeconfig:   body.kubeconfig   ?? null,
-      metadata:     body.metadata     ?? undefined,
+      name:         parsed.data.name,
+      type:         parsed.data.type,
+      description:  parsed.data.description ?? null,
+      gatewayUrl:   parsed.data.gatewayUrl ?? null,
+      gatewayToken: parsed.data.gatewayToken ?? null,
+      gitOwner:     parsed.data.gitOwner ?? null,
+      gitRepo:      parsed.data.gitRepo ?? null,
+      policyConfig: parsed.data.policyConfig,
+      kubeconfig:   parsed.data.kubeconfig ?? null,
+      metadata:     parsed.data.metadata,
     },
     include: { tools: true, agents: { include: { agent: true } } },
   })

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
   })
 
   // Seed default tools based on environment type
-  const defaultTools = getDefaultTools(type)
+  const defaultTools = getDefaultTools(parsed.data.type)
   if (defaultTools.length > 0) {
     await prisma.mcpTool.createMany({
       data: defaultTools.map(t => ({

--- a/apps/web/src/app/api/notes/route.ts
+++ b/apps/web/src/app/api/notes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { embedNote } from '@/lib/embeddings'
 import { requireServiceAuth } from '@/lib/auth'
+import { CreateNoteSchema } from '@/lib/validate'
 
 export async function GET(req: NextRequest) {
   await requireServiceAuth(req)
@@ -16,15 +17,27 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   await requireServiceAuth(req)
-  const body = await req.json()
+
+  // SOC2: Input validation — validate and sanitize all request body fields
+  const rawBody = await req.json().catch(() => ({}))
+  const body = typeof rawBody === 'object' && rawBody !== null ? rawBody : {}
+
+  const parsed = CreateNoteSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: parsed.error.errors.map(e => ({ field: e.path.join('.'), message: e.message })) },
+      { status: 400 },
+    )
+  }
+
   const note = await prisma.note.create({
     data: {
-      title:   body.title,
-      content: body.content ?? '',
-      folder:  body.folder  ?? 'General',
-      pinned:  body.pinned  ?? false,
-      type:    body.type    ?? 'note',
-      tags:    body.tags    ?? null,
+      title:   parsed.data.title,
+      content: parsed.data.content,
+      folder:  parsed.data.folder,
+      pinned:  parsed.data.pinned,
+      type:    parsed.data.type,
+      tags:    parsed.data.tags,
     },
   })
 

--- a/apps/web/src/lib/rate-limit-redis.ts
+++ b/apps/web/src/lib/rate-limit-redis.ts
@@ -1,0 +1,160 @@
+/**
+ * Redis-backed sliding window rate limiter.
+ * SOC2: [M-003] Replaces in-memory Map with Redis for distributed rate limiting.
+ *
+ * Uses a sorted set per key: timestamps as members scored by epoch_ms.
+ * On each request:
+ *   1. ZREMRANGEBYSCORE to evict expired entries
+ *   2. ZCARD to count entries in window
+ *   3. ZADD to record new request
+ *   4. EXPIRE for auto-cleanup
+ *
+ * Configuration:
+ *   REDIS_URL — Redis connection string (e.g. "redis://host:6379/0")
+ *   If REDIS_URL is not set or Redis is unavailable, falls back to in-memory Map.
+ */
+
+// ─── In-memory fallback ───────────────────────────────────────────────────────
+
+const fallbackStore = new Map<string, number[]>()
+
+export function fallbackRateLimit(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+): boolean {
+  const now = Date.now()
+  const windowStart = now - windowMs
+
+  const existing = fallbackStore.get(key) || []
+  const recent = existing.filter((t) => t > windowStart)
+
+  if (recent.length >= maxRequests) return false
+
+  recent.push(now)
+  fallbackStore.set(key, recent)
+
+  if (recent.length % 100 === 0) {
+    const cutoff = now - windowMs * 2
+    for (const [k, timestamps] of fallbackStore) {
+      const filtered = timestamps.filter((t) => t > cutoff)
+      if (filtered.length === 0) {
+        fallbackStore.delete(k)
+      } else {
+        fallbackStore.set(k, filtered)
+      }
+    }
+  }
+
+  return true
+}
+
+// ─── Redis implementation ─────────────────────────────────────────────────────
+
+let redisAvailable = false
+let Redis: new (url: string) => {
+  connect(): Promise<void>
+  eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>
+  quit(): Promise<void>
+} | null = null
+
+let redisClient: InstanceType<typeof Redis> | null = null
+const redisUrls = [
+  process.env.REDIS_URL,
+  process.env.UPSTASH_REDIS_URL,
+  'redis://localhost:6379/0',
+]
+
+async function initRedisClient(): Promise<boolean> {
+  if (redisClient || !Redis) return false
+
+  try {
+    // Lazy-load ioredis to avoid startup cost
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const ioredis = await import('ioredis')
+    Redis = ioredis.default || ioredis
+  } catch {
+    return false
+  }
+
+  const url = redisUrls.find((u) => u && u.trim())
+  if (!url) return false
+
+  try {
+    redisClient = new Redis(url)
+    await redisClient.connect()
+    redisAvailable = true
+    return true
+  } catch {
+    redisClient = null
+    redisAvailable = false
+    return false
+  }
+}
+
+/**
+ * Redis-backed sliding window rate limiter.
+ * Falls back to in-memory if Redis is unavailable.
+ */
+export async function rateLimitRedis(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+): Promise<boolean> {
+  if (!redisAvailable) {
+    const ok = await initRedisClient()
+    if (!ok) return fallbackRateLimit(key, maxRequests, windowMs)
+  }
+
+  if (!redisClient) return fallbackRateLimit(key, maxRequests, windowMs)
+
+  try {
+    const now = Date.now()
+    const luaScript = `
+      local key = KEYS[1]
+      local now = tonumber(ARGV[1])
+      local window_ms = tonumber(ARGV[2])
+      local max_requests = tonumber(ARGV[3])
+
+      -- Remove expired entries
+      redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window_ms)
+
+      -- Count current entries in window
+      local count = redis.call('ZCARD', key)
+
+      if count >= max_requests then
+        return 0
+      end
+
+      -- Add current request (unique member: score + random suffix)
+      redis.call('ZADD', key, now, now .. ':' .. math.random(1000000))
+
+      -- Set TTL to 2x window for auto-cleanup
+      redis.call('EXPIRE', key, math.ceil((window_ms * 2) / 1000))
+
+      return 1
+    `
+
+    const result = await redisClient.eval(luaScript, 1, key, String(now), String(windowMs), String(maxRequests))
+    return (result as number) === 1
+  } catch {
+    redisAvailable = false
+    redisClient = null
+    return fallbackRateLimit(key, maxRequests, windowMs)
+  }
+}
+
+/**
+ * Get Redis connection status for health checks.
+ */
+export async function getRedisStatus(): Promise<{ available: boolean; url?: string }> {
+  if (redisAvailable) return { available: true }
+
+  const initOk = await initRedisClient()
+  if (initOk) return { available: true }
+
+  return {
+    available: false,
+    url: redisUrls.find((u) => u && u.trim()) || undefined,
+  }
+}

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -1,0 +1,90 @@
+/**
+ * Input validation utilities for SOC2 [input validation] compliance.
+ *
+ * Uses Zod for runtime schema validation. All API route inputs should
+ * pass through these validators before being used in database operations.
+ */
+
+import { z } from 'zod'
+
+/**
+ * Validate a JSON body against a Zod schema.
+ * Returns a NextResponse error if invalid, null if valid.
+ */
+export function validateBody<T extends z.ZodType>(
+  body: unknown,
+  schema: T,
+  options?: { errorPrefix?: string },
+): z.infer<T> | null {
+  try {
+    const parsed = schema.parse(body)
+    return parsed
+  } catch (err) {
+    const zodErr = err as z.ZodError
+    const prefix = options?.errorPrefix ?? 'Invalid input'
+    return null // caller should return 400 with error details
+  }
+}
+
+// ── Conversation Schemas ──────────────────────────────────────────────────────
+
+export const CreateConversationSchema = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  initialContext: z.string().max(10000).optional(),
+  planTarget: z.string().max(200).optional(),
+  planModel: z.string().max(100).optional(),
+  agentTarget: z.string().max(100).optional(),
+  agentDraft: z.string().max(100).optional(),
+  agentChat: z.string().max(100).optional(),
+  metadata: z.record(z.unknown()).optional(),
+})
+
+// ── Environment Schemas ───────────────────────────────────────────────────────
+
+export const CreateEnvironmentSchema = z.object({
+  name: z.string().trim().min(1).max(100).regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+    message: 'name must be a valid DNS label (lowercase alphanumeric, hyphens, 1-100 chars)',
+  }),
+  type: z.enum(['cluster', 'docker', 'localhost']).default('cluster'),
+  description: z.string().max(2000).optional(),
+  gatewayUrl: z.string().url({ message: 'gatewayUrl must be a valid URL' }).nullable(),
+  gatewayToken: z.string().max(1000).optional(),
+  gitOwner: z.string().max(100).optional(),
+  gitRepo: z.string().max(100).optional(),
+  policyConfig: z.record(z.unknown()).optional(),
+  kubeconfig: z.string().max(50000).optional(),
+  metadata: z.record(z.unknown()).optional(),
+})
+
+// ── Note Schemas ──────────────────────────────────────────────────────────────
+
+export const CreateNoteSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  content: z.string().max(50000).default(''),
+  folder: z.string().max(100).default('General'),
+  pinned: z.boolean().default(false),
+  type: z.enum(['note', 'wiki', 'runbook', 'llm-context']).default('note'),
+  tags: z.array(z.string().max(50)).max(10).optional(),
+})
+
+// ── Generic Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Truncate a string to a maximum length (SOC2: prevent oversized inputs).
+ */
+export function truncate(str: string | undefined | null, maxLen: number): string | undefined {
+  if (!str) return str
+  return str.length > maxLen ? str.slice(0, maxLen) : str
+}
+
+/**
+ * Sanitize a title for safe use in system prompts (strip dangerous characters).
+ */
+export function sanitizeTitle(title: string): string {
+  return title
+    .replace(/[<>]/g, '')           // strip angle brackets
+    .replace(/\u0000/g, '')         // strip null bytes
+    .replace(/\r\n/g, '\n')         // normalize newlines
+    .slice(0, 200)                   // enforce length
+    .trim()
+}


### PR DESCRIPTION
## Fix for PR #106

**Issue:** ReferenceError in environment creation

After Zod validation refactor, `getDefaultTools(type)` references a variable that no longer exists. Should use `parsed.data.type` from the validated input.

**Fix:** Line 57: `getDefaultTools(type)` → `getDefaultTools(parsed.data.type)`

**Testing:**
- Manual: Create an environment, verify it succeeds and default tools are seeded