### PR TITLE
fix: planning conversations broken by wrong Zod types + missing chat sidebar

### DIFF
--- a/apps/web/src/app/(app)/chat/page.tsx
+++ b/apps/web/src/app/(app)/chat/page.tsx
@@ -1,7 +1,8 @@
 'use client'
-import { Suspense } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { Suspense, useState, useEffect, useCallback } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
 import { ChatWindow } from '@/components/chat/ChatWindow'
+import { ConversationList } from '@/components/chat/ConversationList'
 
 interface Conversation {
   id: string
@@ -10,11 +11,111 @@ interface Conversation {
   _count: { messages: number }
 }
 
+interface PlanningConvo {
+  id: string
+  title: string | null
+  metadata: { planTarget: { type: string; id: string } }
+}
+
+interface AgentConvo {
+  id: string
+  title: string | null
+  metadata: { agentTarget?: { id: string; name: string }; agentChat?: { id: string; name: string }; agentDraft?: boolean }
+}
+
+interface DebugConvo {
+  id: string
+  title: string | null
+}
+
+interface Epic {
+  id: string
+  title: string
+  features: { id: string; title: string }[]
+}
+
+interface Agent {
+  id: string
+  name: string
+}
+
 function ChatContent() {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const conversationId = searchParams.get('conversation') as string | null
   const taskId = searchParams.get('task')
   const context = searchParams.get('context')
+
+  const [convos, setConvos]               = useState<Conversation[]>([])
+  const [planningConvos, setPlanningConvos] = useState<PlanningConvo[]>([])
+  const [agentConvos, setAgentConvos]     = useState<AgentConvo[]>([])
+  const [debugConvos, setDebugConvos]     = useState<DebugConvo[]>([])
+  const [epics, setEpics]                 = useState<Epic[]>([])
+  const [agents, setAgents]               = useState<Agent[]>([])
+
+  const loadConvos = useCallback(async () => {
+    try {
+      const data: Array<{ id: string; title: string | null; createdAt: string; metadata?: Record<string, unknown>; _count: { messages: number } }>
+        = await fetch('/api/chat/conversations', { cache: 'no-store' }).then(r => r.json())
+
+      const plain: Conversation[]     = []
+      const planning: PlanningConvo[] = []
+      const agent: AgentConvo[]       = []
+      const debug: DebugConvo[]       = []
+
+      for (const c of data) {
+        const meta = c.metadata as Record<string, unknown> | undefined
+        if (meta?.planTarget)                          planning.push(c as unknown as PlanningConvo)
+        else if (meta?.agentTarget || meta?.agentChat || meta?.agentDraft) agent.push(c as unknown as AgentConvo)
+        else if (meta?.debugChat)                      debug.push(c as DebugConvo)
+        else                                           plain.push(c)
+      }
+
+      setConvos(plain)
+      setPlanningConvos(planning)
+      setAgentConvos(agent)
+      setDebugConvos(debug)
+    } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => {
+    loadConvos()
+    Promise.all([
+      fetch('/api/epics').then(r => r.json()).catch(() => []),
+      fetch('/api/agents').then(r => r.json()).catch(() => []),
+    ]).then(([e, a]) => {
+      setEpics(e)
+      setAgents(a)
+    })
+  }, [loadConvos])
+
+  const handleSelect = (id: string) => {
+    const url = new URL(window.location.href)
+    if (id) {
+      url.searchParams.set('conversation', id)
+    } else {
+      url.searchParams.delete('conversation')
+    }
+    url.searchParams.delete('task')
+    url.searchParams.delete('context')
+    router.push(url.pathname + url.search)
+  }
+
+  const handleDelete = (id: string) => {
+    setConvos(p => p.filter(c => c.id !== id))
+    setPlanningConvos(p => p.filter(c => c.id !== id))
+    setAgentConvos(p => p.filter(c => c.id !== id))
+    setDebugConvos(p => p.filter(c => c.id !== id))
+    if (conversationId === id) handleSelect('')
+  }
+
+  const handleRename = (id: string, title: string) => {
+    const patch = (arr: Conversation[]) => arr.map(c => c.id === id ? { ...c, title } : c)
+    setConvos(patch)
+    setPlanningConvos(p => p.map(c => c.id === id ? { ...c, title } : c))
+    setAgentConvos(p => p.map(c => c.id === id ? { ...c, title } : c))
+    setDebugConvos(p => p.map(c => c.id === id ? { ...c, title } : c))
+  }
 
   const handleConversationCreated = (convo: Conversation) => {
     const url = new URL(window.location.href)
@@ -22,10 +123,23 @@ function ChatContent() {
     if (taskId) url.searchParams.set('task', taskId)
     if (context) url.searchParams.set('context', context)
     window.history.replaceState(null, '', url.toString())
+    setConvos(p => [convo, ...p])
   }
 
   return (
     <div className="absolute inset-0 flex overflow-hidden">
+      <ConversationList
+        convos={convos}
+        planningConvos={planningConvos}
+        agentConvos={agentConvos}
+        debugConvos={debugConvos}
+        epics={epics}
+        agents={agents}
+        onSelect={handleSelect}
+        activeId={conversationId ?? undefined}
+        onDelete={handleDelete}
+        onRename={handleRename}
+      />
       <ChatWindow
         conversationId={conversationId}
         onConversationCreated={handleConversationCreated}

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -74,11 +74,11 @@ export function validateBody<T extends z.ZodType>(
 export const CreateConversationSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   initialContext: z.string().max(10000).optional(),
-  planTarget: z.string().max(200).optional(),
+  planTarget: z.object({ type: z.string().max(50), id: z.string().max(100) }).optional(),
   planModel: z.string().max(100).optional(),
-  agentTarget: z.string().max(100).optional(),
-  agentDraft: z.string().max(100).optional(),
-  agentChat: z.string().max(100).optional(),
+  agentTarget: z.object({ id: z.string().max(100), name: z.string().max(200) }).optional(),
+  agentDraft: z.boolean().optional(),
+  agentChat: z.object({ id: z.string().max(100), name: z.string().max(200) }).optional(),
   metadata: z.record(z.unknown()).optional(),
 })
 
@@ -313,11 +313,11 @@ export const ChatroomMessageSchema = z.object({
 
 export const CreateConversationSchema2 = z.object({
   initialContext: z.string().max(10000).optional(),
-  planTarget: z.string().max(200).optional(),
+  planTarget: z.object({ type: z.string().max(50), id: z.string().max(100) }).optional(),
   planModel: z.string().max(100).optional(),
-  agentTarget: z.string().max(100).optional(),
-  agentDraft: z.string().max(100).optional(),
-  agentChat: z.string().max(100).optional(),
+  agentTarget: z.object({ id: z.string().max(100), name: z.string().max(200) }).optional(),
+  agentDraft: z.boolean().optional(),
+  agentChat: z.object({ id: z.string().max(100), name: z.string().max(200) }).optional(),
 })
 
 export const ImportNovaSchema = z.object({


### PR DESCRIPTION
## Root Cause

Two bugs introduced when Zod input validation was added to the conversations POST route:

### Bug 1 — Schema type mismatch (silent 400 on every planning POST)

`CreateConversationSchema` and `CreateConversationSchema2` typed these fields incorrectly:

| Field | Schema type | Actual client payload |
|---|---|---|
| `planTarget` | `z.string()` | `{ type: string, id: string }` |
| `agentTarget` | `z.string()` | `{ id: string, name: string }` |
| `agentChat` | `z.string()` | `{ id: string, name: string }` |
| `agentDraft` | `z.string()` | `true` (boolean) |

Zod rejected every planning/agent conversation creation with a 400. The client silently swallowed this and navigated to `/chat?conversation=undefined`. Nothing in the chat window loaded because no conversation existed.

### Bug 2 — ConversationList never rendered on the /chat page

`ConversationList` was a fully-built component that was never wired up to the `/chat` page. Users saw a bare chat window with no way to navigate between conversations.

## Fix

- Corrected Zod types in both schemas to match actual payloads
- Wired `ConversationList` into `/chat/page.tsx` with client-side fetching of conversations (split into plain / planning / agent / debug buckets), epics, and agents
- Delete/rename operations update local state immediately; conversation selection pushes the URL

## Test plan

- [ ] Click "Plan with AI" on an epic, feature, or task — conversation should be created and AI should auto-respond with the planning prompt
- [ ] Click "Plan with AI" on a team member in the Team panel — agent creation modal should work and auto-send initial context
- [ ] Navigate to `/chat` directly — sidebar should show all conversations grouped by type (Planning Chats, Agent Chats, Debug Chats)
- [ ] Create a new conversation, rename it, delete it — sidebar updates immediately
- [ ] Verify existing regular chat conversations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)