### PR TITLE
fix: widen SchemaProperty type to support array items and nested objects

### DIFF
--- a/apps/web/src/lib/agent-runner/types.ts
+++ b/apps/web/src/lib/agent-runner/types.ts
@@ -1,9 +1,18 @@
+interface SchemaProperty {
+  type: string
+  description?: string
+  enum?: string[]
+  items?: SchemaProperty | { type: string; properties?: Record<string, SchemaProperty>; required?: string[] }
+  properties?: Record<string, SchemaProperty>
+  required?: string[]
+}
+
 export interface ManagementToolDef {
   name: string
   description: string
   inputSchema: {
     type: string
-    properties?: Record<string, { type: string; description?: string; enum?: string[] }>
+    properties?: Record<string, SchemaProperty>
     required?: string[]
   }
 }
@@ -40,7 +49,7 @@ export interface GatewayTool {
   description: string
   inputSchema: {
     type: string
-    properties?: Record<string, { type: string; description?: string; enum?: string[] }>
+    properties?: Record<string, SchemaProperty>
     required?: string[]
   }
 }


### PR DESCRIPTION
## Summary
Fixes TypeScript build error in `management-tools.ts`.

The `inputSchema.properties` type only allowed flat `{ type, description, enum }` — no `items` or nested `properties`. The `orion_propose_gitops` tool (added in PR #241) uses an array property with `items`, which the narrow type rejected.

## Error
\`\`\`
./src/lib/management-tools.ts:213:11
Type error: Object literal may only specify known properties, and 'items' does not exist in type '{ type: string; description?: string | undefined; enum?: string[] | undefined; }'.
\`\`\`

## Fix
Extract a recursive `SchemaProperty` interface that supports `items`, nested `properties`, and `required`. Apply it to both `ManagementToolDef` and `GatewayTool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)