### PR TITLE
fix: correct npm build script for apps/web Docker context

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,7 +21,7 @@ RUN npm install --legacy-peer-deps
 COPY . .
 RUN npx prisma generate
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build:web
+RUN npm run build
 
 FROM node:20-alpine AS runner
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
Fix Docker build failure by using the correct npm script for the apps/web build context.

The build was failing with "Missing script: build:web" because with `context: apps/web`,
the Dockerfile only has access to apps/web/package.json which defines a `build` script,
not `build:web`. Updated the Dockerfile to run the correct script.

## Changes
- Fix Dockerfile line 24: changed `npm run build:web` to `npm run build`
- Fix workflow: ensure `context: apps/web` is set correctly

## Test Plan
- [x] Verify Dockerfile syntax is correct  
- [ ] Monitor build pipeline for successful container build
- [ ] Confirm deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)