### PR TITLE
fix: prevent crash when /api/jobs returns 429, raise UI polling rate limits

### DIFF
--- a/apps/web/src/components/jobs/JobsPanel.tsx
+++ b/apps/web/src/components/jobs/JobsPanel.tsx
@@ -260,8 +260,10 @@ export function JobsPanel() {
 
   const fetchJobs = useCallback(async () => {
     try {
-      const data: BackgroundJob[] = await fetch('/api/jobs').then(r => r.json())
-      setJobs(data)
+      const res  = await fetch('/api/jobs')
+      if (!res.ok) return
+      const data: unknown = await res.json()
+      if (Array.isArray(data)) setJobs(data as BackgroundJob[])
     } catch { /* silent */ }
   }, [])
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -39,6 +39,10 @@ const RATE_LIMITS: Record<string, [number, number]> = {
   // Tool generation — moderate limit (cost control)
   '/api/tools/generate': [20, 15 * 60 * 1000],
 
+  // UI polling endpoints — high limit (browser polls every few seconds)
+  '/api/jobs': [2000, 15 * 60 * 1000],
+  '/api/agents': [2000, 15 * 60 * 1000],
+
   // Default — global limit
   'default': [100, 15 * 60 * 1000],
 }


### PR DESCRIPTION
## Summary

- `JobsPanel` called `.filter()` on the 429 error object (not an array), crashing the React tree and cascading into hydration errors (#425, #418, #423) visible in the browser console
- Fixed by checking `Array.isArray(data)` before calling `setJobs`
- Added explicit high rate limits for `/api/jobs` and `/api/agents` (2000/15min) — browser polls these every 5 seconds, far exceeding the 100/15min default

## Root cause

`JobsPanel` polls `/api/jobs` every 5 seconds → 180 requests/15 min. Default rate limit is 100/15 min. After ~8 minutes the panel gets a 429, `r.json()` returns `{ error: "..." }`, `.filter()` throws `e.filter is not a function`, React unmounts the tree, hydration errors follow.

## Test plan

- [ ] Open ORION in browser, leave it open for 15+ minutes — no React console errors
- [ ] `/api/jobs` returns array under normal conditions → jobs panel works
- [ ] `/api/jobs` returning a non-array (error, null) → panel stays silent, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)