### PR TITLE
fix: accept custom provider in resolveOpenAIConfig

### DIFF
--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -154,7 +154,7 @@ async function resolveOpenAIConfig(modelId: string): Promise<{ baseUrl: string; 
     model = await prisma.externalModel.findUnique({ where: { id: extId } })
   }
 
-  if (!model || model.provider !== 'openai') {
+  if (!model || (model.provider !== 'openai' && model.provider !== 'custom')) {
     throw new Error(`No OpenAI-compatible model configured for ID: ${modelId}`)
   }
 


### PR DESCRIPTION
## Summary

`resolveOpenAIConfig` in `openai-runner.ts` checked `model.provider !== 'openai'` and threw for anything else. The dispatcher (merged in #212) routes `provider='custom'` (LM Studio, llama.cpp, vLLM, etc.) to `openaiRunner` — but `resolveOpenAIConfig` rejected it, causing Alpha's watcher cycle to fail every time with:

```
No OpenAI-compatible model configured for ID: ext:cmnv391920001p70603yvas6v
```

One-line fix: accept both `openai` and `custom` as valid OpenAI-compatible providers.

## Test plan

- [ ] Alpha watcher cycle completes without error after deploy
- [ ] `docker logs deploy-orion-1` shows `Running watcher: Alpha` followed by tool calls, not an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)