### PR TITLE
refactor: extract shared plan-patch handler for tasks, epics, and features

### DIFF
--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateEpicSchema } from '@/lib/validate'
+import { handlePlanPatch } from '@/lib/plan-patch'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
@@ -37,30 +38,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json().catch(() => ({})) as Record<string, unknown>
-  const id = params.id
-
-  const existing = await prisma.epic.findUnique({ where: { id } })
-  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-
-  const data: Record<string, unknown> = {}
-  if (body.plan            !== undefined) data.plan            = body.plan
-  if (body.planApprovedBy  !== undefined) data.planApprovedBy  = body.planApprovedBy
-  if (body.planApprovedAt  !== undefined) data.planApprovedAt  = body.planApprovedAt ? new Date(body.planApprovedAt as string) : null
-
-  if (body.plan !== undefined) {
-    await prisma.auditLog.create({
-      data: {
-        userId: req.headers.get('x-user-id') ?? 'system',
-        action: 'plan.updated',
-        target: `epic:${id}`,
-        detail: { field: 'plan', entityType: 'epic', entityId: id },
-      },
-    }).catch(() => {})
-  }
-
-  const epic = await prisma.epic.update({ where: { id }, data })
-  return NextResponse.json(epic)
+  return handlePlanPatch('epic', params.id, req)
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {

--- a/apps/web/src/app/api/features/[id]/route.ts
+++ b/apps/web/src/app/api/features/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateFeatureSchema } from '@/lib/validate'
+import { handlePlanPatch } from '@/lib/plan-patch'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
@@ -38,30 +39,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json().catch(() => ({})) as Record<string, unknown>
-  const id = params.id
-
-  const existing = await prisma.feature.findUnique({ where: { id } })
-  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-
-  const data: Record<string, unknown> = {}
-  if (body.plan            !== undefined) data.plan            = body.plan
-  if (body.planApprovedBy  !== undefined) data.planApprovedBy  = body.planApprovedBy
-  if (body.planApprovedAt  !== undefined) data.planApprovedAt  = body.planApprovedAt ? new Date(body.planApprovedAt as string) : null
-
-  if (body.plan !== undefined) {
-    await prisma.auditLog.create({
-      data: {
-        userId: req.headers.get('x-user-id') ?? 'system',
-        action: 'plan.updated',
-        target: `feature:${id}`,
-        detail: { field: 'plan', entityType: 'feature', entityId: id },
-      },
-    }).catch(() => {})
-  }
-
-  const feature = await prisma.feature.update({ where: { id }, data })
-  return NextResponse.json(feature)
+  return handlePlanPatch('feature', params.id, req)
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateTaskSchema } from '@/lib/validate'
+import { handlePlanPatch } from '@/lib/plan-patch'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
@@ -65,31 +66,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json().catch(() => ({})) as Record<string, unknown>
-  const id = params.id
-
-  const existing = await prisma.task.findUnique({ where: { id } })
-  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-
-  const data: Record<string, unknown> = {}
-  if (body.plan            !== undefined) data.plan            = body.plan
-  if (body.planProgress    !== undefined) data.planProgress    = body.planProgress !== null ? Number(body.planProgress) : null
-  if (body.planApprovedBy  !== undefined) data.planApprovedBy  = body.planApprovedBy
-  if (body.planApprovedAt  !== undefined) data.planApprovedAt  = body.planApprovedAt ? new Date(body.planApprovedAt as string) : null
-
-  if (body.plan !== undefined) {
-    await prisma.auditLog.create({
-      data: {
-        userId: req.headers.get('x-user-id') ?? 'system',
-        action: 'plan.updated',
-        target: `task:${id}`,
-        detail: { field: 'plan', entityType: 'task', entityId: id },
-      },
-    }).catch(() => {})
-  }
-
-  const task = await prisma.task.update({ where: { id }, data })
-  return NextResponse.json(task)
+  return handlePlanPatch('task', params.id, req)
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {

--- a/apps/web/src/lib/plan-patch.ts
+++ b/apps/web/src/lib/plan-patch.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export async function handlePlanPatch(
+  model: 'task' | 'epic' | 'feature',
+  id: string,
+  req: NextRequest,
+): Promise<NextResponse> {
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+
+  const existing = await (prisma[model] as any).findUnique({ where: { id } })
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const data: Record<string, unknown> = {}
+  if (body.plan           !== undefined) data.plan           = body.plan
+  if (body.planApprovedBy !== undefined) data.planApprovedBy = body.planApprovedBy
+  if (body.planApprovedAt !== undefined) data.planApprovedAt = body.planApprovedAt ? new Date(body.planApprovedAt as string) : null
+  if (model === 'task' && body.planProgress !== undefined) {
+    data.planProgress = body.planProgress !== null ? Number(body.planProgress) : null
+  }
+
+  if (body.plan !== undefined) {
+    await prisma.auditLog.create({
+      data: {
+        userId: req.headers.get('x-user-id') ?? 'system',
+        action: 'plan.updated',
+        target: `${model}:${id}`,
+        detail: { field: 'plan', entityType: model, entityId: id },
+      },
+    }).catch(() => {})
+  }
+
+  const result = await (prisma[model] as any).update({ where: { id }, data })
+  return NextResponse.json(result)
+}


### PR DESCRIPTION
## Summary
- Create `lib/plan-patch.ts` with a shared `handlePlanPatch()` utility
- Replace copy-pasted PATCH handlers in `tasks/[id]`, `epics/[id]`, and `features/[id]` route files with a single call

## Behaviour unchanged
- Same fields updated: `plan`, `planApprovedBy`, `planApprovedAt` (all three); `planProgress` (tasks only)
- Same 404 check on entity existence
- Same audit log entry (`plan.updated`) when `plan` field changes
- Same `x-user-id` header for audit actor

## Test plan
- [ ] PATCH `/api/tasks/:id` with `{ plan: "..." }` → 200, audit log created
- [ ] PATCH `/api/epics/:id` with `{ planApprovedBy: "user" }` → 200
- [ ] PATCH `/api/features/:id` with non-existent id → 404
- [ ] PATCH `/api/tasks/:id` with `{ planProgress: 50 }` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)