### PR TITLE
fix: handle optional epicId in features/route.ts Prisma create

### DIFF
--- a/apps/web/src/app/api/features/route.ts
+++ b/apps/web/src/app/api/features/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     data: {
       title: data.title,
       description: data.description ?? null,
-      epicId: data.epicId,
+      ...(data.epicId && { epicId: data.epicId }),
       status: data.status,
       createdBy: caller?.id ?? 'gateway',
     },


### PR DESCRIPTION
## Summary
- Fixes `features/route.ts` Prisma create: optional `epicId` was passed as `undefined`
  which Prisma rejects (expects field absent, not explicitly undefined)
- Changed `epicId: data.epicId` to `...(data.epicId && { epicId: data.epicId })`

## Build context
- Follow-up to PR #156 — this commit was added after PR #156 merged
- Error: `Type 'string | undefined' is not assignable to type 'undefined'`