### PR TITLE
fix: sanitize error messages to prevent information leakage (P2)

### DIFF
--- a/apps/web/src/app/api/api-keys/[id]/route.ts
+++ b/apps/web/src/app/api/api-keys/[id]/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { revokeApiKey, verifyApiKey } from '@/lib/api-key'
+import { sanitizeError } from '@/lib/errors'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 type User = { id: string }
@@ -51,7 +52,7 @@ export async function DELETE(
 
     return NextResponse.json({ ok: true })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = sanitizeError(err)
     return NextResponse.json({ error: msg }, { status: 500 })
   }
 }

--- a/apps/web/src/app/api/api-keys/route.ts
+++ b/apps/web/src/app/api/api-keys/route.ts
@@ -8,6 +8,7 @@
  * Auth: session cookie (via requireAdmin) OR x-api-key header
  */
 import { NextRequest, NextResponse } from 'next/server'
+import { sanitizeError } from '@/lib/errors'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { createApiKey, listUserKeys, verifyApiKey } from '@/lib/api-key'
@@ -55,7 +56,7 @@ export async function GET(req: NextRequest) {
       })),
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = sanitizeError(err)
     return NextResponse.json({ error: msg }, { status: 401 })
   }
 }
@@ -88,7 +89,7 @@ export async function POST(req: NextRequest) {
       id: apiKeyResult.info.id,
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = sanitizeError(err)
     return NextResponse.json({ error: msg }, { status: 500 })
   }
 }

--- a/apps/web/src/app/api/epics/[id]/generate-features/route.ts
+++ b/apps/web/src/app/api/epics/[id]/generate-features/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { sanitizeError } from '@/lib/errors'
 import fs from 'fs'
 import path from 'path'
 
@@ -63,7 +64,7 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON array
       }
     }
   } catch (err) {
-    return NextResponse.json({ error: `Claude error: ${err instanceof Error ? err.message : String(err)}` }, { status: 500 })
+    return NextResponse.json({ error: `Claude error: ${sanitizeError(err)}` }, { status: 500 })
   }
 
   // Extract JSON array from response (handle cases where Claude wraps it in backticks)

--- a/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
+++ b/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { sanitizeError } from '@/lib/errors'
 import fs from 'fs'
 import path from 'path'
 
@@ -69,7 +70,7 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON:
       }
     }
   } catch (err) {
-    return NextResponse.json({ error: `Claude error: ${err instanceof Error ? err.message : String(err)}` }, { status: 500 })
+    return NextResponse.json({ error: `Claude error: ${sanitizeError(err)}` }, { status: 500 })
   }
 
   // Extract JSON array from response

--- a/apps/web/src/app/api/notes/search/route.ts
+++ b/apps/web/src/app/api/notes/search/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { generateEmbedding, vectorSearch } from '@/lib/embeddings'
 import { requireServiceAuth } from '@/lib/auth'
+import { sanitizeError } from '@/lib/errors'
 
 export const dynamic = 'force-dynamic'
 
@@ -47,7 +48,7 @@ export async function POST(req: NextRequest) {
       results,
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = sanitizeError(err)
     return NextResponse.json({ error: msg }, { status: 500 })
   }
 }

--- a/apps/web/src/app/api/setup/git-provider/route.ts
+++ b/apps/web/src/app/api/setup/git-provider/route.ts
@@ -23,6 +23,7 @@ import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
 import { createProvider, invalidateGitProviderCache, type GitProviderConfig, type GitProviderType } from '@/lib/git-provider'
 import { GiteaGitProvider } from '@/lib/git-provider/gitea-provider'
+import { sanitizeError } from '@/lib/errors'
 import { encryptJson } from '@/lib/encryption'
 import { randomBytes } from 'crypto'
 
@@ -64,7 +65,7 @@ export async function POST(req: NextRequest) {
         const tokenName = `orion-admin-${Date.now()}`
         token = await giteaProvider.createAdminToken(adminUser, adminPassword, tokenName)
       } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = sanitizeError(err)
         return NextResponse.json(
           { error: `Failed to create Gitea admin token: ${msg}` },
           { status: 502 },
@@ -100,7 +101,7 @@ export async function POST(req: NextRequest) {
       )
     }
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = sanitizeError(err)
     return NextResponse.json(
       { error: `Git provider connection failed: ${msg}` },
       { status: 502 },

--- a/apps/web/src/app/api/tools/generate/route.ts
+++ b/apps/web/src/app/api/tools/generate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getCurrentUser } from '@/lib/auth'
+import { sanitizeError } from '@/lib/errors'
 
 // Allowed shell commands per environment type (allowlist)
 const ALLOWED_COMMAND_PREFIXES = {
@@ -242,7 +243,6 @@ Rules:
       execConfig,
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ error: `Generation failed: ${msg}` }, { status: 500 })
+    return NextResponse.json({ error: `Generation failed: ${sanitizeError(err)}` }, { status: 500 })
   }
 }

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,0 +1,87 @@
+/**
+ * Error sanitization utilities for SOC2 [CC7] — prevent information leakage.
+ *
+ * Strips internal details (stack traces, connection strings, file paths) from
+ * error messages before forwarding them to clients.
+ */
+
+/**
+ * Sanitize an error for safe display to clients.
+ * - Prisma errors: return mapped user-friendly messages
+ * - Network/API errors: return generic message
+ * - Unknown errors: return 'An unexpected error occurred'
+ */
+export function sanitizeError(err: unknown): string {
+  if (err instanceof Error) {
+    // Prisma known errors — map to user-friendly messages
+    if (err.name === 'PrismaClientKnownRequestError') {
+      return handlePrismaKnown(err)
+    }
+    if (err.name === 'PrismaClientUnknownRequestError') {
+      return 'A database error occurred. Please try again later.'
+    }
+    if (err.name === 'PrismaClientInitializationError') {
+      return 'The database is currently unavailable. Please try again later.'
+    }
+    if (err.name === 'PrismaClientRustPanicError') {
+      return 'An internal error occurred. Please try again later.'
+    }
+    // Check for common error patterns in message/stack
+    const msg = err.message
+    if (msg.includes('ENOTFOUND') || msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT')) {
+      return 'The requested service is temporarily unavailable. Please try again later.'
+    }
+    if (msg.includes('ECONNRESET') || msg.includes('socket hang up')) {
+      return 'The connection was reset. Please try again.'
+    }
+    if (msg.includes('EROFS') || msg.includes('EACCES') || msg.includes('ENOENT')) {
+      return 'A system error occurred. Please try again later.'
+    }
+    if (msg.includes('model timed out') || msg.includes('abort')) {
+      return 'The request timed out. Please try again.'
+    }
+    // Generic Error — strip stack traces
+    return err.message.split('\n')[0].split(':')[0].trim()
+  }
+
+  if (typeof err === 'string') {
+    // Check if it's a JSON string (e.g., API error body)
+    try {
+      const parsed = JSON.parse(err)
+      if (typeof parsed?.message === 'string') {
+        return sanitizeError(new Error(parsed.message))
+      }
+    } catch {
+      // Not JSON — treat as plain string
+    }
+    // Strip anything that looks like a file path or stack trace
+    const clean = err.replace(/(?:at\s+)?[^\n]*(?:\.ts|\.js|:\d+:\d+)/g, '').trim()
+    return clean || 'An unexpected error occurred'
+  }
+
+  return 'An unexpected error occurred'
+}
+
+/**
+ * Handle Prisma known request errors by extracting user-facing messages.
+ */
+function handlePrismaKnown(err: Error): string {
+  const msg = err.message
+  if (msg.includes('Unique constraint failed') || msg.includes('duplicate key')) {
+    return 'A resource with this value already exists.'
+  }
+  if (msg.includes('Foreign key constraint failed')) {
+    return 'The requested resource is referenced by other data. Remove references first.'
+  }
+  if (msg.includes('check constraint')) {
+    return 'The provided value is invalid. Please check your input.'
+  }
+  if (msg.includes('null constraint')) {
+    return 'Required fields are missing.'
+  }
+  if (msg.includes('does not exist')) {
+    return 'The requested resource was not found.'
+  }
+  // Generic Prisma error
+  return 'A database error occurred. Please try again later.'
+}


### PR DESCRIPTION
## Summary

Addresses SOC2 [CC7] error handling and information leakage findings.

### New `lib/errors.ts`
- `sanitizeError(err)` — strips internal details (stack traces, connection strings, file paths, error codes)
- Maps Prisma error types to user-friendly messages (unique constraint, foreign key, etc.)
- Detects network error patterns (ECONNREFUSED, ETIMEDOUT, ECONNRESET)

### Updated Routes
8 routes now use `sanitizeError()` instead of raw `err.message`:
- `api-keys/` — API key management (Prisma errors)
- `tools/generate/` — LLM generation (provider errors)
- `features/[id]/generate-tasks/` — LLM generation (provider errors)
- `epics/[id]/generate-features/` — LLM generation (provider errors)
- `notes/search/` — vector search (embedding service errors)
- `setup/git-provider/` — git provider connectivity errors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>