### PR TITLE
refactor: extract shared UI components

### DIFF
--- a/apps/web/src/components/tasks/BugManager.tsx
+++ b/apps/web/src/components/tasks/BugManager.tsx
@@ -1,7 +1,9 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
-import { Plus, X, Trash2, ChevronRight, User } from 'lucide-react'
+import { Plus, Trash2, ChevronRight, User } from 'lucide-react'
 import type { Bug, TaskUser } from '@/types/tasks'
+import { KanbanBoard } from '../ui/KanbanBoard'
+import { CreateEntityModal } from '../ui/CreateEntityModal'
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -163,62 +165,54 @@ export function BugManager({ initialBugs, users }: Props) {
           </button>
         </div>
 
-        {/* Columns */}
-        <div className="flex gap-3 overflow-x-auto overflow-y-hidden flex-1">
-          {STATUS_COLUMNS.map(col => {
-            const colBugs = byStatus(col)
-            return (
-              <div key={col} className={`flex-shrink-0 w-52 flex flex-col rounded-lg border border-border-subtle border-t-2 ${statusTopBorder[col]} bg-bg-sidebar overflow-hidden`}>
-                <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle">
-                  <span className="text-xs font-medium text-text-secondary">{statusLabel[col]}</span>
-                  <span className="text-[10px] text-text-muted">{colBugs.length}</span>
+        <KanbanBoard
+          columns={STATUS_COLUMNS.map(col => ({
+            key: col,
+            label: statusLabel[col],
+            topBorderClass: statusTopBorder[col],
+            items: byStatus(col),
+            emptyText: 'No bugs',
+            renderItem: (bug: Bug) => {
+              const sev = severityConfig[bug.severity] ?? severityConfig.medium
+              const isSelected = selectedBug?.id === bug.id
+              return (
+                <div
+                  onClick={() => {
+                    if (isSelected) {
+                      setSelectedBug(null)
+                      setIsDetailModalOpen(false)
+                    } else {
+                      setSelectedBug(bug)
+                      setIsDetailModalOpen(true)
+                    }
+                  }}
+                  className={`p-2.5 rounded-lg border cursor-pointer transition-colors ${
+                    isSelected
+                      ? 'border-accent bg-accent/10'
+                      : 'border-border-subtle bg-bg-raised hover:border-border-visible'
+                  }`}
+                >
+                  <p className="text-xs text-text-primary leading-snug line-clamp-2 mb-1.5">{bug.title}</p>
+                  <div className="flex items-center justify-between">
+                    <span className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border ${sev.bg} ${sev.color}`}>
+                      <span className={`w-1.5 h-1.5 rounded-full ${sev.dot}`} />
+                      {sev.label}
+                    </span>
+                    {bug.area && (
+                      <span className="text-[10px] text-text-muted truncate max-w-[70px]">{bug.area}</span>
+                    )}
+                  </div>
+                  {bug.assignedUser && (
+                    <div className="flex items-center gap-1 mt-1.5">
+                      <User size={9} className="text-text-muted" />
+                      <span className="text-[10px] text-text-muted truncate">{bug.assignedUser.name ?? bug.assignedUser.username}</span>
+                    </div>
+                  )}
                 </div>
-                <div className="flex-1 overflow-y-auto p-2 space-y-2">
-                  {colBugs.map(bug => {
-                    const sev = severityConfig[bug.severity] ?? severityConfig.medium
-                    const isSelected = selectedBug?.id === bug.id
-                    return (
-                      <div
-                        key={bug.id}
-                        onClick={() => {
-                          if (isSelected) {
-                            setSelectedBug(null)
-                            setIsDetailModalOpen(false)
-                          } else {
-                            setSelectedBug(bug)
-                            setIsDetailModalOpen(true)
-                          }
-                        }}
-                        className={`p-2.5 rounded-lg border cursor-pointer transition-colors ${
-                          isSelected
-                            ? 'border-accent bg-accent/10'
-                            : 'border-border-subtle bg-bg-raised hover:border-border-visible'
-                        }`}
-                      >
-                        <p className="text-xs text-text-primary leading-snug line-clamp-2 mb-1.5">{bug.title}</p>
-                        <div className="flex items-center justify-between">
-                          <span className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border ${sev.bg} ${sev.color}`}>
-                            <span className={`w-1.5 h-1.5 rounded-full ${sev.dot}`} />
-                            {sev.label}
-                          </span>
-                          {bug.area && (
-                            <span className="text-[10px] text-text-muted truncate max-w-[70px]">{bug.area}</span>
-                          )}
-                        </div>
-                        {bug.assignedUser && (
-                          <div className="flex items-center gap-1 mt-1.5">
-                            <User size={9} className="text-text-muted" />
-                            <span className="text-[10px] text-text-muted truncate">{bug.assignedUser.name ?? bug.assignedUser.username}</span>
-                          </div>
-                        )}
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-            )
-          })}
-        </div>
+              )
+            },
+          }))}
+        />
       </div>
 
       {/* ── Detail panel ────────────────────────────────────────────────────── */}
@@ -340,81 +334,60 @@ export function BugManager({ initialBugs, users }: Props) {
 
       {/* ── Create modal ─────────────────────────────────────────────────────── */}
       {modal && (
-        <>
-          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40" onClick={() => setModal(false)} />
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <div className="bg-bg-sidebar border border-border-subtle rounded-xl shadow-2xl w-full max-w-md">
-              <div className="flex items-center justify-between px-5 py-4 border-b border-border-subtle">
-                <h2 className="text-sm font-semibold text-text-primary">Report a Bug</h2>
-                <button onClick={() => setModal(false)} className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors">
-                  <X size={16} />
-                </button>
-              </div>
-              <div className="p-5 space-y-4">
-                <div className="space-y-1">
-                  <label className="text-xs text-text-secondary">Title *</label>
-                  <input
-                    value={form.title}
-                    onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
-                    onKeyDown={e => e.key === 'Enter' && createBug()}
-                    placeholder="Short description of the bug"
-                    className="w-full text-sm bg-bg-raised border border-border-visible rounded px-3 py-2 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
-                    autoFocus
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1">
-                    <label className="text-xs text-text-secondary">Severity</label>
-                    <select
-                      value={form.severity}
-                      onChange={e => setForm(f => ({ ...f, severity: e.target.value }))}
-                      className="w-full text-sm bg-bg-raised border border-border-visible rounded px-3 py-2 text-text-primary focus:outline-none focus:border-accent"
-                    >
-                      <option value="critical">Critical</option>
-                      <option value="high">High</option>
-                      <option value="medium">Medium</option>
-                      <option value="low">Low</option>
-                    </select>
-                  </div>
-                  <div className="space-y-1">
-                    <label className="text-xs text-text-secondary">Area</label>
-                    <input
-                      value={form.area}
-                      onChange={e => setForm(f => ({ ...f, area: e.target.value }))}
-                      placeholder="e.g. Auth, Traefik"
-                      className="w-full text-sm bg-bg-raised border border-border-visible rounded px-3 py-2 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
-                    />
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <label className="text-xs text-text-secondary">Description</label>
-                  <textarea
-                    value={form.description}
-                    onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-                    rows={4}
-                    placeholder="Steps to reproduce, expected vs actual behaviour…"
-                    className="w-full text-sm bg-bg-raised border border-border-visible rounded px-3 py-2 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none"
-                  />
-                </div>
-              </div>
-              <div className="flex justify-end gap-2 px-5 py-4 border-t border-border-subtle">
-                <button
-                  onClick={() => setModal(false)}
-                  className="px-4 py-2 rounded text-sm text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={createBug}
-                  disabled={!form.title.trim() || saving}
-                  className="px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                >
-                  {saving ? 'Reporting…' : 'Report Bug'}
-                </button>
-              </div>
+        <CreateEntityModal
+          title="Report a Bug"
+          onClose={() => setModal(false)}
+          onSubmit={createBug}
+          submitLabel="Report Bug"
+          submitting={saving}
+          submitDisabled={!form.title.trim()}
+        >
+          <div className="space-y-1">
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
+            <input
+              value={form.title}
+              onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
+              onKeyDown={e => e.key === 'Enter' && createBug()}
+              placeholder="Short description of the bug"
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              autoFocus
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Severity</label>
+              <select
+                value={form.severity}
+                onChange={e => setForm(f => ({ ...f, severity: e.target.value }))}
+                className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+              >
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Area</label>
+              <input
+                value={form.area}
+                onChange={e => setForm(f => ({ ...f, area: e.target.value }))}
+                placeholder="e.g. Auth, Traefik"
+                className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              />
             </div>
           </div>
-        </>
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Description</label>
+            <textarea
+              value={form.description}
+              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+              rows={4}
+              placeholder="Steps to reproduce, expected vs actual behaviour…"
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none"
+            />
+          </div>
+        </CreateEntityModal>
       )}
     </div>
   )

--- a/apps/web/src/components/tasks/EpicDetailPanel.tsx
+++ b/apps/web/src/components/tasks/EpicDetailPanel.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { X, Trash2, GitBranch, Plus, Sparkles, Loader2, MessageSquare } from 'lucide-react'
+import { Trash2, GitBranch, Plus, Sparkles, Loader2, MessageSquare } from 'lucide-react'
 import type { Epic, Feature } from '@/types/tasks'
 import { PlanWithAIButton } from './PlanWithAIButton'
+import { DetailPanelShell } from '../ui/DetailPanelShell'
 
 interface Props {
   epic: Epic
@@ -72,117 +73,113 @@ export function EpicDetailPanel({ epic, onUpdate, onDelete, onPlanWithClaude, on
   }
 
   return (
-    <aside className="w-full max-w-2xl max-h-[85vh] flex flex-col rounded-xl border border-border-subtle bg-bg-sidebar shadow-2xl overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
-        <span className="text-xs font-semibold text-text-secondary">Epic</span>
-        <button onClick={onClose} className="text-text-muted hover:text-text-primary"><X size={14} /></button>
-      </div>
-
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title</label>
-          <input
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-            onBlur={save}
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
-          />
-        </div>
-
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Status</label>
-          <select
-            value={status}
-            onChange={e => { setStatus(e.target.value); onUpdate({ status: e.target.value }) }}
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
-          >
-            <option value="active">Active</option>
-            <option value="completed">Completed</option>
-            <option value="archived">Archived</option>
-          </select>
-        </div>
-
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
-          <textarea
-            value={desc}
-            onChange={e => setDesc(e.target.value)}
-            onBlur={save}
-            rows={4}
-            placeholder="What is this epic about?"
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
-          />
-        </div>
-
-        <div>
-          <label className="text-[10px] text-accent uppercase tracking-wide mb-1 block">Claude&apos;s Plan</label>
-          <textarea
-            value={plan}
-            onChange={e => setPlan(e.target.value)}
-            onBlur={save}
-            rows={6}
-            placeholder="No plan yet — use 'Plan with Claude' to generate one..."
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
-          />
-        </div>
-
-        {/* Features list */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <label className="text-[10px] text-text-muted uppercase tracking-wide">Features ({epic.features.length})</label>
-            <button onClick={onNewFeature} className="flex items-center gap-1 text-[10px] text-accent hover:text-accent/80">
-              <Plus size={10} /> Add
+    <DetailPanelShell
+      onClose={onClose}
+      header={<span className="text-xs font-semibold text-text-secondary">Epic</span>}
+      footer={
+        <>
+          <PlanWithAIButton onSelect={onPlanWithClaude} />
+          {epicPlanningRoom && (
+            <button
+              onClick={() => router.push(`/messages?r=${epicPlanningRoom.id}`)}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 transition-colors"
+            >
+              <MessageSquare size={14} /> Continue Planning
             </button>
-          </div>
-          <div className="space-y-1">
-            {epic.features.map(f => (
-              <div
-                key={f.id}
-                onClick={() => onSelectFeature(f)}
-                className="flex items-center gap-2 px-2 py-1.5 rounded border border-border-subtle bg-bg-raised hover:border-accent/40 cursor-pointer transition-colors"
-              >
-                <GitBranch size={11} className="text-text-muted flex-shrink-0" />
-                <span className="text-xs text-text-primary flex-1 truncate">{f.title}</span>
-                <span className="text-[10px] text-text-muted">{f._count?.tasks ?? 0}</span>
-              </div>
-            ))}
-            {epic.features.length === 0 && (
-              <p className="text-[10px] text-text-muted py-2 text-center">No features yet</p>
-            )}
-          </div>
-        </div>
-
-        <p className="text-[10px] text-text-muted">Created {new Date(epic.createdAt).toLocaleDateString()}</p>
+          )}
+          {plan && (
+            <button
+              onClick={handleGenerate}
+              disabled={generating}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+              {generating ? 'Generating features...' : 'Generate Features from Plan'}
+            </button>
+          )}
+          {genError && <p className="text-[10px] text-status-error text-center">{genError}</p>}
+          <button
+            onClick={onDelete}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-border-subtle text-text-muted text-sm hover:border-status-error hover:text-status-error transition-colors"
+          >
+            <Trash2 size={14} /> Delete Epic
+          </button>
+        </>
+      }
+    >
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title</label>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          onBlur={save}
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        />
       </div>
 
-      <div className="p-3 border-t border-border-subtle space-y-2">
-        <PlanWithAIButton onSelect={onPlanWithClaude} />
-        {epicPlanningRoom && (
-          <button
-            onClick={() => router.push(`/messages?r=${epicPlanningRoom.id}`)}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 transition-colors"
-          >
-            <MessageSquare size={14} /> Continue Planning
-          </button>
-        )}
-        {plan && (
-          <button
-            onClick={handleGenerate}
-            disabled={generating}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
-            {generating ? 'Generating features...' : 'Generate Features from Plan'}
-          </button>
-        )}
-        {genError && <p className="text-[10px] text-status-error text-center">{genError}</p>}
-        <button
-          onClick={onDelete}
-          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-border-subtle text-text-muted text-sm hover:border-status-error hover:text-status-error transition-colors"
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Status</label>
+        <select
+          value={status}
+          onChange={e => { setStatus(e.target.value); onUpdate({ status: e.target.value }) }}
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
         >
-          <Trash2 size={14} /> Delete Epic
-        </button>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+          <option value="archived">Archived</option>
+        </select>
       </div>
-    </aside>
+
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
+        <textarea
+          value={desc}
+          onChange={e => setDesc(e.target.value)}
+          onBlur={save}
+          rows={4}
+          placeholder="What is this epic about?"
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
+        />
+      </div>
+
+      <div>
+        <label className="text-[10px] text-accent uppercase tracking-wide mb-1 block">Claude&apos;s Plan</label>
+        <textarea
+          value={plan}
+          onChange={e => setPlan(e.target.value)}
+          onBlur={save}
+          rows={6}
+          placeholder="No plan yet — use 'Plan with Claude' to generate one..."
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-[10px] text-text-muted uppercase tracking-wide">Features ({epic.features.length})</label>
+          <button onClick={onNewFeature} className="flex items-center gap-1 text-[10px] text-accent hover:text-accent/80">
+            <Plus size={10} /> Add
+          </button>
+        </div>
+        <div className="space-y-1">
+          {epic.features.map(f => (
+            <div
+              key={f.id}
+              onClick={() => onSelectFeature(f)}
+              className="flex items-center gap-2 px-2 py-1.5 rounded border border-border-subtle bg-bg-raised hover:border-accent/40 cursor-pointer transition-colors"
+            >
+              <GitBranch size={11} className="text-text-muted flex-shrink-0" />
+              <span className="text-xs text-text-primary flex-1 truncate">{f.title}</span>
+              <span className="text-[10px] text-text-muted">{f._count?.tasks ?? 0}</span>
+            </div>
+          ))}
+          {epic.features.length === 0 && (
+            <p className="text-[10px] text-text-muted py-2 text-center">No features yet</p>
+          )}
+        </div>
+      </div>
+
+      <p className="text-[10px] text-text-muted">Created {new Date(epic.createdAt).toLocaleDateString()}</p>
+    </DetailPanelShell>
   )
 }

--- a/apps/web/src/components/tasks/FeatureDetailPanel.tsx
+++ b/apps/web/src/components/tasks/FeatureDetailPanel.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { X, Trash2, Sparkles, Loader2, MessageSquare } from 'lucide-react'
+import { Trash2, Sparkles, Loader2, MessageSquare } from 'lucide-react'
 import type { Feature } from '@/types/tasks'
 import { PlanWithAIButton } from './PlanWithAIButton'
+import { DetailPanelShell } from '../ui/DetailPanelShell'
 
 interface Props {
   feature: Feature
@@ -78,98 +79,97 @@ export function FeatureDetailPanel({ feature, epicTitle, onUpdate, onDelete, onP
   }
 
   return (
-    <aside className="w-full max-w-2xl max-h-[85vh] flex flex-col rounded-xl border border-border-subtle bg-bg-sidebar shadow-2xl overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
-        <div>
+    <DetailPanelShell
+      onClose={onClose}
+      header={
+        <>
           <p className="text-[10px] text-text-muted">{epicTitle}</p>
           <span className="text-xs font-semibold text-text-secondary">Feature</span>
-        </div>
-        <button onClick={onClose} className="text-text-muted hover:text-text-primary"><X size={14} /></button>
-      </div>
-
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title</label>
-          <input
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-            onBlur={save}
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
-          />
-        </div>
-
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Status</label>
-          <select
-            value={status}
-            onChange={e => { setStatus(e.target.value); onUpdate({ status: e.target.value }) }}
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
-          >
-            <option value="active">Active</option>
-            <option value="completed">Completed</option>
-            <option value="archived">Archived</option>
-          </select>
-        </div>
-
-        <div>
-          <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
-          <textarea
-            value={desc}
-            onChange={e => setDesc(e.target.value)}
-            onBlur={save}
-            rows={4}
-            placeholder="What does this feature deliver?"
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
-          />
-        </div>
-
-        <div>
-          <label className="text-[10px] text-accent uppercase tracking-wide mb-1 block">Claude&apos;s Plan</label>
-          <textarea
-            value={plan}
-            onChange={e => setPlan(e.target.value)}
-            onBlur={save}
-            rows={6}
-            placeholder="No plan yet — use 'Plan with Claude' to generate one..."
-            className="w-full px-2.5 py-1.5 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
-          />
-        </div>
-
-        <div className="flex items-center gap-2 text-[10px] text-text-muted">
-          <span>{feature._count?.tasks ?? 0} tasks</span>
-          <span>·</span>
-          <span>Created {new Date(feature.createdAt).toLocaleDateString()}</span>
-        </div>
-      </div>
-
-      <div className="p-3 border-t border-border-subtle space-y-2">
-        <PlanWithAIButton onSelect={onPlanWithClaude} />
-        <button
-          onClick={handlePlanFeature}
-          disabled={creatingRoom}
-          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {creatingRoom ? <Loader2 size={14} className="animate-spin" /> : <MessageSquare size={14} />}
-          Plan Feature
-        </button>
-        {plan && (
+        </>
+      }
+      footer={
+        <>
+          <PlanWithAIButton onSelect={onPlanWithClaude} />
           <button
-            onClick={handleGenerate}
-            disabled={generating}
+            onClick={handlePlanFeature}
+            disabled={creatingRoom}
             className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
-            {generating ? 'Generating tasks...' : 'Generate Tasks from Plan'}
+            {creatingRoom ? <Loader2 size={14} className="animate-spin" /> : <MessageSquare size={14} />}
+            Plan Feature
           </button>
-        )}
-        {genError && <p className="text-[10px] text-status-error text-center">{genError}</p>}
-        <button
-          onClick={onDelete}
-          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-border-subtle text-text-muted text-sm hover:border-status-error hover:text-status-error transition-colors"
-        >
-          <Trash2 size={14} /> Delete Feature
-        </button>
+          {plan && (
+            <button
+              onClick={handleGenerate}
+              disabled={generating}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-accent/40 text-accent text-sm hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+              {generating ? 'Generating tasks...' : 'Generate Tasks from Plan'}
+            </button>
+          )}
+          {genError && <p className="text-[10px] text-status-error text-center">{genError}</p>}
+          <button
+            onClick={onDelete}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-border-subtle text-text-muted text-sm hover:border-status-error hover:text-status-error transition-colors"
+          >
+            <Trash2 size={14} /> Delete Feature
+          </button>
+        </>
+      }
+    >
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title</label>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          onBlur={save}
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        />
       </div>
-    </aside>
+
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Status</label>
+        <select
+          value={status}
+          onChange={e => { setStatus(e.target.value); onUpdate({ status: e.target.value }) }}
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+          <option value="archived">Archived</option>
+        </select>
+      </div>
+
+      <div>
+        <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
+        <textarea
+          value={desc}
+          onChange={e => setDesc(e.target.value)}
+          onBlur={save}
+          rows={4}
+          placeholder="What does this feature deliver?"
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
+        />
+      </div>
+
+      <div>
+        <label className="text-[10px] text-accent uppercase tracking-wide mb-1 block">Claude&apos;s Plan</label>
+        <textarea
+          value={plan}
+          onChange={e => setPlan(e.target.value)}
+          onBlur={save}
+          rows={6}
+          placeholder="No plan yet — use 'Plan with Claude' to generate one..."
+          className="w-full px-2.5 py-1.5 text-sm rounded border border-accent/30 bg-accent/5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed"
+        />
+      </div>
+
+      <div className="flex items-center gap-2 text-[10px] text-text-muted">
+        <span>{feature._count?.tasks ?? 0} tasks</span>
+        <span>·</span>
+        <span>Created {new Date(feature.createdAt).toLocaleDateString()}</span>
+      </div>
+    </DetailPanelShell>
   )
 }

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -5,6 +5,8 @@ import { useSession } from 'next-auth/react'
 import { Plus, X, Trash2, ChevronRight, Flag, Menu, Terminal, CheckCircle2, XCircle, Play, MessageSquare, ChevronDown, ChevronUp, Send, Loader2, User } from 'lucide-react'
 import type { Agent, Task, Feature, Epic, SelectionState, PlanTarget, Bug } from '@/types/tasks'
 import { BugManager } from './BugManager'
+import { KanbanBoard } from '../ui/KanbanBoard'
+import { CreateEntityModal } from '../ui/CreateEntityModal'
 
 interface TaskEvent {
   id: string
@@ -637,63 +639,58 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
         </div>
 
         {/* Board */}
-        <div className="flex gap-3 flex-1 overflow-x-auto overflow-y-hidden">
-          {columns.map(col => {
+        <KanbanBoard
+          columnWidth="w-60"
+          columnBg="bg-bg-card"
+          columns={columns.map(col => {
             const cfg = STATUS_CONFIG[col] ?? { label: col.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()), border: 'border-t-border-visible' }
-            return (
-            <div key={col} className={`flex-shrink-0 w-60 flex flex-col rounded-lg border border-border-subtle bg-bg-card border-t-2 ${cfg.border}`}>
-              <div className="flex items-center justify-between px-3 py-2.5 border-b border-border-subtle">
-                <span className="text-xs font-semibold text-text-secondary">{cfg.label}</span>
-                <span className="text-xs text-text-muted bg-bg-raised px-1.5 py-0.5 rounded">{byStatus(col).length}</span>
-              </div>
-              <div className="flex-1 overflow-y-auto p-2 space-y-2">
-                {byStatus(col).map(task => {
-                  const p = priorityConfig[task.priority] ?? priorityConfig.medium
-                  const isSelected = panel?.kind === 'task' && panel.task.id === task.id
-                  return (
-                    <div
-                      key={task.id}
-                      onClick={() => setPanel(isSelected ? null : { kind: 'task', task })}
-                      className={`rounded-lg border p-3 cursor-pointer transition-all ${
-                        isSelected ? 'border-accent bg-accent/10' : 'border-border-subtle bg-bg-raised hover:border-border-visible'
-                      }`}
-                    >
-                      <div className="flex items-start justify-between gap-2">
-                        <p className="text-xs text-text-primary leading-snug flex-1">{task.title}</p>
-                        <ChevronRight size={12} className={`flex-shrink-0 mt-0.5 text-text-muted transition-transform ${isSelected ? 'rotate-90' : ''}`} />
-                      </div>
-                      {task.description && (
-                        <p className="text-[10px] text-text-muted mt-1.5 line-clamp-2 leading-relaxed">{task.description}</p>
-                      )}
-                      <div className="flex items-center gap-2 mt-2">
-                        <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${p.dot}`} />
-                        <span className={`text-[10px] ${p.color}`}>{p.label}</span>
-                        <div className="ml-auto flex items-center gap-1">
-                          {task.plan && <span className="text-[10px] text-accent">has plan</span>}
-                          {task.agent && (() => {
-                            const idx = agents.findIndex(a => a.id === task.agent!.id)
-                            return (
-                              <div
-                                title={task.agent.name}
-                                className={`w-4 h-4 rounded-full ${AGENT_COLORS[idx >= 0 ? idx % AGENT_COLORS.length : 0]} flex items-center justify-center`}
-                              >
-                                <span className="text-[7px] font-bold text-white">{agentInitials(task.agent.name)}</span>
-                              </div>
-                            )
-                          })()}
-                        </div>
+            return {
+              key: col,
+              label: cfg.label,
+              topBorderClass: cfg.border,
+              items: byStatus(col),
+              emptyText: 'No tasks',
+              renderItem: (task: Task) => {
+                const p = priorityConfig[task.priority] ?? priorityConfig.medium
+                const isSelected = panel?.kind === 'task' && panel.task.id === task.id
+                return (
+                  <div
+                    onClick={() => setPanel(isSelected ? null : { kind: 'task', task })}
+                    className={`rounded-lg border p-3 cursor-pointer transition-all ${
+                      isSelected ? 'border-accent bg-accent/10' : 'border-border-subtle bg-bg-raised hover:border-border-visible'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-xs text-text-primary leading-snug flex-1">{task.title}</p>
+                      <ChevronRight size={12} className={`flex-shrink-0 mt-0.5 text-text-muted transition-transform ${isSelected ? 'rotate-90' : ''}`} />
+                    </div>
+                    {task.description && (
+                      <p className="text-[10px] text-text-muted mt-1.5 line-clamp-2 leading-relaxed">{task.description}</p>
+                    )}
+                    <div className="flex items-center gap-2 mt-2">
+                      <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${p.dot}`} />
+                      <span className={`text-[10px] ${p.color}`}>{p.label}</span>
+                      <div className="ml-auto flex items-center gap-1">
+                        {task.plan && <span className="text-[10px] text-accent">has plan</span>}
+                        {task.agent && (() => {
+                          const idx = agents.findIndex(a => a.id === task.agent!.id)
+                          return (
+                            <div
+                              title={task.agent.name}
+                              className={`w-4 h-4 rounded-full ${AGENT_COLORS[idx >= 0 ? idx % AGENT_COLORS.length : 0]} flex items-center justify-center`}
+                            >
+                              <span className="text-[7px] font-bold text-white">{agentInitials(task.agent.name)}</span>
+                            </div>
+                          )
+                        })()}
                       </div>
                     </div>
-                  )
-                })}
-                {byStatus(col).length === 0 && (
-                  <p className="text-[10px] text-text-muted text-center py-4">No tasks</p>
-                )}
-              </div>
-            </div>
-            )
+                  </div>
+                )
+              },
+            }
           })}
-        </div>
+        />
       </div>
 
 
@@ -912,127 +909,95 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
 
       {/* Create Task */}
       {taskModal && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setTaskModal(false)}>
-          <div className="bg-bg-card border border-border-visible rounded-xl p-6 w-[480px] max-w-[90vw] shadow-2xl" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h2 className="text-sm font-semibold text-text-primary">New Task</h2>
-                {activeFeatureId && (
-                  <p className="text-[10px] text-accent mt-0.5">
-                    Adding to: {epics.flatMap(e => e.features).find(f => f.id === activeFeatureId)?.title}
-                  </p>
-                )}
-              </div>
-              <button onClick={() => setTaskModal(false)} className="text-text-muted hover:text-text-primary"><X size={16} /></button>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
-                <input autoFocus value={taskForm.title} onChange={e => setTaskForm(f => ({ ...f, title: e.target.value }))}
-                  onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createTask()}
-                  placeholder="What needs to be done?"
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
-              </div>
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
-                <textarea value={taskForm.description} onChange={e => setTaskForm(f => ({ ...f, description: e.target.value }))} rows={3}
-                  placeholder="Context, goals, requirements..."
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
-              </div>
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Priority</label>
-                <div className="flex gap-2">
-                  {Object.entries(priorityConfig).map(([k, v]) => (
-                    <button key={k} onClick={() => setTaskForm(f => ({ ...f, priority: k }))}
-                      className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded text-xs border transition-colors ${
-                        taskForm.priority === k ? 'border-accent bg-accent/15 text-accent' : 'border-border-subtle text-text-muted hover:border-border-visible'
-                      }`}>
-                      <Flag size={10} />{v.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 mt-5">
-              <button onClick={() => setTaskModal(false)} className="px-4 py-2 text-sm text-text-muted hover:text-text-primary">Cancel</button>
-              <button onClick={createTask} disabled={!taskForm.title.trim() || saving}
-                className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 transition-colors">
-                {saving ? 'Creating…' : 'Create Task'}
-              </button>
+        <CreateEntityModal
+          title="New Task"
+          subtitle={activeFeatureId ? `Adding to: ${epics.flatMap(e => e.features).find(f => f.id === activeFeatureId)?.title}` : undefined}
+          onClose={() => setTaskModal(false)}
+          onSubmit={createTask}
+          submitLabel="Create Task"
+          submitting={saving}
+          submitDisabled={!taskForm.title.trim()}
+        >
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
+            <input autoFocus value={taskForm.title} onChange={e => setTaskForm(f => ({ ...f, title: e.target.value }))}
+              onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createTask()}
+              placeholder="What needs to be done?"
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+          </div>
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
+            <textarea value={taskForm.description} onChange={e => setTaskForm(f => ({ ...f, description: e.target.value }))} rows={3}
+              placeholder="Context, goals, requirements..."
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
+          </div>
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Priority</label>
+            <div className="flex gap-2">
+              {Object.entries(priorityConfig).map(([k, v]) => (
+                <button key={k} onClick={() => setTaskForm(f => ({ ...f, priority: k }))}
+                  className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded text-xs border transition-colors ${
+                    taskForm.priority === k ? 'border-accent bg-accent/15 text-accent' : 'border-border-subtle text-text-muted hover:border-border-visible'
+                  }`}>
+                  <Flag size={10} />{v.label}
+                </button>
+              ))}
             </div>
           </div>
-        </div>
+        </CreateEntityModal>
       )}
 
       {/* Create Epic */}
       {epicModal && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setEpicModal(false)}>
-          <div className="bg-bg-card border border-border-visible rounded-xl p-6 w-[480px] max-w-[90vw] shadow-2xl" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-sm font-semibold text-text-primary">New Epic</h2>
-              <button onClick={() => setEpicModal(false)} className="text-text-muted hover:text-text-primary"><X size={16} /></button>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
-                <input autoFocus value={epicForm.title} onChange={e => setEpicForm(f => ({ ...f, title: e.target.value }))}
-                  onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createEpic()}
-                  placeholder="What is this initiative about?"
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
-              </div>
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Description</label>
-                <textarea value={epicForm.description} onChange={e => setEpicForm(f => ({ ...f, description: e.target.value }))} rows={3}
-                  placeholder="High-level goals and scope..."
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 mt-5">
-              <button onClick={() => setEpicModal(false)} className="px-4 py-2 text-sm text-text-muted hover:text-text-primary">Cancel</button>
-              <button onClick={createEpic} disabled={!epicForm.title.trim() || saving}
-                className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 transition-colors">
-                {saving ? 'Creating…' : 'Create Epic'}
-              </button>
-            </div>
+        <CreateEntityModal
+          title="New Epic"
+          onClose={() => setEpicModal(false)}
+          onSubmit={createEpic}
+          submitLabel="Create Epic"
+          submitting={saving}
+          submitDisabled={!epicForm.title.trim()}
+        >
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
+            <input autoFocus value={epicForm.title} onChange={e => setEpicForm(f => ({ ...f, title: e.target.value }))}
+              onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createEpic()}
+              placeholder="What is this initiative about?"
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
           </div>
-        </div>
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Description</label>
+            <textarea value={epicForm.description} onChange={e => setEpicForm(f => ({ ...f, description: e.target.value }))} rows={3}
+              placeholder="High-level goals and scope..."
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
+          </div>
+        </CreateEntityModal>
       )}
 
       {/* Create Feature */}
       {featureModal && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setFeatureModal(null)}>
-          <div className="bg-bg-card border border-border-visible rounded-xl p-6 w-[480px] max-w-[90vw] shadow-2xl" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h2 className="text-sm font-semibold text-text-primary">New Feature</h2>
-                <p className="text-[10px] text-text-muted mt-0.5">Under: {featureModal.epicTitle}</p>
-              </div>
-              <button onClick={() => setFeatureModal(null)} className="text-text-muted hover:text-text-primary"><X size={16} /></button>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
-                <input autoFocus value={featureForm.title} onChange={e => setFeatureForm(f => ({ ...f, title: e.target.value }))}
-                  onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createFeature()}
-                  placeholder="What does this feature deliver?"
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
-              </div>
-              <div>
-                <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Description</label>
-                <textarea value={featureForm.description} onChange={e => setFeatureForm(f => ({ ...f, description: e.target.value }))} rows={3}
-                  placeholder="Scope, acceptance criteria..."
-                  className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 mt-5">
-              <button onClick={() => setFeatureModal(null)} className="px-4 py-2 text-sm text-text-muted hover:text-text-primary">Cancel</button>
-              <button onClick={createFeature} disabled={!featureForm.title.trim() || saving}
-                className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 transition-colors">
-                {saving ? 'Creating…' : 'Create Feature'}
-              </button>
-            </div>
+        <CreateEntityModal
+          title="New Feature"
+          subtitle={`Under: ${featureModal.epicTitle}`}
+          onClose={() => setFeatureModal(null)}
+          onSubmit={createFeature}
+          submitLabel="Create Feature"
+          submitting={saving}
+          submitDisabled={!featureForm.title.trim()}
+        >
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Title *</label>
+            <input autoFocus value={featureForm.title} onChange={e => setFeatureForm(f => ({ ...f, title: e.target.value }))}
+              onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createFeature()}
+              placeholder="What does this feature deliver?"
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
           </div>
-        </div>
+          <div>
+            <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Description</label>
+            <textarea value={featureForm.description} onChange={e => setFeatureForm(f => ({ ...f, description: e.target.value }))} rows={3}
+              placeholder="Scope, acceptance criteria..."
+              className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none leading-relaxed" />
+          </div>
+        </CreateEntityModal>
       )}
     </div>
   )

--- a/apps/web/src/components/ui/CreateEntityModal.tsx
+++ b/apps/web/src/components/ui/CreateEntityModal.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { X } from 'lucide-react'
+
+interface Props {
+  title: string
+  subtitle?: string
+  onClose: () => void
+  onSubmit: () => void
+  submitLabel: string
+  submitting: boolean
+  submitDisabled: boolean
+  children: React.ReactNode
+}
+
+export function CreateEntityModal({
+  title,
+  subtitle,
+  onClose,
+  onSubmit,
+  submitLabel,
+  submitting,
+  submitDisabled,
+  children,
+}: Props) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-bg-card border border-border-visible rounded-xl p-6 w-[480px] max-w-[90vw] shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+            {subtitle && <p className="text-[10px] text-text-muted mt-0.5">{subtitle}</p>}
+          </div>
+          <button onClick={onClose} className="text-text-muted hover:text-text-primary">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="space-y-3">{children}</div>
+        <div className="flex justify-end gap-2 mt-5">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-text-muted hover:text-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSubmit}
+            disabled={submitDisabled || submitting}
+            className="px-4 py-2 text-sm rounded bg-accent text-white hover:bg-accent/80 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? 'Creating…' : submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/DetailPanelShell.tsx
+++ b/apps/web/src/components/ui/DetailPanelShell.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { X } from 'lucide-react'
+
+interface Props {
+  header: React.ReactNode
+  footer: React.ReactNode
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export function DetailPanelShell({ header, footer, onClose, children }: Props) {
+  return (
+    <aside className="w-full max-w-2xl max-h-[85vh] flex flex-col rounded-xl border border-border-subtle bg-bg-sidebar shadow-2xl overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+        <div>{header}</div>
+        <button onClick={onClose} className="text-text-muted hover:text-text-primary">
+          <X size={14} />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">{children}</div>
+      <div className="p-3 border-t border-border-subtle space-y-2">{footer}</div>
+    </aside>
+  )
+}

--- a/apps/web/src/components/ui/KanbanBoard.tsx
+++ b/apps/web/src/components/ui/KanbanBoard.tsx
@@ -1,0 +1,45 @@
+'use client'
+import React from 'react'
+
+export interface KanbanColumn<T> {
+  key: string
+  label: string
+  topBorderClass: string
+  items: T[]
+  renderItem: (item: T) => React.ReactNode
+  emptyText?: string
+}
+
+interface Props<T> {
+  columns: KanbanColumn<T>[]
+  columnWidth?: string
+  columnBg?: string
+}
+
+export function KanbanBoard<T>({ columns, columnWidth = 'w-52', columnBg = 'bg-bg-sidebar' }: Props<T>) {
+  return (
+    <div className="flex gap-3 overflow-x-auto overflow-y-hidden flex-1">
+      {columns.map(col => (
+        <div
+          key={col.key}
+          className={`flex-shrink-0 ${columnWidth} flex flex-col rounded-lg border border-border-subtle border-t-2 ${col.topBorderClass} ${columnBg} overflow-hidden`}
+        >
+          <div className="flex items-center justify-between px-3 py-2 border-b border-border-subtle">
+            <span className="text-xs font-medium text-text-secondary">{col.label}</span>
+            <span className="text-[10px] text-text-muted">{col.items.length}</span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2 space-y-2">
+            {col.items.map((item, i) => (
+              <React.Fragment key={i}>{col.renderItem(item)}</React.Fragment>
+            ))}
+            {col.items.length === 0 && (
+              <p className="text-[10px] text-text-muted text-center py-4">
+                {col.emptyText ?? 'No items'}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `KanbanBoard<T>` — generic kanban column layout used by TasksPage and BugManager
- Adds `CreateEntityModal` — shared modal shell for entity creation dialogs
- Adds `DetailPanelShell` — shared `<aside>` wrapper with header, scroll area, and footer used by EpicDetailPanel and FeatureDetailPanel
- Refactors TasksPage, BugManager, EpicDetailPanel, FeatureDetailPanel to use the new components

## Test plan
- [ ] Task kanban board renders correctly (open/in_progress/done columns)
- [ ] Bug kanban board renders correctly
- [ ] Create task/epic/feature modals open, submit, and close correctly
- [ ] Epic detail panel opens and closes with correct layout
- [ ] Feature detail panel opens and closes with correct layout
- [ ] No visual regressions in TasksPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)