### PR TITLE
fix: use GHCR_PAT for self-hosted runner GHCR authentication

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-gateway
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -30,8 +29,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Build and push
         id: build

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-web
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -30,8 +29,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Build and push
         id: build


### PR DESCRIPTION
Fixes 'permission_denied: write_package' error on GHCR push.

## Problem
Self-hosted GitHub Actions runners don't have GHCR push permissions with GITHUB_TOKEN.

## Solution
Use a Personal Access Token (GHCR_PAT) with 'write:packages' scope instead.

## Required Setup
You need to create a GitHub Personal Access Token and add it as a repository secret:

1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
2. Click 'Generate new token (classic)'
3. Give it a name: 'GHCR_PAT'
4. Select scope: **write:packages** (and read:packages)
5. Generate and copy the token
6. Go to your repo → Settings → Secrets and variables → Actions
7. Add new repository secret: Name='GHCR_PAT', Value='your-token-here'
8. Click 'Add secret'

After that, the builds will succeed and push to GHCR.