### PR TITLE
feat: configurable default AI model for generate-features/tasks

### DIFF
--- a/apps/web/src/app/(app)/admin/settings/page.tsx
+++ b/apps/web/src/app/(app)/admin/settings/page.tsx
@@ -2,10 +2,18 @@
 import { useState, useEffect } from 'react'
 import { Save, RefreshCw } from 'lucide-react'
 
+interface ExternalModel {
+  id: string
+  name: string
+  modelId: string
+  provider: string
+  enabled: boolean
+}
+
 interface Settings {
   'app.name': string
   'app.description': string
-  'model.default': string
+  'ai.default-model': string
   'chat.historyLimit': number
   'features.notes': boolean
   'features.backups': boolean
@@ -14,7 +22,7 @@ interface Settings {
 const DEFAULTS: Settings = {
   'app.name': 'ORION',
   'app.description': '',
-  'model.default': 'claude',
+  'ai.default-model': 'claude',
   'chat.historyLimit': 10,
   'features.notes': true,
   'features.backups': true,
@@ -22,31 +30,46 @@ const DEFAULTS: Settings = {
 
 export default function SettingsPage() {
   const [settings, setSettings] = useState<Settings>(DEFAULTS)
+  const [externalModels, setExternalModels] = useState<ExternalModel[]>([])
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch('/api/admin/settings')
-      .then(r => r.json())
-      .then((data: Partial<Settings>) => {
-        setSettings(s => ({ ...s, ...data }))
-        setLoading(false)
-      })
-      .catch(() => setLoading(false))
+    Promise.all([
+      fetch('/api/admin/settings').then(r => r.json()).catch(() => ({})),
+      fetch('/api/admin/models').then(r => r.json()).catch(() => []),
+    ]).then(([data, modelsData]) => {
+      setSettings(s => ({
+        ...s,
+        ...data,
+        // API stores all values as strings — coerce back to their correct types
+        'chat.historyLimit': parseInt(data['chat.historyLimit']) || s['chat.historyLimit'],
+        'features.notes': data['features.notes'] === undefined ? s['features.notes'] : data['features.notes'] === 'true',
+        'features.backups': data['features.backups'] === undefined ? s['features.backups'] : data['features.backups'] === 'true',
+      }))
+      setExternalModels((Array.isArray(modelsData) ? modelsData : []).filter((m: ExternalModel) => m.enabled))
+      setLoading(false)
+    })
   }, [])
 
   const handleSave = async () => {
     setSaving(true)
     setError(null)
     try {
-      const res = await fetch('/api/admin/settings', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings),
-      })
-      if (!res.ok) throw new Error('Failed to save')
+      // API takes one key-value pair at a time — save all in parallel
+      const entries = Object.entries(settings) as [string, unknown][]
+      const results = await Promise.all(
+        entries.map(([key, value]) =>
+          fetch('/api/admin/settings', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ key, value: String(value) }),
+          })
+        )
+      )
+      if (results.some(r => !r.ok)) throw new Error('Failed to save one or more settings')
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
     } catch (e) {
@@ -102,15 +125,22 @@ export default function SettingsPage() {
           />
         </SettingRow>
 
-        {/* Default model */}
-        <SettingRow label="Default Model" description="Model used by default in Claude Chat">
+        {/* Default AI model */}
+        <SettingRow
+          label="Default AI Model"
+          description="Model used for all AI features (generate features, generate tasks, planning). Falls back to the first enabled external model if not set."
+        >
           <select
-            value={settings['model.default']}
-            onChange={e => set('model.default', e.target.value)}
+            value={settings['ai.default-model']}
+            onChange={e => set('ai.default-model', e.target.value)}
             className="w-full px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
           >
-            <option value="claude">Claude (default)</option>
-            <option value="ollama">Ollama</option>
+            <option value="claude">Claude (built-in)</option>
+            {externalModels.map(m => (
+              <option key={m.id} value={m.id}>
+                {m.name} ({m.modelId})
+              </option>
+            ))}
           </select>
         </SettingRow>
 

--- a/apps/web/src/app/api/epics/[id]/generate-features/route.ts
+++ b/apps/web/src/app/api/epics/[id]/generate-features/route.ts
@@ -1,28 +1,23 @@
+/**
+ * POST /api/epics/[id]/generate-features
+ *
+ * Uses the system default AI model to extract features from an epic plan.
+ * Configure the default model in Settings → AI.
+ */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import fs from 'fs'
-import path from 'path'
+import { callDefaultModel } from '@/lib/default-model'
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
   const epic = await prisma.epic.findUnique({
-    where: { id: params.id },
+    where: { id },
     include: { features: { include: { _count: { select: { tasks: true } } } } },
   })
 
   if (!epic) return NextResponse.json({ error: 'Epic not found' }, { status: 404 })
   if (!epic.plan) return NextResponse.json({ error: 'Epic has no plan yet — plan with Claude first' }, { status: 400 })
-
-  // Set up Claude credentials (same as claude.ts)
-  if (process.env.CLAUDE_CREDENTIALS_PATH) {
-    const srcCreds = path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
-    const claudeHome = '/tmp/claude-home'
-    const destDir = path.join(claudeHome, '.claude')
-    fs.mkdirSync(destDir, { recursive: true })
-    try { fs.copyFileSync(srcCreds, path.join(destDir, '.credentials.json')) } catch { /* ignore */ }
-    process.env.HOME = claudeHome
-  }
-
-  const { query } = await import('@anthropic-ai/claude-code')
 
   const prompt = `You are extracting features from an epic plan for a software project.
 
@@ -39,61 +34,43 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON array
   ...
 ]`
 
-  let fullText = ''
+  let fullText: string
   try {
-    const response = query({
-      prompt,
-      options: {
-        allowedTools: [],
-        maxTurns: 1,
-      },
-    })
-
-    for await (const msg of response) {
-      if (msg.type === 'assistant') {
-        const m = msg as { type: 'assistant'; message: { content: Array<{ type: string; text?: string }> } }
-        for (const block of m.message.content) {
-          if (block.type === 'text' && block.text) fullText += block.text
-        }
-      } else if (msg.type === 'result') {
-        const r = msg as { type: 'result'; subtype?: string; result?: string }
-        if (r.subtype === 'success' && r.result && !fullText.includes(r.result.trim())) {
-          fullText += r.result
-        }
-      }
-    }
+    fullText = await callDefaultModel(prompt)
   } catch (err) {
-    return NextResponse.json({ error: `Claude error: ${err instanceof Error ? err.message : String(err)}` }, { status: 500 })
+    return NextResponse.json(
+      { error: `AI error: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    )
   }
 
-  // Extract JSON array from response (handle cases where Claude wraps it in backticks)
+  // Extract JSON array from response (handle cases where model wraps it in backticks)
   const jsonMatch = fullText.match(/\[[\s\S]*\]/)
   if (!jsonMatch) {
-    return NextResponse.json({ error: 'Claude did not return a valid JSON array', raw: fullText }, { status: 500 })
+    return NextResponse.json({ error: 'Model did not return a valid JSON array', raw: fullText }, { status: 500 })
   }
 
   let parsed: Array<{ title: string; description?: string }>
   try {
     parsed = JSON.parse(jsonMatch[0])
   } catch {
-    return NextResponse.json({ error: 'Failed to parse Claude response as JSON', raw: fullText }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to parse model response as JSON', raw: fullText }, { status: 500 })
   }
 
   if (!Array.isArray(parsed) || parsed.length === 0) {
-    return NextResponse.json({ error: 'Claude returned an empty or invalid feature list' }, { status: 500 })
+    return NextResponse.json({ error: 'Model returned an empty or invalid feature list' }, { status: 500 })
   }
 
-  // Create all features in DB
   const created = await Promise.all(
     parsed
       .filter(f => f.title?.trim())
       .map(f =>
         prisma.feature.create({
           data: {
-            epicId: params.id,
+            epicId: id,
             title: f.title.trim(),
             description: f.description?.trim() ?? null,
-            createdBy: 'claude',
+            createdBy: 'ai',
           },
           include: { _count: { select: { tasks: true } } },
         })

--- a/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
+++ b/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
@@ -1,28 +1,23 @@
+/**
+ * POST /api/features/[id]/generate-tasks
+ *
+ * Uses the system default AI model to break a feature plan into backlog tasks.
+ * Configure the default model in Settings → AI.
+ */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import fs from 'fs'
-import path from 'path'
+import { callDefaultModel } from '@/lib/default-model'
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
   const feature = await prisma.feature.findUnique({
-    where: { id: params.id },
+    where: { id },
     include: { epic: true },
   })
 
   if (!feature) return NextResponse.json({ error: 'Feature not found' }, { status: 404 })
   if (!feature.plan) return NextResponse.json({ error: 'Feature has no plan yet — plan with Claude first' }, { status: 400 })
-
-  // Set up Claude credentials (same as claude.ts)
-  if (process.env.CLAUDE_CREDENTIALS_PATH) {
-    const srcCreds = path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
-    const claudeHome = '/tmp/claude-home'
-    const destDir = path.join(claudeHome, '.claude')
-    fs.mkdirSync(destDir, { recursive: true })
-    try { fs.copyFileSync(srcCreds, path.join(destDir, '.credentials.json')) } catch { /* ignore */ }
-    process.env.HOME = claudeHome
-  }
-
-  const { query } = await import('@anthropic-ai/claude-code')
 
   const prompt = `You are breaking down a feature plan into concrete backlog tasks for a software project.
 
@@ -45,48 +40,30 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON:
   ...
 ]`
 
-  let fullText = ''
+  let fullText: string
   try {
-    const response = query({
-      prompt,
-      options: {
-        allowedTools: [],
-        maxTurns: 1,
-      },
-    })
-
-    for await (const msg of response) {
-      if (msg.type === 'assistant') {
-        const m = msg as { type: 'assistant'; message: { content: Array<{ type: string; text?: string }> } }
-        for (const block of m.message.content) {
-          if (block.type === 'text' && block.text) fullText += block.text
-        }
-      } else if (msg.type === 'result') {
-        const r = msg as { type: 'result'; subtype?: string; result?: string }
-        if (r.subtype === 'success' && r.result && !fullText.includes(r.result.trim())) {
-          fullText += r.result
-        }
-      }
-    }
+    fullText = await callDefaultModel(prompt)
   } catch (err) {
-    return NextResponse.json({ error: `Claude error: ${err instanceof Error ? err.message : String(err)}` }, { status: 500 })
+    return NextResponse.json(
+      { error: `AI error: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    )
   }
 
-  // Extract JSON array from response
   const jsonMatch = fullText.match(/\[[\s\S]*\]/)
   if (!jsonMatch) {
-    return NextResponse.json({ error: 'Claude did not return a valid JSON array', raw: fullText }, { status: 500 })
+    return NextResponse.json({ error: 'Model did not return a valid JSON array', raw: fullText }, { status: 500 })
   }
 
   let parsed: Array<{ title: string; description?: string; priority?: string }>
   try {
     parsed = JSON.parse(jsonMatch[0])
   } catch {
-    return NextResponse.json({ error: 'Failed to parse Claude response as JSON', raw: fullText }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to parse model response as JSON', raw: fullText }, { status: 500 })
   }
 
   if (!Array.isArray(parsed) || parsed.length === 0) {
-    return NextResponse.json({ error: 'Claude returned an empty or invalid task list' }, { status: 500 })
+    return NextResponse.json({ error: 'Model returned an empty or invalid task list' }, { status: 500 })
   }
 
   const validPriorities = new Set(['low', 'medium', 'high', 'critical'])
@@ -97,11 +74,11 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON:
       .map(t =>
         prisma.task.create({
           data: {
-            featureId:   params.id,
+            featureId:   id,
             title:       t.title.trim(),
             description: t.description?.trim() ?? null,
             priority:    validPriorities.has(t.priority ?? '') ? t.priority! : 'medium',
-            createdBy:   'claude',
+            createdBy:   'ai',
           },
           include: { agent: true },
         })

--- a/apps/web/src/lib/default-model.ts
+++ b/apps/web/src/lib/default-model.ts
@@ -1,0 +1,156 @@
+/**
+ * Default AI model resolver.
+ *
+ * Reads the system-wide default model from SystemSetting key 'ai.default-model'.
+ * Value is either:
+ *   'claude'          — use Claude Code SDK (requires OAuth credentials)
+ *   '<ExternalModel id>' — use that ExternalModel (OpenAI-compatible or Ollama)
+ *
+ * callDefaultModel(prompt) handles the routing transparently so callers don't
+ * need to know which model is configured.
+ *
+ * Falls back to the first enabled ExternalModel if no default is set, then
+ * to Claude as a last resort.
+ */
+
+import { prisma } from './db'
+import fs from 'fs'
+import path from 'path'
+
+const SETTING_KEY = 'ai.default-model'
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+export async function getDefaultModelId(): Promise<string> {
+  const setting = await prisma.systemSetting.findUnique({
+    where: { key: SETTING_KEY },
+  })
+
+  if (setting?.value && typeof setting.value === 'string') {
+    return setting.value
+  }
+
+  // No setting — fall back to first enabled external model, then claude
+  const first = await prisma.externalModel.findFirst({
+    where: { enabled: true },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  return first?.id ?? 'claude'
+}
+
+// ── Single-turn prompt call ───────────────────────────────────────────────────
+
+/**
+ * Send a single prompt to the default model and return the text response.
+ * Used by generate-features, generate-tasks, and any other one-shot AI calls.
+ */
+export async function callDefaultModel(prompt: string): Promise<string> {
+  const modelId = await getDefaultModelId()
+
+  if (modelId === 'claude') {
+    return callClaude(prompt)
+  }
+
+  const model = await prisma.externalModel.findUnique({
+    where: { id: modelId },
+  })
+
+  if (!model) {
+    throw new Error(`Default model '${modelId}' not found — configure one in Settings → AI`)
+  }
+
+  if (model.provider === 'ollama') {
+    return callOllama(prompt, model.baseUrl, model.modelId)
+  }
+
+  // openai / anthropic / custom — OpenAI-compatible
+  return callOpenAI(prompt, model.baseUrl, model.modelId, model.apiKey ?? undefined, model.timeoutSecs)
+}
+
+// ── Provider implementations ──────────────────────────────────────────────────
+
+async function callClaude(prompt: string): Promise<string> {
+  // Set up credentials
+  if (process.env.CLAUDE_CREDENTIALS_PATH) {
+    const src = path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
+    const destDir = path.join('/tmp/claude-home', '.claude')
+    fs.mkdirSync(destDir, { recursive: true })
+    try { fs.copyFileSync(src, path.join(destDir, '.credentials.json')) } catch { /* ignore */ }
+    process.env.HOME = '/tmp/claude-home'
+  }
+
+  const { query } = await import('@anthropic-ai/claude-code')
+  let text = ''
+
+  const response = query({
+    prompt,
+    options: { allowedTools: [], maxTurns: 1 },
+  })
+
+  for await (const msg of response) {
+    if (msg.type === 'assistant') {
+      const m = msg as { type: 'assistant'; message: { content: Array<{ type: string; text?: string }> } }
+      for (const block of m.message.content) {
+        if (block.type === 'text' && block.text) text += block.text
+      }
+    } else if (msg.type === 'result') {
+      const r = msg as { type: 'result'; subtype?: string; result?: string }
+      if (r.subtype === 'success' && r.result && !text.includes(r.result.trim())) {
+        text += r.result
+      }
+    }
+  }
+
+  return text
+}
+
+async function callOpenAI(
+  prompt: string,
+  baseUrl: string,
+  modelId: string,
+  apiKey?: string,
+  timeoutSecs = 120,
+): Promise<string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+  const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: modelId,
+      stream: false,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+    signal: AbortSignal.timeout(timeoutSecs * 1000),
+  })
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Model API returned HTTP ${res.status}: ${body.slice(0, 200)}`)
+  }
+
+  const data = await res.json() as { choices?: Array<{ message: { content: string } }> }
+  const content = data.choices?.[0]?.message?.content?.trim()
+
+  if (!content) throw new Error('Model returned an empty response')
+  return content
+}
+
+async function callOllama(prompt: string, baseUrl: string, modelId: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/api/generate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: modelId, prompt, stream: false }),
+    signal: AbortSignal.timeout(120_000),
+  })
+
+  if (!res.ok) throw new Error(`Ollama returned HTTP ${res.status}`)
+
+  const data = await res.json() as { response?: string }
+  const content = data.response?.trim()
+
+  if (!content) throw new Error('Ollama returned an empty response')
+  return content
+}


### PR DESCRIPTION
## Summary

- Adds a system-wide **default AI model** setting in Admin → Settings → AI
- `generate-features` and `generate-tasks` now route through `callDefaultModel()` instead of hardcoding Claude
- Admin can pick Claude (built-in), or any enabled ExternalModel (OpenAI-compatible or Ollama)
- Falls back to first enabled ExternalModel → Claude if no default is configured

## SOC II Compliance

- `setDefaultModelId()` **not exported** — all model config writes go through `/api/admin/settings` PATCH which enforces `requireAdmin()`, `logAudit()`, and Zod validation
- `callDefaultModel()` and `getDefaultModelId()` are read-only server-side utilities — no auth needed
- Boolean settings (`features.notes`, `features.backups`) now correctly coerced on load (string `"false"` was truthy bug — now fixed)

## Test plan

- [ ] Go to Admin → Settings, verify AI model dropdown shows Claude + any enabled ExternalModels
- [ ] Select an ExternalModel, save — verify it persists on reload
- [ ] Toggle a feature off, save, reload — verify it stays off (boolean fix)
- [ ] Open an Epic with a plan, click Generate Features — verify it uses the configured model
- [ ] Open a Feature with a plan, click Generate Tasks — verify it uses the configured model
- [ ] With no model configured, verify fallback to first enabled ExternalModel → Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)