### PR TITLE
fix: add missing X import to BugManager

### DIFF
--- a/apps/web/src/components/tasks/BugManager.tsx
+++ b/apps/web/src/components/tasks/BugManager.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
-import { Plus, Trash2, ChevronRight, User } from 'lucide-react'
+import { Plus, Trash2, ChevronRight, User, X } from 'lucide-react'
 import type { Bug, TaskUser } from '@/types/tasks'
 import { KanbanBoard } from '../ui/KanbanBoard'
 import { CreateEntityModal } from '../ui/CreateEntityModal'


### PR DESCRIPTION
## Summary
- Fixes build failure introduced in #250 — `X` icon used at line 225 of `BugManager.tsx` was missing from the lucide-react import

## Test plan
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)