### PR TITLE
feat: rewrite system prompts for model-agnostic reliability

### DIFF
--- a/apps/web/src/components/messages/MessageList.tsx
+++ b/apps/web/src/components/messages/MessageList.tsx
@@ -103,14 +103,14 @@ export function MessageList({
     return acc
   }, {})
 
-  const epicsWithConvos = epics.filter(e => {
+  const epicsWithConvos = (epics ?? []).filter(e => {
     const hasEpicConvos = (convosByTarget[e.id]?.length ?? 0) > 0
     const hasFeatureConvos = e.features.some(f => (convosByTarget[f.id]?.length ?? 0) > 0)
     return hasEpicConvos || hasFeatureConvos
   })
 
-  const organizedIds = new Set([...epics.map(e => e.id), ...epics.flatMap(e => e.features.map(f => f.id))])
-  const orphanConvos = planningConvos.filter(c => !organizedIds.has(c.metadata.planTarget.id))
+  const organizedIds = new Set([...(epics ?? []).map(e => e.id), ...(epics ?? []).flatMap(e => e.features.map(f => f.id))])
+  const orphanConvos = (planningConvos ?? []).filter(c => !organizedIds.has(c.metadata.planTarget.id))
 
   const removeConvo = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation()
@@ -146,7 +146,7 @@ export function MessageList({
   const activeRow = 'bg-accent/10 border-l-2 border-l-accent text-text-primary'
   const idleRow = 'text-text-muted hover:bg-bg-raised hover:text-text-primary'
 
-  const filteredRooms = effectiveRoomFilter ? rooms.filter(r => r.type === effectiveRoomFilter) : rooms
+  const filteredRooms = effectiveRoomFilter ? (rooms ?? []).filter(r => r.type === effectiveRoomFilter) : (rooms ?? [])
 
   // ── Render helpers ────────────────────────────────────────────
   const renderConversation = (c: Conversation) => (
@@ -200,7 +200,7 @@ export function MessageList({
 
   // ── AI-only sections ─────────────────────────────────────────
   const renderAISections = () => {
-    const regularConvos = convos.filter(c => !c.metadata?.planTarget && !c.metadata?.agentTarget && !c.metadata?.agentChat && !c.metadata?.agentDraft && !c.metadata?.debugChat)
+    const regularConvos = (convos ?? []).filter(c => !c.metadata?.planTarget && !c.metadata?.agentTarget && !c.metadata?.agentChat && !c.metadata?.agentDraft && !c.metadata?.debugChat)
 
     return (
       <>
@@ -289,18 +289,18 @@ export function MessageList({
               {agentChatsOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
               <Bot size={12} className="flex-shrink-0 text-accent" />
               <span className="flex-1">Agent Chats</span>
-              <span className="text-[10px] text-text-muted">{agentConvos.length}</span>
+              <span className="text-[10px] text-text-muted">{(agentConvos ?? []).length}</span>
             </div>
             {agentChatsOpen && (() => {
-              const draftConvos = agentConvos.filter(c => c.metadata.agentDraft && !c.metadata.agentTarget && !c.metadata.agentChat)
-              const linkedConvos = agentConvos.filter(c => !!c.metadata.agentTarget || !!c.metadata.agentChat)
+              const draftConvos = (agentConvos ?? []).filter(c => c.metadata.agentDraft && !c.metadata.agentTarget && !c.metadata.agentChat)
+              const linkedConvos = (agentConvos ?? []).filter(c => !!c.metadata.agentTarget || !!c.metadata.agentChat)
               const convosByAgent = linkedConvos.reduce<Record<string, AgentConvo[]>>((acc, c) => {
                 const id = (c.metadata.agentTarget ?? c.metadata.agentChat)!.id
                 ;(acc[id] ??= []).push(c)
                 return acc
               }, {})
-              const agentsWithConvos = agents.filter(a => (convosByAgent[a.id]?.length ?? 0) > 0)
-              const knownAgentIds = new Set(agents.map(a => a.id))
+              const agentsWithConvos = (agents ?? []).filter(a => (convosByAgent[a.id]?.length ?? 0) > 0)
+              const knownAgentIds = new Set((agents ?? []).map(a => a.id))
               const orphans = linkedConvos.filter(c => !knownAgentIds.has((c.metadata.agentTarget ?? c.metadata.agentChat)!.id))
 
               return (

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -294,7 +294,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
     !inviteSearch || (u.name || u.username || '').toLowerCase().includes(inviteSearch.toLowerCase())
   )
   const filteredAgents = inviteAgents.filter(a =>
-    !inviteSearch || a.name.toLowerCase().includes(inviteSearch.toLowerCase())
+    !inviteSearch || (a.name || '').toLowerCase().includes(inviteSearch.toLowerCase())
   )
 
   return (

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -141,8 +141,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
 
   useEffect(() => { loadRoom() }, [loadRoom])
 
+  // Debounce scroll to avoid performance issues with rapid message arrivals
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    const timer = setTimeout(() => {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }, 100)
+    return () => clearTimeout(timer)
   }, [room?.messages?.length])
 
   // Subscribe to real-time messages via SSE and poll typing state
@@ -169,9 +173,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           // Update room with new message
           setRoom((prev) => {
             if (!prev) return prev
+            const newMessages = [...(prev.messages || []), message]
+            // Keep only the last 200 messages in DOM to avoid performance issues
+            const trimmedMessages = newMessages.length > 200 ? newMessages.slice(-200) : newMessages
             return {
               ...prev,
-              messages: [...(prev.messages || []), message],
+              messages: trimmedMessages,
               totalMessages: (prev.totalMessages || 0) + 1,
             }
           })

--- a/apps/web/src/lib/correlation-id.ts
+++ b/apps/web/src/lib/correlation-id.ts
@@ -7,16 +7,17 @@
  * SOC2 [H-002]: Error handling without information disclosure
  */
 
-import { randomUUID } from 'crypto'
-
 /**
  * Generate a unique correlation ID for a request.
+ * Uses Web Crypto API (edge runtime compatible) instead of Node.js crypto.
  * Returns a short format suitable for including in error responses.
  */
 export function generateCorrelationId(): string {
-  // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-  // Short format: first 8 chars of UUID (sufficient for disambiguation)
-  return randomUUID().split('-')[0]
+  // Generate 4 bytes (32 bits) of random data and convert to hex
+  // Produces 8 hex characters, sufficient for disambiguation
+  const bytes = new Uint8Array(4)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
 }
 
 /**

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -102,13 +102,58 @@ Do not list commands you would hypothetically run. Do not invent output. Just sa
 
 {{clusterContext}}
 
-PLANNING MODE — you are creating a plan for a {{scope}}:
-- Run kubectl commands freely to inspect the cluster and gather information before planning
-- Ask clarifying questions if you genuinely need more information to produce a good plan
-- When you have gathered enough information and are ready to write the final plan, produce it in full:
-  - Use clear sections: Overview, Implementation Steps, Technical Details, Risks & Mitigations
-  - Be specific and actionable — this plan will be saved and used to auto-generate {{generateType}}
-  - Do NOT end the plan itself with open-ended questions like "What would you like to prioritize?" — the plan should be complete and self-contained`,
+---
+
+## Planning Mode
+
+You are creating a plan for: **{{scope}}**
+
+---
+
+### Step 1 — Gather Information
+
+Before writing the plan, gather what you need:
+- Use tools to check current cluster state relevant to this work (existing resources, services, namespaces, configs).
+- Identify what already exists vs what must be created, changed, or removed.
+- Note any conflicts, missing dependencies, or constraints.
+
+If you have no tools available, state clearly what assumptions you are making about current state.
+
+### Step 2 — Ask One Round of Clarifying Questions (optional)
+
+If there is a critical ambiguity that would meaningfully change the plan (not just a preference), ask ONE round of targeted questions. Keep it to 3 questions or fewer. Do not ask about things you can determine from tool results or reasonable defaults.
+
+### Step 3 — Write the Final Plan
+
+When you have enough information, produce the complete plan immediately. Use exactly this structure:
+
+---
+
+## Overview
+[What this accomplishes and why. One paragraph.]
+
+## Pre-conditions
+[What must be true before starting — existing resources, credentials, namespaces, external services.]
+
+## Implementation Steps
+[Numbered list. Each step must be:
+- Specific enough for an AI agent to execute autonomously
+- Include exact resource names, namespaces, image tags, config values, file paths
+- Include the verification check for that step if one is needed]
+
+## Verification
+[How to confirm the full implementation succeeded — specific commands or checks.]
+
+## Risks & Mitigations
+[What could go wrong during execution and how to handle each scenario.]
+
+---
+
+**Important rules for the plan itself:**
+- Be specific and concrete — this plan will be saved and used to auto-generate {{generateType}} which will be executed by AI agents with no additional context from you.
+- Every implementation step must be independently actionable. "Configure the service" is not a step. "Create \`service.yaml\` in \`deployments/myapp/\` with ClusterIP type, port 8080, selector \`app: myapp\`" is a step.
+- Do NOT end the plan with open-ended questions ("What would you like to prioritize?", "Let me know if you'd like to adjust anything"). The plan must be final and self-contained.
+- If you are unsure about a specific value, provide a sensible default and note it as an assumption.`,
   },
 
   {
@@ -116,8 +161,45 @@ PLANNING MODE — you are creating a plan for a {{scope}}:
     name: 'Plan Review System Prompt (Opus)',
     category: 'system',
     description: 'Used by the Opus review pass to refine draft plans. No dynamic variables.',
-    content: `You are a senior technical architect. Your only job is to review and refine the draft plan provided in the prompt.
-Do not run any tools or commands. Do not ask for more information. Output the final plan immediately.`,
+    content: `You are a senior technical architect reviewing and refining a draft implementation plan.
+
+## Your Only Job
+
+Read the draft plan provided below and output a single, improved final plan. Do not run tools. Do not ask questions. Do not request more information. Output the final plan immediately.
+
+## What to Check and Fix
+
+1. **Specificity** — Vague steps like "configure the service" must be rewritten as concrete, executable instructions with exact values, file paths, and resource names.
+2. **Completeness** — Every step needed to go from zero to working must be present. Add anything missing (namespace creation, secret provisioning, DNS, etc.).
+3. **Ordering** — Steps must be in the correct dependency order. Resources must exist before they are referenced.
+4. **Pre-conditions** — Ensure the plan states what must already exist before execution begins.
+5. **Verification** — Each major phase should have a concrete check command confirming it succeeded.
+6. **Risks** — Identify the 2-3 most likely failure points and how to recover from each.
+
+## Output Format
+
+Produce the final plan using exactly this structure:
+
+---
+
+## Overview
+[What this accomplishes and why. One paragraph.]
+
+## Pre-conditions
+[What must be true before starting.]
+
+## Implementation Steps
+[Numbered, specific, independently executable steps with exact values.]
+
+## Verification
+[How to confirm success after all steps complete.]
+
+## Risks & Mitigations
+[Top failure scenarios and recovery steps.]
+
+---
+
+Do not add commentary before or after the plan. Output only the plan itself.`,
   },
 
   {
@@ -130,13 +212,55 @@ Do not run any tools or commands. Do not ask for more information. Output the fi
       { name: '{{taskDescription}}', description: 'Task description (may be empty)' },
       { name: '{{taskPlan}}',        description: 'Implementation plan (may be empty)' },
     ],
-    content: `You are executing a task. Work through it step by step using available tools.
+    content: `## Task Assignment
 
-Task: {{taskTitle}}
+**Task:** {{taskTitle}}
 {{taskDescription}}
 {{taskPlan}}
 
-Complete the task fully. Use tools to verify your work. When done, summarize what was accomplished.`,
+---
+
+## Execution Protocol
+
+You are an autonomous AI agent. Execute this task completely. Do not ask for permission, confirmation, or clarification — work with what you have and proceed.
+
+### Phase 1 — Understand
+Read the task title, description, and plan carefully.
+- If a plan is provided, treat it as the authoritative implementation guide.
+- If no plan is provided, derive concrete steps from the title and description.
+- Identify what tools you will need and in what order.
+
+### Phase 2 — Investigate (use tools immediately)
+If you need current state before acting (e.g., checking what resources exist, reading a file, inspecting config), call the relevant tool NOW. Do not describe what you *would* check — actually check it. Do not ask the user for this information.
+
+### Phase 3 — Execute
+Work through each step in sequence:
+- Call the tool for the step and wait for the real result.
+- Read the result carefully before moving to the next step.
+- If a step fails: read the error message, diagnose the root cause, and try a corrected approach. Do not repeat the exact same call if it already failed.
+- Do not skip steps or mark them complete without actually executing them.
+
+### Phase 4 — Verify
+After completing all steps, confirm the outcome:
+- Run a verification tool call to confirm the intended state is in place (e.g., pod is running, file contains the expected content, service responds).
+- If verification fails, return to Phase 3 and fix the issue.
+
+### Phase 5 — Report
+End with a concise summary:
+- **Completed:** list what was done (specific steps and tool calls used)
+- **Verified:** what was confirmed as working
+- **Issues:** any problems encountered and how they were resolved (or why they could not be resolved)
+
+---
+
+## Rules — Read Before Every Tool Call
+
+1. **Call tools immediately** when you need real data. Never describe a hypothetical command — run it.
+2. **Never hallucinate results.** If you did not call a tool, you do not know the output. Report only what tools actually returned.
+3. **If a tool call fails**, report the real error message. Do not invent a success.
+4. **Max 3 retries per step.** If a step keeps failing after 3 attempts with different approaches, document the blocker clearly and move on or stop — do not loop indefinitely.
+5. **Budget:** You have at most 20 tool calls total. Use them efficiently — combine checks where possible.
+6. **No user interaction.** Do not ask questions mid-task. Make reasonable assumptions and document them in your report.`,
   },
 
   // ── Bootstrap contexts ──────────────────────────────────────────────────────

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -384,8 +384,9 @@ services:
     depends_on:
       redis-master:
         condition: service_healthy
-    command: redis-sentinel /etc/redis-sentinel.conf
+    entrypoint: /entrypoint.sh
     volumes:
+      - ./sentinel-entrypoint.sh:/entrypoint.sh:ro
       - ./redis-sentinel-1.conf:/etc/redis-sentinel.conf:ro
       - redis-sentinel-1-data:/data
     ports:
@@ -411,8 +412,9 @@ services:
     depends_on:
       redis-master:
         condition: service_healthy
-    command: redis-sentinel /etc/redis-sentinel.conf
+    entrypoint: /entrypoint.sh
     volumes:
+      - ./sentinel-entrypoint.sh:/entrypoint.sh:ro
       - ./redis-sentinel-2.conf:/etc/redis-sentinel.conf:ro
       - redis-sentinel-2-data:/data
     ports:
@@ -438,8 +440,9 @@ services:
     depends_on:
       redis-master:
         condition: service_healthy
-    command: redis-sentinel /etc/redis-sentinel.conf
+    entrypoint: /entrypoint.sh
     volumes:
+      - ./sentinel-entrypoint.sh:/entrypoint.sh:ro
       - ./redis-sentinel-3.conf:/etc/redis-sentinel.conf:ro
       - redis-sentinel-3-data:/data
     ports:

--- a/deploy/sentinel-entrypoint.sh
+++ b/deploy/sentinel-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Get the IP address of redis-master and update sentinel config
+echo "Resolving redis-master hostname to IP..."
+MAX_RETRIES=60
+RETRY_COUNT=0
+
+REDIS_MASTER_IP=""
+while [ -z "$REDIS_MASTER_IP" ]; do
+  # Try to resolve redis-master using getent
+  REDIS_MASTER_IP=$(getent hosts redis-master 2>/dev/null | awk '{ print $1 }' | head -1)
+
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+    echo "ERROR: Could not resolve redis-master after $MAX_RETRIES attempts"
+    exit 1
+  fi
+
+  if [ -z "$REDIS_MASTER_IP" ]; then
+    if [ $((RETRY_COUNT % 10)) -eq 0 ]; then
+      echo "Still resolving redis-master... (attempt $RETRY_COUNT/$MAX_RETRIES)"
+    fi
+    sleep 1
+  fi
+done
+
+echo "Resolved redis-master to IP: $REDIS_MASTER_IP"
+
+# Copy config to writable location and update with resolved IP
+cp /etc/redis-sentinel.conf /data/redis-sentinel.conf.tmp
+sed -i "s/redis-master/$REDIS_MASTER_IP/g" /data/redis-sentinel.conf.tmp
+
+echo "Updated sentinel config with resolved IP"
+sleep 1
+
+echo "Starting sentinel..."
+exec redis-sentinel /data/redis-sentinel.conf.tmp


### PR DESCRIPTION
## Summary

- **`system.task-execution`**: Replaces a 5-line stub with a full 5-phase execution protocol (understand → investigate → execute → verify → report). Includes explicit rules against hallucination, max 3 retries per step, a 20-call tool budget, and a ban on mid-task questions. This is the primary fix for non-Claude models skipping steps, inventing output, or looping.
- **`system.planning`**: Replaces vague bullet points with a 3-step structured flow — gather info with tools, one optional clarifying round (≤3 questions), then write the final plan in a required section format. Bans open-ended closing questions.
- **`system.plan-review`**: Adds an explicit checklist (specificity, completeness, ordering, pre-conditions, verification, risks) and enforces a fixed output structure.

## Why

Claude fills in gaps with good judgment. Smaller/non-Claude models (Ollama, OpenAI-compatible) need explicit, imperative instructions for every behavioral expectation. The old prompts were written assuming Claude's implicit reasoning would handle the rest.

## Post-deploy action required

Existing DB records won't auto-update (the `upsert` only creates, never overwrites). After deploy, go to **Administration → Prompts** and click **"Reset to Default"** on:
- `system.task-execution`
- `system.planning`
- `system.plan-review`

## Test plan

- [ ] Assign a task to an Ollama/OpenAI-compatible agent and confirm it calls tools proactively without asking permission
- [ ] Confirm the agent produces a structured completion summary (Completed / Verified / Issues)
- [ ] Open a planning session and confirm the plan output uses the required section structure
- [ ] Verify Claude agents are unaffected (same quality output)
- [ ] Reset prompts in Admin → Prompts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)