### PR TITLE
fix: build failure from backtick + Prisma client + watcher preamble

### DIFF
--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -389,16 +389,16 @@ If a service is already in the core stack, say so clearly so no duplicate deploy
 
 ## Cluster Verification
 
-You have gateway access to the cluster via `kubectl_get`. Use it to verify live cluster state when needed — for example:
+You have gateway access to the cluster via kubectl_get. Use it to verify live cluster state when needed — for example:
 - Check if a namespace already exists before adding it to a plan
 - Verify a service is already deployed (avoid duplicate deployment tasks)
 - Confirm an ingress hostname isn't already in use
 
-Run `kubectl_get` calls proactively when Planner presents deployment tasks — don't just rely on memory of the core stack list.
+Run kubectl_get calls proactively when Planner presents deployment tasks — don't just rely on memory of the core stack list.
 
 ## Standing Rules
 - You do not create tasks — Planner does that. You designate the environment and verify it.
-- You CAN run read-only cluster queries (`kubectl_get`) — use them to give accurate answers, not guesses.
+- You CAN run read-only cluster queries (kubectl_get) — use them to give accurate answers, not guesses.
 - If you are uncertain about a deployment target, check the cluster first, then ask the user if still unclear.
 - Always check the core stack list before declaring a prerequisite deployment is needed.
 - Never suggest *.khalisio.com for admin/internal tools unless the user explicitly wants it public.`,

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -522,6 +522,15 @@ async function runWatchers() {
 
     const wikiContext = buildWikiContext(contextNotes)
 
+    // Inject tool awareness preamble into watcher system prompt — same as task runner
+    const watcherToolList = [
+      ...MANAGEMENT_TOOL_DEFS.map((t: any) => `- ${t.name}: ${t.description.split('\n')[0]}`),
+      ...(gateway ? ['- (gateway tools available: kubectl_get, shell_exec, and others connected via environment gateway)'] : []),
+    ].join('\n')
+    const watcherToolsPreamble = await getPrompt('system.task-runner-tools')
+    const watcherInjectedPreamble = watcherToolsPreamble.replace('{{toolList}}', watcherToolList)
+    const watcherSystemPrompt = watcherInjectedPreamble + '\n\n' + systemPrompt + wikiContext
+
     // Build system room context block so agents know where to post
     const roomLines = Object.entries({
       health:      systemRooms['system.room.health'],
@@ -546,7 +555,7 @@ async function runWatchers() {
       taskPlan:        null,
       agentId:         agent.id,
       agentName:       agent.name,
-      systemPrompt:    systemPrompt + wikiContext,
+      systemPrompt:    watcherSystemPrompt,
       modelId,
       gateway,
       managementTools: {


### PR DESCRIPTION
## Summary

- Removes unescaped backticks from the Atlas system prompt template literal that were breaking the Next.js build (`Expected ',', got 'kubectl_get'`)
- Regenerates Prisma client to resolve `taskId` type error in chat_messages route
- Adds tool awareness preamble injection to the watcher execution path in `worker.ts` — this was only applied to task runners in #270/#271, leaving Pulse's health check cycles without tool awareness

## Why watcher path matters

Pulse runs as a watcher (every 15 min cycle), not as an assigned task. The `createRunner` path gets the preamble; the watcher loop was using raw `systemPrompt + wikiContext` without it. Pulse could not see its own gateway tools during health cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)