### PR TITLE
fix: prevent SSO HMAC bypass when secret not configured (SOC2 #173)

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -198,8 +198,15 @@ async function validateSSoHeaderHmac(headers: Headers): Promise<boolean> {
   const secretPrevious = process.env.SSO_HMAC_SECRET_PREVIOUS  // for key rotation
 
   if (!secret) {
-    // HMAC not configured — allow unsigned headers (backward compat during rollout)
-    return true
+    // SOC2 [SSO-001]: HMAC secret not configured — reject SSO header auth to prevent
+    // header injection if operator enabled header mode but forgot to set SSO_HMAC_SECRET.
+    // Set SSO_ALLOW_UNSIGNED_SSO=true to allow unsigned headers during rollout only.
+    const allowUnsigned = process.env.SSO_ALLOW_UNSIGNED_SSO === 'true'
+    if (allowUnsigned) {
+      console.warn('[SSO] SSO_HMAC_SECRET not configured but SSO_ALLOW_UNSIGNED_SSO=true — unsigned headers allowed')
+      return true
+    }
+    return false
   }
 
   const username = headers.get('x-authentik-username')


### PR DESCRIPTION
## Summary

Addresses SOC2 finding #173: MEDIUM: SSO HMAC validation bypassed when secret not configured.

## Risk

When `SSO_HMAC_SECRET` was not configured, `validateSSoHeaderHmac` silently returned `true`,
allowing any HTTP client to inject `x-authentik-username` headers and authenticate as any user.

## Changes

- When HMAC secret is not configured: now returns `false` (reject SSO header auth)
- New env var `SSO_ALLOW_UNSIGNED_SSO=true` allows the bypass during rollout only
- A warning is logged when unsigned headers are allowed

## Migration path

1. Set `SSO_HMAC_SECRET` to a strong random value
2. Restart ORION (HMAC validation will now work)
3. Remove `SSO_ALLOW_UNSIGNED_SSO` if it was set

## Test plan

- [ ] With SSO_HMAC_SECRET set: valid HMAC headers accepted, invalid rejected
- [ ] Without SSO_HMAC_SECRET: unsigned headers rejected (returns 401)
- [ ] With SSO_ALLOW_UNSIGNED_SSO=true and no secret: headers allowed with warning