### PR TITLE
feat: add audit log export with CSV/JSON format (P2)

### DIFF
--- a/apps/web/src/app/(app)/admin/audit/page.tsx
+++ b/apps/web/src/app/(app)/admin/audit/page.tsx
@@ -10,9 +10,25 @@ export default async function AuditLogPage() {
 
   return (
     <div className="p-6 space-y-6 max-w-5xl">
-      <div>
-        <h1 className="text-lg font-semibold text-text-primary">Audit Log</h1>
-        <p className="text-sm text-text-muted mt-0.5">Last 100 recorded events</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary">Audit Log</h1>
+          <p className="text-sm text-text-muted mt-0.5">Last 100 recorded events</p>
+        </div>
+        <div className="flex gap-2">
+          <a
+            href="/api/admin/audit/export?format=json&limit=10000"
+            className="text-xs px-3 py-1.5 rounded border border-border-subtle hover:bg-bg-raised transition-colors text-text-secondary"
+          >
+            Export JSON
+          </a>
+          <a
+            href="/api/admin/audit/export?format=csv&limit=10000"
+            className="text-xs px-3 py-1.5 rounded border border-border-subtle hover:bg-bg-raised transition-colors text-text-secondary"
+          >
+            Export CSV
+          </a>
+        </div>
       </div>
 
       {entries.length === 0 ? (

--- a/apps/web/src/app/api/admin/audit/export/route.ts
+++ b/apps/web/src/app/api/admin/audit/export/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/audit/export
+ *
+ * Export audit logs in CSV or JSON format with optional filtering.
+ * SOC2: [M-005] Auditor-facing export capability.
+ */
+export async function GET(req: NextRequest) {
+  const admin = await requireAdmin()
+  const params = req.nextUrl.searchParams
+
+  const action = params.get('action') ?? undefined
+  const userId = params.get('userId') ?? undefined
+  const from = params.get('from') ? new Date(params.get('from')!) : undefined
+  const to = params.get('to') ? new Date(params.get('to')!) : undefined
+  const format = (params.get('format') ?? 'json') as 'json' | 'csv'
+  const limitRaw = parseInt(params.get('limit') ?? '1000', 10)
+  const limit = Math.min(Math.max(limitRaw, 1), 10000)
+
+  const where: Record<string, unknown> = {}
+  if (action) where.action = action
+  if (userId) where.userId = userId
+  if (from || to) {
+    where.createdAt = {}
+    if (from) (where.createdAt as any).gte = from
+    if (to) (where.createdAt as any).lte = to
+  }
+
+  const entries = await prisma.auditLog.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  })
+
+  if (format === 'csv') {
+    const headers = ['timestamp', 'userId', 'action', 'target', 'ipAddress', 'userAgent']
+    const csvRows = [
+      headers.join(','),
+      ...entries.map(e =>
+        [
+          e.createdAt.toISOString(),
+          csvEscape(e.userId ?? ''),
+          csvEscape(e.action),
+          csvEscape(e.target ?? ''),
+          csvEscape(e.ipAddress ?? ''),
+          csvEscape(e.userAgent ?? ''),
+        ].join(',')
+      ),
+    ].join('\n')
+
+    return new NextResponse(csvRows, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="audit-log-${new Date().toISOString().split('T')[0]}.csv"`,
+      },
+    })
+  }
+
+  // JSON format (default)
+  return NextResponse.json(
+    { count: entries.length, entries: entries.map(e => ({
+      id: e.id,
+      timestamp: e.createdAt.toISOString(),
+      userId: e.userId,
+      action: e.action,
+      target: e.target,
+      detail: e.detail,
+      ipAddress: e.ipAddress,
+      userAgent: e.userAgent,
+    })) },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="audit-log-${new Date().toISOString().split('T')[0]}.json"`,
+      },
+    },
+  )
+}
+
+function csvEscape(val: string): string {
+  if (val.includes(',') || val.includes('"') || val.includes('\n')) {
+    return `"${val.replace(/"/g, '""')}"`
+  }
+  return val
+}


### PR DESCRIPTION
## Summary

Addresses SOC2 [M-005] findings M1 (no filtering) and M2 (no export) for audit logs.

### New API Endpoint
`GET /api/admin/audit/export` — requires admin session auth.

**Query parameters:**
| Param | Default | Max | Description |
|-------|---------|-----|-------------|
| `action` | all | - | Filter by audit action type |
| `userId` | all | - | Filter by user ID |
| `from` | all | - | Start date (ISO 8601) |
| `to` | all | - | End date (ISO 8601) |
| `limit` | 1000 | 10000 | Number of entries |
| `format` | json | - | `json` or `csv` |

**CSV format:** Proper escaping, attachment filename with date.
**JSON format:** Includes id, timestamp, userId, action, target, detail, ipAddress, userAgent.

### UI Changes
Added "Export JSON" and "Export CSV" buttons to the admin audit log page.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>