### PR TITLE
fix: speed up container startup and increase health check window

### DIFF
--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -9,12 +9,9 @@ for i in 1 2 3 4 5 6 7 8; do
     echo "ERROR: migration failed after 8 attempts"
     exit 1
   fi
-  echo "migration attempt $i failed, retrying in 8s..."
-  sleep 8
+  echo "migration attempt $i failed, retrying in 3s..."
+  sleep 3
 done
-
-echo "Generating Prisma types..."
-node /app/node_modules/prisma/build/index.js generate
 
 echo "Starting orchestrator..."
 node worker.js &

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -66,8 +66,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 10s
       timeout: 5s
-      retries: 12
-      start_period: 30s
+      retries: 18
+      start_period: 60s
     labels:
       traefik.enable: "true"
       traefik.http.routers.orion.rule: "Host(`${ORION_DOMAIN:-orion.khalis.corp}`)"


### PR DESCRIPTION
## Summary
- Remove redundant `prisma generate` from entrypoint (already runs at Docker build time)
- Reduce migration retry sleep from 8s to 3s (postgres is already healthy before orion starts)
- Increase health check start_period from 30s to 60s and retries from 12 to 18 (240s total window)

The deploy step has been failing on every recent main commit because the orion container can't pass its health check in time — migrations + Next.js cold start exceeded the 150s window.

## Test plan
- [ ] Verify CI build passes
- [ ] Verify deploy step completes with orion container becoming healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)