### PR TITLE
feat: add watcher pause/resume toggle to Agent Feed

### DIFF
--- a/apps/web/src/app/(app)/agents/page.tsx
+++ b/apps/web/src/app/(app)/agents/page.tsx
@@ -5,9 +5,10 @@ import { TeamDetailPanel } from '@/components/tasks/TeamDetailPanel'
 export const dynamic = 'force-dynamic'
 
 export default async function AgentsPage() {
-  const [messagesRaw, agentsRaw] = await Promise.all([
+  const [messagesRaw, agentsRaw, pausedSetting] = await Promise.all([
     prisma.agentMessage.findMany({ orderBy: { createdAt: 'desc' }, take: 50, include: { agent: true } }),
     prisma.agent.findMany({ orderBy: { name: 'asc' } }),
+    prisma.systemSetting.findUnique({ where: { key: 'system.watchers.paused' } }),
   ])
 
   const messages = messagesRaw.map((msg: any) => ({
@@ -20,11 +21,13 @@ export default async function AgentsPage() {
     lastSeen: a.lastSeen?.toISOString() ?? null,
   }))
 
+  const initialPaused = pausedSetting?.value === true
+
   return (
     <div className="absolute inset-0 flex flex-col md:flex-row overflow-hidden">
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       <TeamDetailPanel initialAgents={agents as any} />
-      <AgentFeed initialMessages={messages} />
+      <AgentFeed initialMessages={messages} initialPaused={initialPaused} />
     </div>
   )
 }

--- a/apps/web/src/app/api/admin/watchers/route.ts
+++ b/apps/web/src/app/api/admin/watchers/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+export async function GET() {
+  await requireAdmin()
+  const setting = await prisma.systemSetting.findUnique({ where: { key: 'system.watchers.paused' } })
+  return NextResponse.json({ paused: setting?.value === true })
+}
+
+export async function POST(req: NextRequest) {
+  await requireAdmin()
+  const { paused } = await req.json() as { paused: boolean }
+  await prisma.systemSetting.upsert({
+    where:  { key: 'system.watchers.paused' },
+    update: { value: paused },
+    create: { key: 'system.watchers.paused', value: paused },
+  })
+  return NextResponse.json({ paused })
+}

--- a/apps/web/src/components/agents/AgentFeed.tsx
+++ b/apps/web/src/components/agents/AgentFeed.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
-import { Bot, User, Bell, Terminal } from 'lucide-react'
+import { Bot, User, Bell, Terminal, Pause, Play } from 'lucide-react'
 
 interface AgentMsg {
   id: string
@@ -18,8 +18,10 @@ const typeIcon = (type: string) => {
   return <User size={12} className="text-text-muted" />
 }
 
-export function AgentFeed({ initialMessages }: { initialMessages: AgentMsg[] }) {
+export function AgentFeed({ initialMessages, initialPaused = false }: { initialMessages: AgentMsg[]; initialPaused?: boolean }) {
   const [messages, setMessages] = useState(initialMessages)
+  const [paused, setPaused] = useState(initialPaused)
+  const [toggling, setToggling] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -34,10 +36,41 @@ export function AgentFeed({ initialMessages }: { initialMessages: AgentMsg[] }) 
     return () => clearInterval(t)
   }, [])
 
+  const togglePause = async () => {
+    setToggling(true)
+    try {
+      const res = await fetch('/api/admin/watchers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paused: !paused }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setPaused(data.paused)
+      }
+    } finally {
+      setToggling(false)
+    }
+  }
+
   return (
     <aside className="flex-1 min-h-0 flex flex-col border-l border-border-subtle bg-bg-sidebar overflow-hidden">
-      <div className="flex items-center px-4 py-3 border-b border-border-subtle flex-shrink-0">
-        <span className="text-xs font-semibold text-text-secondary">Agent Feed</span>
+      <div className="flex items-center px-4 py-3 border-b border-border-subtle flex-shrink-0 gap-2">
+        <span className="text-xs font-semibold text-text-secondary flex-1">Agent Feed</span>
+        {paused && (
+          <span className="text-[10px] font-medium text-status-warning bg-status-warning/10 px-1.5 py-0.5 rounded">
+            Watchers paused
+          </span>
+        )}
+        <button
+          onClick={togglePause}
+          disabled={toggling}
+          title={paused ? 'Resume watchers' : 'Pause watchers'}
+          className="flex items-center gap-1 text-[10px] font-medium px-2 py-1 rounded border border-border-subtle text-text-secondary hover:text-text-primary hover:border-border-default transition-colors disabled:opacity-50"
+        >
+          {paused ? <Play size={10} /> : <Pause size={10} />}
+          {paused ? 'Resume' : 'Pause'}
+        </button>
       </div>
       <div className="flex-1 overflow-y-auto p-2 space-y-1.5">
         {[...messages].reverse().map(msg => (

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -467,6 +467,12 @@ async function buildSystemSnapshot(): Promise<string> {
 }
 
 async function runWatchers() {
+  const pausedSetting = await prisma.systemSetting.findUnique({ where: { key: 'system.watchers.paused' } })
+  if (pausedSetting?.value === true) {
+    log('Watchers paused — skipping this cycle')
+    return
+  }
+
   const watchers = await prisma.agent.findMany({
     where:   { type: { not: 'human' } },
     include: { environments: { include: { environment: true }, take: 1 } },


### PR DESCRIPTION
## Summary
- Adds a **Pause / Resume** button to the Agent Feed header so admins can stop all persistent watchers from firing without restarting the service
- Worker skips the `runWatchers()` cycle when `system.watchers.paused = true` in SystemSetting
- New `GET/POST /api/admin/watchers` endpoint reads and sets the pause state
- Agent Feed shows a **"Watchers paused"** badge while paused; initial state is hydrated server-side

## Test plan
- [ ] Open the Agents page — button shows "Pause" in header
- [ ] Click Pause — button changes to "Resume", badge appears, worker logs stop showing watcher cycles
- [ ] Click Resume — button returns to "Pause", badge disappears, watcher cycles resume in logs
- [ ] Reload page while paused — badge and Resume button persist (server-side hydration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)