### PR TITLE
fix: add tool_call_id to OpenAIMessage interface

### DIFF
--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -5,6 +5,7 @@ import { getPrompt, interpolate } from '@/lib/system-prompts'
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
   content: string
+  tool_call_id?: string
   tool_calls?: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }>
 }
 


### PR DESCRIPTION
## Summary
Fixes TypeScript build error introduced in the LLM-agnostic runner PR.

`tool_call_id` was correctly added to tool result message objects (required by strict OpenAI-compatible servers like vLLM) but was not declared in the `OpenAIMessage` interface, causing a type error during `npm run build`.

## Error
\`\`\`
Type error: Object literal may only specify known properties, but 'tool_call_id' does not exist in type 'OpenAIMessage'.
\`\`\`

## Fix
Add `tool_call_id?: string` to `OpenAIMessage` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)