### PR TITLE
refactor: seed agent system prompts into SystemPrompt table

### DIFF
--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -543,6 +543,36 @@ export async function ensureSystemAgents(): Promise<void> {
       console.error(`[seed] Failed to seed agent ${def.nova.displayName}:`, err instanceof Error ? err.message : err)
     }
   }
+
+  // Seed agent system prompts into SystemPrompt table for Settings UI visibility.
+  // Uses update: {} so existing admin edits are preserved on restart.
+  for (const def of SYSTEM_AGENT_DEFS) {
+    await prisma.systemPrompt.upsert({
+      where:  { key: `agent.${def.nova.name}.system` },
+      update: {},
+      create: {
+        key:         `agent.${def.nova.name}.system`,
+        name:        `${def.nova.displayName} — System Prompt`,
+        category:    'system',
+        description: def.nova.description,
+        content:     def.agent.systemPrompt,
+      },
+    }).catch(() => {})
+
+    if ((def.agent.contextConfig as any)?.watchPrompt) {
+      await prisma.systemPrompt.upsert({
+        where:  { key: `agent.${def.nova.name}.watch` },
+        update: {},
+        create: {
+          key:         `agent.${def.nova.name}.watch`,
+          name:        `${def.nova.displayName} — Watch Prompt`,
+          category:    'system',
+          description: `Watch cycle prompt for ${def.nova.displayName}`,
+          content:     (def.agent.contextConfig as any).watchPrompt,
+        },
+      }).catch(() => {})
+    }
+  }
 }
 
 // ── Planner lookup helper ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- On startup, \`ensureSystemAgents()\` now upserts each system agent's \`systemPrompt\` (and \`watchPrompt\` where applicable) into the \`SystemPrompt\` table
- All 4 agent prompts (Alpha, Validator, Planner, Environment SME) are now visible and editable in ORION Settings → Prompts without code changes
- Uses \`update: {}\` so existing admin edits are preserved across restarts — no content is ever overwritten

## Agents covered
| Agent | Keys seeded |
|-------|------------|
| Alpha | \`agent.alpha.system\`, \`agent.alpha.watch\` |
| Validator | \`agent.validator.system\`, \`agent.validator.watch\` |
| Planner | \`agent.planner.system\` |
| Environment SME | \`agent.environment-sme.system\` |

## Test plan
- [ ] Restart ORION — confirm no errors in startup logs
- [ ] Open Settings → Prompts — confirm all 6 new entries appear
- [ ] Edit one prompt value — restart ORION — confirm the edit is preserved
- [ ] Verify existing agents are unaffected (prompts in agent metadata unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)