### PR TITLE
feat: unify agent tool access — same tools in chat and watcher mode

### DIFF
--- a/apps/web/src/lib/agent-runner/ollama-runner.ts
+++ b/apps/web/src/lib/agent-runner/ollama-runner.ts
@@ -35,7 +35,7 @@ export const ollamaRunner: AgentRunner = {
       }
     }
 
-    const ollamaToolDefs = gatewayTools.map(t => ({
+    const mgmtToolDefs = (ctx.managementTools?.definitions ?? []).map(t => ({
       type: 'function',
       function: {
         name: t.name,
@@ -43,6 +43,18 @@ export const ollamaRunner: AgentRunner = {
         parameters: t.inputSchema,
       },
     }))
+
+    const ollamaToolDefs = [
+      ...mgmtToolDefs,
+      ...gatewayTools.map(t => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema,
+        },
+      })),
+    ]
 
     const taskTemplate = await getPrompt('system.task-execution')
     const taskPrompt = interpolate(taskTemplate, {
@@ -87,9 +99,12 @@ export const ollamaRunner: AgentRunner = {
             yield { type: 'tool_call', tool: fn.name, args: fn.arguments }
 
             let result: string
-            if (gateway) {
+            const argsRaw = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments)
+            if (ctx.managementTools && ctx.managementTools.definitions.some(d => d.name === fn.name)) {
+              result = await ctx.managementTools.execute(fn.name, argsRaw)
+            } else if (gateway) {
               try {
-                const args = typeof fn.arguments === 'string' ? JSON.parse(fn.arguments) : fn.arguments
+                const args = JSON.parse(argsRaw)
                 result = await gateway.executeTool(fn.name, args)
               } catch (err) {
                 result = `Error: ${err instanceof Error ? err.message : String(err)}`

--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -39,7 +39,7 @@ export const openaiRunner: AgentRunner = {
       }
     }
 
-    const openaiToolDefs = gatewayTools.map(t => ({
+    const mgmtToolDefs = (ctx.managementTools?.definitions ?? []).map(t => ({
       type: 'function',
       function: {
         name: t.name,
@@ -47,6 +47,18 @@ export const openaiRunner: AgentRunner = {
         parameters: t.inputSchema,
       },
     }))
+
+    const openaiToolDefs = [
+      ...mgmtToolDefs,
+      ...gatewayTools.map(t => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema,
+        },
+      })),
+    ]
 
     const taskTemplate = await getPrompt('system.task-execution')
     const taskPrompt = interpolate(taskTemplate, {
@@ -94,9 +106,12 @@ export const openaiRunner: AgentRunner = {
             yield { type: 'tool_call', tool: fn.name, args: fn.arguments }
 
             let result: string
-            if (gateway) {
+            const argsRaw = typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments)
+            if (ctx.managementTools && ctx.managementTools.definitions.some(d => d.name === fn.name)) {
+              result = await ctx.managementTools.execute(fn.name, argsRaw)
+            } else if (gateway) {
               try {
-                const args = typeof fn.arguments === 'string' ? JSON.parse(fn.arguments) : fn.arguments
+                const args = JSON.parse(argsRaw)
                 result = await gateway.executeTool(fn.name, args)
               } catch (err) {
                 result = `Error: ${err instanceof Error ? err.message : String(err)}`

--- a/apps/web/src/lib/agent-runner/types.ts
+++ b/apps/web/src/lib/agent-runner/types.ts
@@ -1,3 +1,13 @@
+export interface ManagementToolDef {
+  name: string
+  description: string
+  inputSchema: {
+    type: string
+    properties?: Record<string, { type: string; description?: string; enum?: string[] }>
+    required?: string[]
+  }
+}
+
 export interface TaskRunContext {
   taskId: string
   taskTitle: string
@@ -8,6 +18,10 @@ export interface TaskRunContext {
   systemPrompt: string
   modelId: string   // e.g. "claude:claude-sonnet-4-6" | "ext:<cuid>" | "ollama:<model>"
   gateway: { url: string; token: string } | null
+  managementTools?: {
+    definitions: ManagementToolDef[]
+    execute: (name: string, argsRaw: string) => Promise<string>
+  }
 }
 
 export type AgentEvent =

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -4,6 +4,7 @@ import { prisma } from './db'
 import { getPrompt, interpolate } from './system-prompts'
 import { generateEmbedding, vectorSearch } from './embeddings'
 import type { SDKAssistantMessage, SDKResultMessage } from '@anthropic-ai/claude-code'
+import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './management-tools'
 
 async function getActiveTasksSection(): Promise<string> {
   const tasks = await prisma.task.findMany({
@@ -945,73 +946,6 @@ async function handleOrionBootstrapEnvironment(argsRaw: string): Promise<string>
   }
 }
 
-async function handleOrionListAgents(argsRaw: string): Promise<string> {
-  try {
-    const { include_archived } = JSON.parse(argsRaw || '{}') as { include_archived?: boolean }
-    const agents = await prisma.agent.findMany({
-      orderBy: { name: 'asc' },
-      include: { tasks: { where: { status: 'running' }, select: { id: true }, take: 1 } },
-    })
-    const filtered = include_archived
-      ? agents
-      : agents.filter((a: any) => !(a.metadata as any)?.archived)
-    return JSON.stringify(
-      filtered.map((a: any) => {
-        const meta = (a.metadata ?? {}) as Record<string, unknown>
-        const cfg  = (meta.contextConfig ?? {}) as Record<string, unknown>
-        return {
-          id:          a.id,
-          name:        a.name,
-          type:        a.type,
-          role:        a.role ?? null,
-          description: a.description ?? null,
-          persistent:  !!cfg.persistent,
-          busy:        a.tasks.length > 0,
-          archived:    !!(meta.archived),
-        }
-      }),
-      null, 2
-    )
-  } catch (e) {
-    return `Error: ${e instanceof Error ? e.message : String(e)}`
-  }
-}
-
-async function handleOrionListTasks(argsRaw: string): Promise<string> {
-  try {
-    const { status, unassigned_only } = JSON.parse(argsRaw || '{}') as {
-      status?: string | string[]
-      unassigned_only?: boolean
-    }
-    const statuses = status
-      ? (Array.isArray(status) ? status : [status])
-      : ['pending', 'running', 'failed']
-    const tasks = await prisma.task.findMany({
-      where: {
-        status: { in: statuses as any },
-        ...(unassigned_only ? { assignedAgent: null, assignedUserId: null } : {}),
-      },
-      include: { agent: { select: { id: true, name: true } } },
-      orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
-      take: 50,
-    })
-    return JSON.stringify(
-      tasks.map((t: any) => ({
-        id:            t.id,
-        title:         t.title,
-        status:        t.status,
-        priority:      t.priority,
-        assignedAgent: t.agent ? { id: t.agent.id, name: t.agent.name } : null,
-        assignedUser:  t.assignedUserId ?? null,
-        description:   t.description ? t.description.slice(0, 200) : null,
-      })),
-      null, 2
-    )
-  } catch (e) {
-    return `Error: ${e instanceof Error ? e.message : String(e)}`
-  }
-}
-
 async function handleGitopsPropose(argsRaw: string, conversationId: string): Promise<string> {
   try {
     const args = JSON.parse(argsRaw || '{}') as {
@@ -1241,33 +1175,11 @@ async function* streamOpenAIChatCore(
         },
       },
     },
-    {
+    // Agent/task coordination tools — shared with watcher mode via management-tools.ts
+    ...MANAGEMENT_TOOL_DEFS.map(t => ({
       type: 'function' as const,
-      function: {
-        name: 'orion_list_agents',
-        description: 'List all agents on the team — their IDs, names, roles, and current busy/available status. Use this to see who is available before assigning work or creating new agents.',
-        parameters: {
-          type: 'object',
-          properties: {
-            include_archived: { type: 'boolean', description: 'Include archived agents (default false)' },
-          },
-        },
-      },
-    },
-    {
-      type: 'function' as const,
-      function: {
-        name: 'orion_list_tasks',
-        description: 'List tasks filtered by status and assignment. Use this to find unassigned work, check what is running, or review failed tasks.',
-        parameters: {
-          type: 'object',
-          properties: {
-            status:          { type: 'string', description: 'Filter by status: pending, running, done, failed. Defaults to pending+running+failed.' },
-            unassigned_only: { type: 'boolean', description: 'Only return tasks with no agent or user assigned (default false)' },
-          },
-        },
-      },
-    },
+      function: { name: t.name, description: t.description, parameters: t.inputSchema },
+    })),
     {
       type: 'function' as const,
       function: {
@@ -1455,10 +1367,8 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
           result = await handleOrionBootstrapEnvironment(tc.argsRaw)
         } else if (tc.name === 'gitops_propose') {
           result = await handleGitopsPropose(tc.argsRaw, conversationId)
-        } else if (tc.name === 'orion_list_agents') {
-          result = await handleOrionListAgents(tc.argsRaw)
-        } else if (tc.name === 'orion_list_tasks') {
-          result = await handleOrionListTasks(tc.argsRaw)
+        } else if (MANAGEMENT_TOOL_DEFS.some(d => d.name === tc.name)) {
+          result = await executeManagedTool(tc.name, tc.argsRaw, userId)
         } else if (tc.name === 'knowledge_search') {
           result = await handleKnowledgeSearch(tc.argsRaw)
         } else if (tc.name === 'knowledge_graph') {

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -1,0 +1,293 @@
+/**
+ * Shared management tool definitions and dispatcher.
+ *
+ * These tools cover agent/task coordination and are available in all runner modes
+ * (watcher, openai-runner, ollama-runner). Chat-specific tools (environment,
+ * gitops, knowledge) remain in claude.ts.
+ *
+ * SOC2 [A-001]: every write is attributed to the caller via actorId and logged to
+ * the agent-feed audit trail.
+ */
+
+import type { ManagementToolDef } from '@/lib/agent-runner/types'
+import { prisma } from '@/lib/db'
+
+// SOC2 [INPUT-001]: mirrors the reserved-name check in POST /api/agents
+export const RESERVED_AGENT_NAMES = ['human', 'user', 'system', 'admin']
+
+// ── Tool definitions ──────────────────────────────────────────────────────────
+
+export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
+  {
+    name: 'orion_list_agents',
+    description: 'List all agents on the team — their IDs, names, roles, and current busy/available status. Use this to see who is available before assigning work or creating new agents.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        include_archived: { type: 'boolean', description: 'Include archived agents (default false)' },
+      },
+    },
+  },
+  {
+    name: 'orion_list_tasks',
+    description: 'List tasks filtered by status and assignment. Use this to find unassigned work, check what is running, or review failed tasks.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status:          { type: 'string',  description: 'Filter by status: pending, running, done, failed. Defaults to pending+running+failed.' },
+        unassigned_only: { type: 'boolean', description: 'Only return tasks with no agent or user assigned (default false)' },
+      },
+    },
+  },
+  {
+    name: 'orion_assign_task',
+    description: 'Assign a pending task to an agent. Sets the task status to pending and records the agent assignment.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id:  { type: 'string', description: 'Task ID to assign' },
+        agent_id: { type: 'string', description: 'Agent ID to assign the task to' },
+      },
+      required: ['task_id', 'agent_id'],
+    },
+  },
+  {
+    name: 'orion_create_agent',
+    description: 'Create a new agent. Use only when no existing agent is suitable for the required work.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name:        { type: 'string', description: 'Unique agent name (cannot be a reserved name: human, user, system, admin)' },
+        role:        { type: 'string', description: 'One-line role description' },
+        type:        { type: 'string', description: 'Agent type: claude, custom, human (default: claude)' },
+        description: { type: 'string', description: 'Optional longer description' },
+        metadata: {
+          type: 'object',
+          description: 'Optional metadata including systemPrompt and contextConfig. E.g. {"systemPrompt":"...","contextConfig":{"persistent":false}}',
+        },
+      },
+      required: ['name', 'role'],
+    },
+  },
+  {
+    name: 'orion_archive_agent',
+    description: 'Soft-archive a transient agent after its work is done. Never deletes — preserves audit trail (SOC2 [A-001]).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id: { type: 'string', description: 'Agent ID to archive' },
+        reason:   { type: 'string', description: 'Optional reason for archiving' },
+      },
+      required: ['agent_id'],
+    },
+  },
+  {
+    name: 'orion_escalate_task',
+    description: 'Escalate a task to a human user. Sets the assignedUserId and status to pending.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: { type: 'string', description: 'Task ID to escalate' },
+        user_id: { type: 'string', description: 'User ID to assign the task to' },
+      },
+      required: ['task_id', 'user_id'],
+    },
+  },
+]
+
+// ── Audit helper ──────────────────────────────────────────────────────────────
+
+async function auditLog(actorId: string | undefined, content: string): Promise<void> {
+  if (!actorId) return
+  await prisma.agentMessage.create({
+    data: {
+      agentId:     actorId,
+      channel:     'agent-feed',
+      content,
+      messageType: 'task_update',
+    },
+  }).catch(() => {})
+}
+
+// ── Tool handlers ─────────────────────────────────────────────────────────────
+
+async function handleListAgents(argsRaw: string): Promise<string> {
+  const { include_archived } = JSON.parse(argsRaw || '{}') as { include_archived?: boolean }
+  const agents = await prisma.agent.findMany({
+    orderBy: { name: 'asc' },
+    include: { tasks: { where: { status: 'running' }, select: { id: true }, take: 1 } },
+  })
+  const filtered = include_archived
+    ? agents
+    : agents.filter((a: any) => !(a.metadata as any)?.archived)
+  return JSON.stringify(
+    filtered.map((a: any) => {
+      const meta = (a.metadata ?? {}) as Record<string, unknown>
+      const cfg  = (meta.contextConfig ?? {}) as Record<string, unknown>
+      return {
+        id:          a.id,
+        name:        a.name,
+        type:        a.type,
+        role:        a.role ?? null,
+        description: a.description ?? null,
+        persistent:  !!cfg.persistent,
+        busy:        a.tasks.length > 0,
+        archived:    !!(meta.archived),
+      }
+    }),
+    null, 2
+  )
+}
+
+async function handleListTasks(argsRaw: string): Promise<string> {
+  const { status, unassigned_only } = JSON.parse(argsRaw || '{}') as {
+    status?: string | string[]
+    unassigned_only?: boolean
+  }
+  const statuses = status
+    ? (Array.isArray(status) ? status : [status])
+    : ['pending', 'running', 'failed']
+  const tasks = await prisma.task.findMany({
+    where: {
+      status: { in: statuses as any },
+      ...(unassigned_only ? { assignedAgent: null, assignedUserId: null } : {}),
+    },
+    include: { agent: { select: { id: true, name: true } } },
+    orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
+    take: 50,
+  })
+  return JSON.stringify(
+    tasks.map((t: any) => ({
+      id:            t.id,
+      title:         t.title,
+      status:        t.status,
+      priority:      t.priority,
+      assignedAgent: t.agent ? { id: t.agent.id, name: t.agent.name } : null,
+      assignedUser:  t.assignedUserId ?? null,
+      description:   t.description ? t.description.slice(0, 200) : null,
+    })),
+    null, 2
+  )
+}
+
+async function handleAssignTask(argsRaw: string, actorId?: string): Promise<string> {
+  const { task_id, agent_id } = JSON.parse(argsRaw || '{}') as { task_id?: string; agent_id?: string }
+  if (!task_id) return 'Error: task_id is required'
+  if (!agent_id) return 'Error: agent_id is required'
+
+  await prisma.task.update({
+    where: { id: task_id },
+    data:  { assignedAgent: agent_id, status: 'pending' },
+  })
+  const [task, agent] = await Promise.all([
+    prisma.task.findUnique({ where: { id: task_id }, select: { title: true } }),
+    prisma.agent.findUnique({ where: { id: agent_id }, select: { name: true } }),
+  ])
+  const msg = `📋 Assigned **${task?.title}** → **${agent?.name}**`
+  await auditLog(actorId, msg)
+  return `Assigned task "${task?.title}" to agent "${agent?.name}"`
+}
+
+async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<string> {
+  const spec = JSON.parse(argsRaw || '{}') as {
+    name?: string
+    role?: string
+    type?: string
+    description?: string
+    metadata?: Record<string, unknown>
+  }
+
+  if (!spec.name?.trim()) return 'Error: name is required'
+  if (!spec.role?.trim()) return 'Error: role is required'
+
+  // SOC2 [INPUT-001]: reserved name guard
+  if (RESERVED_AGENT_NAMES.includes(spec.name.toLowerCase())) {
+    await auditLog(actorId, `⚠️ Cannot create agent: **${spec.name}** is a reserved name`)
+    return `Error: "${spec.name}" is a reserved agent name`
+  }
+
+  const created = await prisma.agent.create({
+    data: {
+      name:        spec.name.trim(),
+      type:        spec.type ?? 'claude',
+      role:        spec.role ?? null,
+      description: spec.description ?? null,
+      ...(spec.metadata && { metadata: spec.metadata as any }),
+    },
+  })
+  const msg = `🤖 Created agent **${created.name}** (\`${created.id}\`) — ${created.role ?? 'no role'}`
+  await auditLog(actorId, msg)
+  return JSON.stringify({ id: created.id, name: created.name, role: created.role }, null, 2)
+}
+
+async function handleArchiveAgent(argsRaw: string, actorId?: string): Promise<string> {
+  const { agent_id, reason } = JSON.parse(argsRaw || '{}') as { agent_id?: string; reason?: string }
+  if (!agent_id) return 'Error: agent_id is required'
+
+  const existing = await prisma.agent.findUnique({
+    where: { id: agent_id },
+    select: { name: true, metadata: true },
+  })
+  if (!existing) return `Error: agent ${agent_id} not found`
+
+  const existingMeta = (existing.metadata ?? {}) as Record<string, unknown>
+  await prisma.agent.update({
+    where: { id: agent_id },
+    data: {
+      metadata: {
+        ...existingMeta,
+        archived:       true,
+        archivedAt:     new Date().toISOString(),
+        archivedReason: reason ?? 'Task completed',
+      } as any,
+    },
+  })
+  const msg = `📦 Archived agent **${existing.name}** — ${reason ?? 'task completed'}`
+  await auditLog(actorId, msg)
+  return `Archived agent "${existing.name}" (${agent_id})`
+}
+
+async function handleEscalateTask(argsRaw: string, actorId?: string): Promise<string> {
+  const { task_id, user_id } = JSON.parse(argsRaw || '{}') as { task_id?: string; user_id?: string }
+  if (!task_id) return 'Error: task_id is required'
+  if (!user_id) return 'Error: user_id is required'
+
+  await prisma.task.update({
+    where: { id: task_id },
+    data:  { assignedUserId: user_id, status: 'pending' },
+  })
+  const [task, user] = await Promise.all([
+    prisma.task.findUnique({ where: { id: task_id }, select: { title: true } }),
+    prisma.user.findUnique({ where: { id: user_id }, select: { name: true, username: true } }),
+  ])
+  const who = user?.name ?? user?.username ?? user_id
+  const msg = `👤 Escalated **${task?.title}** → **${who}**`
+  await auditLog(actorId, msg)
+  return `Escalated task "${task?.title}" to user "${who}"`
+}
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+/**
+ * Execute a management tool by name.
+ *
+ * @param name     - Tool name (must match a MANAGEMENT_TOOL_DEFS entry)
+ * @param argsRaw  - JSON-encoded arguments string
+ * @param actorId  - Optional agent ID for SOC2 audit attribution
+ */
+export async function executeManagedTool(name: string, argsRaw: string, actorId?: string): Promise<string> {
+  try {
+    switch (name) {
+      case 'orion_list_agents':   return await handleListAgents(argsRaw)
+      case 'orion_list_tasks':    return await handleListTasks(argsRaw)
+      case 'orion_assign_task':   return await handleAssignTask(argsRaw, actorId)
+      case 'orion_create_agent':  return await handleCreateAgent(argsRaw, actorId)
+      case 'orion_archive_agent': return await handleArchiveAgent(argsRaw, actorId)
+      case 'orion_escalate_task': return await handleEscalateTask(argsRaw, actorId)
+      default:
+        return `Error: unknown management tool "${name}"`
+    }
+  } catch (e) {
+    return `Error: ${e instanceof Error ? e.message : String(e)}`
+  }
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -11,6 +11,7 @@
 import { prisma } from './lib/db'
 import { createRunner } from './lib/agent-runner'
 import type { TaskRunContext } from './lib/agent-runner'
+import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './lib/management-tools'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -343,139 +344,6 @@ async function buildSystemSnapshot(): Promise<string> {
   return lines.join('\n')
 }
 
-// Mirrors the reserved-name check in POST /api/agents (kept in sync for SOC2 [INPUT-001])
-const RESERVED_AGENT_NAMES = ['human', 'user', 'system', 'admin']
-
-/**
- * Parse an agent's output for structured directives and execute them.
- *
- * Supported directives:
- *   assign       — assign pending tasks to agents (existing behaviour)
- *   create_agent — create a new agent (server-side, attributed to the watcher)
- *
- * Format: JSON block between ---DIRECTIVES--- and ---END---
- * { "assign": [{"taskId":"...","agentId":"..."}], "create_agent": {...}, "message": "..." }
- *
- * SOC2 [A-001]: all mutations go through the orchestrator, never via unauthenticated HTTP.
- * Every action is attributed to the watcher agent ID and written to AgentMessage (agent-feed).
- */
-async function executeDirectives(agentId: string, output: string): Promise<void> {
-  const match = output.match(/---DIRECTIVES---\s*([\s\S]*?)\s*---END---/)
-  if (!match) return
-
-  let directives: {
-    assign?:        Array<{ taskId: string; agentId: string }>
-    assign_user?:   Array<{ taskId: string; userId: string }>
-    archive_agent?: { agentId: string; reason?: string }
-    create_agent?:  { name: string; type?: string; role?: string; description?: string; metadata?: Record<string, unknown> }
-    message?:       string
-  }
-  try {
-    directives = JSON.parse(match[1])
-  } catch {
-    err(`Failed to parse directives from agent output: ${match[1].slice(0, 200)}`)
-    return
-  }
-
-  // ── assign ──────────────────────────────────────────────────────────────────
-  if (directives.assign?.length) {
-    for (const { taskId, agentId: targetAgentId } of directives.assign) {
-      try {
-        await prisma.task.update({
-          where: { id: taskId },
-          data:  { assignedAgent: targetAgentId, status: 'pending' },
-        })
-        const [task, agent] = await Promise.all([
-          prisma.task.findUnique({ where: { id: taskId }, select: { title: true } }),
-          prisma.agent.findUnique({ where: { id: targetAgentId }, select: { name: true } }),
-        ])
-        log(`Orchestrator assigned "${task?.title}" → "${agent?.name}"`)
-        await postToFeed(agentId, `📋 Assigned **${task?.title}** → **${agent?.name}**`)
-      } catch (e) {
-        err(`Failed to execute assignment ${taskId} → ${targetAgentId}: ${e}`)
-      }
-    }
-  }
-
-  // ── assign_user ──────────────────────────────────────────────────────────────
-  // Escalate a task to a human user — equivalent to PUT /api/tasks/:id { assignedUserId }
-  if (directives.assign_user?.length) {
-    for (const { taskId, userId } of directives.assign_user) {
-      try {
-        await prisma.task.update({ where: { id: taskId }, data: { assignedUserId: userId, status: 'pending' } })
-        const [task, user] = await Promise.all([
-          prisma.task.findUnique({ where: { id: taskId }, select: { title: true } }),
-          prisma.user.findUnique({ where: { id: userId }, select: { name: true, username: true } }),
-        ])
-        const who = user?.name ?? user?.username ?? userId
-        log(`Orchestrator escalated "${task?.title}" → user "${who}"`)
-        await postToFeed(agentId, `👤 Escalated **${task?.title}** → **${who}**`)
-      } catch (e) {
-        err(`Failed to escalate task ${taskId} → user ${userId}: ${e}`)
-      }
-    }
-  }
-
-  // ── archive_agent ─────────────────────────────────────────────────────────────
-  // Archive a transient agent after its work is done — equivalent to PUT /api/agents/:id { metadata.archived }
-  // Never deletes — soft-archive only (SOC2 [A-001]: preserves audit trail).
-  if (directives.archive_agent) {
-    const spec = directives.archive_agent as { agentId: string; reason?: string }
-    if (spec.agentId) {
-      try {
-        const existing = await prisma.agent.findUnique({ where: { id: spec.agentId }, select: { name: true, metadata: true } })
-        const existingMeta = (existing?.metadata ?? {}) as Record<string, unknown>
-        await prisma.agent.update({
-          where: { id: spec.agentId },
-          data: {
-            metadata: {
-              ...existingMeta,
-              archived: true,
-              archivedAt: new Date().toISOString(),
-              archivedReason: spec.reason ?? 'Task completed',
-            } as any,
-          },
-        })
-        log(`Orchestrator archived agent "${existing?.name}" (${spec.agentId}) directed by watcher "${agentId}"`)
-        await postToFeed(agentId, `📦 Archived agent **${existing?.name}** — ${spec.reason ?? 'task completed'}`)
-      } catch (e) {
-        err(`Failed to archive agent ${spec.agentId}: ${e}`)
-      }
-    }
-  }
-
-  // ── create_agent ─────────────────────────────────────────────────────────────
-  // Equivalent to POST /api/agents but executed server-side with watcher attribution.
-  // Applies the same reserved-name guard as the HTTP route (SOC2 [INPUT-001]).
-  if (directives.create_agent) {
-    const spec = directives.create_agent
-    if (!spec.name?.trim()) {
-      err(`create_agent directive from "${agentId}" is missing required "name"`)
-    } else if (RESERVED_AGENT_NAMES.includes(spec.name.toLowerCase())) {
-      err(`create_agent directive from "${agentId}": "${spec.name}" is a reserved name`)
-      await postToFeed(agentId, `⚠️ Cannot create agent: **${spec.name}** is a reserved name`)
-    } else {
-      try {
-        const created = await prisma.agent.create({
-          data: {
-            name:        spec.name.trim(),
-            type:        spec.type ?? 'claude',
-            role:        spec.role ?? null,
-            description: spec.description ?? null,
-            ...(spec.metadata && { metadata: spec.metadata as any }),
-          },
-        })
-        log(`Orchestrator created agent "${created.name}" (${created.id}) directed by watcher "${agentId}"`)
-        // SOC2 [A-001]: action attributed to the directing watcher in the agent-feed audit trail
-        await postToFeed(agentId, `🤖 Created agent **${created.name}** (\`${created.id}\`) — ${created.role ?? 'no role'}`)
-      } catch (e) {
-        err(`Failed to execute create_agent directive from "${agentId}": ${e}`)
-        await postToFeed(agentId, `❌ Failed to create agent **${spec.name}**: ${e}`)
-      }
-    }
-  }
-}
-
 async function runWatchers() {
   const watchers = await prisma.agent.findMany({
     where:   { type: { not: 'human' } },
@@ -514,87 +382,10 @@ async function runWatchers() {
 
     const wikiContext = buildWikiContext(contextNotes)
 
-    // Appended to every watcher's system prompt so directive capabilities are always
-    // authoritative, regardless of what the agent's stored systemPrompt says.
-    // This is in the system prompt (not task description) so it takes precedence.
-    const WATCHER_CAPABILITIES = `
-
----
-## WATCHER RUNTIME — READ THIS BEFORE ACTING
-
-You do NOT have an authenticated HTTP client. Every call to /api/agents, /api/tasks,
-or any other ORION endpoint will fail. Do not attempt them.
-
-The orchestrator executes all mutations on your behalf via a directives block.
-Output it at the END of your response (omit keys you don't need):
-
-\`\`\`
----DIRECTIVES---
-{
-  "assign":        [{"taskId":"<id>","agentId":"<id>"}],
-  "assign_user":   [{"taskId":"<id>","userId":"<id>"}],
-  "archive_agent": {"agentId":"<id>","reason":"<why>"},
-  "create_agent":  {
-    "name": "<name>", "role": "<one-line role>", "type": "claude",
-    "description": "<optional>",
-    "metadata": {
-      "systemPrompt": "<full prompt>",
-      "contextConfig": {"persistent": false}
-    }
-  },
-  "message": "<brief reason>"
-}
----END---
-\`\`\`
-
-Directive reference:
-- assign        — route a pending task to an agent (IDs from snapshot)
-- assign_user   — escalate a task to a human user (IDs from snapshot)
-- archive_agent — soft-archive a transient agent after its work completes (never DELETE)
-- create_agent  — create a new agent; orchestrator posts the feed announcement
-- Omit the block entirely if no action is needed this cycle.
----`
-
     // The agent receives all data it needs as context — no outbound calls required.
-    // Writes go through the ---DIRECTIVES--- block; the orchestrator executes them
-    // server-side with full attribution (SOC2 [A-001]).
-    const enrichedPrompt = [
-      watchPrompt,
-      ``,
-      snapshot,
-      ``,
-      `---`,
-      `## Actions`,
-      ``,
-      `All data you need is in the snapshot above. Do NOT call the ORION API directly — there is no`,
-      `authenticated HTTP client available to you. Use directives instead.`,
-      ``,
-      `To assign tasks or create agents, include ONE directives block at the end of your response:`,
-      `\`\`\``,
-      `---DIRECTIVES---`,
-      `{`,
-      `  "assign": [{"taskId":"<id>","agentId":"<id>"}],`,
-      `  "create_agent": {`,
-      `    "name": "<name>",`,
-      `    "role": "<one-line role description>",`,
-      `    "type": "claude",`,
-      `    "description": "<optional longer description>",`,
-      `    "metadata": {`,
-      `      "systemPrompt": "<full system prompt for this agent>",`,
-      `      "contextConfig": {"persistent": false}`,
-      `    }`,
-      `  },`,
-      `  "message": "<brief reason for these actions>"`,
-      `}`,
-      `---END---`,
-      `\`\`\``,
-      ``,
-      `Rules:`,
-      `- Use "assign" to route pending tasks to available agents (IDs in snapshot).`,
-      `- Use "create_agent" only when no existing agent is suitable for a task.`,
-      `- Include only the keys you need — omit "assign" if making no assignments, omit "create_agent" if not creating an agent.`,
-      `- Omit the directives block entirely if no action is needed.`,
-    ].join('\n')
+    // Mutations go through tool calls (orion_assign_task, orion_create_agent, etc.)
+    // executed server-side with full attribution (SOC2 [A-001]).
+    const enrichedPrompt = [watchPrompt, ``, snapshot].join('\n')
 
     const ctx: TaskRunContext = {
       taskId:          `watch:${agent.id}`,
@@ -603,9 +394,13 @@ Directive reference:
       taskPlan:        null,
       agentId:         agent.id,
       agentName:       agent.name,
-      systemPrompt:    systemPrompt + wikiContext + WATCHER_CAPABILITIES,
+      systemPrompt:    systemPrompt + wikiContext,
       modelId,
       gateway,
+      managementTools: {
+        definitions: MANAGEMENT_TOOL_DEFS,
+        execute: (name, argsRaw) => executeManagedTool(name, argsRaw, agent.id),
+      },
     }
 
     try {
@@ -616,13 +411,8 @@ Directive reference:
         if (event.type === 'error') throw new Error(event.error)
       }
 
-      // Execute any directives (task assignments, etc.)
-      await executeDirectives(agent.id, output)
-
-      // Strip directives block before posting to feed
-      const feedOutput = output.replace(/---DIRECTIVES---[\s\S]*?---END---/g, '').trim()
-      if (feedOutput) {
-        await postToFeed(agent.id, `👁 **${agent.name}**:\n\n${feedOutput.slice(0, 1500)}`)
+      if (output.trim()) {
+        await postToFeed(agent.id, `👁 **${agent.name}**:\n\n${output.trim().slice(0, 1500)}`)
       }
     } catch (e) {
       err(`Watcher "${agent.name}" failed: ${e}`)


### PR DESCRIPTION
## Summary

Agents previously had two completely different paradigms depending on mode:
- **Chat mode**: proper LLM tool calls → server-side handlers in `claude.ts`
- **Watcher mode**: text parsing of `---DIRECTIVES---` blocks → `executeDirectives()`

This PR eliminates that split. Every agent now has the same 6 coordination tools whether it is in a conversation or a watcher cycle.

## Changes

### New: `lib/management-tools.ts`
Single source of truth for all agent coordination tools — definitions and handlers:

| Tool | What it does |
|------|-------------|
| `orion_list_agents` | List team roster with id, role, busy/available, archived status |
| `orion_list_tasks` | List tasks filtered by status / unassigned |
| `orion_assign_task` | Assign a task to an agent |
| `orion_create_agent` | Create a new agent (reserved-name guard enforced) |
| `orion_archive_agent` | Soft-archive a transient agent (never DELETE) |
| `orion_escalate_task` | Assign a task to a human user |

All write tools log to `AgentMessage (agent-feed)` with the actor's agent ID for SOC2 `[A-001]` attribution.

### `lib/agent-runner/types.ts`
Added `ManagementToolDef` interface and `managementTools?: { definitions, execute }` to `TaskRunContext`.

### `openai-runner.ts` + `ollama-runner.ts`
Both runners prepend `ctx.managementTools?.definitions` to the tool list and check management tools first in their dispatch loop before forwarding to the gateway.

### `lib/claude.ts`
`MANAGEMENT_TOOLS` array replaced with `...MANAGEMENT_TOOL_DEFS` spread from the shared module. Dispatch uses `executeManagedTool()`. Chat-specific tools (`orion_get_environment`, `gitops_propose`, etc.) remain inline.

### `worker.ts`
- Removed `executeDirectives()` (~115 lines of text-parsing)
- Removed `WATCHER_CAPABILITIES` and `RESERVED_AGENT_NAMES` (now in `management-tools.ts`)
- Watcher `ctx` now includes `managementTools` pointing to `executeManagedTool` with `agent.id` as actor
- `enrichedPrompt` simplified — no directives format needed

## SOC2

- No auth bypass — all tools run as Prisma queries in the server process
- No credentials in LLM context
- All writes attributed to the calling agent via `agentMessage` feed entries
- `orion_create_agent` enforces the same reserved-name guard as `POST /api/agents`
- `orion_archive_agent` never DELETEs — soft-archive only, audit trail preserved

## Supersedes
- #211 (directive-based watcher writes — replaced by tool calls)
- #214 (partial management tools in chat only — superseded by unified approach)

## Test plan

- [ ] Alpha watcher cycle: `orion_list_agents` returns team roster as a tool result
- [ ] Alpha watcher cycle: `orion_assign_task` assigns a task without errors; feed entry appears
- [ ] Alpha watcher cycle: `orion_create_agent` creates an agent; reserved names rejected
- [ ] Alpha chat: same 6 tools available and working identically
- [ ] Agent with no gateway still has all 6 management tools
- [ ] Agent with a gateway has management tools + gateway tools together

🤖 Generated with [Claude Code](https://claude.com/claude-code)