### PR TITLE
fix: remove crypto module from middleware to resolve edge runtime crash

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
-import { timingSafeEqual } from 'crypto'
 import { getOrCreateCorrelationId } from './lib/correlation-id'
 
 // SOC2: [M-004] Wrap console.log BEFORE any other import to catch all log output
@@ -186,13 +185,11 @@ function nextWithNonce(req: NextRequest, nonce: string, correlationId: string): 
 /** Constant-time string comparison to prevent timing attacks on token auth (SOC2 #166) */
 function timingSafeCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false
-  const bufA = Buffer.from(a)
-  const bufB = Buffer.from(b)
-  try {
-    return timingSafeEqual(bufA, bufB)
-  } catch {
-    return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
   }
+  return result === 0
 }
 
 export async function middleware(req: NextRequest) {


### PR DESCRIPTION
## Problem
ORION deployment fails because middleware uses Node.js crypto module, causing Next.js to compile it as edge runtime despite the `runtime: 'nodejs'` config not being recognized.

## Solution
Replaced `timingSafeEqual` from Node.js crypto with a custom bitwise XOR constant-time comparison that works in both edge and Node.js runtimes.

Maintains SOC2 #166 timing-attack resistance without the crypto dependency.

## Tests
- Startup health check should pass within 60s
- Authentication endpoints should work normally
