### PR TITLE
fix: add maxTokens to ExternalModel to cap thinking model generation

### DIFF
--- a/apps/web/prisma/migrations/1_external_model_max_tokens/migration.sql
+++ b/apps/web/prisma/migrations/1_external_model_max_tokens/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ExternalModel" ADD COLUMN "maxTokens" INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -434,6 +434,7 @@ model ExternalModel {
   modelId     String
   enabled     Boolean  @default(true)
   timeoutSecs Int      @default(120)
+  maxTokens   Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }

--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -25,7 +25,7 @@ interface OpenAIResponse {
 export const openaiRunner: AgentRunner = {
   async *run(ctx: TaskRunContext): AsyncGenerator<AgentEvent> {
     // Resolve OpenAI config
-    const { baseUrl, apiKey, modelId, timeoutSecs } = await resolveOpenAIConfig(ctx.modelId)
+    const { baseUrl, apiKey, modelId, timeoutSecs, maxTokens } = await resolveOpenAIConfig(ctx.modelId)
 
     // Fetch tools from gateway (if connected)
     let gatewayTools: GatewayTool[] = []
@@ -88,6 +88,7 @@ export const openaiRunner: AgentRunner = {
             model: modelId,
             messages,
             stream: false,
+            ...(maxTokens !== null && { max_tokens: maxTokens }),
             ...(openaiToolDefs.length > 0 && { tools: openaiToolDefs }),
           }),
           signal: AbortSignal.timeout(timeoutSecs * 1000),
@@ -145,7 +146,7 @@ export const openaiRunner: AgentRunner = {
   },
 }
 
-async function resolveOpenAIConfig(modelId: string): Promise<{ baseUrl: string; apiKey: string | undefined; modelId: string; timeoutSecs: number }> {
+async function resolveOpenAIConfig(modelId: string): Promise<{ baseUrl: string; apiKey: string | undefined; modelId: string; timeoutSecs: number; maxTokens: number | null }> {
   const { prisma } = await import('../db')
   let model = null
 
@@ -162,6 +163,7 @@ async function resolveOpenAIConfig(modelId: string): Promise<{ baseUrl: string; 
     baseUrl: model.baseUrl,
     apiKey: model.apiKey || undefined,
     modelId: model.modelId,
-    timeoutSecs: model.timeoutSecs ?? 120
+    timeoutSecs: model.timeoutSecs ?? 120,
+    maxTokens: (model as any).maxTokens ?? null,
   }
 }


### PR DESCRIPTION
## Summary

- Add optional `maxTokens` field to `ExternalModel` schema
- Pass `max_tokens` to OpenAI-compatible completion requests when set
- Add migration `1_external_model_max_tokens` to add the column

## Why

Thinking models (Qwen3.6, DeepSeek-R1, etc.) generate unlimited tokens by default. With a 35B model and no cap, a single watcher prompt can run for 5+ minutes — far exceeding the default 120s timeout. Every subsequent request queues and also times out, causing all watchers to fail with `Error: fetch failed`.

After this PR deploys, set `maxTokens` and `timeoutSecs` on the ExternalModel through the UI (Settings → External Models) to values appropriate for the model.

## Test plan

- [ ] ExternalModel with `maxTokens` set → `max_tokens` included in completion request body
- [ ] ExternalModel with `maxTokens` null → no `max_tokens` field sent (model default)
- [ ] Migration runs cleanly on fresh install and existing DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)