### PR TITLE
fix: resolve agent LLM from system default, no hardcoded models

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -92,6 +92,39 @@ const runningTasks = new Set<string>()
 function log(msg: string) { process.stdout.write(`[orchestrator] ${msg}\n`) }
 function err(msg: string) { process.stderr.write(`[orchestrator] ERROR: ${msg}\n`) }
 
+// ── Model resolution ──────────────────────────────────────────────────────────
+
+let cachedDefaultModel: string | null = null
+
+/**
+ * Resolve an agent's LLM setting to a concrete model ID.
+ *
+ * Rules:
+ * - falsy / boolean true → use system default (SystemSetting['model.default'])
+ * - bare agent ID (no prefix) → treat as ext:<id>
+ * - already prefixed (claude:*, ollama:*, ext:*) → use as-is
+ *
+ * Falls back to 'claude:claude-sonnet-4-6' only if no system default is set.
+ */
+async function resolveModelId(llm: unknown): Promise<string> {
+  const useDefault = !llm || llm === true
+
+  if (useDefault || typeof llm !== 'string') {
+    if (!cachedDefaultModel) {
+      const setting = await prisma.systemSetting.findUnique({ where: { key: 'model.default' } })
+      cachedDefaultModel = (setting?.value as string | undefined) ?? 'claude:claude-sonnet-4-6'
+    }
+    return cachedDefaultModel
+  }
+
+  // Bare agent/model ID with no routing prefix → treat as external gateway agent
+  if (!llm.startsWith('claude:') && !llm.startsWith('ollama:') && !llm.startsWith('ext:')) {
+    return `ext:${llm}`
+  }
+
+  return llm
+}
+
 // ── Core task runner ───────────────────────────────────────────────────────────
 
 async function runTask(taskId: string): Promise<void> {
@@ -117,9 +150,9 @@ async function runTask(taskId: string): Promise<void> {
 
     const agent = task.agent
     const meta = (agent.metadata ?? {}) as Record<string, unknown>
-    const contextConfig = (meta.contextConfig ?? {}) as Record<string, string>
+    const contextConfig = (meta.contextConfig ?? {}) as Record<string, unknown>
     const agentSystemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a helpful AI agent.'
-    const modelId = contextConfig.llm ?? 'claude:claude-sonnet-4-6'
+    const modelId = await resolveModelId(contextConfig.llm)
 
     // Inject llm-context wiki notes into every agent's system prompt (SOC2: [C-001])
     const contextNotes = await prisma.note.findMany({
@@ -446,7 +479,7 @@ async function runWatchers() {
     log(`Running watcher: "${agent.name}"`)
 
     const systemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a monitoring agent.'
-    const modelId = (cfg.llm as string | undefined) ?? 'claude:claude-sonnet-4-6'
+    const modelId = await resolveModelId(cfg.llm)
     const envLink = agent.environments?.[0]
     const gateway = envLink?.environment?.gatewayUrl && envLink?.environment?.gatewayToken
       ? { url: envLink.environment.gatewayUrl, token: envLink.environment.gatewayToken }

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -112,7 +112,9 @@ async function resolveModelId(llm: unknown): Promise<string> {
   if (useDefault || typeof llm !== 'string') {
     if (!cachedDefaultModel) {
       const setting = await prisma.systemSetting.findUnique({ where: { key: 'model.default' } })
-      cachedDefaultModel = (setting?.value as string | undefined) ?? 'claude:claude-sonnet-4-6'
+      const value = setting?.value as string | undefined
+      if (!value) throw new Error('No default LLM configured — set model.default in System Settings')
+      cachedDefaultModel = value
     }
     return cachedDefaultModel
   }


### PR DESCRIPTION
## Summary

- Agents with no explicit LLM set (`llm: true`, falsy, or unset) now resolve to `SystemSetting['model.default']` instead of a hardcoded `claude:claude-sonnet-4-6`
- Bare agent IDs with no routing prefix (e.g. `cmnv391920001p70603yvas6v`) are auto-normalised to `ext:<id>` so they route through the gateway dispatcher
- If `model.default` is not configured in System Settings, tasks fail with a clear error rather than silently using the wrong model
- Cache on `resolveModelId()` means SystemSetting is only queried once per worker restart

## Why

Agents were silently failing with "Claude Code process exited with code 1" because the worker fell back to the Claude Code SDK runner when no credentials were available in the container. Root causes:
1. `llm: true` (boolean) passed `?? 'claude:claude-sonnet-4-6'` because `??` doesn't fire on non-nullish values
2. Bare agent IDs routed to `claudeRunner` (the fallback) instead of `dispatcherRunner`

## Test plan

- [ ] Agent with `llm: true` → uses `model.default` from System Settings
- [ ] Agent with `llm: "cmnv391920001p70603yvas6v"` (bare ID) → routed as `ext:cmnv391920001p70603yvas6v`
- [ ] Agent with `llm: "ext:..."` → unchanged
- [ ] No `model.default` in SystemSetting → task fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)