### PR TITLE
fix: stray brace breaking TasksPage build

### DIFF
--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -1267,5 +1267,3 @@ function TaskChat({
     </div>
   )
 }
-
-}


### PR DESCRIPTION
## Summary
- Removes the stray `}` at end of TasksPage.tsx introduced in #238
- One-line fix to unblock the build

## Test plan
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)