### PR TITLE
fix: scope gateway token — /api/admin requires session auth (P0)

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -92,17 +92,6 @@ const BEARER_PATHS = [
   '/api/internal',     // internal service-to-service routes (e.g. vault-unsealer)
 ]
 
-// Prefixes that accept service token auth — any sub-path works
-const SERVICE_TOKEN_PREFIXES = [
-  '/api/notes',
-  '/api/agent-groups',
-  '/api/features',
-  '/api/epics',
-  '/api/tasks',
-  '/api/bugs',
-  '/api/admin',
-]
-
 // SOC2: [H-002, L-002] Security headers middleware
 function addSecurityHeaders(res: NextResponse): NextResponse {
   // CSP: style-src 'unsafe-inline' required because React/Next.js uses inline styles
@@ -151,13 +140,18 @@ export async function middleware(req: NextRequest) {
 
   // Service token (gateway) calls — accept Bearer token instead of session.
   // Gateway tools need to read/write notes, list agent-groups, etc.
+  // SOC2: /api/admin/* is NEVER accessible via gateway token — always requires session auth
   const gatewayToken = process.env.ORION_GATEWAY_TOKEN
   if (
     gatewayToken &&
     req.headers.get('authorization') === `Bearer ${gatewayToken}`
   ) {
+    // Admin routes always require session auth — never bypassable
+    if (pathname.startsWith('/api/admin')) {
+      // fall through to session auth
+    }
     // Gateway can do anything except DELETE on notes (safety)
-    if (req.method === 'DELETE' && pathname.startsWith('/api/notes')) {
+    else if (req.method === 'DELETE' && pathname.startsWith('/api/notes')) {
       // fall through to session auth for DELETE on notes
     } else {
       return NextResponse.next()


### PR DESCRIPTION
## Summary

Addresses P0 SOC2 finding: gateway token had blanket access to ALL paths
including `/api/admin/*` without any RBAC check.

### Problem
The `ORION_GATEWAY_TOKEN` was accepted at the middleware level for ALL
paths (except DELETE on notes). This means any service with the gateway
token could access admin routes (user management, SSO config, settings,
models, etc.) without being an admin user.

### Fix
- `/api/admin/*` paths are now **excluded** from the gateway token bypass
- Gateway token requests to admin routes fall through to session auth
- The gateway token can still access notes, tasks, epics, features, bugs, environments, etc.
- Removed dead code: `SERVICE_TOKEN_PREFIXES` array was never referenced

### Impact
- Gateway service will no longer be able to call admin endpoints
- This is correct — admin operations should go through user sessions
- If the gateway needs admin access in the future, it should use explicit per-route service auth via `requireServiceAuth()`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>