### PR TITLE
fix: skip tasks assigned to archived agents

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -152,6 +152,12 @@ async function runTask(taskId: string): Promise<void> {
 
     const agent = task.agent
     const meta = (agent.metadata ?? {}) as Record<string, unknown>
+
+    if (meta.archived === true) {
+      err(`Task ${taskId} assigned to archived agent "${agent.name}" — skipping`)
+      return
+    }
+
     const contextConfig = (meta.contextConfig ?? {}) as Record<string, unknown>
     const agentSystemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a helpful AI agent.'
     const modelId = await resolveModelId(contextConfig.llm)
@@ -603,6 +609,11 @@ async function pollOnce() {
     where: {
       status:        'pending',
       assignedAgent: { not: null },
+      agent: {
+        NOT: {
+          metadata: { path: ['archived'], equals: true },
+        },
+      },
     },
     orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
     take: available,


### PR DESCRIPTION
## Summary
- `pollOnce` now excludes pending tasks where the assigned agent has `metadata.archived = true` — archived agents no longer get picked up by the worker
- `runTask` has a secondary safety guard that logs and skips if an archived agent somehow slips through the poll query

## Root cause
The task poll query had no filter on the agent's archive state. Archived agents (like Kyverno-Policy-Agent-2) could still have tasks run against them after being archived.

## Test plan
- [ ] Merge and deploy
- [ ] Verify archived agents no longer appear as running tasks in the worker logs
- [ ] Confirm active agents still pick up tasks normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)