### PR TITLE
refactor: extract CRUD route factory for list/create handlers

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,35 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/db'
-import { parseBodyOrError, CreateAgentSchema } from '@/lib/validate'
-import { z } from 'zod'
-
-const RESERVED_NAMES = ['human', 'user', 'system', 'admin']
+import { makeCrudRoutes } from '@/lib/crud-route-factory'
+import { CreateAgentSchema } from '@/lib/validate'
+import { RESERVED_AGENT_NAMES } from '@/lib/management-tools'
 
 // SOC2 [INPUT-001]: Extended validation with reserved name check
 const CreateAgentWithReservedCheck = CreateAgentSchema.refine(
-  (data) => !RESERVED_NAMES.includes(data.name.toLowerCase()),
+  (data) => !RESERVED_AGENT_NAMES.includes(data.name.toLowerCase()),
   { message: 'Agent name is reserved', path: ['name'] }
 )
 
-export async function GET() {
-  const agents = await prisma.agent.findMany({ orderBy: { name: 'asc' } })
-  return NextResponse.json(agents)
-}
-
-export async function POST(req: NextRequest) {
-  // SOC2 [INPUT-001]: Validate request body with Zod schema
-  const result = await parseBodyOrError(req, CreateAgentWithReservedCheck)
-  if ('error' in result) return result.error
-
-  const { data } = result  // { name, type, role?, metadata? }
-
-  const agent = await prisma.agent.create({
-    data: {
-      name:     data.name,
-      type:     data.type ?? 'claude',
-      role:     data.role ?? null,
-      ...(data.metadata && { metadata: data.metadata as any }),
-    },
-  })
-  return NextResponse.json(agent, { status: 201 })
-}
+export const { GET, POST } = makeCrudRoutes({
+  model:        'agent',
+  createSchema: CreateAgentWithReservedCheck,
+  requireAuth:  false,
+  orderBy:      { name: 'asc' },
+  transformData: (data) => ({
+    name:     data.name,
+    type:     data.type ?? 'claude',
+    role:     data.role ?? null,
+    ...(data.metadata ? { metadata: data.metadata } : {}),
+  }),
+})

--- a/apps/web/src/app/api/bugs/route.ts
+++ b/apps/web/src/app/api/bugs/route.ts
@@ -1,47 +1,22 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
-import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { makeCrudRoutes } from '@/lib/crud-route-factory'
+import { CreateBugSchema } from '@/lib/validate'
 
-export async function GET(req: NextRequest) {
-  await requireServiceAuth(req)
-  const bugs = await prisma.bug.findMany({
-    orderBy: { updatedAt: 'desc' },
-    include: { assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } } },
-  })
-  return NextResponse.json(bugs)
+const BUG_INCLUDE = {
+  assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } },
 }
 
-export async function POST(req: NextRequest) {
-  const caller = await requireServiceAuth(req)
-  const isService = caller === null
-  const body = await req.json()
-
-  // Validate bug input
-  const parsed = z.object({
-    title: z.string().min(1).max(500),
-    description: z.string().max(10000).optional(),
-    severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
-    status: z.enum(['open', 'in_progress', 'resolved', 'wont_fix']).optional(),
-    area: z.string().max(100).optional(),
-    reportedBy: z.string().max(200).optional(),
-    assignedUserId: z.string().max(100).optional(),
-  }).safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
-  }
-
-  const bug = await prisma.bug.create({
-    data: {
-      title:          parsed.data.title,
-      description:    parsed.data.description ?? null,
-      severity:       parsed.data.severity    ?? 'medium',
-      status:         parsed.data.status      ?? 'open',
-      area:           parsed.data.area        ?? null,
-      reportedBy:     parsed.data.reportedBy  ?? 'admin',
-      assignedUserId: parsed.data.assignedUserId ?? null,
-    },
-    include: { assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } } },
-  })
-  return NextResponse.json(bug, { status: 201 })
-}
+export const { GET, POST } = makeCrudRoutes({
+  model:        'bug',
+  createSchema: CreateBugSchema,
+  orderBy:      { updatedAt: 'desc' },
+  include:      BUG_INCLUDE,
+  transformData: (data) => ({
+    title:          data.title,
+    description:    data.description    ?? null,
+    severity:       data.severity       ?? 'medium',
+    status:         data.status         ?? 'open',
+    area:           data.area           ?? null,
+    reportedBy:     data.reportedBy     ?? 'admin',
+    assignedUserId: data.assignedUserId ?? null,
+  }),
+})

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -1,48 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
-import { parseBodyOrError, CreateEpicSchema } from '@/lib/validate'
+import { makeCrudRoutes } from '@/lib/crud-route-factory'
+import { CreateEpicSchema } from '@/lib/validate'
 
-export async function GET(req: NextRequest) {
-  await requireServiceAuth(req)
-  const epics = await prisma.epic.findMany({
-    orderBy: { updatedAt: 'desc' },
-    include: { features: { include: { _count: { select: { tasks: true } } }, orderBy: { createdAt: 'asc' } } },
-  })
-  return NextResponse.json(epics)
+const EPIC_INCLUDE = {
+  features: {
+    include: { _count: { select: { tasks: true } } },
+    orderBy: { createdAt: 'asc' as const },
+  },
 }
 
-export async function POST(req: NextRequest) {
-  const caller = await requireServiceAuth(req)
-  const isService = caller === null
-
-  // SOC2 [INPUT-001]: Validate request body with Zod schema
-  const result = await parseBodyOrError(req, CreateEpicSchema)
-  if ('error' in result) return result.error
-
-  const { data } = result
-
-  const epic = await prisma.epic.create({
-    data: {
-      title: data.title,
-      description: data.description ?? null,
-      plan: data.plan,
-      status: data.status,
-      createdBy: caller?.id ?? 'gateway',
-    },
-    include: { features: { include: { _count: { select: { tasks: true } } } } },
-  })
-
-  // Auto-create a planning chat room for this epic
-  await prisma.chatRoom.create({
-    data: {
-      name: `${epic.title} — Planning`,
-      type: 'planning',
-      epicId: epic.id,
-      createdBy: caller?.id ?? 'system',
-      ...(caller ? { members: { create: [{ userId: caller.id, role: 'lead' }] } } : {}),
-    },
-  })
-
-  return NextResponse.json(epic, { status: 201 })
-}
+export const { GET, POST } = makeCrudRoutes({
+  model:        'epic',
+  createSchema: CreateEpicSchema,
+  orderBy:      { updatedAt: 'desc' },
+  include:      EPIC_INCLUDE,
+  transformData: (data, caller) => ({
+    title:       data.title,
+    description: data.description ?? null,
+    plan:        data.plan,
+    status:      data.status,
+    createdBy:   caller?.id ?? 'gateway',
+  }),
+  afterCreate: async (record, caller) => {
+    const epic = record as { id: string; title: string }
+    await prisma.chatRoom.create({
+      data: {
+        name:      `${epic.title} — Planning`,
+        type:      'planning',
+        epicId:    epic.id,
+        createdBy: caller?.id ?? 'system',
+        ...(caller?.id ? { members: { create: [{ userId: caller.id, role: 'lead' }] } } : {}),
+      },
+    })
+  },
+})

--- a/apps/web/src/app/api/notes/route.ts
+++ b/apps/web/src/app/api/notes/route.ts
@@ -1,48 +1,14 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { prisma } from '@/lib/db'
-import { embedNote } from '@/lib/embeddings'
-import { requireServiceAuth } from '@/lib/auth'
+import { makeCrudRoutes } from '@/lib/crud-route-factory'
 import { CreateNoteSchema } from '@/lib/validate'
+import { embedNote } from '@/lib/embeddings'
 
-export async function GET(req: NextRequest) {
-  await requireServiceAuth(req)
-  const { searchParams } = new URL(req.url)
-  const type = searchParams.get('type')
-  const notes = await prisma.note.findMany({
-    where: type ? { type } : undefined,
-    orderBy: [{ pinned: 'desc' }, { updatedAt: 'desc' }],
-  })
-  return NextResponse.json(notes)
-}
-
-export async function POST(req: NextRequest) {
-  await requireServiceAuth(req)
-
-  // SOC2: Input validation — validate and sanitize all request body fields
-  const rawBody = await req.json().catch(() => ({}))
-  const body = typeof rawBody === 'object' && rawBody !== null ? rawBody : {}
-
-  const parsed = CreateNoteSchema.safeParse(body)
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Invalid input', details: parsed.error.errors.map(e => ({ field: e.path.join('.'), message: e.message })) },
-      { status: 400 },
-    )
-  }
-
-  const note = await prisma.note.create({
-    data: {
-      title:   parsed.data.title,
-      content: parsed.data.content,
-      folder:  parsed.data.folder,
-      pinned:  parsed.data.pinned,
-      type:    parsed.data.type,
-      tags:    parsed.data.tags,
-    },
-  })
-
-  // Embed asynchronously — don't block the response
-  embedNote(note).catch(err => console.error('[embed] failed for new note:', err))
-
-  return NextResponse.json(note, { status: 201 })
-}
+export const { GET, POST } = makeCrudRoutes({
+  model:        'note',
+  createSchema: CreateNoteSchema,
+  listFilters:  ['type'],
+  orderBy:      [{ pinned: 'desc' }, { updatedAt: 'desc' }],
+  afterCreate:  async (record) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    embedNote(record as any).catch(err => console.error('[embed] failed for new note:', err))
+  },
+})

--- a/apps/web/src/lib/crud-route-factory.ts
+++ b/apps/web/src/lib/crud-route-factory.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { ZodType } from 'zod'
+import { prisma } from '@/lib/db'
+import { parseBodyOrError } from '@/lib/validate'
+import { requireServiceAuth } from '@/lib/auth'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Caller = any
+
+export function makeCrudRoutes(config: {
+  model: string
+  createSchema: ZodType
+  requireAuth?: boolean                  // default true
+  include?: object
+  orderBy?: object | object[]
+  listFilters?: string[]                 // query param names forwarded as where filters
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformData?: (data: any, caller: Caller) => Record<string, unknown>
+  afterCreate?: (record: unknown, caller: Caller) => Promise<void>
+}) {
+  const needsAuth = config.requireAuth !== false
+
+  return {
+    GET: async (req: NextRequest) => {
+      if (needsAuth) await requireServiceAuth(req)
+      const where: Record<string, unknown> = {}
+      if (config.listFilters?.length) {
+        const url = new URL(req.url)
+        for (const f of config.listFilters) {
+          const v = url.searchParams.get(f)
+          if (v != null) where[f] = v
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const records = await (prisma as any)[config.model].findMany({
+        ...(Object.keys(where).length ? { where } : {}),
+        ...(config.orderBy !== undefined ? { orderBy: config.orderBy } : {}),
+        ...(config.include ? { include: config.include } : {}),
+      })
+      return NextResponse.json(records)
+    },
+
+    POST: async (req: NextRequest) => {
+      const caller: Caller = needsAuth ? await requireServiceAuth(req) : null
+      const result = await parseBodyOrError(req, config.createSchema)
+      if ('error' in result) return result.error
+
+      const raw = result.data as Record<string, unknown>
+      const data = config.transformData ? config.transformData(raw, caller) : raw
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const record = await (prisma as any)[config.model].create({
+        data,
+        ...(config.include ? { include: config.include } : {}),
+      })
+
+      if (config.afterCreate) {
+        await config.afterCreate(record, caller).catch(() => {})
+      }
+
+      return NextResponse.json(record, { status: 201 })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Create \`lib/crud-route-factory.ts\` with a \`makeCrudRoutes()\` factory and apply it to 4 routes.

## Routes refactored
| Route | Change |
|-------|--------|
| \`agents/route.ts\` | Factory with no auth, \`orderBy: name asc\`, reserved name check stays outside |
| \`bugs/route.ts\` | Factory with auth, \`CreateBugSchema\`, assignedUser include |
| \`notes/route.ts\` | Factory with auth, \`type\` query filter, multi-field orderBy, \`embedNote\` afterCreate |
| \`epics/route.ts\` | Factory with auth, nested features include, \`createdBy\` via transformData, planning chatRoom afterCreate |

## Routes left as-is
- \`tasks/route.ts\` — 4 query filters + conditional \`assignedAgent\` field mapping in create
- \`features/route.ts\` — complex afterCreate (chatRoom + agent membership upserts)

## Factory API
\`\`\`ts
makeCrudRoutes({
  model, createSchema,
  requireAuth?,   // default true
  include?,       // passed to findMany + create
  orderBy?,       // single object or array
  listFilters?,   // query param names forwarded as where filters
  transformData?, // (data, caller) => create data
  afterCreate?,   // (record, caller) => Promise<void>
})
\`\`\`

## Bonus fix
\`agents/route.ts\` now imports \`RESERVED_AGENT_NAMES\` from \`management-tools\` instead of duplicating the constant locally.

## Test plan
- [ ] GET \`/api/agents\` → returns agents list
- [ ] POST \`/api/agents\` with reserved name (\`admin\`) → 400
- [ ] POST \`/api/agents\` with valid name → 201
- [ ] GET \`/api/bugs\` → returns bugs with assignedUser
- [ ] POST \`/api/bugs\` with missing title → 400
- [ ] GET \`/api/notes?type=note\` → filters by type
- [ ] POST \`/api/epics\` → creates epic + planning chat room

🤖 Generated with [Claude Code](https://claude.com/claude-code)