### PR TITLE
feat: add orion_list_agents and orion_list_tasks management tools

### DIFF
--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -944,6 +944,73 @@ async function handleOrionBootstrapEnvironment(argsRaw: string): Promise<string>
   }
 }
 
+async function handleOrionListAgents(argsRaw: string): Promise<string> {
+  try {
+    const { include_archived } = JSON.parse(argsRaw || '{}') as { include_archived?: boolean }
+    const agents = await prisma.agent.findMany({
+      orderBy: { name: 'asc' },
+      include: { tasks: { where: { status: 'running' }, select: { id: true }, take: 1 } },
+    })
+    const filtered = include_archived
+      ? agents
+      : agents.filter((a: any) => !(a.metadata as any)?.archived)
+    return JSON.stringify(
+      filtered.map((a: any) => {
+        const meta = (a.metadata ?? {}) as Record<string, unknown>
+        const cfg  = (meta.contextConfig ?? {}) as Record<string, unknown>
+        return {
+          id:          a.id,
+          name:        a.name,
+          type:        a.type,
+          role:        a.role ?? null,
+          description: a.description ?? null,
+          persistent:  !!cfg.persistent,
+          busy:        a.tasks.length > 0,
+          archived:    !!(meta.archived),
+        }
+      }),
+      null, 2
+    )
+  } catch (e) {
+    return `Error: ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
+async function handleOrionListTasks(argsRaw: string): Promise<string> {
+  try {
+    const { status, unassigned_only } = JSON.parse(argsRaw || '{}') as {
+      status?: string | string[]
+      unassigned_only?: boolean
+    }
+    const statuses = status
+      ? (Array.isArray(status) ? status : [status])
+      : ['pending', 'running', 'failed']
+    const tasks = await prisma.task.findMany({
+      where: {
+        status: { in: statuses as any },
+        ...(unassigned_only ? { assignedAgent: null, assignedUserId: null } : {}),
+      },
+      include: { agent: { select: { id: true, name: true } } },
+      orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
+      take: 50,
+    })
+    return JSON.stringify(
+      tasks.map((t: any) => ({
+        id:            t.id,
+        title:         t.title,
+        status:        t.status,
+        priority:      t.priority,
+        assignedAgent: t.agent ? { id: t.agent.id, name: t.agent.name } : null,
+        assignedUser:  t.assignedUserId ?? null,
+        description:   t.description ? t.description.slice(0, 200) : null,
+      })),
+      null, 2
+    )
+  } catch (e) {
+    return `Error: ${e instanceof Error ? e.message : String(e)}`
+  }
+}
+
 async function handleGitopsPropose(argsRaw: string, conversationId: string): Promise<string> {
   try {
     const args = JSON.parse(argsRaw || '{}') as {
@@ -1176,6 +1243,33 @@ async function* streamOpenAIChatCore(
     {
       type: 'function' as const,
       function: {
+        name: 'orion_list_agents',
+        description: 'List all agents on the team — their IDs, names, roles, and current busy/available status. Use this to see who is available before assigning work or creating new agents.',
+        parameters: {
+          type: 'object',
+          properties: {
+            include_archived: { type: 'boolean', description: 'Include archived agents (default false)' },
+          },
+        },
+      },
+    },
+    {
+      type: 'function' as const,
+      function: {
+        name: 'orion_list_tasks',
+        description: 'List tasks filtered by status and assignment. Use this to find unassigned work, check what is running, or review failed tasks.',
+        parameters: {
+          type: 'object',
+          properties: {
+            status:          { type: 'string', description: 'Filter by status: pending, running, done, failed. Defaults to pending+running+failed.' },
+            unassigned_only: { type: 'boolean', description: 'Only return tasks with no agent or user assigned (default false)' },
+          },
+        },
+      },
+    },
+    {
+      type: 'function' as const,
+      function: {
         name: 'knowledge_search',
         description: 'Semantically search the knowledge base (notes, runbooks, wiki pages) for content relevant to a query. Returns notes ranked by similarity.',
         parameters: {
@@ -1360,6 +1454,10 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
           result = await handleOrionBootstrapEnvironment(tc.argsRaw)
         } else if (tc.name === 'gitops_propose') {
           result = await handleGitopsPropose(tc.argsRaw, conversationId)
+        } else if (tc.name === 'orion_list_agents') {
+          result = await handleOrionListAgents(tc.argsRaw)
+        } else if (tc.name === 'orion_list_tasks') {
+          result = await handleOrionListTasks(tc.argsRaw)
         } else if (tc.name === 'knowledge_search') {
           result = await handleKnowledgeSearch(tc.argsRaw)
         } else if (tc.name === 'knowledge_graph') {


### PR DESCRIPTION
## Summary

Alpha had no tool to query agents or tasks in chat mode. The watcher loop injects this data via the system snapshot, but when chatting with Alpha directly there was no equivalent — so Alpha tried to call `/api/agents` over HTTP, which fails at the middleware auth gate.

Two new server-side management tools, following the same pattern as `orion_get_environment`:

### `orion_list_agents`
Returns all agents with `id`, `name`, `type`, `role`, `description`, `persistent`, `busy`, `archived`. Excludes archived agents by default (`include_archived: true` to see them). Queries Prisma directly — no HTTP, no auth bypass.

### `orion_list_tasks`
Returns up to 50 tasks filtered by `status` (default: pending+running+failed) and optionally `unassigned_only: true`. Includes the assigned agent name if set.

Both tools are available to all agent backends (OpenAI-compatible, Ollama, Claude Code SDK) via the `MANAGEMENT_TOOLS` array in `streamAgentChat()`.

## SOC2

- No auth bypass — Prisma queries run in the server process under its own DB credentials
- No credentials exposed to the LLM — tool results are plain JSON data
- Read-only — no mutations

## Test plan

- [ ] Alpha in chat: `orion_list_agents` returns team roster with IDs and busy status
- [ ] Alpha in chat: `orion_list_tasks` returns pending/unassigned tasks
- [ ] Alpha no longer attempts to call `/api/agents` directly
- [ ] Other agents without gateway access also have these tools available

🤖 Generated with [Claude Code](https://claude.com/claude-code)