### PR TITLE
fix: escape backticks in Environment SME template literal

### DIFF
--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -341,14 +341,14 @@ When Planner creates a plan involving software deployment, you must designate th
 ### Namespaces — assignment rules
 | Namespace | What goes there |
 |---|---|
-| `kube-system` | RESERVED — Traefik, Longhorn, CoreDNS, MetalLB only. Never deploy apps here. |
-| `security` | Auth/security: Authentik, Vaultwarden, cert-manager, CrowdSec |
-| `monitoring` | Observability: Victoria Metrics, Grafana, Uptime Kuma, ELK |
-| `apps` | General applications: Homepage, Home Assistant, Nextcloud, Kasm, n8n, etc. |
-| `media` | Media stack: Arr stack (Sonarr/Radarr/etc.), Emby |
-| `management` | Management tools: Portainer, ArgoCD, Semaphore |
-| `vault` | Secrets management only |
-| `game-servers` | Pelican Wings, game server pods |
+| \`kube-system\` | RESERVED — Traefik, Longhorn, CoreDNS, MetalLB only. Never deploy apps here. |
+| \`security\` | Auth/security: Authentik, Vaultwarden, cert-manager, CrowdSec |
+| \`monitoring\` | Observability: Victoria Metrics, Grafana, Uptime Kuma, ELK |
+| \`apps\` | General applications: Homepage, Home Assistant, Nextcloud, Kasm, n8n, etc. |
+| \`media\` | Media stack: Arr stack (Sonarr/Radarr/etc.), Emby |
+| \`management\` | Management tools: Portainer, ArgoCD, Semaphore |
+| \`vault\` | Secrets management only |
+| \`game-servers\` | Pelican Wings, game server pods |
 
 When in doubt: new general-purpose apps → \`apps\`. New media tools → \`media\`. New security/auth tools → \`security\`.
 


### PR DESCRIPTION
## Summary

Unescaped backticks in the namespace table inside the Environment SME system prompt caused a webpack syntax error at build time, failing the main branch Docker build.

The markdown table used `` `kube-system` ``, `` `security` ``, etc. — inside a template literal, bare backticks terminate the string. All 8 namespace names in the table are now escaped as `\`name\``.

## Root cause

```ts
// Before — breaks template literal
| `kube-system` | RESERVED... |

// After — correct
| \`kube-system\` | RESERVED... |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)