### PR TITLE
fix: correct undefined variable references in TOTP login route

### DIFF
--- a/apps/web/src/app/api/auth/totp-login/route.ts
+++ b/apps/web/src/app/api/auth/totp-login/route.ts
@@ -100,7 +100,7 @@ export async function POST(req: NextRequest) {
   }
 
   const user = await prisma.user.findUnique({
-    where: { username },
+    where: { username: data.username },
     select: {
       id: true,
       username: true,
@@ -122,7 +122,7 @@ export async function POST(req: NextRequest) {
   if (!user.passwordHash) {
     return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
   }
-  const valid = await compare(password, user.passwordHash)
+  const valid = await compare(data.password, user.passwordHash)
   if (!valid) {
     return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
   }


### PR DESCRIPTION
Fixes webpack build errors caused by undefined variable references.

## Problem

The TOTP login route had two undefined variable references causing webpack compilation to fail during Docker builds:

**Line 103**: `where: { username }` - variable 'username' doesn't exist  
**Line 125**: `compare(password, ...)` - variable 'password' doesn't exist

These variables are only available within the `data` object from the Zod validation.

## Solution

Changed references to use the validated data object:
- `username` → `data.username`  
- `password` → `data.password`

## Testing

Once merged, the GitHub Actions Docker build should succeed for the web app.