### PR TITLE
fix: hash password in user creation endpoint

### DIFF
--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, CreateUserSchema } from '@/lib/validate'
+import { hash } from 'bcryptjs'
 
 export async function GET() {
   await requireAdmin()
@@ -19,11 +20,14 @@ export async function POST(req: NextRequest) {
   if ('error' in result) return result.error
   const { data } = result
 
+  // Hash password before storing (cost 14 to match password validation)
+  const passwordHash = await hash(data.password, 14)
+
   const user = await prisma.user.create({
     data: {
       username: data.username,
       email: data.email,
-      password: data.password,
+      passwordHash,
       name: data.name,
       role: data.role,
     },


### PR DESCRIPTION
## Summary
Fixes TypeScript/Prisma error in user creation endpoint: the `password` field doesn't exist in UserCreateInput, only `passwordHash`.

Updated to hash the plaintext password using bcryptjs (cost 14, consistent with other password hashing in the app) before storing in the database.

## Test plan
- [ ] GitHub Actions build passes
- [ ] Docker image builds successfully  
- [ ] User creation endpoint accepts password and stores hashed value