### PR TITLE
fix: inject tool awareness into agents to eliminate hallucination

### DIFF
--- a/apps/web/src/app/api/chatrooms/route.ts
+++ b/apps/web/src/app/api/chatrooms/route.ts
@@ -124,7 +124,7 @@ export async function POST(req: NextRequest) {
     }).catch(() => {})
   }
 
-  // ── Planning rooms: auto-add Planner + Environment SME + seed initial context ─
+  // ── Planning rooms: auto-add Planner + Atlas + seed initial context ──────────
   if (room.type === 'planning') {
     const [plannerId, envSMEId] = await Promise.all([
       getPlannerAgentId(),
@@ -139,7 +139,7 @@ export async function POST(req: NextRequest) {
         create: { roomId: room.id, agentId: plannerId, role: 'lead' },
       })
 
-      // Add Environment SME as a member (idempotent)
+      // Add Atlas as a member (idempotent)
       if (envSMEId) {
         await prisma.chatRoomMember.upsert({
           where:  { roomId_agentId: { roomId: room.id, agentId: envSMEId } },

--- a/apps/web/src/app/api/setup/complete/route.ts
+++ b/apps/web/src/app/api/setup/complete/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
   // Invalidate setup token — cannot be reused
   await prisma.systemSetting.delete({ where: { key: 'setup.token' } }).catch(() => {})
 
-  // Seed system agents (Alpha, Validator, Planner, Pulse) as Novas + imported Agents
+  // Seed system agents (Alpha, Veritas, Planner, Pulse) as Novas + imported Agents
   await ensureSystemAgents()
 
   // Seed System epic + Health / Operations / Maintenance features + chatrooms

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -163,11 +163,25 @@ export async function executeTool(
 // ── System prompt addendum ────────────────────────────────────────────────────
 
 export const TOOLS_SYSTEM_ADDENDUM = `
-You have access to the following ORION tools. Use them when asked — do not pretend to perform an action when you can call a tool instead.
 
-Tools available:
-- create_task: Log a new task (title, description, priority, status)
-- update_task: Update an existing task by ID (status, title, description, priority)
-- create_agent: Create a new AI agent and invite it to this chat room (name, role, systemPrompt, llm)
+## Your Tools in This Chat Room
 
-When you use a tool, report the result back to the user clearly (e.g. "Done — I've created task #abc123 titled 'LOTR Writer'").`
+You have access to these ORION coordination tools. Use them — do not pretend to perform an action when you can call a tool instead.
+
+- **create_task**: Log a new task on the board (title, description, priority, status)
+- **update_task**: Update an existing task by ID (status, title, description, priority)
+- **create_agent**: Create a new AI agent and invite it to this chat room (name, role, systemPrompt, llm)
+
+## Scope — What You Can and Cannot Do Here
+
+**You are in a chat room. You can only coordinate here.**
+
+- ✅ Create tasks, update tasks, create agents
+- ✅ Discuss plans, answer questions, designate environments
+- ❌ You CANNOT run kubectl, helm, docker, or any infrastructure commands from chat
+- ❌ You CANNOT deploy, apply manifests, or access the cluster directly from chat
+- ❌ Do NOT claim to execute infrastructure work — you do not have those tools here
+
+**If infrastructure work is needed**: use \`create_task\` to log it on the board. A task-running agent with full infrastructure tool access will pick it up and execute it.
+
+When you use a tool, report the result back clearly (e.g. "Done — created task #abc123: 'Deploy Gitea ingress'").`

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -45,7 +45,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        status:          { type: 'string',  description: 'Filter by status: pending, running, pending_validation, done, failed. Defaults to pending+running+failed. Use "pending_validation" to find tasks awaiting Validator review.' },
+        status:          { type: 'string',  description: 'Filter by status: pending, running, pending_validation, done, failed. Defaults to pending+running+failed. Use "pending_validation" to find tasks awaiting Veritas review.' },
         unassigned_only: { type: 'boolean', description: 'Only return tasks with no agent or user assigned (default false)' },
       },
     },
@@ -201,7 +201,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
         plan:              { type: 'string', description: 'Numbered step-by-step implementation plan. Each step should be specific enough for a smaller LLM to execute. E.g.:\n1. Read /path/to/file and understand X\n2. Edit Y to add Z\n3. Run the test suite\n4. Verify output matches expected' },
         targetEnvironment: {
           type: 'object',
-          description: 'For deployment tasks — the target environment as designated by the Environment SME. Pass as an object with keys: namespace (e.g. "apps"), hostname (e.g. "myapp.khalisio.com"), storageClass (e.g. "longhorn", if storage needed), vaultPath (e.g. "secret/data/myapp", if secrets needed).',
+          description: 'For deployment tasks — the target environment as designated by the Atlas. Pass as an object with keys: namespace (e.g. "apps"), hostname (e.g. "myapp.khalisio.com"), storageClass (e.g. "longhorn", if storage needed), vaultPath (e.g. "secret/data/myapp", if secrets needed).',
         },
         dedup_key: {
           type: 'string',
@@ -213,7 +213,7 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
   },
   {
     name: 'orion_propose_gitops',
-    description: 'Propose a GitOps change for a cluster environment. Creates a branch, commits manifests, opens a PR, and auto-merges if the change matches policy (e.g. scaling, patch image tags). Use this for ALL infrastructure work — deploying services, creating configmaps/secrets, updating ingresses, etc.\n\nREQUIRED: you must know the target environment. Ask the Environment SME in the feature room, or check orion_list_agents for the Environment SME. If you have no way to get the environment designation, use environment_id: "localhost" as a fallback.\n\nRules:\n- Always include a clear reasoning field explaining why the change is needed\n- Provide operation_description for policy classification (e.g. "deploy new service", "update image tag")\n- Write manifests with namespace, proper labels, and correct resource types\n- For deployments: include namespace selector, resource limits if appropriate\n- For services: use ClusterIP unless ingress is explicitly needed',
+    description: 'Propose a GitOps change for a cluster environment. Creates a branch, commits manifests, opens a PR, and auto-merges if the change matches policy (e.g. scaling, patch image tags). Use this for ALL infrastructure work — deploying services, creating configmaps/secrets, updating ingresses, etc.\n\nREQUIRED: you must know the target environment. Ask the Atlas in the feature room, or check orion_list_agents for the Atlas. If you have no way to get the environment designation, use environment_id: "localhost" as a fallback.\n\nRules:\n- Always include a clear reasoning field explaining why the change is needed\n- Provide operation_description for policy classification (e.g. "deploy new service", "update image tag")\n- Write manifests with namespace, proper labels, and correct resource types\n- For deployments: include namespace selector, resource limits if appropriate\n- For services: use ClusterIP unless ingress is explicitly needed',
     inputSchema: {
       type: 'object',
       properties: {
@@ -388,6 +388,7 @@ async function handleCreateAgent(argsRaw: string, actorId?: string): Promise<str
   if (!spec.name?.trim())         return 'Error: name is required'
   if (!spec.role?.trim())         return 'Error: role is required'
   if (!spec.systemPrompt?.trim()) return 'Error: systemPrompt is required — agents without a system prompt will not behave correctly'
+  if (spec.systemPrompt.trim().length < 20) return 'Error: systemPrompt is too short (minimum 20 characters) — provide a meaningful role description'
 
   // SOC2 [INPUT-001]: reserved name guard
   if (RESERVED_AGENT_NAMES.includes(spec.name.toLowerCase())) {
@@ -444,6 +445,10 @@ async function handleArchiveAgent(argsRaw: string, actorId?: string): Promise<st
   if (!existing) return `Error: agent ${agent_id} not found`
 
   const existingMeta = (existing.metadata ?? {}) as Record<string, unknown>
+  const contextConfig = (existingMeta.contextConfig ?? {}) as Record<string, unknown>
+  if (contextConfig.persistent === true) {
+    return `Error: agent "${existing.name}" is a persistent system agent and cannot be archived.`
+  }
   await prisma.agent.update({
     where: { id: agent_id },
     data: {

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -101,10 +101,11 @@ async function callClaude(
   history: HistoryEntry[],
   latestMessage: string,
   modelId?: string,
+  hasTools = false,
 ): Promise<string | null> {
   setupClaudeCredentials()
   const { query } = await import('@anthropic-ai/claude-code')
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
   // Claude query() only accepts a single prompt string — prepend history as context
   const historyBlock = history.length
     ? history.map(e => `${e.name}: ${e.content}`).join('\n') + '\n\n'
@@ -142,8 +143,9 @@ async function callOllamaChat(
   latestMessage: string,
   model: string,
   baseUrl: string,
+  hasTools = false,
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const res = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
@@ -297,7 +299,7 @@ export async function triggerRoomAgentReplies(
   const triggeredAgents = mentionedNames.length > 0
     ? agentMembers.filter((a: any) => mentionedNames.some(n => a.name.toLowerCase() === n.toLowerCase()))
     : agentMembers.filter((a: any) => {
-        // Watcher agents (e.g. Alpha, Validator) have watchPrompt set — they coordinate
+        // Watcher agents (e.g. Alpha, Veritas) have watchPrompt set — they coordinate
         // on a schedule and must not auto-reply to every message. They only speak when
         // explicitly @mentioned.
         const cc = ((a.metadata ?? {}) as Record<string, unknown>).contextConfig as Record<string, unknown> | undefined
@@ -372,7 +374,7 @@ export async function triggerRoomAgentReplies(
           }
           const baseUrl = extModel.baseUrl ?? 'http://localhost:11434'
           if (extModel.provider === 'ollama') {
-            reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl)
+            reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, !!toolContext)
           } else {
             // openai / custom — OpenAI-compatible (supports tool calling)
             reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext)
@@ -380,11 +382,17 @@ export async function triggerRoomAgentReplies(
         } else if (llm.startsWith('ollama:')) {
           const model   = llm.slice('ollama:'.length)
           const baseUrl = await resolveOllamaBaseUrl()
-          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl)
+          if (toolsEnabled) {
+            console.warn(`[room-agents] ${agent.name} has tools enabled but ${llm} route does not support function calling — scope awareness injected but tool invocation unavailable`)
+          }
+          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext)
         } else {
           // claude / claude:<model>
           const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel)
+          if (toolsEnabled) {
+            console.warn(`[room-agents] ${agent.name} has tools enabled but ${llm} route does not support function calling — scope awareness injected but tool invocation unavailable`)
+          }
+          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext)
         }
       } finally {
         clearTyping(roomId, agent.name)

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -8,7 +8,7 @@
  *      admin customisations to prompts and LLM are preserved across restarts).
  *   3. Tracked with a NovaDeployment record.
  *
- * System agents: Alpha (coordinator), Validator (QA gate), Planner (planning specialist), Pulse (cluster health watcher).
+ * System agents: Alpha (coordinator), Veritas (QA gate), Planner (planning specialist), Pulse (cluster health watcher).
  */
 
 import { prisma } from './db'
@@ -84,7 +84,7 @@ Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N
 
 Only create a new agent when no existing agent can handle the task. Before creating, check the full agent list.
 
-Current team: Archivist (backups), Cipher (secrets/Vault), Debugger (failures), Environment SME (cluster knowledge), Forge (CI/CD), Gatekeeper (identity/SSO), Mason (web development), Planner (planning), Pulse (cluster health), Sentinel (monitoring/observability), Validator (QA), Warden (security), Weaver (networking).
+Current team: Archivist (backups), Atlas (cluster environment), Cipher (secrets/Vault), Debugger (failures), Forge (CI/CD), Gatekeeper (identity/SSO), Mason (web development), Planner (planning), Pulse (cluster health), Sentinel (monitoring/observability), Veritas (QA), Warden (security), Weaver (networking).
 
 When creating a new agent, follow these rules exactly:
 1. Choose a single evocative word as the name — it must represent the agent domain, not describe it generically.
@@ -100,7 +100,7 @@ When creating a new agent, follow these rules exactly:
 - Never execute or write code — assign to an existing specialist agent instead
 - Never delete agents — only archive
 - Never modify epics or features
-- Do not reassign tasks in pending_validation status — Validator is reviewing them
+- Do not reassign tasks in pending_validation status — Veritas is reviewing them
 - Never create transient agents for failed tasks — always assign to the Debugger`,
       contextConfig: {
         llm:             'claude',
@@ -111,7 +111,7 @@ When creating a new agent, follow these rules exactly:
 1. Call orion_list_agents to see who is available
 2. Call orion_list_tasks with status: "failed" — for each failed task: call orion_get_task_events to read the failure. If it has failed 3 or more times, call orion_escalate_task. Otherwise, assign it to the Debugger agent via orion_assign_task and call orion_reopen_task.
 3. Call orion_list_tasks with unassigned_only: true — take up to 20 pending results
-4. For each unassigned task: assign to the most suitable available agent based on the task title and description. Escalate to human only if truly no suitable agent exists.
+4. For each unassigned task: assign to the most suitable available agent based on the task title and description. Routing hints: assign debugging/failure investigation tasks to Debugger; assign planning/decomposition tasks to Planner. Escalate to human only if truly no suitable agent exists.
 5. Archive transient agents whose work is finished (done/pending_validation)
 6. If you took any action, call orion_send_message to post one summary line to the operations room: "Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N"
 
@@ -121,24 +121,24 @@ Cap at 20 total task actions per cycle.`,
     },
   },
 
-  // ── Validator ────────────────────────────────────────────────────────────────
+  // ── Veritas ───────────────────────────────────────────────────────────────────
   {
     nova: {
-      name:        'validator',
-      displayName: 'Validator',
-      description: 'QA gate agent. Only Validator can move tasks from pending_validation to done — after verifying real execution occurred.',
+      name:        'veritas',
+      displayName: 'Veritas',
+      description: 'QA gate agent. Only Veritas can move tasks from pending_validation to done — after verifying real execution occurred.',
       version:     '1.0.0',
       tags:        ['system', 'qa', 'watcher'],
     },
     agent: {
       type:        'claude',
       role:        'QA / Validation',
-      description: 'Persistent watcher that gates the done state — only Validator moves tasks from pending_validation to done after verifying real execution occurred.',
-      systemPrompt: `You are Validator, the quality-assurance agent for this engineering team. Your sole job is to verify that tasks in pending_validation status were actually executed before closing them — and to reopen any that were self-reported done without real work.
+      description: 'Persistent watcher that gates the done state — only Veritas moves tasks from pending_validation to done after verifying real execution occurred.',
+      systemPrompt: `You are Veritas, the truth-verification agent for this engineering team. Your sole job is to verify that tasks in pending_validation status were actually executed before closing them — and to reopen any that were self-reported done without real work.
 
 ## How tasks reach you
 
-When an agent finishes a task, the worker sets it to \`pending_validation\` instead of \`done\`. Only you (Validator) move tasks to \`done\` — by calling orion_close_task after confirming real execution happened.
+When an agent finishes a task, the worker sets it to \`pending_validation\` instead of \`done\`. Only you (Veritas) move tasks to \`done\` — by calling orion_close_task after confirming real execution happened.
 
 ## Validation Rules
 
@@ -165,7 +165,7 @@ Step 3: Call orion_close_task for each task you confirm was genuinely completed.
 Step 4: Call orion_reopen_task for each task that failed validation. Give a specific reason.
 
 Step 5: If you closed or reopened any tasks, post one brief summary to the feed:
-Validator | Cycle [timestamp] | Reviewed: N | Confirmed done: N | Reopened: N
+Veritas | Cycle [timestamp] | Reviewed: N | Confirmed done: N | Reopened: N
 
 If there was nothing in pending_validation, do nothing — do not post to the feed.
 
@@ -176,8 +176,9 @@ If there was nothing in pending_validation, do nothing — do not post to the fe
 - Be concise in summaries`,
       contextConfig: {
         llm:             'claude',
+        tools:           true,
         persistent:      true,
-        watchPrompt:     'Check for tasks in pending_validation status using orion_list_tasks. If there are none, do nothing and stay silent. For each pending_validation task, call orion_get_task_events and check toolCallCount. Close confirmed completions with orion_close_task. Reopen hallucinated ones with orion_reopen_task. If you took action, call orion_send_message to post one summary line to the operations room: "Validator | Cycle [timestamp] | Reviewed: N | Confirmed done: N | Reopened: N"',
+        watchPrompt:     'Check for tasks in pending_validation status using orion_list_tasks. If there are none, do nothing and stay silent. For each pending_validation task, call orion_get_task_events and check toolCallCount. Close confirmed completions with orion_close_task. Reopen hallucinated ones with orion_reopen_task. If you took action, call orion_send_message to post one summary line to the operations room: "Veritas | Cycle [timestamp] | Reviewed: N | Confirmed done: N | Reopened: N"',
         watchIntervalMin: 5,
       },
     },
@@ -207,14 +208,14 @@ There is a "Save as Plan" button in this chat (hover any message to reveal it �
 
 ## Environment Collaboration — CRITICAL
 
-The **Environment SME** is in this room with you. Before creating any task that involves deploying software, you MUST get an environment designation from them.
+The **Atlas** is in this room with you. Before creating any task that involves deploying software, you MUST get an environment designation from them.
 
 **How to trigger it**: After presenting your plan but before calling orion_create_task, explicitly ask:
-> "Environment SME — can you provide the environment designation for [component]?"
+> "Atlas — can you provide the environment designation for [component]?"
 
-Wait for the Environment SME to respond with namespace, hostname, storage, secrets path, and any node constraints. Include that information in every deployment task's plan.
+Wait for the Atlas to respond with namespace, hostname, storage, secrets path, and any node constraints. Include that information in every deployment task's plan.
 
-**If no environment designation is given**, do not create deployment tasks — ask the Environment SME first.
+**If no environment designation is given**, do not create deployment tasks — ask the Atlas first.
 
 ## Infrastructure Prerequisites — CRITICAL
 
@@ -232,11 +233,11 @@ Before planning any feature or task that depends on external software or service
 - CoreDNS (kube-system namespace)
 
 **Any other software must be deployed before it can be configured or used.** If a feature depends on software not in the list above, the FIRST task in that feature must deploy it. A deployment task must include all of these steps:
-1. Create namespace (kubectl create namespace) — use the namespace from the Environment SME designation
-2. Add Helm repo and provision storage (PVC via Longhorn if needed — size and StorageClass from Environment SME)
-3. Create Secret/ExternalSecret for credentials via Vault+ESO (Vault path from Environment SME)
+1. Create namespace (kubectl create namespace) — use the namespace from the Atlas designation
+2. Add Helm repo and provision storage (PVC via Longhorn if needed — size and StorageClass from Atlas)
+3. Create Secret/ExternalSecret for credentials via Vault+ESO (Vault path from Atlas)
 4. Deploy via Helm chart with a values file saved to deployments/<service>/values.yaml
-5. Create Kubernetes Ingress pointing to the service (hostname from Environment SME designation)
+5. Create Kubernetes Ingress pointing to the service (hostname from Atlas designation)
 6. Verify the deployment is healthy (kubectl rollout status, curl the ingress endpoint)
 
 When calling orion_create_task for a deployment task, always include the environment in the task metadata:
@@ -297,11 +298,11 @@ Rules for task plans:
     },
   },
 
-  // ── Environment SME ──────────────────────────────────────────────────────────
+  // ── Atlas ─────────────────────────────────────────────────────────────────────
   {
     nova: {
-      name:        'environment-sme',
-      displayName: 'Environment SME',
+      name:        'atlas',
+      displayName: 'Atlas',
       description: 'Cluster environment specialist. Auto-added to every planning room. Answers where software should be deployed, which namespace, storage class, ingress pattern, and what prerequisites are already present.',
       version:     '1.0.0',
       tags:        ['system', 'environment', 'infrastructure', 'planning'],
@@ -310,7 +311,7 @@ Rules for task plans:
       type:        'claude',
       role:        'Environment Specialist',
       description: 'Auto-added to every planning room. Designates target environments, namespaces, storage, and ingress patterns for deployment tasks. Enforces cluster conventions and prevents duplicate deployments.',
-      systemPrompt: `You are the Environment SME — the cluster environment specialist for this team. You are added to every planning room to answer one critical question: where does this software run, and what does it need?
+      systemPrompt: `You are the Atlas — the cluster environment specialist for this team. You are added to every planning room to answer one critical question: where does this software run, and what does it need?
 
 ## Your Responsibilities
 
@@ -420,6 +421,7 @@ When creating tasks for issues:
 3. Never create duplicate tasks — check for existing open tasks first.
 4. Output a brief summary of what you found.`,
       contextConfig: {
+        tools:            true,
         persistent:       true,
         watchIntervalMin: 15,
         watchPrompt: `Check cluster health and report issues as unassigned tasks for Alpha to route.
@@ -610,8 +612,8 @@ export async function getPlannerAgentId(): Promise<string | null> {
   return agent?.id ?? null
 }
 
-/** Returns the Environment SME agent ID, or null if not yet seeded. */
+/** Returns the Atlas agent ID, or null if not yet seeded. */
 export async function getEnvironmentSMEAgentId(): Promise<string | null> {
-  const agent = await prisma.agent.findUnique({ where: { name: 'Environment SME' }, select: { id: true } })
+  const agent = await prisma.agent.findUnique({ where: { name: 'Atlas' }, select: { id: true } })
   return agent?.id ?? null
 }

--- a/apps/web/src/lib/seed-system-epic.ts
+++ b/apps/web/src/lib/seed-system-epic.ts
@@ -8,7 +8,7 @@
  * Structure:
  *   Epic: "System"
  *     Feature: "Health"      → ChatRoom for Pulse reports + cluster health tasks
- *     Feature: "Operations"  → ChatRoom for Alpha/Validator cycle summaries
+ *     Feature: "Operations"  → ChatRoom for Alpha/Veritas cycle summaries
  *     Feature: "Maintenance" → ChatRoom for scheduled upkeep, upgrades, patches
  *
  * After seeding, room IDs are stored in SystemSetting:
@@ -38,9 +38,9 @@ const SYSTEM_FEATURES: SystemFeatureDef[] = [
   },
   {
     title:       'Operations',
-    description: 'Day-to-day operational activity. Alpha and Validator post cycle summaries here.',
+    description: 'Day-to-day operational activity. Alpha and Veritas post cycle summaries here.',
     settingKey:  'system.room.operations',
-    agents:      ['Alpha', 'Validator'],
+    agents:      ['Alpha', 'Veritas'],
   },
   {
     title:       'Maintenance',
@@ -58,7 +58,7 @@ export async function ensureSystemEpic(): Promise<void> {
       epic = await prisma.epic.create({
         data: {
           title:       'System',
-          description: 'Reserved for system-level operations. Features here are owned by system agents — Alpha, Validator, Pulse, and other persistent watchers.',
+          description: 'Reserved for system-level operations. Features here are owned by system agents — Alpha, Veritas, Pulse, and other persistent watchers.',
           status:      'active',
           createdBy:   'system',
         },

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -412,6 +412,27 @@ Your job:
   },
 
   {
+    key: 'system.task-runner-tools',
+    name: 'Task Runner — Tool Awareness Preamble',
+    category: 'system',
+    description: 'Prepended to every task-running agent\'s system prompt. Lists available management tools and gateway tools. Injected: {{toolList}}.',
+    variables: [
+      { name: '{{toolList}}', description: 'Newline-separated list of available tool names and descriptions' },
+    ],
+    content: `## Your Available Tools
+
+You are an autonomous agent executing a task. You have the following tools available RIGHT NOW via function calling. Use them — do not describe what you would do, do not ask permission, just call them.
+
+{{toolList}}
+
+Rules:
+- Call tools immediately when you need real data or need to take action
+- Never hallucinate tool output — if you did not call a tool, you do not know the result
+- If a tool fails, report the real error — do not invent success
+- Do not explain that you are going to call a tool — just call it`,
+  },
+
+  {
     key: 'system.agent-creation',
     name: 'Agent Creation Planning System Prompt',
     category: 'system',

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -13,6 +13,7 @@ import { createRunner } from './lib/agent-runner'
 import type { TaskRunContext } from './lib/agent-runner'
 import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './lib/management-tools'
 import { getSystemRooms } from './lib/seed-system-epic'
+import { getPrompt } from './lib/system-prompts'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -170,13 +171,23 @@ async function runTask(taskId: string): Promise<void> {
       select: { title: true, content: true },
     })
     const wikiContext = buildWikiContext(contextNotes)
-    const systemPrompt = agentSystemPrompt + wikiContext
 
     // Get the agent's first linked environment (if any)
     const envLink = agent.environments?.[0]
     const gateway = envLink?.environment?.gatewayUrl && envLink?.environment?.gatewayToken
       ? { url: envLink.environment.gatewayUrl, token: envLink.environment.gatewayToken }
       : null
+
+    // Inject tool awareness preamble — lists all available tools at runtime
+    // This is injected here (not in the agent's stored prompt) so it always reflects
+    // the current tool set, not a stale snapshot from when the agent was created.
+    const toolList = [
+      ...MANAGEMENT_TOOL_DEFS.map((t: any) => `- ${t.name}: ${t.description.split('\n')[0]}`),
+      ...(gateway ? ['- (gateway tools available: kubectl_get, shell_exec, and others connected via environment gateway)'] : []),
+    ].join('\n')
+    const toolsPreamble = await getPrompt('system.task-runner-tools')
+    const injectedPreamble = toolsPreamble.replace('{{toolList}}', toolList)
+    const systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + wikiContext
 
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
 


### PR DESCRIPTION
## Summary

- **Root cause**: Agents were fabricating kubectl output and claiming to run infrastructure commands because they had zero system-level knowledge of what tools were actually available to them
- **Task runners**: 17 management tools were silently passed via function-calling with no system prompt instruction to use them — agents defaulted to text explanation instead of tool invocation
- **Chat room agents**: Only 3 coordination tools available (create_task, update_task, create_agent) — most agents didn't have `tools: true` set, and none were told they couldn't run kubectl from chat

## Changes

- **`worker.ts`**: Inject `system.task-runner-tools` preamble at execution time — lists all management + gateway tools with a hard "call them, don't describe them" rule. Injected at runtime so it always reflects the current tool set, never stale
- **`system-prompts.ts`**: Add `system.task-runner-tools` to `PROMPT_DEFAULTS` (admin-editable via UI)
- **`agent-tools.ts`**: Update `TOOLS_SYSTEM_ADDENDUM` with explicit scope section — tells chat agents they cannot run kubectl/helm and to use `create_task` for infrastructure work instead
- **`room-agents.ts`**: Pass `hasTools` to `callClaude` and `callOllamaChat` so scope awareness is injected even on routes that don't support function calling; add warn log for tools-enabled agents on incompatible routes
- **`management-tools.ts`**: Add 20-char minimum to `orion_create_agent` systemPrompt validation; persistent-agent guard in `orion_archive_agent` (prevents Warden from archiving Atlas etc.)
- **`seed-system-agents.ts`**: Enable `tools: true` for Veritas and Pulse; add Debugger/Planner routing hints to Alpha's watchPrompt
- Rename Environment SME → **Atlas**, Validator → **Veritas** throughout

## Reviewed by Opus

Architectural review confirmed: runtime injection in worker.ts is strictly superior to creation-time injection (no stale prompts, no hidden text Alpha didn't write). Fix 5 (auto-inject in create_agent) was dropped per Opus recommendation.

## Test plan

- [ ] Deploy and verify task-running agents call tools instead of describing them
- [ ] Verify chat room agents respond with "I'll create a task for that" for infrastructure requests instead of fabricating kubectl output
- [ ] Verify Alpha routes debugging tasks to Debugger and planning tasks to Planner
- [ ] Verify `orion_create_agent` rejects prompts under 20 chars
- [ ] Verify persistent agents (Atlas, Veritas, Alpha) cannot be archived via Warden

🤖 Generated with [Claude Code](https://claude.com/claude-code)