### PR TITLE
fix: route custom provider external models to openaiRunner

### DIFF
--- a/apps/web/src/lib/agent-runner/dispatcher-runner.ts
+++ b/apps/web/src/lib/agent-runner/dispatcher-runner.ts
@@ -9,10 +9,11 @@ import { openaiRunner } from './openai-runner'
  * - claude:* or 'claude' -> claudeRunner
  * - ollama:* -> ollamaRunner
  * - ext:<id> -> lookup provider in DB and route to:
- *    - openai -> openaiRunner
- *    - ollama -> ollamaRunner
- *    - anthropic -> claudeRunner (if modelId starts with claude:)
- *    - default -> claudeRunner
+ *    - openai   -> openaiRunner
+ *    - custom   -> openaiRunner (OpenAI-compatible: LM Studio, llama.cpp, vLLM)
+ *    - ollama   -> ollamaRunner
+ *    - anthropic -> claudeRunner
+ *    - default  -> claudeRunner
  */
 export const dispatcherRunner: AgentRunner = {
   async *run(ctx: TaskRunContext): AsyncGenerator<AgentEvent> {
@@ -34,6 +35,9 @@ export const dispatcherRunner: AgentRunner = {
         // If it's an external anthropic model, it might need a custom runner,
         // but for now we'll try the claudeRunner with its modelId.
         yield* claudeRunner.run(ctx)
+      } else if (model.provider === 'custom') {
+        // OpenAI-compatible endpoint (LM Studio, llama.cpp, vLLM, etc.)
+        yield* openaiRunner.run(ctx)
       } else {
         yield { type: 'error', error: `Provider ${model.provider} not supported for external models.` }
       }


### PR DESCRIPTION
## Summary

Alpha uses an `ExternalModel` with `provider='custom'` pointing to an OpenAI-compatible endpoint (Qwen3.6 at `http://10.2.2.9:8080`). The dispatcher had no handler for `custom`, so every watcher cycle failed immediately with:

```
Provider custom not supported for external models.
```

Custom providers follow the OpenAI `/v1/chat/completions` wire format (LM Studio, llama.cpp, vLLM, etc.), so routing them to `openaiRunner` is correct.

## Changes

- `dispatcher-runner.ts`: add `custom` provider case → `openaiRunner`
- Updated JSDoc to document all five provider routes

## Test plan

- [ ] Alpha watcher cycle completes without errors after deploy
- [ ] `docker logs deploy-orion-1` shows `Running watcher: Alpha` followed by output, not an error
- [ ] Other provider routes (openai, ollama, anthropic, unknown) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)