### PR TITLE
fix: remove implicit gateway fallback — agents must be explicitly linked

### DIFF
--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -534,7 +534,13 @@ export async function* streamAgentChat(
   )
 
   // ── Helper: load gateway tools from this agent's connected environments ────────
-  // Priority: explicit @mention target > agent-linked env > any connected env.
+  // Priority: explicit @mention target > agent-linked env > STOP.
+  //
+  // SOC2 [A-002]: The previous "fall back to any connected environment" behaviour
+  // allowed agents with no explicit gateway assignment to inherit a gateway from
+  // any connected environment — exposing the gatewayToken to the LLM context and
+  // enabling unauthenticated API access via the gateway's sh tool.
+  // Agents must be explicitly linked to an environment to receive gateway tools.
   const loadAgentGateway = async () => {
     const { GatewayClient } = await import('./agent-runner/gateway-client')
     type GatewayTool = import('./agent-runner/types').GatewayTool
@@ -546,7 +552,7 @@ export async function* streamAgentChat(
         })
       : null
 
-    // Try environments linked to this specific agent
+    // Try environments explicitly linked to this agent
     if (!connectedEnv && agentId) {
       connectedEnv = await prisma.environment.findFirst({
         where: {
@@ -558,12 +564,7 @@ export async function* streamAgentChat(
       })
     }
 
-    // Fall back to any connected environment
-    if (!connectedEnv) {
-      connectedEnv = await prisma.environment.findFirst({
-        where: { status: 'connected', gatewayUrl: { not: null }, gatewayToken: { not: null } },
-      })
-    }
+    // No implicit fallback — an agent without an explicit environment link gets no gateway tools.
 
     if (!connectedEnv?.gatewayUrl || !connectedEnv.gatewayToken) return null
 


### PR DESCRIPTION
## Summary

**Security finding** — Alpha (a coordinator agent with no gateway assignment) was able to discover the `gatewayToken` and query the ORION API directly, bypassing the directive system entirely.

### Root cause

`loadAgentGateway()` in `streamAgentChat()` had a three-tier fallback:
1. `@mention`-targeted environment
2. Agent-linked environment
3. **Any connected environment** ← this was the problem

When Alpha had no explicit environment link, it inherited whichever gateway happened to be connected. The gateway's `sh` tool gave it unrestricted shell access, allowing it to discover `ORION_GATEWAY_TOKEN` (or the environment's `gatewayToken`) via `env` and use it to authenticate API calls.

### Fix

Remove the implicit fallback entirely. An agent now receives gateway tools **only if**:
1. The user `@mention`s a specific environment in the chat, **or**
2. The agent has an explicit `AgentEnvironment` record in the DB

Agents without explicit gateway access get the existing `noGwSuffix` message and no tool access.

### SOC2 impact

- **`[A-002]` Least privilege**: agents can only access environments they are explicitly authorised to use
- **No auth bypass added**: the middleware is unchanged; all API access still requires session or gateway token
- **Audit trail unchanged**: `postToFeed` and orchestrator logging are unaffected

> **Note:** The gateway token Alpha discovered should be rotated. It was exposed in an LLM context window and potentially logged in conversation history.

## Test plan

- [ ] Agent with no environment link gets `No MCP gateway is connected` in chat — no tools available
- [ ] Agent with an explicit `AgentEnvironment` link still receives gateway tools normally
- [ ] User `@mention` of a specific environment still works for all agents
- [ ] Alpha in chat mode cannot run shell commands or query the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)