### PR TITLE
fix: show all feature room messages in task chat tab

### DIFF
--- a/apps/web/src/app/api/tasks/[id]/chat/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/chat/route.ts
@@ -24,7 +24,6 @@ export async function GET(
     orderBy: { createdAt: 'asc' },
     include: {
       messages: {
-        where: { taskId: params.id },
         orderBy: { createdAt: 'asc' },
         include: {
           agent: { select: { id: true, name: true, type: true } },

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -873,7 +873,7 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                     <TaskChat rooms={taskChatRooms} loading={chatLoading} activeRoom={activeChatRoom}
                       onRoomChange={setActiveChatRoom} onSend={sendChatMessage} sending={chatSending}
                       inputRef={chatInputRef} onInput={setChatInput} input={chatInput}
-                      onOpenChat={roomId => router.push(`/messages?roomId=${roomId}`)} />
+                      onOpenChat={roomId => router.push(`/messages?r=${roomId}`)} />
                   )}
                 </div>
                 {taskTab === 'details' && (


### PR DESCRIPTION
## Summary
- Remove strict `taskId` filter from task chat API — all existing messages have `taskId=NULL`, causing the tab to always appear empty. Shows all feature room messages now; new messages tagged going forward.
- Fix 'Open in Chat' button: was sending `?roomId=` but messages page reads `?r=`

## Test plan
- [ ] Task chat tab shows messages from the feature room
- [ ] 'Open in Chat' button navigates directly to the correct room in Messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)