### PR TITLE
feat: enforce chat room membership for agent messages

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -595,10 +595,16 @@ async function handleSendMessage(argsRaw: string, actorId?: string): Promise<str
   const { room_id, content } = parseArgs(argsRaw) as { room_id?: string; content?: string }
   if (!room_id)  return 'Error: room_id is required'
   if (!content?.trim()) return 'Error: content is required'
+  if (!actorId) return 'Error: actorId is required to send messages (SOC2 attribution)'
 
   const room = await prisma.chatRoom.findUnique({ where: { id: room_id }, select: { name: true } })
   if (!room) return `Error: room ${room_id} not found`
-  if (!actorId) return 'Error: actorId is required to send messages (SOC2 attribution)'
+
+  // Hard rule: agents can only post to rooms they are members of
+  const membership = await prisma.chatRoomMember.findUnique({
+    where: { roomId_agentId: { roomId: room_id, agentId: actorId } },
+  })
+  if (!membership) return `Error: you are not a member of room "${room.name}" — agents may only send messages to rooms they belong to`
 
   await prisma.chatMessage.create({
     data: {

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -199,10 +199,14 @@ async function runTask(taskId: string): Promise<void> {
       await postToRoom(featureRoomId, agent.id, `▶ Starting task: **${task.title}**`)
     }
 
+    const roomNote = featureRoomId
+      ? `\n\n[Chat room for this task: ${featureRoomId} — use this room_id when calling orion_send_message]`
+      : ''
+
     const ctx: TaskRunContext = {
       taskId,
       taskTitle:       task.title,
-      taskDescription: task.description ?? null,
+      taskDescription: (task.description ?? '') + roomNote,
       taskPlan:        task.plan ?? null,
       agentId:         agent.id,
       agentName:       agent.name,


### PR DESCRIPTION
## Summary
- `orion_send_message` now checks that the calling agent is a member of the target room before posting — hard rejection if not
- Task execution appends the feature room ID to the task context so agents know exactly which room to use
- When a task starts, the worker already adds the agent as a member of the feature room (`findOrCreateFeatureRoom`), so that room is always valid for the agent to post to
- Watchers (Alpha, Validator) are never added to any room, so `orion_send_message` is structurally blocked for them — they must use plain text output

## Behaviour after this change
- Agent running a task → can only post to its feature's designated chat room
- Watcher agents → `orion_send_message` returns an error; output text is posted to the agent feed by the worker
- No agent can post into a planning room, direct chat, or any room it wasn't explicitly added to

## Test plan
- [ ] Task agent successfully posts to its feature room
- [ ] Task agent cannot post to a different room (returns membership error)
- [ ] Alpha watcher cycle completes without posting to any chat room
- [ ] Validator watcher cycle completes without posting to any chat room

🤖 Generated with [Claude Code](https://claude.com/claude-code)