### PR TITLE
fix: resolve npm dependency issues in Docker builds

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
@@ -38,7 +38,7 @@ RUN ARCH=${TARGETARCH:-amd64} \
     && chmod +x /usr/local/bin/helm
 
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev --legacy-peer-deps
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 3001

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # Build tools needed for node-pty native compilation
 RUN apk add --no-cache make g++
 COPY package.json package-lock.json* ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev --legacy-peer-deps
 
 FROM node:20-alpine AS builder
 WORKDIR /app
@@ -17,7 +17,7 @@ RUN apk add --no-cache openssl make g++
 COPY --from=deps /app/node_modules ./node_modules
 # Install devDependencies (esbuild, tsx, typescript) for the build step
 COPY package.json package-lock.json* ./
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY . .
 RUN npx prisma generate
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary
- Changes `npm ci` to `npm install` with `--legacy-peer-deps` flag in Docker builds
- Regenerates `package-lock.json` with proper dependency resolution
- Fixes missing package errors that were blocking V1.0.0 deployment

## Test Plan
- Build succeeds with Docker buildx
- Both web and gateway images build without dependency resolution errors
- Applications deploy successfully