### PR TITLE
feat: task chat tab shows filtered feature room messages per task

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -246,7 +246,8 @@ model Task {
   planApprovedAt  DateTime?
   events          TaskEvent[]
   metadata        Json?
-  chatRooms       ChatRoom[]  @relation("ChatRoomTask")
+  chatRooms       ChatRoom[]    @relation("ChatRoomTask")
+  chatMessages    ChatMessage[]
 }
 
 model TaskEvent {
@@ -767,6 +768,7 @@ model ChatMessage {
   room          ChatRoom    @relation(fields: [roomId], references: [id], onDelete: Cascade)
   agentId       String?
   userId        String?
+  taskId        String?
   senderType    String              // "agent" | "human" | "system"
   content       String          @db.Text
   attachments   Json?
@@ -775,7 +777,9 @@ model ChatMessage {
 
   agent         Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
   user          User?       @relation(fields: [userId], references: [id], onDelete: SetNull)
+  task          Task?       @relation(fields: [taskId], references: [id], onDelete: SetNull)
 
   @@index([roomId, createdAt])
+  @@index([roomId, taskId, createdAt])
   @@map("chat_messages")
 }

--- a/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
@@ -72,6 +72,8 @@ export async function POST(
   const content = String(body.content ?? '')
   if (!content.trim()) return NextResponse.json({ error: 'Message content required' }, { status: 400 })
 
+  const taskId = body.taskId ? String(body.taskId) : undefined
+
   const msg = await prisma.chatMessage.create({
     data: {
       roomId: id,
@@ -80,6 +82,7 @@ export async function POST(
       senderType: body.senderType ? String(body.senderType) : (agentId ? 'agent' : 'human'),
       content: content.trim(),
       attachments: (body.attachments as any) ?? undefined,
+      taskId: taskId ?? null,
     },
     include: {
       agent: { select: { id: true, name: true } },

--- a/apps/web/src/app/api/tasks/[id]/chat/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/chat/route.ts
@@ -1,21 +1,30 @@
 /**
  * /api/tasks/[id]/chat
  *
- * GET — Fetch chat rooms and messages for a task
+ * GET — Fetch the feature chat room for a task, filtered to messages tagged to this task.
+ *       Also returns the roomId so the UI can link directly to the full feature room.
  */
 import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
 
 export async function GET(
   _req: Request,
   { params }: { params: { id: string } }
 ) {
-  const { prisma } = await import('@/lib/db')
+  const task = await prisma.task.findUnique({
+    where: { id: params.id },
+    select: { feature: { select: { id: true } } },
+  })
+
+  const featureId = task?.feature?.id
+  if (!featureId) return NextResponse.json({ rooms: [] })
 
   const rooms = await prisma.chatRoom.findMany({
-    where: { taskId: params.id },
+    where: { featureId },
     orderBy: { createdAt: 'asc' },
     include: {
       messages: {
+        where: { taskId: params.id },
         orderBy: { createdAt: 'asc' },
         include: {
           agent: { select: { id: true, name: true, type: true } },

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -198,7 +198,7 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
       const res = await fetch(`/api/chatrooms/${activeChatRoom}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content }),
+        body: JSON.stringify({ content, taskId: panel.task.id }),
       })
       if (res.ok) {
         // Refresh room messages
@@ -872,7 +872,8 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                   {taskTab === 'chat' && (
                     <TaskChat rooms={taskChatRooms} loading={chatLoading} activeRoom={activeChatRoom}
                       onRoomChange={setActiveChatRoom} onSend={sendChatMessage} sending={chatSending}
-                      inputRef={chatInputRef} onInput={setChatInput} input={chatInput} />
+                      inputRef={chatInputRef} onInput={setChatInput} input={chatInput}
+                      onOpenChat={roomId => router.push(`/messages?roomId=${roomId}`)} />
                   )}
                 </div>
                 {taskTab === 'details' && (
@@ -1123,7 +1124,7 @@ const SENDER_BG: Record<string, string> = {
 }
 
 function TaskChat({
-  rooms, loading, activeRoom, onRoomChange, onSend, sending, inputRef, onInput, input
+  rooms, loading, activeRoom, onRoomChange, onSend, sending, inputRef, onInput, input, onOpenChat
 }: {
   rooms: Array<{id:string;name:string;type:string;messages:Array<{id:string;senderType:string;content:string;sender:{type:string;id:string|null;name:string};createdAt:string}>}>
   loading: boolean
@@ -1134,6 +1135,7 @@ function TaskChat({
   inputRef: React.RefObject<HTMLInputElement | null>
   onInput: (v: string) => void
   input: string
+  onOpenChat?: (roomId: string) => void
 }) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
@@ -1158,26 +1160,40 @@ function TaskChat({
 
   const messages = currentRoom.messages.length > 0 ? currentRoom.messages : []
 
+  const roomIdForLink = activeRoom ?? (rooms[0]?.id ?? null)
+
   return (
     <div className="flex flex-col h-full">
-      {/* Room selector */}
-      {rooms.length > 1 && (
-        <div className="flex gap-1.5 mb-3 overflow-x-auto pb-1">
-          {rooms.map(room => (
-            <button
-              key={room.id}
-              onClick={() => onRoomChange(room.id)}
-              className={`flex-shrink-0 px-2.5 py-1 rounded text-[10px] border transition-colors ${
-                activeRoom === room.id
-                  ? 'bg-accent/15 border-accent/40 text-accent'
-                  : 'bg-bg-raised border-border-subtle text-text-muted hover:text-text-secondary'
-              }`}
-            >
-              {room.name}
-            </button>
-          ))}
-        </div>
-      )}
+      {/* Room selector + open in chat button */}
+      <div className="flex items-center gap-1.5 mb-3">
+        {rooms.length > 1 && (
+          <div className="flex gap-1.5 overflow-x-auto pb-1 flex-1">
+            {rooms.map(room => (
+              <button
+                key={room.id}
+                onClick={() => onRoomChange(room.id)}
+                className={`flex-shrink-0 px-2.5 py-1 rounded text-[10px] border transition-colors ${
+                  activeRoom === room.id
+                    ? 'bg-accent/15 border-accent/40 text-accent'
+                    : 'bg-bg-raised border-border-subtle text-text-muted hover:text-text-secondary'
+                }`}
+              >
+                {room.name}
+              </button>
+            ))}
+          </div>
+        )}
+        {roomIdForLink && onOpenChat && (
+          <button
+            onClick={() => onOpenChat(roomIdForLink)}
+            className="flex-shrink-0 ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-[10px] border border-border-subtle bg-bg-raised text-text-muted hover:text-text-secondary hover:border-accent/40 transition-colors"
+            title="Open full feature chat room"
+          >
+            <MessageSquare size={10} />
+            Open in Chat
+          </button>
+        )}
+      </div>
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto space-y-3 pr-1">

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -202,7 +202,7 @@ async function runTask(taskId: string): Promise<void> {
     await postToFeed(agent.id, `▶ Starting task: **${task.title}**`, taskId)
     // Additionally post to feature room if one exists
     if (featureRoomId) {
-      await postToRoom(featureRoomId, agent.id, `▶ Starting task: **${task.title}**`)
+      await postToRoom(featureRoomId, agent.id, `▶ Starting task: **${task.title}**`, taskId)
     }
 
     const roomNote = featureRoomId
@@ -251,7 +251,7 @@ async function runTask(taskId: string): Promise<void> {
           }).catch(() => {})
           if (featureRoomId) {
             const argsSummary = String(event.args ?? '').slice(0, 200)
-            await postToRoom(featureRoomId, agent.id, `🔧 \`${event.tool}\`(${argsSummary})`)
+            await postToRoom(featureRoomId, agent.id, `🔧 \`${event.tool}\`(${argsSummary})`, taskId)
           }
           break
 
@@ -266,7 +266,7 @@ async function runTask(taskId: string): Promise<void> {
           if (featureRoomId) {
             // SOC2: redact secrets, truncate to 300 chars before posting to room
             const safeResult = redactSecrets(event.result).slice(0, 300)
-            await postToRoom(featureRoomId, agent.id, `↩ \`${event.tool}\`: ${safeResult}`)
+            await postToRoom(featureRoomId, agent.id, `↩ \`${event.tool}\`: ${safeResult}`, taskId)
           }
           break
         }
@@ -289,7 +289,7 @@ async function runTask(taskId: string): Promise<void> {
       // SOC2: always keep postToFeed for audit trail
       postToFeed(agent.id, completionMsg, taskId),
       // Also post to feature room if one exists
-      ...(featureRoomId ? [postToRoom(featureRoomId, agent.id, completionMsg)] : []),
+      ...(featureRoomId ? [postToRoom(featureRoomId, agent.id, completionMsg, taskId)] : []),
       prisma.claudeInvocation.create({
         data: {
           conversationId: conversation.id,
@@ -382,10 +382,11 @@ function redactSecrets(content: string): string {
 
 /**
  * Post a message to a ChatRoom. agentId provides SOC2 attribution.
+ * taskId tags the message to a specific task for filtered views.
  */
-async function postToRoom(roomId: string, agentId: string, content: string) {
+async function postToRoom(roomId: string, agentId: string, content: string, taskId?: string) {
   await prisma.chatMessage.create({
-    data: { roomId, agentId, senderType: 'agent', content },
+    data: { roomId, agentId, senderType: 'agent', content, taskId: taskId ?? null },
   }).catch(() => {})
 }
 


### PR DESCRIPTION
## Summary
- Add `taskId` to `ChatMessage` schema — messages in feature rooms can now be tagged to the specific task they relate to
- Worker tags all room messages during task execution with the `taskId`
- Task chat API now resolves the feature room and filters to messages for that task only (fixes the tab always being empty)
- Chatrooms messages POST accepts `taskId` in body and persists it
- User messages sent from the task chat tab are automatically tagged to the task
- Add "Open in Chat" button on task chat tab to navigate to the full feature room

## Test plan
- [ ] Task chat tab shows agent messages (tool calls, results, start/completion) from task execution
- [ ] User message sent from task chat tab appears only in that task's filtered view, not other tasks' views
- [ ] "Open in Chat" button navigates to `/messages?roomId=<id>`
- [ ] Feature room full view still shows all messages from all tasks unfiltered
- [ ] Tasks without a feature show an empty chat tab (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)