### PR TITLE
fix: prevent assigning tasks to archived agents

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -324,6 +324,13 @@ async function handleAssignTask(argsRaw: string, actorId?: string): Promise<stri
   if (!task_id) return 'Error: task_id is required'
   if (!agent_id) return 'Error: agent_id is required'
 
+  const targetAgent = await prisma.agent.findUnique({ where: { id: agent_id }, select: { name: true, metadata: true } })
+  if (!targetAgent) return `Error: agent "${agent_id}" not found`
+  const targetMeta = (targetAgent.metadata ?? {}) as Record<string, unknown>
+  if (targetMeta.archived === true) {
+    return `Error: agent "${targetAgent.name}" is archived and cannot be assigned tasks. Use orion_list_agents to find an active agent.`
+  }
+
   await prisma.task.update({
     where: { id: task_id },
     data:  { assignedAgent: agent_id, status: 'pending' },
@@ -364,9 +371,13 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
   // Prevents Alpha's watcher from stacking Debugger agents on each cycle.
   const existingByName = await prisma.agent.findUnique({
     where:  { name: spec.name.trim() },
-    select: { id: true, name: true, role: true },
+    select: { id: true, name: true, role: true, metadata: true },
   })
   if (existingByName) {
+    const existingMeta = (existingByName.metadata ?? {}) as Record<string, unknown>
+    if (existingMeta.archived === true) {
+      return `Error: an archived agent named "${spec.name.trim()}" already exists (id: ${existingByName.id}). Choose a different name — do not reuse archived agent names.`
+    }
     return JSON.stringify({ id: existingByName.id, name: existingByName.name, role: existingByName.role, note: 'Agent already exists — returning existing record' }, null, 2)
   }
 

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -152,6 +152,12 @@ async function runTask(taskId: string): Promise<void> {
 
     const agent = task.agent
     const meta = (agent.metadata ?? {}) as Record<string, unknown>
+
+    if (meta.archived === true) {
+      err(`Task ${taskId} assigned to archived agent "${agent.name}" — skipping`)
+      return
+    }
+
     const contextConfig = (meta.contextConfig ?? {}) as Record<string, unknown>
     const agentSystemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a helpful AI agent.'
     const modelId = await resolveModelId(contextConfig.llm)
@@ -603,6 +609,11 @@ async function pollOnce() {
     where: {
       status:        'pending',
       assignedAgent: { not: null },
+      agent: {
+        NOT: {
+          metadata: { path: ['archived'], equals: true },
+        },
+      },
     },
     orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
     take: available,


### PR DESCRIPTION
## Summary
- `handleAssignTask` now rejects assignments to archived agents with a clear error message directing Alpha to use `orion_list_agents` instead
- `handleCreateAgent` idempotency guard now returns an error when an archived agent with the same name exists, rather than returning the archived agent's ID

## Root cause
Alpha's `orion_create_agent` called with name "Harbor-Agent" found the existing archived agent via the idempotency guard and returned it as "already exists — returning existing record". Alpha then passed that archived agent's ID to `orion_assign_task`, which had no archived check and accepted the assignment. Tasks then queued against an archived agent.

## Also fixed
- `Kyverno-Security-Agent` had a malformed LLM value (`cmnv391920001p70603yvas6v` missing `ext:` prefix) — patched directly in DB.

## Test plan
- [ ] Merge and deploy
- [ ] Verify Alpha can no longer assign tasks to archived agents (errors surface in agent feed)
- [ ] Verify Alpha creates agents with new names when a name collides with an archived one

🤖 Generated with [Claude Code](https://claude.com/claude-code)