### PR TITLE
fix: move 'Open in Chat' button inline with task detail tabs

### DIFF
--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -768,7 +768,7 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                   <button onClick={() => setPanel(null)} className="text-text-muted hover:text-text-primary"><X size={14} /></button>
                 </div>
                 {/* Tabs */}
-                <div className="flex border-b border-border-subtle px-4">
+                <div className="flex items-center border-b border-border-subtle px-4">
                   <button onClick={() => setTaskTab('details')}
                     className={`px-3 py-2 text-[11px] font-medium border-b-2 transition-colors ${taskTab === 'details' ? 'border-accent text-accent' : 'border-transparent text-text-muted hover:text-text-secondary'}`}>
                     Details
@@ -781,6 +781,16 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                     className={`px-3 py-2 text-[11px] font-medium border-b-2 transition-colors ${taskTab === 'chat' ? 'border-accent text-accent' : 'border-transparent text-text-muted hover:text-text-secondary'}`}>
                     Chat
                   </button>
+                  {taskTab === 'chat' && (activeChatRoom ?? taskChatRooms[0]?.id) && (
+                    <button
+                      onClick={() => router.push(`/messages?r=${activeChatRoom ?? taskChatRooms[0]?.id}`)}
+                      className="ml-auto flex items-center gap-1 px-2 py-1 mb-px rounded text-[10px] border border-border-subtle bg-bg-raised text-text-muted hover:text-text-secondary hover:border-accent/40 transition-colors"
+                      title="Open full feature chat room"
+                    >
+                      <MessageSquare size={10} />
+                      Open in Chat
+                    </button>
+                  )}
                 </div>
                 <div className="flex-1 overflow-y-auto p-4 space-y-4">
                   {taskTab === 'details' && (<>
@@ -872,8 +882,7 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                   {taskTab === 'chat' && (
                     <TaskChat rooms={taskChatRooms} loading={chatLoading} activeRoom={activeChatRoom}
                       onRoomChange={setActiveChatRoom} onSend={sendChatMessage} sending={chatSending}
-                      inputRef={chatInputRef} onInput={setChatInput} input={chatInput}
-                      onOpenChat={roomId => router.push(`/messages?r=${roomId}`)} />
+                      inputRef={chatInputRef} onInput={setChatInput} input={chatInput} />
                   )}
                 </div>
                 {taskTab === 'details' && (
@@ -1124,7 +1133,7 @@ const SENDER_BG: Record<string, string> = {
 }
 
 function TaskChat({
-  rooms, loading, activeRoom, onRoomChange, onSend, sending, inputRef, onInput, input, onOpenChat
+  rooms, loading, activeRoom, onRoomChange, onSend, sending, inputRef, onInput, input
 }: {
   rooms: Array<{id:string;name:string;type:string;messages:Array<{id:string;senderType:string;content:string;sender:{type:string;id:string|null;name:string};createdAt:string}>}>
   loading: boolean
@@ -1135,7 +1144,6 @@ function TaskChat({
   inputRef: React.RefObject<HTMLInputElement | null>
   onInput: (v: string) => void
   input: string
-  onOpenChat?: (roomId: string) => void
 }) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
@@ -1160,40 +1168,26 @@ function TaskChat({
 
   const messages = currentRoom.messages.length > 0 ? currentRoom.messages : []
 
-  const roomIdForLink = activeRoom ?? (rooms[0]?.id ?? null)
-
   return (
     <div className="flex flex-col h-full">
-      {/* Room selector + open in chat button */}
-      <div className="flex items-center gap-1.5 mb-3">
-        {rooms.length > 1 && (
-          <div className="flex gap-1.5 overflow-x-auto pb-1 flex-1">
-            {rooms.map(room => (
-              <button
-                key={room.id}
-                onClick={() => onRoomChange(room.id)}
-                className={`flex-shrink-0 px-2.5 py-1 rounded text-[10px] border transition-colors ${
-                  activeRoom === room.id
-                    ? 'bg-accent/15 border-accent/40 text-accent'
-                    : 'bg-bg-raised border-border-subtle text-text-muted hover:text-text-secondary'
-                }`}
-              >
-                {room.name}
-              </button>
-            ))}
-          </div>
-        )}
-        {roomIdForLink && onOpenChat && (
-          <button
-            onClick={() => onOpenChat(roomIdForLink)}
-            className="flex-shrink-0 ml-auto flex items-center gap-1 px-2.5 py-1 rounded text-[10px] border border-border-subtle bg-bg-raised text-text-muted hover:text-text-secondary hover:border-accent/40 transition-colors"
-            title="Open full feature chat room"
-          >
-            <MessageSquare size={10} />
-            Open in Chat
-          </button>
-        )}
-      </div>
+      {/* Room selector (only shown when multiple rooms exist) */}
+      {rooms.length > 1 && (
+        <div className="flex gap-1.5 mb-3 overflow-x-auto pb-1">
+          {rooms.map(room => (
+            <button
+              key={room.id}
+              onClick={() => onRoomChange(room.id)}
+              className={`flex-shrink-0 px-2.5 py-1 rounded text-[10px] border transition-colors ${
+                activeRoom === room.id
+                  ? 'bg-accent/15 border-accent/40 text-accent'
+                  : 'bg-bg-raised border-border-subtle text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              {room.name}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto space-y-3 pr-1">


### PR DESCRIPTION
Moves the 'Open in Chat' button from inside the chat tab content area into the tab bar, right-aligned. Only visible when the Chat tab is active and a room exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)