### PR TITLE
fix: critical SOC2 security findings (P0)

### DIFF
--- a/apps/web/src/app/api/setup/bootstrap-config/route.ts
+++ b/apps/web/src/app/api/setup/bootstrap-config/route.ts
@@ -1,10 +1,24 @@
 export const dynamic = 'force-dynamic'
 
 import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
 
 // Returns server-side env vars needed by the setup wizard UI.
 // (NEXT_PUBLIC_ vars are baked at build time so we expose them server-side instead.)
 export async function GET() {
+  // Only expose Gitea credentials during setup — after completion they're
+  // stored encrypted in the database and this endpoint should not leak them.
+  const setting = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
+  if (setting?.value === true) {
+    return NextResponse.json({
+      managementIp: process.env.MANAGEMENT_IP ?? '',
+      giteaBundled: false,
+      giteaAdminToken: '',
+      giteaAdminUser: '',
+      giteaAdminPassword: '',
+    })
+  }
+
   // Bundled Gitea: prefer pre-generated API token (no basic-auth / password-change issues).
   // Fall back to user+password if token not yet generated.
   const adminToken    = process.env.GITEA_ADMIN_TOKEN ?? ''

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -32,9 +32,7 @@ export const authOptions: NextAuthOptions = {
   // so browsers will not send cookies on insecure requests.
   cookies: {
     sessionToken: {
-      name: process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
-        ? '__Secure-next-auth.session-token'
-        : 'next-auth.session-token',
+      name: 'next-auth.session-token',
       options: {
         httpOnly: true,
         sameSite: 'strict' as const,
@@ -43,9 +41,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     callbackUrl: {
-      name: process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
-        ? '__Secure-next-auth.callback-url'
-        : 'next-auth.callback-url',
+      name: 'next-auth.callback-url',
       options: {
         sameSite: 'lax' as const,
         path: '/',
@@ -53,9 +49,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     csrfToken: {
-      name: process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
-        ? '__Secure-next-auth.csrf-token'
-        : 'next-auth.csrf-token',
+      name: 'next-auth.csrf-token',
       options: {
         httpOnly: true,
         sameSite: 'lax' as const,

--- a/apps/web/src/lib/setup-guard.ts
+++ b/apps/web/src/lib/setup-guard.ts
@@ -4,9 +4,13 @@ import { jwtVerify } from 'jose'
 export async function requireWizardSession(req: NextRequest): Promise<boolean> {
   const token = req.cookies.get('__orion_wizard')?.value
   if (!token) return false
+  // SOC2: NEXTAUTH_SECRET must be configured — no fallback.
+  // Without it, wizard tokens cannot be verified and setup must be blocked.
+  const secret = process.env.NEXTAUTH_SECRET
+  if (!secret) return false
   try {
-    const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? 'fallback-secret')
-    const { payload } = await jwtVerify(token, secret)
+    const secretBytes = new TextEncoder().encode(secret)
+    const { payload } = await jwtVerify(token, secretBytes)
     return payload.wizard === true
   } catch {
     return false


### PR DESCRIPTION
## Summary

Resolves 3 critical/high SOC2 compliance findings from the SOC2 audit report.

### Changes

**1. Remove hardcoded `'fallback-secret'` from `setup-guard.ts`**
- Without `NEXTAUTH_SECRET`, the wizard token verification silently fell back to a hardcoded secret
- Anyone could forge a `wizard: true` JWT and create an admin account
- Fix: Block setup if `NEXTAUTH_SECRET` is not set

**2. Remove `__Secure-` cookie prefix from `auth.ts`**
- The `__Secure-` prefix caused a cookie name mismatch: auth.ts set `__Secure-next-auth.session-token` in production, but middleware.ts always looked for `next-auth.session-token`
- This meant the middleware could not read the session token in production, breaking authentication
- Fix: Use consistent cookie names across all environments

**3. Add setup state gate to `bootstrap-config/route.ts`**
- The endpoint returned plaintext Gitea admin credentials (token, username, password) at all times
- After setup completion, these are stored encrypted in the database and should not be exposed
- Fix: Return empty credentials when `setup.completed` is true

### SOC2 Findings Addressed
- C1: Setup wizard fallback secret
- C2: Gitea admin credentials exposure
- H4: Middleware session cookie name mismatch

### Next Steps
- `soc2-fix-audit-logging` (P1) — builds on this
- `soc2-fix-ssrf-docker` (P1) — builds on this
- `soc2-fix-session-invalidation` (P1) — builds on this