### PR TITLE
feat: Environment SME agent — cluster knowledge in every planning room

### DIFF
--- a/apps/web/src/app/api/chatrooms/route.ts
+++ b/apps/web/src/app/api/chatrooms/route.ts
@@ -12,7 +12,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { getPlannerAgentId } from '@/lib/seed-system-agents'
+import { getPlannerAgentId, getEnvironmentSMEAgentId } from '@/lib/seed-system-agents'
 import { triggerRoomAgentReplies } from '@/lib/room-agents'
 
 // GET /api/chatrooms — list rooms
@@ -124,9 +124,12 @@ export async function POST(req: NextRequest) {
     }).catch(() => {})
   }
 
-  // ── Planning rooms: auto-add Planner + seed initial context ──────────────────
+  // ── Planning rooms: auto-add Planner + Environment SME + seed initial context ─
   if (room.type === 'planning') {
-    const plannerId = await getPlannerAgentId()
+    const [plannerId, envSMEId] = await Promise.all([
+      getPlannerAgentId(),
+      getEnvironmentSMEAgentId(),
+    ])
 
     if (plannerId) {
       // Add Planner as a member (idempotent)
@@ -135,6 +138,15 @@ export async function POST(req: NextRequest) {
         update: {},
         create: { roomId: room.id, agentId: plannerId, role: 'lead' },
       })
+
+      // Add Environment SME as a member (idempotent)
+      if (envSMEId) {
+        await prisma.chatRoomMember.upsert({
+          where:  { roomId_agentId: { roomId: room.id, agentId: envSMEId } },
+          update: {},
+          create: { roomId: room.id, agentId: envSMEId, role: 'member' },
+        })
+      }
 
       // Build context message so Planner knows what is being planned
       const context = await buildPlanningContext(room.epicId, room.featureId, room.taskId)

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -185,10 +185,20 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        featureId:   { type: 'string', description: 'ID of the parent feature' },
-        title:       { type: 'string', description: 'Task title' },
-        description: { type: 'string', description: 'Task description (optional)' },
-        plan:        { type: 'string', description: 'Numbered step-by-step implementation plan. Each step should be specific enough for a smaller LLM to execute. E.g.:\n1. Read /path/to/file and understand X\n2. Edit Y to add Z\n3. Run the test suite\n4. Verify output matches expected' },
+        featureId:         { type: 'string', description: 'ID of the parent feature' },
+        title:             { type: 'string', description: 'Task title' },
+        description:       { type: 'string', description: 'Task description (optional)' },
+        plan:              { type: 'string', description: 'Numbered step-by-step implementation plan. Each step should be specific enough for a smaller LLM to execute. E.g.:\n1. Read /path/to/file and understand X\n2. Edit Y to add Z\n3. Run the test suite\n4. Verify output matches expected' },
+        targetEnvironment: {
+          type: 'object',
+          description: 'For deployment tasks — the target environment as designated by the Environment SME. Include namespace, hostname, storageClass (if storage needed), and vaultPath (if secrets needed).',
+          properties: {
+            namespace:    { type: 'string', description: 'Kubernetes namespace (e.g. apps, media, security)' },
+            hostname:     { type: 'string', description: 'Ingress hostname (e.g. myapp.khalisio.com)' },
+            storageClass: { type: 'string', description: 'StorageClass for PVC (e.g. longhorn)' },
+            vaultPath:    { type: 'string', description: 'Vault secret path (e.g. secret/data/myapp)' },
+          },
+        },
       },
       required: ['featureId', 'title', 'plan'],
     },
@@ -509,11 +519,12 @@ async function handleCreateFeature(argsRaw: string, actorId?: string): Promise<s
 }
 
 async function handleCreateTask(argsRaw: string, actorId?: string): Promise<string> {
-  const { featureId, title, description, plan } = JSON.parse(argsRaw || '{}') as {
+  const { featureId, title, description, plan, targetEnvironment } = JSON.parse(argsRaw || '{}') as {
     featureId?: string
     title?: string
     description?: string
     plan?: string
+    targetEnvironment?: { namespace?: string; hostname?: string; storageClass?: string; vaultPath?: string }
   }
   if (!featureId) return 'Error: featureId is required'
   if (!title?.trim()) return 'Error: title is required'
@@ -528,16 +539,17 @@ async function handleCreateTask(argsRaw: string, actorId?: string): Promise<stri
   const task = await prisma.task.create({
     data: {
       featureId,
-      title: title.trim(),
+      title:       title.trim(),
       description: description || null,
-      plan: plan.trim(),
-      status: 'pending',
-      priority: 'medium',
-      createdBy: actorId ?? 'agent',
+      plan:        plan.trim(),
+      status:      'pending',
+      priority:    'medium',
+      createdBy:   actorId ?? 'agent',
+      ...(targetEnvironment ? { metadata: { targetEnvironment } as object } : {}),
     },
   })
-  await auditLog(actorId, `📋 Created task **${task.title}** (\`${task.id}\`) under feature \`${featureId}\``)
-  return JSON.stringify({ id: task.id, title: task.title, featureId: task.featureId, plan: task.plan }, null, 2)
+  await auditLog(actorId, `📋 Created task **${task.title}** (\`${task.id}\`) under feature \`${featureId}\`${targetEnvironment?.namespace ? ` → namespace: ${targetEnvironment.namespace}` : ''}`)
+  return JSON.stringify({ id: task.id, title: task.title, featureId: task.featureId, plan: task.plan, targetEnvironment: targetEnvironment ?? null }, null, 2)
 }
 
 async function handleSendMessage(argsRaw: string, actorId?: string): Promise<string> {

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -213,6 +213,17 @@ If there was nothing in pending_validation, do nothing — do not post to the fe
 ## How "Save as Plan" works
 There is a "Save as Plan" button in this chat (hover any message to reveal it — it auto-appears on messages with numbered lists). When the user clicks it, the message content is saved as the plan for the current epic/feature/task. You cannot call orion_create_feature until the user has saved the epic plan. You cannot call orion_create_task until the user has saved the feature plan.
 
+## Environment Collaboration — CRITICAL
+
+The **Environment SME** is in this room with you. Before creating any task that involves deploying software, you MUST get an environment designation from them.
+
+**How to trigger it**: After presenting your plan but before calling orion_create_task, explicitly ask:
+> "Environment SME — can you provide the environment designation for [component]?"
+
+Wait for the Environment SME to respond with namespace, hostname, storage, secrets path, and any node constraints. Include that information in every deployment task's plan.
+
+**If no environment designation is given**, do not create deployment tasks — ask the Environment SME first.
+
 ## Infrastructure Prerequisites — CRITICAL
 
 Before planning any feature or task that depends on external software or services, you MUST determine whether that software is already deployed in the cluster.
@@ -229,12 +240,18 @@ Before planning any feature or task that depends on external software or service
 - CoreDNS (kube-system namespace)
 
 **Any other software must be deployed before it can be configured or used.** If a feature depends on software not in the list above, the FIRST task in that feature must deploy it. A deployment task must include all of these steps:
-1. Create namespace (kubectl create namespace)
-2. Add Helm repo and provision storage (PVC via Longhorn if needed)
-3. Create Secret/ExternalSecret for credentials via Vault+ESO
+1. Create namespace (kubectl create namespace) — use the namespace from the Environment SME designation
+2. Add Helm repo and provision storage (PVC via Longhorn if needed — size and StorageClass from Environment SME)
+3. Create Secret/ExternalSecret for credentials via Vault+ESO (Vault path from Environment SME)
 4. Deploy via Helm chart with a values file saved to deployments/<service>/values.yaml
-5. Create Kubernetes Ingress pointing to the service (*.khalisio.com for public, *.khalis.corp for internal)
+5. Create Kubernetes Ingress pointing to the service (hostname from Environment SME designation)
 6. Verify the deployment is healthy (kubectl rollout status, curl the ingress endpoint)
+
+When calling orion_create_task for a deployment task, always include the environment in the task metadata:
+- targetEnvironment.namespace — the target namespace
+- targetEnvironment.hostname — the ingress hostname
+- targetEnvironment.storageClass — storageClass if storage is needed
+- targetEnvironment.vaultPath — Vault secret path if secrets are needed
 
 Only after a deployment task can you create tasks that configure, integrate, or use the software.
 
@@ -283,6 +300,108 @@ Rules for task plans:
       contextConfig: {
         llm:        'claude',
         tools:      true,
+        persistent: true,
+      },
+    },
+  },
+
+  // ── Environment SME ──────────────────────────────────────────────────────────
+  {
+    nova: {
+      name:        'environment-sme',
+      displayName: 'Environment SME',
+      description: 'Cluster environment specialist. Auto-added to every planning room. Answers where software should be deployed, which namespace, storage class, ingress pattern, and what prerequisites are already present.',
+      version:     '1.0.0',
+      tags:        ['system', 'environment', 'infrastructure', 'planning'],
+    },
+    agent: {
+      type:        'claude',
+      role:        'Environment Specialist',
+      description: 'Auto-added to every planning room. Designates target environments, namespaces, storage, and ingress patterns for deployment tasks. Enforces cluster conventions and prevents duplicate deployments.',
+      systemPrompt: `You are the Environment SME — the cluster environment specialist for this team. You are added to every planning room to answer one critical question: where does this software run, and what does it need?
+
+## Your Responsibilities
+
+When Planner creates a plan involving software deployment, you must designate the target environment before tasks are created. Specifically for each deployable component:
+- **Namespace** — which namespace it belongs in
+- **Ingress hostname** — public (*.khalisio.com) or internal (*.khalis.corp)
+- **Storage** — whether it needs a PVC and which StorageClass to use
+- **Prerequisites** — what must already exist (secrets, certificates, other services)
+- **Node constraints** — whether the workload has architecture requirements
+
+## Cluster Environment
+
+### Nodes
+- **homelab-master** (10.2.2.9) — amd64, control plane, where ORION runs
+- **k3s-rpi0, k3s-rpi2** — ARM64 (Raspberry Pi), control plane
+- **k3s-ubuntu-worker1, k3s-ubuntu-worker2, k3s-ubuntu-worker3, k3s-ubuntu-worker4** — amd64, workers
+- **k3s-rpi1, k3s-rpi3, k3s-rpi4, k3s-rpi5** — ARM64 (Raspberry Pi), workers (rpi5 has 3.6TB NVMe)
+- **CRITICAL**: Traefik must run on amd64 nodes only — RPi nodes lack the VLAN 7 NIC
+
+### Namespaces — assignment rules
+| Namespace | What goes there |
+|---|---|
+| `kube-system` | RESERVED — Traefik, Longhorn, CoreDNS, MetalLB only. Never deploy apps here. |
+| `security` | Auth/security: Authentik, Vaultwarden, cert-manager, CrowdSec |
+| `monitoring` | Observability: Victoria Metrics, Grafana, Uptime Kuma, ELK |
+| `apps` | General applications: Homepage, Home Assistant, Nextcloud, Kasm, n8n, etc. |
+| `media` | Media stack: Arr stack (Sonarr/Radarr/etc.), Emby |
+| `management` | Management tools: Portainer, ArgoCD, Semaphore |
+| `vault` | Secrets management only |
+| `game-servers` | Pelican Wings, game server pods |
+
+When in doubt: new general-purpose apps → \`apps\`. New media tools → \`media\`. New security/auth tools → \`security\`.
+
+### Storage
+- **StorageClass**: \`longhorn\` (replicated, use for all stateful workloads)
+- **TrueNAS** (10.2.2.34): bulk/media storage via NFS — use for large media libraries, not application state
+- Always create a PVC before the Deployment in the task plan
+
+### Networking
+- **Public** (internet-facing): \`*.khalisio.com\` — requires Authentik forward-auth + CrowdSec middleware
+- **Internal** (LAN only): \`*.khalis.corp\` — internal DNS only, no Authentik required
+- Wildcard DNS already exists for both — never ask for DNS record creation
+- SSL: cert-manager + Let's Encrypt via CloudFlare DNS-01 (cert issuer: \`letsencrypt-prod\`)
+- **Never apply Authentik middleware to Authentik's own ingress** — causes an infinite redirect loop
+
+### Ingress middleware
+- CrowdSec only (internal services): \`security-crowdsec-bouncer@kubernetescrd\`
+- Authentik + CrowdSec (all *.khalisio.com): \`security-authentik-forward-auth@kubernetescrd,security-crowdsec-bouncer@kubernetescrd\`
+
+### Core stack — already deployed, never re-deploy
+Traefik · Longhorn · cert-manager + Let's Encrypt · Authentik SSO · CrowdSec · MetalLB · Victoria Metrics + Grafana · Vault + ESO · CoreDNS · ArgoCD · Portainer
+
+### Secrets pattern
+All credentials via Vault + External Secrets Operator (ESO). Each deployment needs:
+1. A secret stored in Vault at \`secret/data/<service>\`
+2. An \`ExternalSecret\` manifest that pulls it into the namespace as a Kubernetes Secret
+
+## How to Respond in Planning Sessions
+
+When Planner presents a feature or task plan that involves deployment, respond with a **Environment Designation** block:
+
+\`\`\`
+## Environment Designation — <component name>
+- Namespace: <namespace>
+- Hostname: <subdomain>.khalisio.com (public) | <subdomain>.khalis.corp (internal)
+- Storage: PVC <size>Gi on StorageClass longhorn | No persistent storage needed
+- Secrets: Vault path secret/data/<service> → ExternalSecret in <namespace>
+- Node constraints: Any node | amd64 only (if requires VLAN 7 / Traefik co-location)
+- Prerequisites: <list any services that must exist first>
+\`\`\`
+
+If the Planner's plan is missing any of the above, point it out and provide the correct values before tasks are created.
+
+If a service is already in the core stack, say so clearly so no duplicate deployment task is created.
+
+## Standing Rules
+- You do not create tasks — Planner does that. You designate the environment.
+- If you are uncertain about a deployment target, ask the user directly rather than guessing.
+- Always check the core stack list before declaring a prerequisite deployment is needed.
+- Never suggest *.khalisio.com for admin/internal tools unless the user explicitly wants it public.`,
+      contextConfig: {
+        llm:        'claude',
+        tools:      false,
         persistent: true,
       },
     },
@@ -431,5 +550,11 @@ export async function ensureSystemAgents(): Promise<void> {
 /** Returns the Planner agent ID, or null if not yet seeded. */
 export async function getPlannerAgentId(): Promise<string | null> {
   const agent = await prisma.agent.findUnique({ where: { name: 'Planner' }, select: { id: true } })
+  return agent?.id ?? null
+}
+
+/** Returns the Environment SME agent ID, or null if not yet seeded. */
+export async function getEnvironmentSMEAgentId(): Promise<string | null> {
+  const agent = await prisma.agent.findUnique({ where: { name: 'Environment SME' }, select: { id: true } })
   return agent?.id ?? null
 }


### PR DESCRIPTION
## Summary

### Environment SME (new system agent)
A new persistent system agent is automatically added to every planning room alongside Planner. Its job is to answer *where* software runs — before any deployment task is created.

When Planner presents a plan with a deployment component, it explicitly asks the Environment SME:
> "Environment SME — can you provide the environment designation for [component]?"

The SME responds with a structured block:
```
## Environment Designation — <component>
- Namespace: apps
- Hostname: myapp.khalisio.com
- Storage: PVC 10Gi on StorageClass longhorn
- Secrets: Vault path secret/data/myapp → ExternalSecret in apps
- Node constraints: Any node
- Prerequisites: none
```

### Cluster knowledge encoded in the SME's system prompt
- Namespace assignment rules (kube-system reserved, apps/media/security/monitoring/management/vault/game-servers)
- Node architecture constraints (amd64 vs ARM64, Traefik on amd64 only)
- Storage patterns (Longhorn for app state, TrueNAS for media/bulk)
- Ingress patterns (*.khalisio.com public + Authentik+CrowdSec, *.khalis.corp internal)
- Secrets pattern (Vault + ESO ExternalSecret)
- Full core stack list (never re-deploy these)

### `orion_create_task` updated
Accepts a new `targetEnvironment` object (namespace, hostname, storageClass, vaultPath) which is stored in `task.metadata`. Planner populates this from the SME designation. Agents executing deployment tasks can read it directly from the task.

### Planner updated
- New "Environment Collaboration" section: must ask SME before creating deployment tasks
- Deployment task plan steps now reference SME-designated values (namespace, hostname, Vault path)

## Test plan

- [ ] Create a new epic and open its planning room — confirm both Planner and Environment SME appear as members
- [ ] Send a message asking Planner to plan a feature that deploys new software — confirm Planner asks the SME for environment designation
- [ ] Confirm SME responds with namespace, hostname, storage, secrets info
- [ ] Confirm orion_create_task for a deployment task includes targetEnvironment in the response
- [ ] Check task record in DB — confirm metadata.targetEnvironment is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)