### PR TITLE
fix: use k3s context in orion_cluster_health for full ingress visibility

### DIFF
--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -243,7 +243,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
   },
   {
     name: 'orion_cluster_health',
-    description: 'Check the health of all cluster ingresses. For each ingress host, tests HTTP reachability and SSL certificate validity. Returns a structured report of healthy and degraded services, including SSL expiry warnings and error details.',
+    description: 'Check the health of all K3s cluster ingresses. For each ingress host, tests HTTP reachability and SSL certificate validity. Returns a structured report of healthy and degraded services, including SSL expiry warnings and error details.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -793,7 +793,9 @@ async function handleClusterHealth(argsRaw: string): Promise<string> {
   let rawIngresses: IngressEntry[]
   try {
     const nsFlag = namespace ? `-n ${namespace}` : '-A'
-    const { stdout } = await execAsync(`kubectl get ingress ${nsFlag} -o json`, { timeout: 15_000 })
+    // Use the k3s context explicitly — ORION may have multiple kubeconfig contexts
+    const contextFlag = '--context default'
+    const { stdout } = await execAsync(`kubectl get ingress ${nsFlag} ${contextFlag} -o json`, { timeout: 15_000 })
     const data = JSON.parse(stdout) as { items: any[] }
     rawIngresses = data.items.flatMap((item) =>
       (item.spec?.rules ?? [])


### PR DESCRIPTION
## Summary

- `orion_cluster_health` was calling `kubectl get ingress` without specifying a context, defaulting to the Talos cluster context (3 ingresses)
- The K3s cluster (`--context default`) has 52 ingresses including all app services, Gitea, ORION, Vault, Vaultwarden, media stack, etc.
- Pulse was reporting "All 3 services healthy" when it should be checking all 52

## Fix

Added `--context default` to the kubectl call in `handleClusterHealth`. The ORION container mounts `/root/.kube` read-only with both contexts available — this just ensures the right one is used.

## Test plan

- [ ] Deploy and verify Pulse next cycle reports 52 services (not 3)
- [ ] Confirm degraded services (e.g. Gitea SSL cert issue) are detected and tasks created

🤖 Generated with [Claude Code](https://claude.com/claude-code)