### PR TITLE
fix: use generic error messages for MFA endpoints (P2)

### DIFF
--- a/apps/web/src/app/api/auth/mfa/verify/route.ts
+++ b/apps/web/src/app/api/auth/mfa/verify/route.ts
@@ -52,7 +52,7 @@ async function handleTotpLogin(username: string, password: string, code?: string
   })
 
   if (!user || !user.active || !user.totpEnabled || !user.totpSecret) {
-    return NextResponse.json({ error: 'MFA not enabled for this account' }, { status: 403 })
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
   }
 
   // Verify password

--- a/apps/web/src/app/api/auth/totp-login/route.ts
+++ b/apps/web/src/app/api/auth/totp-login/route.ts
@@ -120,7 +120,7 @@ export async function POST(req: NextRequest) {
   })
 
   if (!user || !user.active || !user.totpEnabled || !user.totpSecret) {
-    return NextResponse.json({ error: 'MFA not enabled for this account' }, { status: 403 })
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
   }
 
   // Verify password


### PR DESCRIPTION
## Summary

Prevents account enumeration via MFA status detection by using generic error messages.

### Change
Both `auth/mfa/verify` and `auth/totp-login` previously returned:
- `403 "MFA not enabled for this account"` when user doesn't exist or doesn't have MFA
- `401 "Invalid credentials"` for wrong password

Attackers could distinguish between "user exists but no MFA" and "user doesn't exist" based on the status code + message. Now both scenarios return the same `401 "Invalid credentials"`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>