### PR TITLE
fix: resolve Prisma metadata field type in agent creation

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest) {
       name:     data.name,
       type:     data.type ?? 'claude',
       role:     data.role ?? null,
-      metadata: data.metadata ?? undefined,
+      ...(data.metadata && { metadata: data.metadata }),
     },
   })
   return NextResponse.json(agent, { status: 201 })


### PR DESCRIPTION
Fixes Prisma type error in agent creation endpoint.

The metadata field cannot be explicitly set to 'undefined' - use conditional
spread operator to only include it when actually provided by the user.