### PR TITLE
feat: seed System epic with Health/Operations/Maintenance chatrooms

### DIFF
--- a/PARKING_LOT.md
+++ b/PARKING_LOT.md
@@ -1,0 +1,31 @@
+# Parking Lot
+
+Ideas and architectural discussions deferred for a future session.
+
+---
+
+## Nova / Nebula — System Agent Distribution
+
+**Date parked:** 2026-05-03
+
+### The question
+System agents (Alpha, Validator, Planner, Environment SME, Pulse) are seeded via `seed-system-agents.ts` as Nova DB records with `source: 'bundled'`. They show up in the Nebula catalog. But there's no way to:
+1. **Sync a running agent back to its Nova's latest config** — the seed is create-only to preserve admin edits, so there's no "apply latest Nova" button.
+2. **Download them on a fresh install without shipping the code** — they're bundled in source, not published to `orion-nub`.
+
+### What was discussed
+Two approaches were considered:
+
+**Publish to `orion-nub` (remote catalog)**
+Add the system agent JSON configs to the remote `orion-nub` repo. Load them in `loadRemoteNovae()`. The Nebula UI would show a "Sync / Re-import" button that pushes the latest Nova config into the running agent (with an overwrite warning).
+
+**"Sync from Nova" button in Nebula (bundled)**
+Keep the configs in `seed-system-agents.ts` but add a UI action in Nebula that re-applies the Nova's current `systemPrompt` / `contextConfig` to the linked agent — useful when you've updated the seed and redeployed but want to push the change to the live agent without a DB migration.
+
+### Why it was parked
+The system chatroom architecture needed to be resolved first (agents need somewhere to post before we invest in making their configs more portable). This should be revisited once the System Epic / chatroom seeding is stable.
+
+### Questions to answer before picking it up
+- Do we want system agents to be upgradeable independently of an ORION image release?
+- Should the "sync" action be admin-only and require explicit confirmation, or can agents trigger it on themselves?
+- If configs live in `orion-nub`, who controls the repo and what's the review process for prompt changes?

--- a/apps/web/src/app/api/setup/complete/route.ts
+++ b/apps/web/src/app/api/setup/complete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
 import { ensureSystemAgents } from '@/lib/seed-system-agents'
+import { ensureSystemEpic } from '@/lib/seed-system-epic'
 
 export async function POST(req: NextRequest) {
   if (!await requireWizardSession(req)) {
@@ -17,8 +18,11 @@ export async function POST(req: NextRequest) {
   // Invalidate setup token — cannot be reused
   await prisma.systemSetting.delete({ where: { key: 'setup.token' } }).catch(() => {})
 
-  // Seed system agents (Alpha, Validator, Planner) as Novas + imported Agents
+  // Seed system agents (Alpha, Validator, Planner, Pulse) as Novas + imported Agents
   await ensureSystemAgents()
+
+  // Seed System epic + Health / Operations / Maintenance features + chatrooms
+  await ensureSystemEpic()
 
   const res = NextResponse.json({ ok: true })
   res.cookies.delete('__orion_wizard')

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -9,5 +9,8 @@ export async function register() {
 
     const { ensureSystemAgents } = await import('./lib/seed-system-agents')
     await ensureSystemAgents()
+
+    const { ensureSystemEpic } = await import('./lib/seed-system-epic')
+    await ensureSystemEpic()
   }
 }

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -113,7 +113,7 @@ When creating a new agent, follow these rules exactly:
 3. Call orion_list_tasks with unassigned_only: true — take up to 20 pending results
 4. For each unassigned task: assign to the most suitable available agent based on the task title and description. Escalate to human only if truly no suitable agent exists.
 5. Archive transient agents whose work is finished (done/pending_validation)
-6. If you took any action, output one line of plain text: "Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N". Do not call orion_send_message.
+6. If you took any action, call orion_send_message to post one summary line to the operations room: "Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N"
 
 Cap at 20 total task actions per cycle.`,
         watchIntervalMin: 3,
@@ -177,7 +177,7 @@ If there was nothing in pending_validation, do nothing — do not post to the fe
       contextConfig: {
         llm:             'claude',
         persistent:      true,
-        watchPrompt:     'Check for tasks in pending_validation status using orion_list_tasks. If there are none, do nothing and stay silent. For each pending_validation task, call orion_get_task_events and check toolCallCount. Close confirmed completions with orion_close_task. Reopen hallucinated ones with orion_reopen_task. Post one feed summary only if you took action.',
+        watchPrompt:     'Check for tasks in pending_validation status using orion_list_tasks. If there are none, do nothing and stay silent. For each pending_validation task, call orion_get_task_events and check toolCallCount. Close confirmed completions with orion_close_task. Reopen hallucinated ones with orion_reopen_task. If you took action, call orion_send_message to post one summary line to the operations room: "Validator | Cycle [timestamp] | Reviewed: N | Confirmed done: N | Reopened: N"',
         watchIntervalMin: 5,
       },
     },
@@ -425,12 +425,11 @@ When creating tasks for issues:
         watchPrompt: `Check cluster health and report issues as unassigned tasks for Alpha to route.
 
 1. Call orion_cluster_health to get the full ingress health report.
-2. If all services are healthy, output nothing and stop.
+2. If all services are healthy, call orion_send_message to post one line to the health room: "Pulse | Cycle [timestamp] | All N services healthy" — then stop.
 3. For each degraded service:
    a. Call orion_list_tasks with status: "pending" — check if an open fix task already exists for this host.
    b. If no existing task: call orion_create_task with no assignedAgent. Title: "Fix [issue]: [hostname]". Description: include namespace, ingress name, exact error, and HTTP status.
-4. Output one line of plain text: "Pulse | Cycle [timestamp] | Checked: N | Degraded: N | Tasks created: N"
-Do not call orion_send_message.`,
+4. Call orion_send_message to post one summary line to the health room: "Pulse | Cycle [timestamp] | Checked: N | Degraded: N | Tasks created: N"`,
       },
     },
   },

--- a/apps/web/src/lib/seed-system-epic.ts
+++ b/apps/web/src/lib/seed-system-epic.ts
@@ -1,0 +1,155 @@
+/**
+ * System Epic seeding — runs on startup via instrumentation.ts.
+ *
+ * Seeds a permanent "System" epic with features that system agents use as
+ * their communication space. All records are created idempotently (by title
+ * for the epic/features, by featureId for rooms) so restarts are safe.
+ *
+ * Structure:
+ *   Epic: "System"
+ *     Feature: "Health"      → ChatRoom for Pulse reports + cluster health tasks
+ *     Feature: "Operations"  → ChatRoom for Alpha/Validator cycle summaries
+ *     Feature: "Maintenance" → ChatRoom for scheduled upkeep, upgrades, patches
+ *
+ * After seeding, room IDs are stored in SystemSetting:
+ *   system.room.health      → ChatRoom ID for the Health feature
+ *   system.room.operations  → ChatRoom ID for the Operations feature
+ *   system.room.maintenance → ChatRoom ID for the Maintenance feature
+ *
+ * The worker reads these settings and injects them into each watcher's
+ * enriched prompt so agents always know where to post.
+ */
+
+import { prisma } from './db'
+
+interface SystemFeatureDef {
+  title:       string
+  description: string
+  settingKey:  string   // SystemSetting key where the room ID is stored
+  agents:      string[] // agent displayNames to add as members
+}
+
+const SYSTEM_FEATURES: SystemFeatureDef[] = [
+  {
+    title:       'Health',
+    description: 'Cluster health monitoring. Pulse posts ingress and SSL status reports here. Fix tasks are tracked in this feature.',
+    settingKey:  'system.room.health',
+    agents:      ['Pulse', 'Alpha', 'Sentinel'],
+  },
+  {
+    title:       'Operations',
+    description: 'Day-to-day operational activity. Alpha and Validator post cycle summaries here.',
+    settingKey:  'system.room.operations',
+    agents:      ['Alpha', 'Validator'],
+  },
+  {
+    title:       'Maintenance',
+    description: 'Scheduled maintenance, upgrades, and routine housekeeping tasks.',
+    settingKey:  'system.room.maintenance',
+    agents:      ['Alpha', 'Warden', 'Archivist'],
+  },
+]
+
+export async function ensureSystemEpic(): Promise<void> {
+  try {
+    // 1. Upsert the System epic (match by title)
+    let epic = await prisma.epic.findFirst({ where: { title: 'System' } })
+    if (!epic) {
+      epic = await prisma.epic.create({
+        data: {
+          title:       'System',
+          description: 'Reserved for system-level operations. Features here are owned by system agents — Alpha, Validator, Pulse, and other persistent watchers.',
+          status:      'active',
+          createdBy:   'system',
+        },
+      })
+      console.log(`[seed] Created System epic (${epic.id})`)
+    }
+
+    for (const def of SYSTEM_FEATURES) {
+      // 2. Upsert feature (match by epicId + title)
+      let feature = await prisma.feature.findFirst({
+        where: { epicId: epic.id, title: def.title },
+      })
+      if (!feature) {
+        feature = await prisma.feature.create({
+          data: {
+            epicId:      epic.id,
+            title:       def.title,
+            description: def.description,
+            status:      'active',
+            createdBy:   'system',
+          },
+        })
+        console.log(`[seed] Created System feature: ${def.title} (${feature.id})`)
+      }
+
+      // 3. Upsert ChatRoom (@@unique on featureId guarantees one room per feature)
+      let room = await prisma.chatRoom.findFirst({ where: { featureId: feature.id } })
+      if (!room) {
+        room = await prisma.chatRoom.create({
+          data: {
+            name:       `System — ${def.title}`,
+            description: def.description,
+            type:       'ops',
+            featureId:  feature.id,
+            epicId:     epic.id,
+            createdBy:  'system',
+          },
+        })
+        console.log(`[seed] Created system chatroom: ${room.name} (${room.id})`)
+      }
+
+      // 4. Store room ID in SystemSetting so the worker can inject it into watch prompts
+      await prisma.systemSetting.upsert({
+        where:  { key: def.settingKey },
+        update: { value: room.id },
+        create: { key: def.settingKey, value: room.id },
+      })
+
+      // 5. Add system agents as members (skip if already a member)
+      const agentRecords = await prisma.agent.findMany({
+        where: { name: { in: def.agents } },
+        select: { id: true, name: true },
+      })
+
+      for (const agent of agentRecords) {
+        await prisma.chatRoomMember.upsert({
+          where:  { roomId_agentId: { roomId: room.id, agentId: agent.id } },
+          update: {},
+          create: { roomId: room.id, agentId: agent.id, role: 'member' },
+        })
+      }
+    }
+  } catch (err) {
+    console.error('[seed] Failed to seed system epic:', err instanceof Error ? err.message : err)
+  }
+}
+
+/**
+ * Look up a system room ID by its setting key.
+ * Returns null if the system epic hasn't been seeded yet.
+ */
+export async function getSystemRoomId(key: 'system.room.health' | 'system.room.operations' | 'system.room.maintenance'): Promise<string | null> {
+  const setting = await prisma.systemSetting.findUnique({ where: { key } })
+  return typeof setting?.value === 'string' ? setting.value : null
+}
+
+/**
+ * Returns all three system room IDs as a keyed object.
+ * Missing rooms return null — callers should handle gracefully.
+ */
+export async function getSystemRooms(): Promise<Record<string, string | null>> {
+  const settings = await prisma.systemSetting.findMany({
+    where: { key: { in: ['system.room.health', 'system.room.operations', 'system.room.maintenance'] } },
+  })
+  const map: Record<string, string | null> = {
+    'system.room.health':      null,
+    'system.room.operations':  null,
+    'system.room.maintenance': null,
+  }
+  for (const s of settings) {
+    if (typeof s.value === 'string') map[s.key] = s.value
+  }
+  return map
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -12,6 +12,7 @@ import { prisma } from './lib/db'
 import { createRunner } from './lib/agent-runner'
 import type { TaskRunContext } from './lib/agent-runner'
 import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './lib/management-tools'
+import { getSystemRooms } from './lib/seed-system-epic'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -496,17 +497,30 @@ async function runWatchers() {
       : null
 
     // Pre-fetch all context the agent needs — no API calls from the agent side
-    const [contextNotes, snapshot] = await Promise.all([
+    const [contextNotes, snapshot, systemRooms] = await Promise.all([
       prisma.note.findMany({ where: { type: 'llm-context' }, select: { title: true, content: true } }),
       buildSystemSnapshot(),
+      getSystemRooms(),
     ])
 
     const wikiContext = buildWikiContext(contextNotes)
 
+    // Build system room context block so agents know where to post
+    const roomLines = Object.entries({
+      health:      systemRooms['system.room.health'],
+      operations:  systemRooms['system.room.operations'],
+      maintenance: systemRooms['system.room.maintenance'],
+    })
+      .filter(([, id]) => id !== null)
+      .map(([name, id]) => `  ${name}: ${id}`)
+    const roomContext = roomLines.length > 0
+      ? `\n[System rooms — use these room_id values with orion_send_message]\n${roomLines.join('\n')}`
+      : ''
+
     // The agent receives all data it needs as context — no outbound calls required.
     // Mutations go through tool calls (orion_assign_task, orion_create_agent, etc.)
     // executed server-side with full attribution (SOC2 [A-001]).
-    const enrichedPrompt = [watchPrompt, ``, snapshot].join('\n')
+    const enrichedPrompt = [watchPrompt, roomContext, ``, snapshot].join('\n')
 
     const ctx: TaskRunContext = {
       taskId:          `watch:${agent.id}`,


### PR DESCRIPTION
## Summary

- Adds `seed-system-epic.ts`: idempotent seed of a **System** epic with three features (Health, Operations, Maintenance) and one ChatRoom per feature. Room IDs are stored in `SystemSetting` so the worker can inject them into watch prompts without extra tool calls.
- `worker.ts`: pre-fetches system room IDs and injects a `[System rooms]` block into every watcher's enriched prompt
- `instrumentation.ts` + `setup/complete/route.ts`: call `ensureSystemEpic` on startup and wizard completion
- Watcher prompts updated: Alpha + Validator post cycle summaries to the Operations room; Pulse posts health reports to the Health room
- `PARKING_LOT.md`: documents the Nova/Nebula distribution discussion for a future session

## Structure

```
Epic: System
  ├── Feature: Health       → Pulse health reports + cluster fix tasks
  ├── Feature: Operations   → Alpha + Validator cycle summaries
  └── Feature: Maintenance  → Warden + Archivist scheduled upkeep
```

## Test plan

- [ ] Deploy and verify System epic + 3 features appear on the task board
- [ ] Verify 3 ChatRooms are created and system agents are members
- [ ] Trigger Alpha watcher cycle — confirm summary posts to Operations room
- [ ] Trigger Pulse watcher cycle — confirm health report posts to Health room
- [ ] Restart ORION — verify seed is idempotent (no duplicates created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)