### PR TITLE
fix: Docker build context path corrections

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -37,8 +37,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: apps/web/Dockerfile
+          context: apps/web
           platforms: linux/amd64
           push: true
           tags: |

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -37,7 +37,8 @@ jobs:
         id: build
         uses: docker/build-push-action@v5
         with:
-          context: apps/web
+          context: .
+          file: apps/web/Dockerfile
           platforms: linux/amd64
           push: true
           tags: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **orion-web** (5817 symbols, 8934 relationships, 239 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **orion-web** (7519 symbols, 11361 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ All share the same `.git` dir but have isolated working directories.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **orion-web** (5817 symbols, 8934 relationships, 239 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **orion-web** (7519 symbols, 11361 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY package.json package-lock.json* ./
 RUN npm install --legacy-peer-deps
 COPY . .
-RUN cd apps/web && npx prisma generate
+RUN npx prisma generate
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build:web
 
@@ -58,14 +58,14 @@ RUN ARCH=${TARGETARCH:-amd64} \
 ENV SHELL=/bin/bash
 
 # Standalone output
-COPY --from=builder /app/apps/web/.next/standalone ./
-COPY --from=builder /app/apps/web/.next/static ./.next/static
-COPY --from=builder /app/apps/web/prisma ./prisma
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/prisma ./prisma
 
 # Copy all node_modules from builder (includes all production + transitive dependencies)
 COPY --from=builder /app/node_modules ./node_modules
 
-COPY --from=builder /app/apps/web/worker.js ./worker.js
+COPY --from=builder /app/worker.js ./worker.js
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x entrypoint.sh
 EXPOSE 3000


### PR DESCRIPTION
## Summary
Fix Docker build failures in the web container by correcting path references for the apps/web build context.

- Remove nested path prefixes in Dockerfile that fail with context=apps/web
- Update workflow to use standard context configuration
- Correct prisma generate command and COPY paths

## Test Plan
- [x] Verify Dockerfile syntax is correct
- [ ] Monitor build pipeline for successful container build
- [ ] Confirm deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)