### PR TITLE
fix: inject system default LLM when creating agents via management tool

### DIFF
--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -154,7 +154,7 @@ async function resolveOpenAIConfig(modelId: string): Promise<{ baseUrl: string; 
     model = await prisma.externalModel.findUnique({ where: { id: extId } })
   }
 
-  if (!model || model.provider !== 'openai') {
+  if (!model || (model.provider !== 'openai' && model.provider !== 'custom')) {
     throw new Error(`No OpenAI-compatible model configured for ID: ${modelId}`)
   }
 

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -11,6 +11,7 @@
 
 import type { ManagementToolDef } from '@/lib/agent-runner/types'
 import { prisma } from '@/lib/db'
+import { getDefaultModelId } from '@/lib/default-model'
 
 // SOC2 [INPUT-001]: mirrors the reserved-name check in POST /api/agents
 export const RESERVED_AGENT_NAMES = ['human', 'user', 'system', 'admin']
@@ -59,7 +60,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
       properties: {
         name:        { type: 'string', description: 'Unique agent name (cannot be a reserved name: human, user, system, admin)' },
         role:        { type: 'string', description: 'One-line role description' },
-        type:        { type: 'string', description: 'Agent type: claude, custom, human (default: claude)' },
+        type:        { type: 'string', description: 'Agent type for AI agents (default: claude). Do NOT use "human" — that is reserved for human users.' },
         description: { type: 'string', description: 'Optional longer description' },
         metadata: {
           type: 'object',
@@ -206,13 +207,20 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
     return `Error: "${spec.name}" is a reserved agent name`
   }
 
+  // Resolve default LLM so created agents don't fall back to Claude Code SDK
+  const defaultLlm = await getDefaultModelId()
+  const incomingMeta   = (spec.metadata ?? {}) as Record<string, unknown>
+  const incomingCfg    = (incomingMeta.contextConfig ?? {}) as Record<string, unknown>
+  const contextConfig  = { ...incomingCfg, llm: incomingCfg.llm ?? defaultLlm }
+  const mergedMetadata = { ...incomingMeta, contextConfig }
+
   const created = await prisma.agent.create({
     data: {
       name:        spec.name.trim(),
-      type:        spec.type ?? 'claude',
+      type:        (spec.type && spec.type !== 'human') ? spec.type : 'claude',
       role:        spec.role ?? null,
       description: spec.description ?? null,
-      ...(spec.metadata && { metadata: spec.metadata as any }),
+      metadata:    mergedMetadata as any,
     },
   })
   const msg = `🤖 Created agent **${created.name}** (\`${created.id}\`) — ${created.role ?? 'no role'}`


### PR DESCRIPTION
## Summary

- `handleCreateAgent` now calls `getDefaultModelId()` and injects the result into `contextConfig.llm` when the caller doesn't supply one — agents created by Alpha will use the configured system default instead of falling through to Claude Code SDK
- Added a guard: if `type: 'human'` is passed it is silently clamped to `'claude'` — Alpha was misled by the old description which listed 'human' as an option
- Updated `type` field description to explicitly say **do not use 'human'** for AI workers

## Root cause

`worker.ts` reads `contextConfig.llm ?? 'claude:claude-sonnet-4-6'` — the `claude:` prefix routes to `claudeRunner` which uses the Claude Code SDK. Without OAuth credentials in the container that fails immediately (exit 1). Every agent Alpha spun up had no `llm` in its metadata, so all of them hit this path.

## Test plan

- [ ] Deploy and ask Alpha to create a new agent — confirm the returned JSON shows `contextConfig.llm` set to the system default model ID
- [ ] Verify newly created agents start tasks using the Qwen model (not Claude Code SDK)
- [ ] Confirm existing broken agents (Container-Registry-Agent, Identity-Access-Agent, etc.) need a one-time metadata patch

## Follow-up (manual) — patch existing broken agents

```sql
UPDATE "Agent"
SET metadata = jsonb_set(
  COALESCE(metadata, '{}'),
  '{contextConfig,llm}',
  '"ext:cmnv391920001p70603yvas6v"'
)
WHERE (metadata->'contextConfig'->>'llm') IS NULL
  AND (metadata->>'archived') IS DISTINCT FROM 'true';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)