### PR TITLE
fix: Dockerfile prisma schema path for monorepo build context

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY package.json package-lock.json* ./
 RUN npm install --legacy-peer-deps
 COPY . .
-RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
+RUN cd apps/web && npx prisma generate
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build:web
 


### PR DESCRIPTION
## Problem

The Docker build failed because the Dockerfile runs in the repo root context but was trying to reference `apps/web/prisma/schema.prisma` as a path argument. Prisma schema lookup is relative to the current working directory, not absolute paths.

## Solution

Changed the Dockerfile to `cd apps/web && npx prisma generate` so prisma runs from the correct directory where it can find the schema.

## Test plan

- [x] Local Docker build succeeds
- [ ] GH Actions build succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)