### PR TITLE
fix: replace db push with migrate deploy (SOC2 #168)

### DIFF
--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -2,16 +2,19 @@
 set -e
 echo "Running database migrations..."
 for i in 1 2 3 4 5 6 7 8; do
-  if node /app/node_modules/prisma/build/index.js db push --skip-generate --accept-data-loss; then
+  if node /app/node_modules/prisma/build/index.js migrate deploy; then
     break
   fi
   if [ "$i" -eq 8 ]; then
-    echo "ERROR: db push failed after 8 attempts"
+    echo "ERROR: migration failed after 8 attempts"
     exit 1
   fi
-  echo "db push attempt $i failed, retrying in 8s..."
+  echo "migration attempt $i failed, retrying in 8s..."
   sleep 8
 done
+
+echo "Generating Prisma types..."
+node /app/node_modules/prisma/build/index.js generate
 
 echo "Starting orchestrator..."
 node worker.js &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,16 +2,19 @@
 set -e
 echo "Running database migrations..."
 for i in 1 2 3 4 5 6 7 8; do
-  if node /app/node_modules/prisma/build/index.js db push --skip-generate --accept-data-loss; then
+  if node /app/node_modules/prisma/build/index.js migrate deploy; then
     break
   fi
   if [ "$i" -eq 8 ]; then
-    echo "ERROR: db push failed after 8 attempts"
+    echo "ERROR: migration failed after 8 attempts"
     exit 1
   fi
-  echo "db push attempt $i failed, retrying in 8s..."
+  echo "migration attempt $i failed, retrying in 8s..."
   sleep 8
 done
+
+echo "Generating Prisma types..."
+node /app/node_modules/prisma/build/index.js generate
 
 echo "Starting orchestrator..."
 node worker.js &


### PR DESCRIPTION
## Summary

Addresses SOC2 finding #168: HIGH: db push --accept-data-loss in entrypoint.sh destroys data.

## Changes

Replaced `prisma db push --skip-generate --accept-data-loss` with `prisma migrate deploy` in:
- `entrypoint.sh` (root orchestrator entrypoint)
- `apps/web/entrypoint.sh` (Next.js app entrypoint)

`prisma migrate deploy` is the production-safe migration command that:
- Only applies pending migrations (never drops data)
- Generates proper migration history
- Is designed for production environments

Also added `prisma generate` after migrations to ensure Prisma types are up to date.

## Risk

LOW — migrate deploy is a safe replacement. Only fails if there are uncommitted schema changes that would be lost.

## Test plan

- [ ] Spin up a test environment with existing database data
- [ ] Verify migrations run successfully
- [ ] Verify all data survives
- [ ] Verify prisma generate runs after migrations