### PR TITLE
feat: add tamper-evidence to audit logs via hash chain (P1)

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -251,14 +251,15 @@ model TaskEvent {
 }
 
 model AuditLog {
-  id         String   @id @default(cuid())
-  userId     String
-  action     String
-  target     String
-  detail     Json?
-  ipAddress  String?  // SOC2: [M-005] Source IP for audit trail
-  userAgent  String?  // SOC2: [M-005] Client user-agent for audit trail
-  createdAt  DateTime @default(now())
+  id          String   @id @default(cuid())
+  userId      String
+  action      String
+  target      String
+  detail      Json?
+  ipAddress   String?  // SOC2: [M-005] Source IP for audit trail
+  userAgent   String?  // SOC2: [M-005] Client user-agent for audit trail
+  createdAt   DateTime @default(now())
+  previousHash String?  // SOC2: [M-005] Hash chain for tamper-evidence
 
   // SOC2: [M-005, L-001] Indexes for user-specific queries and date range filters
   @@index([userId])

--- a/apps/web/src/app/api/admin/audit/verify/route.ts
+++ b/apps/web/src/app/api/admin/audit/verify/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { createHash } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/admin/audit/verify
+ *
+ * Verifies the integrity of the audit log hash chain.
+ * Walks from first to last entry and checks that each entry's
+ * previousHash matches the hash of the prior entry.
+ *
+ * Returns detailed results with any broken links in the chain.
+ */
+export async function GET(req: NextRequest) {
+  await requireAdmin()
+  const params = req.nextUrl.searchParams
+  const limit = Math.min(
+    parseInt(params.get('limit') ?? '1000', 10),
+    10000,
+  ) || 1000
+
+  // Fetch entries ordered by createdAt ascending (oldest first)
+  const entries = await prisma.auditLog.findMany({
+    orderBy: { createdAt: 'asc' },
+    take: limit,
+    select: {
+      id: true,
+      userId: true,
+      action: true,
+      target: true,
+      detail: true,
+      ipAddress: true,
+      userAgent: true,
+      createdAt: true,
+      previousHash: true,
+    },
+  })
+
+  if (entries.length === 0) {
+    return NextResponse.json({
+      valid: true,
+      entryCount: 0,
+      message: 'No audit log entries to verify.',
+      chain: [],
+    })
+  }
+
+  const chain: Array<{
+    id: string
+    index: number
+    action: string
+    previousHash: string | null
+    hash: string
+    valid: boolean
+    expectedHash: string | null
+    note?: string
+  }> = []
+
+  let prevHash: string | null = null
+  let brokenAt: number | null = null
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]
+
+    // Compute what the previousHash should be
+    const expectedPreviousHash = prevHash
+
+    // Compute this entry's hash (for use by the next entry)
+    const entryData = {
+      id: entry.id,
+      userId: entry.userId,
+      action: entry.action,
+      target: entry.target,
+      detail: entry.detail,
+      ipAddress: entry.ipAddress,
+      userAgent: entry.userAgent,
+      createdAt: entry.createdAt,
+      previousHash: entry.previousHash,
+    }
+    const entryHash = createHash('sha256').update(
+      JSON.stringify(entryData),
+    ).digest('hex')
+
+    const isValid = entry.previousHash === prevHash
+    const note = i === 0
+      ? 'First entry — previousHash should be null'
+      : !isValid && brokenAt === null
+        ? 'Chain broken here'
+        : undefined
+
+    chain.push({
+      id: entry.id,
+      index: i,
+      action: entry.action,
+      previousHash: entry.previousHash,
+      hash: entryHash,
+      valid: isValid,
+      expectedHash: expectedPreviousHash,
+      note,
+    })
+
+    if (!isValid && brokenAt === null) {
+      brokenAt = i
+    }
+
+    // The next entry's previousHash should be THIS entry's hash
+    prevHash = entryHash
+  }
+
+  const valid = brokenAt === null
+
+  return NextResponse.json({
+    valid,
+    entryCount: entries.length,
+    brokenAt: brokenAt ?? undefined,
+    chain: chain.slice(0, 100), // Return first 100 entries for inspection
+    chainComplete: entries.length <= 100,
+  })
+}

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -82,16 +82,17 @@ function hashAuditEntry(entry: {
 }
 
 /**
- * Fetch the previous audit log's previousHash for the hash chain.
- * Returns null if this is the first entry or the previous entry's hash is null.
+ * Compute the hash of the previous audit log entry for the hash chain.
+ * Returns null if this is the first entry.
  */
 async function getPreviousHash(): Promise<string | null> {
   try {
     const prev = await prisma.auditLog.findFirst({
       orderBy: { createdAt: 'desc' },
-      select: { previousHash: true },
     })
-    return prev?.previousHash ?? null
+    if (!prev) return null
+    // Compute the hash of the previous entry's full content
+    return hashAuditEntry(prev)
   } catch {
     return null
   }

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -3,10 +3,15 @@
  *
  * Creates audit log entries with IP address and user-agent tracking.
  * Non-blocking — failures are silently logged to prevent impact on request processing.
+ *
+ * Hash chain for tamper-evidence: each entry's `previousHash` is SHA-256 of
+ * (previous entry's action + timestamp + detail + previousHash).
+ * This allows verification that the log has not been modified.
  */
 
 import { prisma } from './db'
 import type { NextRequest } from 'next/server'
+import { createHash } from 'crypto'
 
 export type AuditAction =
   | 'user_login'
@@ -49,6 +54,50 @@ export type AuditAction =
   | 'vault_reseal'
 
 /**
+ * Compute a SHA-256 hash of an audit entry's content for the hash chain.
+ */
+function hashAuditEntry(entry: {
+  id: string
+  userId: string
+  action: string
+  target: string
+  detail: unknown
+  ipAddress: string | null
+  userAgent: string | null
+  createdAt: Date
+  previousHash: string | null
+}): string {
+  const data = JSON.stringify({
+    id: entry.id,
+    userId: entry.userId,
+    action: entry.action,
+    target: entry.target,
+    detail: entry.detail,
+    ipAddress: entry.ipAddress,
+    userAgent: entry.userAgent,
+    createdAt: entry.createdAt.toISOString(),
+    previousHash: entry.previousHash,
+  })
+  return createHash('sha256').update(data).digest('hex')
+}
+
+/**
+ * Fetch the previous audit log's previousHash for the hash chain.
+ * Returns null if this is the first entry or the previous entry's hash is null.
+ */
+async function getPreviousHash(): Promise<string | null> {
+  try {
+    const prev = await prisma.auditLog.findFirst({
+      orderBy: { createdAt: 'desc' },
+      select: { previousHash: true },
+    })
+    return prev?.previousHash ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Log an audit event. Non-blocking — never throws.
  */
 export async function logAudit(params: {
@@ -60,6 +109,7 @@ export async function logAudit(params: {
   userAgent?: string | null
 }): Promise<void> {
   try {
+    const prevHash = await getPreviousHash()
     await prisma.auditLog.create({
       data: {
         userId: params.userId,
@@ -68,6 +118,7 @@ export async function logAudit(params: {
         detail: params.detail ?? {},
         ipAddress: params.ipAddress ?? undefined,
         userAgent: params.userAgent ?? undefined,
+        previousHash: prevHash ?? undefined,
       },
     })
   } catch {


### PR DESCRIPTION
## Summary

Addresses SOC2 [M-005, C1] finding: audit logs stored in the same database
are not tamper-proof. Any admin could delete/modify logs via direct DB access.

### Implementation

**Hash Chain for Tamper-Evidence:**
- New `previousHash` column on `AuditLog` model (requires DB migration)
- Each new audit entry's `previousHash` = SHA-256 hash of the previous entry's full content
- Modifying any entry breaks the chain — all subsequent entries' `previousHash` values won't match
- **Note**: Provides tamper-evidence (detecting modifications) not tamper-proofing (preventing modifications)

**Verification Endpoint: `GET /api/admin/audit/verify`**
- Requires admin session auth
- Walks entries from oldest to newest
- Checks each entry's `previousHash` against the computed hash
- Returns `{ valid, entryCount, brokenAt, chain }`
- Returns first 100 entries for inspection
- Marks `chainComplete: false` if more than 100 entries exist

**Schema Migration Required:**
```sql
ALTER TABLE "AuditLog" ADD COLUMN "previousHash" TEXT;
```

### Limitations
- In-memory hash chain only — stored in the same DB as application data
- True tamper-proofing requires external shipping (syslog, S3, dedicated audit database)
- Existing entries have no hash chain (only new entries after migration)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>