### PR TITLE
feat: chat room hierarchy and auto-creation for epics/features

### DIFF
--- a/apps/web/src/app/(app)/admin/models/page.tsx
+++ b/apps/web/src/app/(app)/admin/models/page.tsx
@@ -11,6 +11,7 @@ interface ExternalModel {
   modelId: string
   enabled: boolean
   timeoutSecs: number
+  maxTokens: number | null
 }
 
 interface Health {
@@ -26,9 +27,10 @@ interface ModelForm {
   modelId: string
   enabled: boolean
   timeoutSecs: number
+  maxTokens: number | null
 }
 
-const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120 }
+const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120, maxTokens: null }
 
 const PROVIDER_LABELS: Record<string, string> = {
   openai: 'OpenAI Compatible',
@@ -91,7 +93,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
   const isNew = model === null
   const [form, setForm] = useState<ModelForm>(
     model
-      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120 }
+      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120, maxTokens: model.maxTokens ?? null }
       : EMPTY_FORM
   )
   const [saving, setSaving]         = useState(false)
@@ -107,7 +109,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
     if (!form.name || !form.baseUrl || !form.modelId) { setError('Name, Base URL, and Model ID are required.'); return }
     setSaving(true); setError(null)
     try {
-      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs }
+      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs, maxTokens: form.maxTokens }
       const res = model
         ? await fetch(`/api/admin/models/${model.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
         : await fetch('/api/admin/models', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -223,6 +225,16 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
                 max={3600}
                 value={form.timeoutSecs}
                 onChange={e => setForm(f => ({ ...f, timeoutSecs: Math.max(10, parseInt(e.target.value) || 120) }))}
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Max Tokens (blank = unlimited)">
+              <input
+                type="number"
+                min={1}
+                value={form.maxTokens ?? ''}
+                onChange={e => setForm(f => ({ ...f, maxTokens: e.target.value ? Math.max(1, parseInt(e.target.value)) : null }))}
+                placeholder="unlimited"
                 className={inputCls}
               />
             </FormField>

--- a/apps/web/src/app/(app)/messages/page.tsx
+++ b/apps/web/src/app/(app)/messages/page.tsx
@@ -30,6 +30,10 @@ interface Room {
   id: string
   name: string
   type: string
+  epicId?: string | null
+  featureId?: string | null
+  epic?: { id: string; title: string } | null
+  feature?: { id: string; title: string } | null
   created_at: string
   _count: { messages: number; members: number }
   task?: { id: string; title: string } | null
@@ -67,7 +71,7 @@ function MessagesContent() {
         fetch('/api/chat/conversations').then(r => r.json().catch(() => [])).then((d: any) => Array.isArray(d) ? d : []),
         fetch('/api/epics').then(r => r.json().catch(() => [])).then((d: any) => Array.isArray(d) ? d : []),
         fetch('/api/agents').then(r => r.json().catch(() => [])).then((d: any) => Array.isArray(d) ? d : []),
-        fetch('/api/chatrooms').then(r => r.json().catch(() => ({ rooms: [] }))).then((d: any) => d.rooms || []),
+        fetch('/api/chatrooms?all=true').then(r => r.json().catch(() => ({ rooms: [] }))).then((d: any) => d.rooms || []),
       ])
       setConvos(convosRes)
       setEpics(epicsRes)

--- a/apps/web/src/app/api/admin/models/[id]/route.ts
+++ b/apps/web/src/app/api/admin/models/[id]/route.ts
@@ -21,6 +21,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (body.modelId     !== undefined) updateData.modelId     = body.modelId
   if (body.enabled     !== undefined) updateData.enabled     = body.enabled
   if (body.timeoutSecs !== undefined) updateData.timeoutSecs = body.timeoutSecs
+  if ('maxTokens' in body)            updateData.maxTokens   = body.maxTokens  // null clears the cap
   if (body.apiKey)                    updateData.apiKey      = body.apiKey
 
   const model = await prisma.externalModel.update({

--- a/apps/web/src/app/api/chatrooms/route.ts
+++ b/apps/web/src/app/api/chatrooms/route.ts
@@ -21,7 +21,8 @@ export async function GET(req: NextRequest) {
   const type = searchParams.get('type') ?? undefined
   const featureId = searchParams.get('featureId') ?? undefined
   const epicId = searchParams.get('epicId') ?? undefined
-  const limit = Math.min(parseInt(searchParams.get('limit') ?? '50') || 50, 200)
+  const all = searchParams.get('all') === 'true'  // skip member filter — for hierarchy view
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '100') || 100, 200)
   const cursor = searchParams.get('cursor')
 
   const where: Record<string, unknown> = {}
@@ -36,11 +37,15 @@ export async function GET(req: NextRequest) {
     orderBy: { updatedAt: 'desc' },
     include: {
       _count: { select: { messages: true, members: true } },
-      task: { select: { id: true, title: true } },
+      task:    { select: { id: true, title: true } },
       feature: { select: { id: true, title: true } },
-      epic: { select: { id: true, title: true } },
+      epic:    { select: { id: true, title: true } },
     },
   })
+
+  if (all) {
+    return NextResponse.json({ rooms })
+  }
 
   const session = await getServerSession(authOptions)
   const userId = session?.user?.id

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -32,5 +32,17 @@ export async function POST(req: NextRequest) {
     },
     include: { features: { include: { _count: { select: { tasks: true } } } } },
   })
+
+  // Auto-create a planning chat room for this epic
+  await prisma.chatRoom.create({
+    data: {
+      name: `${epic.title} — Planning`,
+      type: 'planning',
+      epicId: epic.id,
+      createdBy: caller?.id ?? 'system',
+      ...(caller ? { members: { create: [{ userId: caller.id, role: 'lead' }] } } : {}),
+    },
+  })
+
   return NextResponse.json(epic, { status: 201 })
 }

--- a/apps/web/src/app/api/features/route.ts
+++ b/apps/web/src/app/api/features/route.ts
@@ -35,5 +35,33 @@ export async function POST(req: NextRequest) {
     } as any,
     include: { _count: { select: { tasks: true } } },
   })
+
+  // Auto-create a feature chat room and add any already-assigned agents
+  const room = await prisma.chatRoom.create({
+    data: {
+      name: feature.title,
+      type: 'feature',
+      featureId: feature.id,
+      ...(data.epicId ? { epicId: data.epicId } : {}),
+      createdBy: caller?.id ?? 'system',
+      ...(caller ? { members: { create: [{ userId: caller.id, role: 'lead' }] } } : {}),
+    },
+  })
+
+  // Add any agents already assigned to tasks in this feature
+  const assignedAgents = await prisma.task.findMany({
+    where: { featureId: feature.id, assignedAgent: { not: null } },
+    select: { assignedAgent: true },
+    distinct: ['assignedAgent'],
+  })
+  for (const { assignedAgent } of assignedAgents) {
+    if (!assignedAgent) continue
+    await prisma.chatRoomMember.upsert({
+      where: { roomId_agentId: { roomId: room.id, agentId: assignedAgent } },
+      create: { roomId: room.id, agentId: assignedAgent, role: 'member' },
+      update: {},
+    })
+  }
+
   return NextResponse.json(feature, { status: 201 })
 }

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -45,6 +45,22 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     data: dbData,
     include: { agent: true, assignedUser: true },
   })
+
+  // When an agent is assigned, add them to the feature's chat room (if one exists)
+  if (data.assignedAgentId && existing.featureId) {
+    const featureRoom = await prisma.chatRoom.findFirst({
+      where: { featureId: existing.featureId, type: 'feature' },
+      select: { id: true },
+    })
+    if (featureRoom) {
+      await prisma.chatRoomMember.upsert({
+        where: { roomId_agentId: { roomId: featureRoom.id, agentId: data.assignedAgentId as string } },
+        create: { roomId: featureRoom.id, agentId: data.assignedAgentId as string, role: 'member' },
+        update: {},
+      })
+    }
+  }
+
   return NextResponse.json(task)
 }
 

--- a/apps/web/src/components/messages/MessageList.tsx
+++ b/apps/web/src/components/messages/MessageList.tsx
@@ -33,6 +33,10 @@ interface Room {
   id: string
   name: string
   type: string
+  epicId?: string | null
+  featureId?: string | null
+  epic?: { id: string; title: string } | null
+  feature?: { id: string; title: string } | null
   created_at: string
   _count: { messages: number; members: number }
   task?: { id: string; title: string } | null
@@ -179,23 +183,67 @@ export function MessageList({
     </div>
   )
 
-  const renderRoom = (room: Room) => (
-    <button
+  const [editingRoomId, setEditingRoomId] = useState<string | null>(null)
+  const [editRoomValue, setEditRoomValue] = useState('')
+  const roomInputRef = useRef<HTMLInputElement>(null)
+
+  const startRoomEdit = (e: React.MouseEvent, room: Room) => {
+    e.stopPropagation()
+    setEditingRoomId(room.id)
+    setEditRoomValue(room.name)
+    setTimeout(() => roomInputRef.current?.focus(), 0)
+  }
+
+  const commitRoomEdit = async (id: string) => {
+    if (editRoomValue.trim()) {
+      await fetch(`/api/chatrooms/${id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: editRoomValue.trim() }) })
+      onRename?.(id, editRoomValue.trim())
+    }
+    setEditingRoomId(null)
+  }
+
+  const deleteRoom = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation()
+    if (!confirm('Delete this chat room and all its messages?')) return
+    await fetch(`/api/chatrooms/${id}`, { method: 'DELETE' })
+    onDelete?.(`r_${id}`)
+  }
+
+  const renderRoom = (room: Room, indent = false) => (
+    <div
       key={room.id}
-      className={`w-full text-left px-4 py-3 border-b border-border-subtle transition-colors ${activeId === `r_${room.id}` ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-bg-raised'}`}
-      onClick={() => { onSelect(`r_${room.id}`); onMobileSelect?.() }}
+      className={`group w-full text-left border-b border-border-subtle transition-colors ${indent ? 'pl-5' : ''} ${activeId === `r_${room.id}` ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-bg-raised'}`}
+      onClick={() => { if (editingRoomId !== room.id) { onSelect(`r_${room.id}`); onMobileSelect?.() } }}
     >
-      <div className="flex items-center gap-2 mb-1">
-        <Hash size={12} className="text-text-muted" />
-        <span className="text-xs font-medium text-text-primary truncate">{room.name}</span>
-        <span className={`ml-auto px-1.5 py-0.5 rounded text-[9px] flex-shrink-0 ${TYPE_COLORS[room.type] || TYPE_COLORS.general}`}>{room.type}</span>
+      <div className="flex items-center gap-1.5 px-3 py-2">
+        <Hash size={11} className="text-text-muted flex-shrink-0" />
+        {editingRoomId === room.id ? (
+          <div className="flex items-center gap-1 flex-1 min-w-0" onClick={e => e.stopPropagation()}>
+            <input ref={roomInputRef} value={editRoomValue} onChange={e => setEditRoomValue(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') commitRoomEdit(room.id); if (e.key === 'Escape') setEditingRoomId(null) }}
+              onBlur={() => commitRoomEdit(room.id)}
+              className="flex-1 min-w-0 text-xs bg-bg-raised border border-accent rounded px-1 py-0.5 text-text-primary focus:outline-none" />
+            <button onClick={() => commitRoomEdit(room.id)} className="text-green-400 hover:text-green-300"><Check size={11} /></button>
+            <button onClick={() => setEditingRoomId(null)} className="text-text-muted hover:text-red-400"><X size={11} /></button>
+          </div>
+        ) : (
+          <>
+            <span className="text-xs text-text-primary truncate flex-1">{room.name}</span>
+            <span className={`px-1.5 py-0.5 rounded text-[9px] flex-shrink-0 ${TYPE_COLORS[room.type] || TYPE_COLORS.general}`}>{room.type}</span>
+            <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0">
+              <button onClick={e => startRoomEdit(e, room)} className="p-0.5 rounded text-text-muted hover:text-accent hover:bg-accent/10"><Pencil size={10} /></button>
+              <button onClick={e => deleteRoom(e, room.id)} className="p-0.5 rounded text-text-muted hover:text-red-400 hover:bg-red-400/10"><Trash2 size={10} /></button>
+            </div>
+          </>
+        )}
       </div>
-      <div className="flex items-center gap-2 ml-4">
-        <span className="text-[10px] text-text-muted">{room._count.messages} msgs</span>
-        <span className="text-[10px] text-text-muted flex items-center gap-0.5"><Users size={10} /> {room._count.members}</span>
-      </div>
-      {room.task && <div className="ml-4 text-[10px] text-accent mt-0.5 truncate">linked: {room.task.title}</div>}
-    </button>
+      {!editingRoomId && (
+        <div className="flex items-center gap-2 px-3 pb-1.5 ml-4">
+          <span className="text-[10px] text-text-muted">{room._count.messages} msgs</span>
+          <span className="text-[10px] text-text-muted flex items-center gap-0.5"><Users size={9} /> {room._count.members}</span>
+        </div>
+      )}
+    </div>
   )
 
   // ── AI-only sections ─────────────────────────────────────────
@@ -371,34 +419,115 @@ export function MessageList({
     )
   }
 
-  const renderRoomSections = () => (
-    <>
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-3 border-b border-border-subtle flex-shrink-0">
-        <span className="text-xs font-semibold text-text-secondary">Chat Rooms</span>
-        <button onClick={onCreateNew} className="p-1 rounded text-text-muted hover:text-accent hover:bg-accent/10 transition-colors" title="New room">
-          <Plus size={14} />
-        </button>
-      </div>
+  const renderRoomSections = () => {
+    // Group rooms by epic hierarchy
+    const epicIds = new Set((epics ?? []).map(e => e.id))
+    const roomsByEpicId = new Map<string, Room[]>()
+    const roomsByFeatureId = new Map<string, Room[]>()
+    const unattachedRooms: Room[] = []
 
-      {/* Filter chips */}
-      <div className="px-3 py-2 border-b border-border-subtle">
-        <div className="flex items-center gap-1 flex-wrap">
-          <button onClick={() => setRoomFilter('')} className={`px-2 py-0.5 rounded text-[10px] ${!effectiveRoomFilter ? 'bg-accent/20 text-accent' : 'text-text-muted hover:text-text-primary'}`}>All</button>
-          {['task', 'feature', 'general', 'ops'].map(t => (
-            <button key={t} onClick={() => setRoomFilter(effectiveRoomFilter === t ? '' : t)} className={`px-2 py-0.5 rounded text-[10px] capitalize ${effectiveRoomFilter === t ? 'bg-accent/20 text-accent' : 'text-text-muted hover:text-text-primary'}`}>{t}</button>
-          ))}
+    for (const room of rooms ?? []) {
+      if (room.epicId && !room.featureId) {
+        const list = roomsByEpicId.get(room.epicId) ?? []
+        list.push(room)
+        roomsByEpicId.set(room.epicId, list)
+      } else if (room.featureId) {
+        const list = roomsByFeatureId.get(room.featureId) ?? []
+        list.push(room)
+        roomsByFeatureId.set(room.featureId, list)
+      } else {
+        unattachedRooms.push(room)
+      }
+    }
+
+    // Epics that have at least one room (directly or via features)
+    const epicsWithRooms = (epics ?? []).filter(epic =>
+      (roomsByEpicId.get(epic.id)?.length ?? 0) > 0 ||
+      epic.features.some(f => (roomsByFeatureId.get(f.id)?.length ?? 0) > 0)
+    )
+
+    // Rooms attached to features whose epic isn't in our epics list (orphaned)
+    const allKnownFeatureIds = new Set((epics ?? []).flatMap(e => e.features.map(f => f.id)))
+    const featureRoomsWithoutEpic = [...roomsByFeatureId.entries()]
+      .filter(([fId]) => !allKnownFeatureIds.has(fId))
+      .flatMap(([, rs]) => rs)
+
+    return (
+      <>
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-3 border-b border-border-subtle flex-shrink-0">
+          <span className="text-xs font-semibold text-text-secondary">Chat Rooms</span>
+          <button onClick={onCreateNew} className="p-1 rounded text-text-muted hover:text-accent hover:bg-accent/10 transition-colors" title="New room">
+            <Plus size={14} />
+          </button>
         </div>
-      </div>
 
-      {/* Room list */}
-      {filteredRooms.length === 0 ? (
-        <div className="p-4 text-center text-text-muted text-xs">No chat rooms yet.</div>
-      ) : (
-        filteredRooms.map(renderRoom)
-      )}
-    </>
-  )
+        {rooms.length === 0 ? (
+          <div className="p-4 text-center text-text-muted text-xs">No chat rooms yet.</div>
+        ) : (
+          <>
+            {/* Epic hierarchy */}
+            {epicsWithRooms.map(epic => {
+              const isOpen = expandedEpics.has(epic.id)
+              const epicRooms = roomsByEpicId.get(epic.id) ?? []
+              const featureCount = epic.features.filter(f => (roomsByFeatureId.get(f.id)?.length ?? 0) > 0).length
+              const totalRooms = epicRooms.length + featureCount
+
+              return (
+                <div key={epic.id}>
+                  {/* Epic heading */}
+                  <div
+                    onClick={() => toggleEpic(epic.id)}
+                    className={`${rowBase} font-medium text-text-secondary hover:text-text-primary px-3 py-2 border-b border-border-subtle`}
+                  >
+                    {isOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    <Layers size={12} className="flex-shrink-0 text-accent" />
+                    <span className="flex-1 truncate text-[11px]">{epic.title}</span>
+                    <span className="text-[10px] text-text-muted">{totalRooms}</span>
+                  </div>
+
+                  {isOpen && (
+                    <div className="border-l border-border-subtle ml-3">
+                      {/* Epic-level rooms (planning etc.) */}
+                      {epicRooms.map(r => renderRoom(r, true))}
+
+                      {/* Feature rooms */}
+                      {epic.features.map(feature => {
+                        const fRooms = roomsByFeatureId.get(feature.id) ?? []
+                        if (fRooms.length === 0) return null
+                        return (
+                          <div key={feature.id}>
+                            <div className="flex items-center gap-1.5 px-3 py-1 text-[10px] text-text-muted border-b border-border-subtle bg-bg-base/30">
+                              <GitBranch size={9} className="flex-shrink-0" />
+                              <span className="truncate">{feature.title}</span>
+                            </div>
+                            {fRooms.map(r => renderRoom(r, true))}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+
+            {/* Feature rooms whose epic isn't loaded */}
+            {featureRoomsWithoutEpic.map(r => renderRoom(r))}
+
+            {/* Unattached rooms */}
+            {unattachedRooms.length > 0 && (
+              <>
+                {(epicsWithRooms.length > 0 || featureRoomsWithoutEpic.length > 0) && (
+                  <div className="px-3 py-1 text-[10px] text-text-muted uppercase tracking-wide border-b border-border-subtle bg-bg-base/30">Other</div>
+                )}
+                {unattachedRooms.map(r => renderRoom(r))}
+              </>
+            )}
+          </>
+        )}
+      </>
+    )
+  }
 
   // ── Main render ───────────────────────────────────────────────
   return (


### PR DESCRIPTION
## Summary

- Auto-create a **planning room** when an epic is created
- Auto-create a **feature room** when a feature is created; agents already assigned to tasks in that feature are added automatically
- Auto-add an agent to the feature room whenever they are assigned to a task in that feature
- Messages sidebar shows a collapsible **Epic → Planning room → Feature rooms** hierarchy in the Rooms view
- **Inline rename** (pencil icon) and **delete** (trash icon) on all chat rooms
- `/api/chatrooms?all=true` skips the member-only filter so the full hierarchy can be loaded

Also includes: admin UI field for `maxTokens` on external models (configure token limits without direct DB access).

## Test plan

- [ ] Create an epic — confirm a Planning room appears under it in the Messages sidebar
- [ ] Create a feature under that epic — confirm a Feature room appears under the epic in the sidebar
- [ ] Assign an agent to a task in that feature — confirm the agent is added to the feature room's members
- [ ] Rename a room via the pencil icon — confirm the name updates
- [ ] Delete a room via the trash icon — confirm it's removed from the sidebar
- [ ] Collapse/expand an epic section in the sidebar
- [ ] Open Admin → Models, edit a model, confirm Max Tokens field saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)