### PR TITLE
fix: correct npm otplib version from 4.4.1 to 13.4.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,7 +43,7 @@
     "three": "^0.184.0",
     "ws": "^8.18.0",
     "zod": "^3.25.0",
-    "otplib": "^4.4.1",
+    "otplib": "^13.4.0",
     "qrcode": "^1.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

otplib version 4.4.1 does not exist in the npm registry. This causes all Docker builds to fail with:

```
npm error notarget No matching version found for otplib@^4.4.1.
```

Updated to latest stable version 13.4.0 which is available in npm.

## Testing

Verify Docker build succeeds with npm ci completing without errors.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)