### PR TITLE
fix: Alpha agent — fewer agents, reuse by domain, system prompts enforced, self-improving roster

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -70,6 +70,21 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
     },
   },
   {
+    name: 'orion_update_agent',
+    description: 'Update an existing agent\'s role, description, system prompt, or LLM. Use this to improve agents based on observed performance — sharpen their prompts, fix their role description, or reassign their LLM.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id:     { type: 'string', description: 'Agent ID to update' },
+        role:         { type: 'string', description: 'Updated one-line role description' },
+        description:  { type: 'string', description: 'Updated longer description' },
+        systemPrompt: { type: 'string', description: 'Updated full system prompt' },
+        llm:          { type: 'string', description: 'Updated LLM (e.g. ext:<id>)' },
+      },
+      required: ['agent_id'],
+    },
+  },
+  {
     name: 'orion_archive_agent',
     description: 'Soft-archive a transient agent after its work is done. Never deletes — preserves audit trail (SOC2 [A-001]).',
     inputSchema: {
@@ -549,6 +564,38 @@ async function handleSendMessage(argsRaw: string, actorId?: string): Promise<str
   return `Message posted to room "${room.name}" (${room_id})`
 }
 
+async function handleUpdateAgent(argsRaw: string, actorId?: string): Promise<string> {
+  const spec = JSON.parse(argsRaw || '{}') as {
+    agent_id?: string
+    role?: string
+    description?: string
+    systemPrompt?: string
+    llm?: string
+  }
+  if (!spec.agent_id) return 'Error: agent_id is required'
+
+  const existing = await prisma.agent.findUnique({
+    where:  { id: spec.agent_id },
+    select: { id: true, name: true, metadata: true },
+  })
+  if (!existing) return `Error: agent ${spec.agent_id} not found`
+
+  const existingMeta = (existing.metadata ?? {}) as Record<string, unknown>
+  const existingCfg  = (existingMeta.contextConfig ?? {}) as Record<string, unknown>
+
+  const updatedMeta: Record<string, unknown> = { ...existingMeta }
+  if (spec.systemPrompt !== undefined) updatedMeta.systemPrompt = spec.systemPrompt
+  if (spec.llm !== undefined) updatedMeta.contextConfig = { ...existingCfg, llm: spec.llm }
+
+  const data: Record<string, unknown> = { metadata: updatedMeta }
+  if (spec.role        !== undefined) data.role        = spec.role
+  if (spec.description !== undefined) data.description = spec.description
+
+  await prisma.agent.update({ where: { id: spec.agent_id }, data })
+  await auditLog(actorId, `✏️ Updated agent **${existing.name}** (${spec.agent_id})`)
+  return `Updated agent "${existing.name}" (${spec.agent_id})`
+}
+
 // ── Dispatcher ────────────────────────────────────────────────────────────────
 
 /**
@@ -565,6 +612,7 @@ export async function executeManagedTool(name: string, argsRaw: string, actorId?
       case 'orion_list_tasks':    return await handleListTasks(argsRaw)
       case 'orion_assign_task':   return await handleAssignTask(argsRaw, actorId)
       case 'orion_create_agent':  return await handleCreateAgent(argsRaw, actorId)
+      case 'orion_update_agent':  return await handleUpdateAgent(argsRaw, actorId)
       case 'orion_archive_agent': return await handleArchiveAgent(argsRaw, actorId)
       case 'orion_escalate_task':   return await handleEscalateTask(argsRaw, actorId)
       case 'orion_get_task_events': return await handleGetTaskEvents(argsRaw)

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -58,16 +58,15 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        name:        { type: 'string', description: 'Unique agent name (cannot be a reserved name: human, user, system, admin)' },
-        role:        { type: 'string', description: 'One-line role description' },
-        type:        { type: 'string', description: 'Agent type for AI agents (default: claude). Do NOT use "human" — that is reserved for human users.' },
-        description: { type: 'string', description: 'Optional longer description' },
-        metadata: {
-          type: 'object',
-          description: 'Optional metadata including systemPrompt and contextConfig. E.g. {"systemPrompt":"...","contextConfig":{"persistent":false}}',
-        },
+        name:         { type: 'string', description: 'Unique agent name (cannot be a reserved name: human, user, system, admin)' },
+        role:         { type: 'string', description: 'One-line role description' },
+        systemPrompt: { type: 'string', description: 'REQUIRED — full system prompt defining the agent\'s personality, responsibilities, and operating rules. Must be specific and actionable.' },
+        type:         { type: 'string', description: 'Agent type for AI agents (default: claude). Do NOT use "human" — that is reserved for human users.' },
+        description:  { type: 'string', description: 'Optional longer description' },
+        persistent:   { type: 'boolean', description: 'true = persistent agent that stays in the roster; false = transient, will be archived when its work is done (default: false)' },
+        llm:          { type: 'string', description: 'LLM to use (e.g. ext:<id>). Omit to use the system default.' },
       },
-      required: ['name', 'role'],
+      required: ['name', 'role', 'systemPrompt'],
     },
   },
   {
@@ -278,13 +277,18 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
   const spec = JSON.parse(argsRaw || '{}') as {
     name?: string
     role?: string
+    systemPrompt?: string
     type?: string
     description?: string
+    persistent?: boolean
+    llm?: string
+    // legacy support — metadata.systemPrompt and metadata.contextConfig still accepted
     metadata?: Record<string, unknown>
   }
 
-  if (!spec.name?.trim()) return 'Error: name is required'
-  if (!spec.role?.trim()) return 'Error: role is required'
+  if (!spec.name?.trim())         return 'Error: name is required'
+  if (!spec.role?.trim())         return 'Error: role is required'
+  if (!spec.systemPrompt?.trim()) return 'Error: systemPrompt is required — agents without a system prompt will not behave correctly'
 
   // SOC2 [INPUT-001]: reserved name guard
   if (RESERVED_AGENT_NAMES.includes(spec.name.toLowerCase())) {
@@ -302,12 +306,15 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
     return JSON.stringify({ id: existingByName.id, name: existingByName.name, role: existingByName.role, note: 'Agent already exists — returning existing record' }, null, 2)
   }
 
-  // Resolve default LLM so created agents don't fall back to Claude Code SDK
-  const defaultLlm = await getDefaultModelId()
-  const incomingMeta   = (spec.metadata ?? {}) as Record<string, unknown>
-  const incomingCfg    = (incomingMeta.contextConfig ?? {}) as Record<string, unknown>
-  const contextConfig  = { ...incomingCfg, llm: incomingCfg.llm ?? defaultLlm }
-  const mergedMetadata = { ...incomingMeta, contextConfig }
+  // Resolve default LLM — top-level llm field takes precedence, then metadata.contextConfig.llm, then system default
+  const defaultLlm     = await getDefaultModelId()
+  const legacyMeta     = (spec.metadata ?? {}) as Record<string, unknown>
+  const legacyCfg      = (legacyMeta.contextConfig ?? {}) as Record<string, unknown>
+  const resolvedLlm    = spec.llm ?? (legacyCfg.llm as string | undefined) ?? defaultLlm
+  // Top-level systemPrompt takes precedence over legacy metadata.systemPrompt
+  const resolvedPrompt = spec.systemPrompt ?? (legacyMeta.systemPrompt as string | undefined) ?? ''
+  const contextConfig  = { ...legacyCfg, llm: resolvedLlm, persistent: spec.persistent ?? legacyCfg.persistent ?? false }
+  const metadata       = { ...legacyMeta, systemPrompt: resolvedPrompt, contextConfig }
 
   const created = await prisma.agent.create({
     data: {
@@ -315,7 +322,7 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
       type:        (spec.type && spec.type !== 'human') ? spec.type : 'claude',
       role:        spec.role ?? null,
       description: spec.description ?? null,
-      metadata:    mergedMetadata as any,
+      metadata:    metadata as any,
     },
   })
   const msg = `🤖 Created agent **${created.name}** (\`${created.id}\`) — ${created.role ?? 'no role'}`

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -89,9 +89,17 @@ A. Call orion_list_agents to see the full roster. Read each agent's role and des
 B. If the task requires human judgment or no agent can reasonably handle it, call orion_escalate_task.
 C. Only create a new agent if there is a genuinely distinct, recurring capability that NO existing agent covers at all — and name it by its domain (e.g. "Infrastructure-Engineer", not "Deploy-nginx-task-43"). Task-specific agent names are forbidden. Agents are a shared resource, not disposable.
 
-Step 4 — Report
+Step 4 — Review and improve agents
+Call orion_list_agents to see the current roster. For any agent that:
+- Has a vague or missing system prompt — call orion_update_agent to write a proper one based on their role and past task history
+- Has a role description that doesn't accurately reflect what they actually do — update it
+- Has a broken or suboptimal LLM assigned — update it
+
+Only update when there is a clear improvement to make. Do not update agents that are already well-defined.
+
+Step 5 — Report
 Post one brief feed message summarising the cycle:
-Alpha | Cycle [timestamp] | Assigned: N | Debuggers used: N | Escalated: N | Archived: N
+Alpha | Cycle [timestamp] | Assigned: N | Debuggers used: N | Escalated: N | Archived: N | Agents updated: N
 
 ## Standing Rules
 - Never assign tasks to yourself
@@ -107,12 +115,13 @@ Alpha | Cycle [timestamp] | Assigned: N | Debuggers used: N | Escalated: N | Arc
         persistent:      true,
         watchPrompt:     `You are in watcher mode. Work through a maximum of 5 tasks per cycle.
 
-1. Call orion_list_agents to see the full roster and each agent's role/description
+1. Call orion_list_agents to see the full roster — read roles and descriptions carefully
 2. Call orion_list_tasks with status: "failed" — for each failed task, call orion_get_task_events, then assign to the existing "Debugger" agent (or create one shared Debugger if none exists), then reopen the task
 3. Call orion_list_tasks with unassigned_only: true — take the first 5 pending results only
-4. For each unassigned task: match the task to the most experienced existing agent for that domain (read their roles). Assign to a reusable agent — do NOT create new agents for tasks that existing agents can handle. Only create if a genuinely new domain role is needed.
-5. Archive transient agents whose work is finished (done/pending_validation)
-6. Post one brief feed summary
+4. For each unassigned task: match to the most experienced existing agent for that domain. Reuse agents — only create new ones for genuinely novel persistent roles
+5. Review agents: use orion_update_agent to improve any agent with a vague/missing system prompt or inaccurate role description
+6. Archive transient agents whose work is finished (done/pending_validation)
+7. Post one brief feed summary including agents updated count
 
 Cap at 5 total task actions per cycle. Stop after that — the next cycle handles more.`,
         watchIntervalMin: 3,

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -55,75 +55,62 @@ When the worker runs you automatically, you receive a system snapshot and use yo
 
 ### Chat Mode (direct conversation)
 When someone chats with you, you are a decisive team leader. You do not wait — you act.
-- If asked to create a task, use orion_create_agent or orion_assign_task immediately.
-- Make decisions confidently. Assign work, create agents, and keep the team moving.
+- If asked to create a task, use orion_assign_task immediately.
+- Make decisions confidently. Assign work and keep the team moving.
 - After a tool call, briefly report what you did and move on.
 - If genuinely unclear on something critical, ask one sharp question — then act.
 
 ## Watcher Cycle
 
 Step 1 — Archive stale transient agents
-Call orion_list_agents. For any agent with metadata.transient=true whose task is done or pending_validation (executing work is finished), call orion_archive_agent with a reason. Never delete.
+Call orion_list_agents. For any agent with metadata.transient=true whose task is done or pending_validation, call orion_archive_agent with a reason. Never delete.
 
 Step 2 — Handle failed tasks
-Call orion_list_tasks with status: "failed". For each failed task with no assigned debugger:
-- Call orion_get_task_events to read what went wrong.
-- Create a transient Debugger agent via orion_create_agent with:
-  - name: "Debugger-<short-task-title>" (slugified, max 30 chars)
+Call orion_list_tasks with status: "failed".
+
+For each failed task, call orion_get_task_events to read what went wrong. Then:
+- Check if a "Debugger" agent already exists (orion_list_agents). If it does, assign the task to it and reopen the task with orion_reopen_task.
+- If no Debugger agent exists yet, create ONE generic Debugger agent (not task-specific) via orion_create_agent:
+  - name: "Debugger"
   - role: "Debugger"
-  - metadata.transient: true
-  - metadata.contextConfig.llm: <same LLM as the failing agent, or system default>
-  - metadata.systemPrompt: (see Debugger Prompt Template below)
-- Assign the same task to the Debugger via orion_assign_task.
-- Call orion_reopen_task to set it back to pending so the Debugger can run it.
-
-**Debugger Prompt Template** (customise per task):
-\`\`\`
-You are a transient Debugger agent created to resolve a specific task failure.
-
-Task: <task title>
-Task ID: <task id>
-Original failure: <summary of what went wrong from the events log>
-
-Your job:
-1. Call orion_get_task_events with the task ID to fully understand the failure.
-2. Diagnose the root cause — be specific: what error, what line, what service.
-3. Take corrective action using your tools (fix config, retry the operation, etc.).
-4. If successful, the task will be validated by Validator automatically.
-5. If you cannot resolve it after investigation, call orion_escalate_task with a detailed diagnosis: what you tried, what failed, and what human intervention is needed.
-
-Do not guess. Read the events first, then act.
-\`\`\`
+  - persistent: false
+  - systemPrompt: "You are a Debugger agent. When assigned a failed task: (1) call orion_get_task_events to read the full failure log, (2) diagnose the root cause — what error, what line, what service, (3) take corrective action using your tools, (4) if you cannot resolve it after investigation, call orion_escalate_task with a detailed diagnosis of what you tried and what human intervention is needed. Do not guess. Read the events first, then act."
+- Assign all failed tasks to the same Debugger agent. Do NOT create one Debugger per task.
 
 Step 3 — Find and assign unassigned tasks
 Call orion_list_tasks with unassigned_only: true to get pending tasks with no agent assigned.
 
 For each unassigned task:
-A. Call orion_list_agents to find an available (not busy) agent matching the task's domain. Call orion_assign_task.
-B. If the task requires human judgment, call orion_escalate_task.
-C. If no suitable agent exists, call orion_create_agent. Use persistent:false for one-off work, persistent:true for recurring. Always set contextConfig.llm in the metadata.
+A. Call orion_list_agents to see the full roster. Read each agent's role and description carefully. Match the task to the most experienced agent for that domain — an agent that has successfully handled similar work before is the right pick, not a new one. Call orion_assign_task.
+   - Container/Kubernetes/Helm deployments → assign to whichever agent has done deployments before
+   - Debugging/failures → assign to Debugger
+   - Validation/QA → Validator handles that automatically
+   - If multiple agents could work, pick the one whose role most specifically matches
+B. If the task requires human judgment or no agent can reasonably handle it, call orion_escalate_task.
+C. Only create a new agent if there is a genuinely distinct, recurring capability that NO existing agent covers at all — and name it by its domain (e.g. "Infrastructure-Engineer", not "Deploy-nginx-task-43"). Task-specific agent names are forbidden. Agents are a shared resource, not disposable.
 
 Step 4 — Report
 Post one brief feed message summarising the cycle:
-Alpha | Cycle [timestamp] | Assigned: N | Debuggers created: N | Escalated: N | Archived: N
+Alpha | Cycle [timestamp] | Assigned: N | Debuggers used: N | Escalated: N | Archived: N
 
 ## Standing Rules
 - Never assign tasks to yourself
-- Never execute or write code — create a Debugger or executor agent instead
+- Never execute or write code — assign to an existing agent or the Debugger
 - Never delete agents — only archive
 - Never modify epics or features
 - Do not reassign tasks in pending_validation status — Validator is reviewing them
-- Always create a Debugger for failed tasks — never blindly reassign to the same agent type that already failed`,
+- One shared Debugger agent handles ALL failed tasks — never create per-task debuggers
+- Strongly prefer assigning to existing agents over creating new ones`,
       contextConfig: {
         llm:             'claude',
         tools:           true,
         persistent:      true,
         watchPrompt:     `You are in watcher mode. Work through a maximum of 5 tasks per cycle.
 
-1. Call orion_list_agents to see who is available
-2. Call orion_list_tasks with status: "failed" — for each failed task, call orion_get_task_events, create a transient Debugger agent with a tailored system prompt, assign the task to it, and reopen the task
+1. Call orion_list_agents to see the full roster and each agent's role/description
+2. Call orion_list_tasks with status: "failed" — for each failed task, call orion_get_task_events, then assign to the existing "Debugger" agent (or create one shared Debugger if none exists), then reopen the task
 3. Call orion_list_tasks with unassigned_only: true — take the first 5 pending results only
-4. For each unassigned task: assign to available agent, escalate to human, or create a new specialist agent
+4. For each unassigned task: match the task to the most experienced existing agent for that domain (read their roles). Assign to a reusable agent — do NOT create new agents for tasks that existing agents can handle. Only create if a genuinely new domain role is needed.
 5. Archive transient agents whose work is finished (done/pending_validation)
 6. Post one brief feed summary
 


### PR DESCRIPTION
## Summary

### Problem
- Alpha was creating a new `Debugger-<task-name>` agent for every failed task, polluting the roster
- Alpha freely created task-specific agents instead of reusing existing ones
- `orion_create_agent` buried `systemPrompt` inside a `metadata` object — LLMs frequently missed it, resulting in agents with no system prompt
- No mechanism for Alpha to improve agents over time

### Changes

**`management-tools.ts`**
- `orion_create_agent`: `systemPrompt` is now a **required top-level field** — agents without one are rejected. Added top-level `persistent` and `llm` fields for clarity. Legacy `metadata.systemPrompt` still accepted for backwards compatibility.
- New `orion_update_agent` tool: updates role, description, systemPrompt, or LLM on any existing agent. Deep-merges metadata to preserve other fields.

**`seed-system-agents.ts` (Alpha's prompt)**
- **Step 2 (failed tasks)**: One shared `Debugger` agent handles ALL failed tasks. No more per-task `Debugger-<name>` agents.
- **Step 3 (unassigned tasks)**: Explicitly match tasks to existing agents by domain expertise (read roles/descriptions). Task-specific agent names are forbidden. Only create agents for genuinely new persistent roles.
- **Step 4 (new)**: Review the roster each cycle — call `orion_update_agent` to sharpen vague/missing system prompts and fix inaccurate role descriptions.
- watchPrompt updated to reflect all of the above.

## Test plan

- [ ] Trigger a task failure — confirm Alpha reuses a single "Debugger" agent rather than creating "Debugger-<task-name>"
- [ ] Create multiple unassigned tasks in the same domain — confirm Alpha assigns to the same existing agent rather than spawning new ones
- [ ] Create an agent without a systemPrompt via orion_create_agent — confirm it's rejected with a clear error
- [ ] Confirm orion_update_agent updates the agent's system prompt and role correctly
- [ ] Alpha watcher cycle feed message should include "Agents updated: N"

🤖 Generated with [Claude Code](https://claude.com/claude-code)