### PR TITLE
fix: add replay attack prevention for webhook handlers (P2)

### DIFF
--- a/apps/web/src/app/api/webhooks/gitea/route.ts
+++ b/apps/web/src/app/api/webhooks/gitea/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getGitProvider } from '@/lib/git-provider'
+import { isDuplicateWebhookId, extractWebhookId, isStaleWebhook } from '@/lib/webhook-idempotency'
 
 export async function POST(req: NextRequest) {
   const rawBody = await req.text()
@@ -33,6 +34,17 @@ export async function POST(req: NextRequest) {
 
   if (!provider.verifyWebhookSignature(rawBody, headers, secret)) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  // SOC2: [CC7] Replay attack prevention — reject stale webhooks
+  if (isStaleWebhook(headers)) {
+    return NextResponse.json({ error: 'Webhook too old (stale delivery)' }, { status: 410 })
+  }
+
+  // SOC2: [CC7] Idempotency — skip duplicate webhook deliveries
+  const webhookId = extractWebhookId(headers)
+  if (webhookId && isDuplicateWebhookId(webhookId)) {
+    return NextResponse.json({ ok: true, skipped: 'duplicate' })
   }
 
   // Detect event type (provider-agnostic)

--- a/apps/web/src/lib/webhook-idempotency.ts
+++ b/apps/web/src/lib/webhook-idempotency.ts
@@ -1,0 +1,75 @@
+/**
+ * Webhook idempotency — prevents duplicate processing on webhook retries.
+ *
+ * SOC2: [CC7] Replay attack prevention for webhook handlers.
+ */
+
+interface IdempotencyEntry {
+  seenAt: number
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+const MAX_CACHE_SIZE = 5000
+
+const cache = new Map<string, IdempotencyEntry>()
+
+/**
+ * Check if a webhook ID has been seen recently.
+ * Returns true if this is a duplicate (should be skipped).
+ */
+export function isDuplicateWebhookId(id: string): boolean {
+  if (!id) return false
+
+  const now = Date.now()
+
+  if (cache.has(id)) {
+    return true
+  }
+
+  cache.set(id, { seenAt: now })
+
+  // Evict old entries if cache is full
+  if (cache.size > MAX_CACHE_SIZE) {
+    const entries = Array.from(cache.entries())
+    entries.sort((a, b) => a[1].seenAt - b[1].seenAt)
+    // Remove oldest 25%
+    const removeCount = Math.floor(MAX_CACHE_SIZE * 0.25)
+    for (let i = 0; i < removeCount; i++) {
+      cache.delete(entries[i][0])
+    }
+  }
+
+  return false
+}
+
+/**
+ * Extract the webhook delivery ID from request headers.
+ * Returns null if no delivery ID is present.
+ */
+export function extractWebhookId(headers: Record<string, string>): string | null {
+  // GitHub: X-GitHub-Delivery
+  // GitLab: X-Gitlab-Event (not a unique ID, but X-Gitlab-Token could be used)
+  // Gitea: X-Gitea-Delivery (if available) or X-Gitea-Event + timestamp
+  return (
+    headers['x-github-delivery'] ??
+    headers['x-gitea-delivery'] ??
+    headers['x-hook-delivery-id'] ??
+    null
+  )
+}
+
+/**
+ * Check if a webhook is too old (replay attack prevention).
+ * Checks X-GitHub-Timestamp header (epoch seconds).
+ * Returns true if the webhook should be rejected.
+ */
+export function isStaleWebhook(headers: Record<string, string>): boolean {
+  const timestampStr = headers['x-github-timestamp'] ?? headers['x-timestamp']
+  if (!timestampStr) return false
+
+  const webhookTime = parseInt(timestampStr, 10) * 1000 // convert seconds to ms
+  const now = Date.now()
+
+  // Reject webhooks older than 5 minutes
+  return (now - webhookTime) > 5 * 60 * 1000
+}


### PR DESCRIPTION
## Summary

Addresses SOC2 [CC7] finding: webhook handlers only verify HMAC signature
but have no timestamp or nonce validation. Retried webhooks are processed
twice, causing duplicate actions.

### New `lib/webhook-idempotency.ts`
- `isDuplicateWebhookId()` — in-memory cache keyed by webhook delivery ID
  (X-GitHub-Delivery, X-Gitea-Delivery, X-Hook-Delivery-ID)
- `isStaleWebhook()` — rejects webhooks older than 5 minutes
  (checks X-GitHub-Timestamp or X-Timestamp headers)
- `extractWebhookId()` — extracts delivery ID from headers
- Cache auto-evicts oldest 25% when exceeding 5000 entries

### Updated Gitea Webhook Handler
- Rejects stale webhooks with `410 Gone`
- Skips duplicate deliveries with `200 {ok: true, skipped: 'duplicate'}`

**Note**: Only the Gitea webhook route exists currently. The idempotency
module is provider-agnostic and ready for GitHub/GitLab webhook routes
when they are added.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>