### PR TITLE
fix: remove nested properties from orion_create_task targetEnvironment schema

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -191,13 +191,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
         plan:              { type: 'string', description: 'Numbered step-by-step implementation plan. Each step should be specific enough for a smaller LLM to execute. E.g.:\n1. Read /path/to/file and understand X\n2. Edit Y to add Z\n3. Run the test suite\n4. Verify output matches expected' },
         targetEnvironment: {
           type: 'object',
-          description: 'For deployment tasks — the target environment as designated by the Environment SME. Include namespace, hostname, storageClass (if storage needed), and vaultPath (if secrets needed).',
-          properties: {
-            namespace:    { type: 'string', description: 'Kubernetes namespace (e.g. apps, media, security)' },
-            hostname:     { type: 'string', description: 'Ingress hostname (e.g. myapp.khalisio.com)' },
-            storageClass: { type: 'string', description: 'StorageClass for PVC (e.g. longhorn)' },
-            vaultPath:    { type: 'string', description: 'Vault secret path (e.g. secret/data/myapp)' },
-          },
+          description: 'For deployment tasks — the target environment as designated by the Environment SME. Pass as an object with keys: namespace (e.g. "apps"), hostname (e.g. "myapp.khalisio.com"), storageClass (e.g. "longhorn", if storage needed), vaultPath (e.g. "secret/data/myapp", if secrets needed).',
         },
       },
       required: ['featureId', 'title', 'plan'],


### PR DESCRIPTION
## Summary

The `inputSchema` property type only supports flat property definitions — nested `properties` objects are not allowed by the type. The `targetEnvironment` field in `orion_create_task` used a nested `properties` block which caused a TypeScript compile error at build time.

Fixed by flattening it to a plain `{ type: 'object', description: '...' }` with a descriptive string that tells the LLM what keys to include.

## Error

```
./src/lib/management-tools.ts:195:11
Type error: Object literal may only specify known properties, and 'properties' does not exist in type '{ type: string; description?: string | undefined; enum?: string[] | undefined; }'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)