### PR TITLE
fix: resolve async/await in recovery code consume function

### DIFF
--- a/apps/web/src/lib/totp.ts
+++ b/apps/web/src/lib/totp.ts
@@ -89,10 +89,22 @@ export async function consumeRecoveryCode(
   hashedCodes: string[],
   cost: number = 14,
 ): Promise<string[] | null> {
-  if (!await verifyRecoveryCode(code, hashedCodes, cost)) {
+  const { compare } = await import('bcryptjs')
+
+  // Find the index of the matching recovery code
+  let matchedIndex = -1
+  for (let i = 0; i < hashedCodes.length; i++) {
+    if (await compare(code, hashedCodes[i])) {
+      matchedIndex = i
+      break
+    }
+  }
+
+  // If no match found, return null
+  if (matchedIndex === -1) {
     return null
   }
-  const { hash } = await import('bcryptjs')
-  // Remove the matching code and rehash the rest
-  return hashedCodes.filter((hc) => hc !== (await hash(code, cost)))
+
+  // Return array without the consumed code
+  return hashedCodes.filter((_, i) => i !== matchedIndex)
 }


### PR DESCRIPTION
## Summary
Fixes webpack build error in `src/lib/totp.ts` caused by using `await` inside a non-async filter callback in the `consumeRecoveryCode` function.

The original implementation attempted to:
- Filter recovery codes while hashing them
- Compare hash outputs (which fails because bcrypt creates new hashes each time)

The fixed implementation:
- Properly iterates through hashed codes with async/await
- Uses `bcrypt.compare()` to find the matching code
- Returns a new array without the consumed code

This resolves the build failure: "await isn't allowed in non-async function"

## Test plan
- [ ] GitHub Actions build passes
- [ ] Docker image builds successfully
- [ ] Recovery code consumption works in login flow