### PR TITLE
feat: add Pulse system agent with cluster health monitoring

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -12,6 +12,12 @@
 import type { ManagementToolDef } from '@/lib/agent-runner/types'
 import { prisma } from '@/lib/db'
 import { getDefaultModelId } from '@/lib/default-model'
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import tls from 'tls'
+import https from 'https'
+
+const execAsync = promisify(exec)
 
 // SOC2 [INPUT-001]: mirrors the reserved-name check in POST /api/agents
 export const RESERVED_AGENT_NAMES = ['human', 'user', 'system', 'admin']
@@ -233,6 +239,16 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
         tool_name:        { type: 'string', description: 'Suggested tool name (e.g. "file_write", "docker_run")' },
       },
       required: ['tool_description'],
+    },
+  },
+  {
+    name: 'orion_cluster_health',
+    description: 'Check the health of all cluster ingresses. For each ingress host, tests HTTP reachability and SSL certificate validity. Returns a structured report of healthy and degraded services, including SSL expiry warnings and error details.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        namespace: { type: 'string', description: 'Limit check to a specific namespace (optional — omit to check all namespaces)' },
+      },
     },
   },
 ]
@@ -713,6 +729,108 @@ async function handleProposeGitops(argsRaw: string, actorId?: string): Promise<s
   }
 }
 
+// ── Cluster health handler ────────────────────────────────────────────────────
+
+interface IngressEntry { namespace: string; ingress: string; host: string }
+interface HealthResult extends IngressEntry {
+  status: 'healthy' | 'degraded'
+  httpStatus: number
+  sslValid: boolean
+  sslDaysUntilExpiry: number
+  issues: string[]
+}
+
+function checkSSLCert(hostname: string): Promise<{ valid: boolean; daysUntilExpiry: number; error?: string }> {
+  return new Promise((resolve) => {
+    const socket = tls.connect(443, hostname, { servername: hostname, rejectUnauthorized: false }, () => {
+      const cert = socket.getPeerCertificate()
+      if (!cert?.valid_to) {
+        socket.destroy()
+        return resolve({ valid: false, daysUntilExpiry: 0, error: 'no certificate returned' })
+      }
+      const daysUntilExpiry = Math.floor((new Date(cert.valid_to).getTime() - Date.now()) / 86_400_000)
+      const valid = socket.authorized
+      socket.destroy()
+      resolve({ valid, daysUntilExpiry })
+    })
+    socket.setTimeout(6_000, () => { socket.destroy(); resolve({ valid: false, daysUntilExpiry: 0, error: 'timeout' }) })
+    socket.on('error', (e) => resolve({ valid: false, daysUntilExpiry: 0, error: e.message }))
+  })
+}
+
+function checkHTTPReachability(hostname: string): Promise<{ statusCode: number; reachable: boolean; error?: string }> {
+  return new Promise((resolve) => {
+    const req = https.get(
+      `https://${hostname}`,
+      { timeout: 8_000, rejectUnauthorized: false, headers: { 'User-Agent': 'ORION-HealthCheck/1.0' } },
+      (res) => {
+        const statusCode = res.statusCode ?? 0
+        resolve({ statusCode, reachable: statusCode > 0 && statusCode < 500 })
+        res.destroy()
+      },
+    )
+    req.on('timeout', () => { req.destroy(); resolve({ statusCode: 0, reachable: false, error: 'timeout' }) })
+    req.on('error', (e) => resolve({ statusCode: 0, reachable: false, error: e.message }))
+  })
+}
+
+async function handleClusterHealth(argsRaw: string): Promise<string> {
+  const { namespace } = parseArgs(argsRaw) as { namespace?: string }
+
+  let rawIngresses: IngressEntry[]
+  try {
+    const nsFlag = namespace ? `-n ${namespace}` : '-A'
+    const { stdout } = await execAsync(`kubectl get ingress ${nsFlag} -o json`, { timeout: 15_000 })
+    const data = JSON.parse(stdout) as { items: any[] }
+    rawIngresses = data.items.flatMap((item) =>
+      (item.spec?.rules ?? [])
+        .filter((r: any) => r.host)
+        .map((r: any) => ({
+          namespace: item.metadata.namespace as string,
+          ingress:   item.metadata.name as string,
+          host:      r.host as string,
+        }))
+    )
+  } catch (e) {
+    return `Error fetching ingresses: ${e instanceof Error ? e.message : String(e)}`
+  }
+
+  if (rawIngresses.length === 0) {
+    return JSON.stringify({ summary: { total: 0, healthy: 0, degraded: 0 }, degraded: [], all: [] })
+  }
+
+  const results: HealthResult[] = await Promise.all(
+    rawIngresses.map(async (ing) => {
+      const [http, ssl] = await Promise.all([
+        checkHTTPReachability(ing.host),
+        checkSSLCert(ing.host),
+      ])
+
+      const issues: string[] = []
+      if (!http.reachable)                            issues.push(`unreachable — ${http.error ?? `HTTP ${http.statusCode}`}`)
+      if (!ssl.valid)                                 issues.push(`invalid SSL cert — ${ssl.error ?? 'certificate not trusted'}`)
+      else if (ssl.daysUntilExpiry <= 0)              issues.push('SSL cert expired')
+      else if (ssl.daysUntilExpiry < 30)              issues.push(`SSL cert expires in ${ssl.daysUntilExpiry} days`)
+
+      return {
+        ...ing,
+        status:              issues.length === 0 ? 'healthy' : 'degraded',
+        httpStatus:          http.statusCode,
+        sslValid:            ssl.valid,
+        sslDaysUntilExpiry:  ssl.daysUntilExpiry,
+        issues,
+      }
+    })
+  )
+
+  const degraded = results.filter((r) => r.status === 'degraded')
+  return JSON.stringify({
+    summary: { total: results.length, healthy: results.length - degraded.length, degraded: degraded.length },
+    degraded,
+    all: results,
+  }, null, 2)
+}
+
 // ── Tool request handler ──────────────────────────────────────────────────────
 
 async function handleRequestTool(argsRaw: string, actorId?: string): Promise<string> {
@@ -751,8 +869,9 @@ const TOOL_REGISTRY: Record<string, Handler> = {
   orion_send_message:   handleSendMessage,
   orion_create_feature: handleCreateFeature,
   orion_create_task:    handleCreateTask,
-  orion_propose_gitops: handleProposeGitops,
-  orion_request_tool:   handleRequestTool,
+  orion_propose_gitops:    handleProposeGitops,
+  orion_request_tool:      handleRequestTool,
+  orion_cluster_health:    handleClusterHealth,
 }
 
 /**

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -742,19 +742,27 @@ interface HealthResult extends IngressEntry {
 
 function checkSSLCert(hostname: string): Promise<{ valid: boolean; daysUntilExpiry: number; error?: string }> {
   return new Promise((resolve) => {
-    const socket = tls.connect(443, hostname, { servername: hostname, rejectUnauthorized: false }, () => {
+    // Connect with default cert validation enabled. The secureConnect callback fires
+    // only when the cert is valid — errors are handled separately below.
+    const socket = tls.connect(443, hostname, { servername: hostname }, () => {
       const cert = socket.getPeerCertificate()
       if (!cert?.valid_to) {
         socket.destroy()
         return resolve({ valid: false, daysUntilExpiry: 0, error: 'no certificate returned' })
       }
       const daysUntilExpiry = Math.floor((new Date(cert.valid_to).getTime() - Date.now()) / 86_400_000)
-      const valid = socket.authorized
       socket.destroy()
-      resolve({ valid, daysUntilExpiry })
+      resolve({ valid: true, daysUntilExpiry })
     })
     socket.setTimeout(6_000, () => { socket.destroy(); resolve({ valid: false, daysUntilExpiry: 0, error: 'timeout' }) })
-    socket.on('error', (e) => resolve({ valid: false, daysUntilExpiry: 0, error: e.message }))
+    socket.on('error', (e: NodeJS.ErrnoException) => {
+      // Map TLS error codes to human-readable messages
+      const msg = e.code === 'CERT_HAS_EXPIRED'             ? 'certificate expired'
+                : e.code === 'DEPTH_ZERO_SELF_SIGNED_CERT'  ? 'self-signed certificate'
+                : e.code === 'ERR_TLS_CERT_ALTNAME_INVALID' ? 'hostname mismatch'
+                : e.message
+      resolve({ valid: false, daysUntilExpiry: 0, error: msg })
+    })
   })
 }
 
@@ -762,7 +770,7 @@ function checkHTTPReachability(hostname: string): Promise<{ statusCode: number; 
   return new Promise((resolve) => {
     const req = https.get(
       `https://${hostname}`,
-      { timeout: 8_000, rejectUnauthorized: false, headers: { 'User-Agent': 'ORION-HealthCheck/1.0' } },
+      { timeout: 8_000, headers: { 'User-Agent': 'ORION-HealthCheck/1.0' } },
       (res) => {
         const statusCode = res.statusCode ?? 0
         resolve({ statusCode, reachable: statusCode > 0 && statusCode < 500 })
@@ -770,7 +778,12 @@ function checkHTTPReachability(hostname: string): Promise<{ statusCode: number; 
       },
     )
     req.on('timeout', () => { req.destroy(); resolve({ statusCode: 0, reachable: false, error: 'timeout' }) })
-    req.on('error', (e) => resolve({ statusCode: 0, reachable: false, error: e.message }))
+    req.on('error', (e: NodeJS.ErrnoException) => {
+      // TLS/cert errors mean the service is running but has a bad cert — treat as
+      // reachable so the SSL check (not this check) surfaces the cert issue.
+      const isCertError = !!(e.code?.startsWith('CERT_') || e.code?.startsWith('ERR_TLS') || e.code === 'DEPTH_ZERO_SELF_SIGNED_CERT')
+      resolve({ statusCode: 0, reachable: isCertError, error: e.message })
+    })
   })
 }
 

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -8,7 +8,7 @@
  *      admin customisations to prompts and LLM are preserved across restarts).
  *   3. Tracked with a NovaDeployment record.
  *
- * System agents: Alpha (coordinator), Validator (QA gate), Planner (planning specialist).
+ * System agents: Alpha (coordinator), Validator (QA gate), Planner (planning specialist), Pulse (cluster health watcher).
  */
 
 import { prisma } from './db'
@@ -55,8 +55,8 @@ When the worker runs you automatically, you receive a system snapshot and use yo
 
 ### Chat Mode (direct conversation)
 When someone chats with you, you are a decisive team leader. You do not wait — you act.
-- If asked to create a task, use orion_assign_task immediately.
-- Make decisions confidently. Assign work and keep the team moving.
+- If asked to create a task, use orion_create_agent or orion_assign_task immediately.
+- Make decisions confidently. Assign work, create agents, and keep the team moving.
 - After a tool call, briefly report what you did and move on.
 - If genuinely unclear on something critical, ask one sharp question — then act.
 
@@ -66,64 +66,56 @@ Step 1 — Archive stale transient agents
 Call orion_list_agents. For any agent with metadata.transient=true whose task is done or pending_validation, call orion_archive_agent with a reason. Never delete.
 
 Step 2 — Handle failed tasks
-Call orion_list_tasks with status: "failed".
-
-For each failed task, call orion_get_task_events to read what went wrong. Then:
-- Check if a "Debugger" agent already exists (orion_list_agents). If it does, assign the task to it and reopen the task with orion_reopen_task.
-- If no Debugger agent exists yet, create ONE generic Debugger agent (not task-specific) via orion_create_agent:
-  - name: "Debugger"
-  - role: "Debugger"
-  - persistent: false
-  - systemPrompt: "You are a Debugger agent. When assigned a failed task: (1) call orion_get_task_events to read the full failure log, (2) diagnose the root cause — what error, what line, what service, (3) take corrective action using your tools, (4) if you cannot resolve it after investigation, call orion_escalate_task with a detailed diagnosis of what you tried and what human intervention is needed. Do not guess. Read the events first, then act."
-- Assign all failed tasks to the same Debugger agent. Do NOT create one Debugger per task.
+Call orion_list_tasks with status: "failed". For each failed task:
+- Call orion_get_task_events to understand what went wrong and how many times it has failed.
+- If failed 3+ times: call orion_escalate_task — do not reassign again.
+- Otherwise: assign to the Debugger agent via orion_assign_task, then call orion_reopen_task.
 
 Step 3 — Find and assign unassigned tasks
-Call orion_list_tasks with unassigned_only: true to get pending tasks with no agent assigned.
+Call orion_list_tasks with unassigned_only: true. For each:
+A. Find available agent matching domain — use orion_assign_task
+B. Requires human judgment — use orion_escalate_task
+C. No suitable agent exists — use orion_create_agent (see Agent Creation Rules below)
 
-For each unassigned task:
-A. Call orion_list_agents to see the full roster. Read each agent's role and description carefully. Match the task to the most experienced agent for that domain — an agent that has successfully handled similar work before is the right pick, not a new one. Call orion_assign_task.
-   - Container/Kubernetes/Helm deployments → assign to whichever agent has done deployments before
-   - Debugging/failures → assign to Debugger
-   - Validation/QA → Validator handles that automatically
-   - If multiple agents could work, pick the one whose role most specifically matches
-B. If the task requires human judgment or no agent can reasonably handle it, call orion_escalate_task.
-C. Only create a new agent if there is a genuinely distinct, recurring capability that NO existing agent covers at all — and name it by its domain (e.g. "Infrastructure-Engineer", not "Deploy-nginx-task-43"). Task-specific agent names are forbidden. Agents are a shared resource, not disposable.
+Step 4 — Report only if tasks were assigned, escalated or archived. If nothing was accomplished, end silently.
+Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N
 
-Step 4 — Review and improve agents
-Call orion_list_agents to see the current roster. For any agent that:
-- Has a vague or missing system prompt — call orion_update_agent to write a proper one based on their role and past task history
-- Has a role description that doesn't accurately reflect what they actually do — update it
-- Has a broken or suboptimal LLM assigned — update it
+## Agent Creation Rules
 
-Only update when there is a clear improvement to make. Do not update agents that are already well-defined.
+Only create a new agent when no existing agent can handle the task. Before creating, check the full agent list.
 
-Step 5 — Report
-Post one brief feed message summarising the cycle:
-Alpha | Cycle [timestamp] | Assigned: N | Debuggers used: N | Escalated: N | Archived: N | Agents updated: N
+Current team: Archivist (backups), Cipher (secrets/Vault), Debugger (failures), Environment SME (cluster knowledge), Forge (CI/CD), Gatekeeper (identity/SSO), Mason (web development), Planner (planning), Pulse (cluster health), Sentinel (monitoring/observability), Validator (QA), Warden (security), Weaver (networking).
+
+When creating a new agent, follow these rules exactly:
+1. Choose a single evocative word as the name — it must represent the agent domain, not describe it generically.
+2. Do not use generic words: Agent, Specialist, Handler, Worker, Bot, Helper, Manager, Engineer, Operator.
+3. Do not use version numbers or suffixes: -v2, -2, -Agent, -Bot.
+4. Examples of good names by domain: backups=Archivist, networking=Weaver, secrets=Cipher, security=Warden, CI/CD=Forge, monitoring=Sentinel, identity=Gatekeeper, web=Mason.
+5. Think: what single word captures the essence of what this agent does? Use that.
+6. Always set contextConfig.llm — use the same model as existing specialist agents unless there is a specific reason not to.
+7. Always write a clear one-sentence description of what the agent does.
 
 ## Standing Rules
 - Never assign tasks to yourself
-- Never execute or write code — assign to an existing agent or the Debugger
+- Never execute or write code — assign to an existing specialist agent instead
 - Never delete agents — only archive
 - Never modify epics or features
 - Do not reassign tasks in pending_validation status — Validator is reviewing them
-- One shared Debugger agent handles ALL failed tasks — never create per-task debuggers
-- Strongly prefer assigning to existing agents over creating new ones`,
+- Never create transient agents for failed tasks — always assign to the Debugger`,
       contextConfig: {
         llm:             'claude',
         tools:           true,
         persistent:      true,
-        watchPrompt:     `You are in watcher mode. Work through a maximum of 5 tasks per cycle.
+        watchPrompt:     `You are in watcher mode. Work through a maximum of 50 tasks per cycle.
 
-1. Call orion_list_agents to see the full roster — read roles and descriptions carefully
-2. Call orion_list_tasks with status: "failed" — for each failed task, call orion_get_task_events, then assign to the existing "Debugger" agent (or create one shared Debugger if none exists), then reopen the task
-3. Call orion_list_tasks with unassigned_only: true — take the first 5 pending results only
-4. For each unassigned task: match to the most experienced existing agent for that domain. Reuse agents — only create new ones for genuinely novel persistent roles
-5. Review agents: use orion_update_agent to improve any agent with a vague/missing system prompt or inaccurate role description
-6. Archive transient agents whose work is finished (done/pending_validation)
-7. Post one brief feed summary including agents updated count
+1. Call orion_list_agents to see who is available
+2. Call orion_list_tasks with status: "failed" — for each failed task: call orion_get_task_events to read the failure. If it has failed 3 or more times, call orion_escalate_task. Otherwise, assign it to the Debugger agent via orion_assign_task and call orion_reopen_task.
+3. Call orion_list_tasks with unassigned_only: true — take up to 20 pending results
+4. For each unassigned task: assign to the most suitable available agent based on the task title and description. Escalate to human only if truly no suitable agent exists.
+5. Archive transient agents whose work is finished (done/pending_validation)
+6. If you took any action, output one line of plain text: "Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N". Do not call orion_send_message.
 
-Cap at 5 total task actions per cycle. Stop after that — the next cycle handles more.`,
+Cap at 20 total task actions per cycle.`,
         watchIntervalMin: 3,
       },
     },
@@ -403,6 +395,42 @@ If a service is already in the core stack, say so clearly so no duplicate deploy
         llm:        'claude',
         tools:      false,
         persistent: true,
+      },
+    },
+  },
+
+  // ── Pulse ─────────────────────────────────────────────────────────────────────
+  {
+    nova: {
+      name:        'pulse',
+      displayName: 'Pulse',
+      description: 'Cluster health watcher. Runs every 15 minutes to check all ingress reachability and SSL certificate validity. Creates unassigned tasks for any degraded services so Alpha can route them to the right specialist.',
+      version:     '1.0.0',
+      tags:        ['system', 'health', 'monitoring', 'ingress', 'ssl'],
+    },
+    agent: {
+      type:        'claude',
+      role:        'Cluster Health Watcher',
+      description: 'Actively monitors all cluster ingresses — checks HTTP reachability and SSL certificate validity. Reports degraded services by creating unassigned tasks for Alpha to route.',
+      systemPrompt: `You are Pulse, the cluster health monitor for this Kubernetes homelab. Your job is to check every ingress, identify problems, and report them so they get fixed. You do not fix things yourself — you create clear, actionable tasks and let the team handle them.
+
+When creating tasks for issues:
+1. Be specific — hostname, exact problem, error detail.
+2. Create one unassigned task per issue. Clear title and description so any agent understands without re-investigating.
+3. Never create duplicate tasks — check for existing open tasks first.
+4. Output a brief summary of what you found.`,
+      contextConfig: {
+        persistent:       true,
+        watchIntervalMin: 15,
+        watchPrompt: `Check cluster health and report issues as unassigned tasks for Alpha to route.
+
+1. Call orion_cluster_health to get the full ingress health report.
+2. If all services are healthy, output nothing and stop.
+3. For each degraded service:
+   a. Call orion_list_tasks with status: "pending" — check if an open fix task already exists for this host.
+   b. If no existing task: call orion_create_task with no assignedAgent. Title: "Fix [issue]: [hostname]". Description: include namespace, ingress name, exact error, and HTTP status.
+4. Output one line of plain text: "Pulse | Cycle [timestamp] | Checked: N | Degraded: N | Tasks created: N"
+Do not call orion_send_message.`,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Adds `orion_cluster_health` tool to `management-tools.ts` — checks all ingress hosts for HTTP reachability and SSL certificate validity using kubectl + Node.js built-in `tls`/`https` modules (no extra dependencies)
- Adds **Pulse** to `seed-system-agents.ts` as a persistent system agent that runs every 15 minutes, calls `orion_cluster_health`, and creates unassigned tasks for degraded services (expired certs, unreachable hosts, 5xx errors) so Alpha can route them to the right specialist
- Syncs Alpha's system prompt in seed file to match current DB version: updated watcher cycle steps, simplified failed-task handling, agent creation naming rules, and Current team roster now includes Pulse

## How Pulse works

1. Watcher cycle fires every 15 min
2. Calls `orion_cluster_health` → gets structured report of all ingress health
3. For each degraded service, checks if a fix task already exists (deduplication)
4. Creates an unassigned task with hostname, namespace, ingress name, and exact error
5. Alpha picks up the unassigned task on its next cycle and routes it to the right specialist
6. Pulse never fixes issues itself

## Test plan

- [ ] Deploy and verify Pulse appears in agent roster
- [ ] Trigger a watcher cycle manually and confirm `orion_cluster_health` returns results
- [ ] Verify Gitea's expired SSL cert is detected and a task is created
- [ ] Confirm Alpha's next cycle picks up the task and assigns it
- [ ] Verify no duplicate tasks are created on subsequent Pulse cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)