### PR TITLE
fix: add rate limiting for SSO header auth requests (P2)

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -69,6 +69,24 @@ async function applyRateLimit(req: NextRequest): Promise<NextResponse | null> {
   return null
 }
 
+/**
+ * SOC2: [M-003] Rate limit SSO header auth requests.
+ * Prevents brute-force user creation via x-authentik-username / x-forwarded-user headers.
+ * Uses IP-based rate limiting (5 req/min per IP).
+ */
+async function applySsoRateLimit(req: NextRequest): Promise<NextResponse | null> {
+  const ip = getRateLimitKey(req)
+  const key = `sso-rate:${ip}`
+  // 5 requests per minute per IP
+  if (!(await rateLimitRedis(key, 5, 60_000))) {
+    return NextResponse.json(
+      { error: 'Too many requests — SSO authentication rate limited' },
+      { status: 429, headers: { 'Retry-After': '60' } }
+    )
+  }
+  return null
+}
+
 const PUBLIC_PATHS = [
   '/setup',
   '/login',
@@ -147,6 +165,14 @@ export async function middleware(req: NextRequest) {
 
   if (PUBLIC_PATHS.some(p => pathname.startsWith(p))) {
     return NextResponse.next()
+  }
+
+  // SOC2: Rate limit SSO header auth — prevents brute-force user creation
+  // via x-forwarded-user / x-authentik-username headers on non-authenticated requests
+  const ssoUser = req.headers.get('x-authentik-username') ?? req.headers.get('x-forwarded-user')
+  if (ssoUser && !req.headers.get('cookie')?.includes('next-auth.session-token')) {
+    const ssoRateLimited = await applySsoRateLimit(req)
+    if (ssoRateLimited) return ssoRateLimited
   }
 
   // Service token (gateway) calls — accept Bearer token instead of session.


### PR DESCRIPTION
## Summary

Addresses SOC2 finding: SSO header auth has no dedicated rate limit.

### Change
- IP-based rate limiting (5 req/min per IP) for requests with `x-authentik-username` or `x-forwarded-user` headers but no session cookie
- Uses existing `rateLimitRedis` utility (Redis-backed with in-memory fallback)
- Returns 429 with `Retry-After: 60` header when rate limited
- Skipped for requests that already have a session cookie (already rate-limited via other paths)

### Why
Without this limit, an attacker could brute-force user creation by sending requests with different `x-authentik-username` values to any authenticated endpoint. The default global rate limit (100 req/15min) is too permissive for user creation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>