### PR TITLE
feat: agent-level tool resolution + build fixes

### DIFF
--- a/apps/web/src/lib/agent-gateway.ts
+++ b/apps/web/src/lib/agent-gateway.ts
@@ -1,0 +1,38 @@
+import { prisma } from './db'
+import { GatewayClient } from './agent-runner/gateway-client'
+import type { GatewayTool } from './agent-runner/types'
+
+export interface AgentGateway {
+  url: string
+  token: string
+  client: GatewayClient
+}
+
+/**
+ * Resolves the gateway for an agent based on its linked AgentEnvironment.
+ * Returns null if the agent has no environment or the environment has no gateway.
+ */
+export async function resolveAgentGateway(agentId: string): Promise<AgentGateway | null> {
+  const envLink = await prisma.agentEnvironment.findFirst({
+    where: { agentId },
+    include: { environment: { select: { gatewayUrl: true, gatewayToken: true } } },
+  })
+  const url   = envLink?.environment?.gatewayUrl
+  const token = envLink?.environment?.gatewayToken
+  if (!url || !token) return null
+  return { url, token, client: new GatewayClient(url, token) }
+}
+
+/**
+ * Fetches the tool definitions for an agent's linked gateway.
+ * Returns empty array if no gateway is linked or gateway is unreachable.
+ */
+export async function resolveAgentGatewayTools(agentId: string): Promise<GatewayTool[]> {
+  const gw = await resolveAgentGateway(agentId)
+  if (!gw) return []
+  try {
+    return await gw.client.listTools()
+  } catch {
+    return []
+  }
+}

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -20,6 +20,9 @@ import { prisma } from './db'
 import { setTyping, clearTyping } from './typing-state'
 import { ORION_TOOL_DEFINITIONS, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agent-tools'
 import { publishChatMessage } from './chat-redis'
+import { resolveAgentGateway } from './agent-gateway'
+import type { AgentGateway } from './agent-gateway'
+import type { GatewayTool } from './agent-runner/types'
 
 // ── Mention parsing ───────────────────────────────────────────────────────────
 
@@ -179,6 +182,8 @@ async function callOpenAIChat(
   baseUrl: string,
   apiKey?: string | null,
   toolContext?: { roomId: string; agentId: string; llm: string },
+  gateway?: AgentGateway | null,
+  gatewayTools?: GatewayTool[],
 ): Promise<string | null> {
   const hasTools = !!toolContext
   const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
@@ -188,11 +193,25 @@ async function callOpenAIChat(
 
   const messages: OpenAIMessage[] = [{ role: 'system', content: sys }, ...chatMsgs]
 
+  // Merge ORION tool definitions with gateway tools (if any)
+  const allTools = hasTools
+    ? [
+        ...ORION_TOOL_DEFINITIONS,
+        ...(gatewayTools ?? []).map(t => ({
+          type: 'function' as const,
+          function: { name: t.name, description: t.description, parameters: t.inputSchema },
+        })),
+      ]
+    : undefined
+
+  // Names of ORION-native tools for dispatch routing
+  const orionToolNames: Set<string> = new Set(ORION_TOOL_DEFINITIONS.map(d => d.function.name))
+
   // Tool-call loop — keep going until the model produces a text reply
   const MAX_TOOL_ROUNDS = 5
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const body: Record<string, unknown> = { model, stream: false, messages }
-    if (hasTools) body.tools = ORION_TOOL_DEFINITIONS
+    if (allTools) body.tools = allTools
 
     const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
@@ -222,11 +241,20 @@ async function callOpenAIChat(
       let args: Record<string, unknown> = {}
       try { args = JSON.parse(tc.function.arguments) } catch { /* ignore */ }
       console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
-      const result = await executeTool(tc.function.name, args, {
-        roomId:        toolContext!.roomId,
-        callerAgentId: toolContext!.agentId,
-        callerLlm:     toolContext!.llm,
-      })
+
+      let result: string
+      if (orionToolNames.has(tc.function.name)) {
+        result = await executeTool(tc.function.name, args, {
+          roomId:        toolContext!.roomId,
+          callerAgentId: toolContext!.agentId,
+          callerLlm:     toolContext!.llm,
+        })
+      } else if (gateway) {
+        result = await gateway.client.executeTool(tc.function.name, args)
+      } else {
+        result = `Error: tool "${tc.function.name}" is not available`
+      }
+
       console.log(`[room-agents] tool result: ${result}`)
       messages.push({ role: 'tool', content: result, tool_call_id: tc.id, name: tc.function.name })
     }
@@ -359,7 +387,11 @@ export async function triggerRoomAgentReplies(
         ? { roomId, agentId: agent.id, llm }
         : undefined
 
-      console.log(`[room-agents] ${agent.name} (${llm}${toolsEnabled ? ', tools' : ''}) → replying to room ${roomId}`)
+      // Resolve gateway from the agent's linked environment (same tools regardless of execution context)
+      const gateway = toolsEnabled ? await resolveAgentGateway(agent.id) : null
+      const gatewayTools = gateway ? await gateway.client.listTools().catch(() => []) : []
+
+      console.log(`[room-agents] ${agent.name} (${llm}${toolsEnabled ? ', tools' : ''}${gateway ? ', gateway' : ''}) → replying to room ${roomId}`)
 
       let reply: string | null = null
 
@@ -377,7 +409,7 @@ export async function triggerRoomAgentReplies(
             reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, !!toolContext)
           } else {
             // openai / custom — OpenAI-compatible (supports tool calling)
-            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext)
+            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext, gateway, gatewayTools)
           }
         } else if (llm.startsWith('ollama:')) {
           const model   = llm.slice('ollama:'.length)

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -389,16 +389,16 @@ If a service is already in the core stack, say so clearly so no duplicate deploy
 
 ## Cluster Verification
 
-You have gateway access to the cluster via `kubectl_get`. Use it to verify live cluster state when needed — for example:
+You have gateway access to the cluster via kubectl_get. Use it to verify live cluster state when needed — for example:
 - Check if a namespace already exists before adding it to a plan
 - Verify a service is already deployed (avoid duplicate deployment tasks)
 - Confirm an ingress hostname isn't already in use
 
-Run `kubectl_get` calls proactively when Planner presents deployment tasks — don't just rely on memory of the core stack list.
+Run kubectl_get calls proactively when Planner presents deployment tasks — don't just rely on memory of the core stack list.
 
 ## Standing Rules
 - You do not create tasks — Planner does that. You designate the environment and verify it.
-- You CAN run read-only cluster queries (`kubectl_get`) — use them to give accurate answers, not guesses.
+- You CAN run read-only cluster queries (kubectl_get) — use them to give accurate answers, not guesses.
 - If you are uncertain about a deployment target, check the cluster first, then ask the user if still unclear.
 - Always check the core stack list before declaring a prerequisite deployment is needed.
 - Never suggest *.khalisio.com for admin/internal tools unless the user explicitly wants it public.`,

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -14,6 +14,7 @@ import type { TaskRunContext } from './lib/agent-runner'
 import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './lib/management-tools'
 import { getSystemRooms } from './lib/seed-system-epic'
 import { getPrompt } from './lib/system-prompts'
+import { resolveAgentGateway } from './lib/agent-gateway'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -136,13 +137,11 @@ async function runTask(taskId: string): Promise<void> {
   const startedAt = Date.now()
 
   try {
-    // Load task with agent and environment
+    // Load task with agent
     const task = await prisma.task.findUnique({
       where: { id: taskId },
       include: {
-        agent: {
-          include: { environments: { include: { environment: true }, take: 1 } },
-        },
+        agent: true,
         feature: { select: { id: true } },
       },
     })
@@ -172,11 +171,9 @@ async function runTask(taskId: string): Promise<void> {
     })
     const wikiContext = buildWikiContext(contextNotes)
 
-    // Get the agent's first linked environment (if any)
-    const envLink = agent.environments?.[0]
-    const gateway = envLink?.environment?.gatewayUrl && envLink?.environment?.gatewayToken
-      ? { url: envLink.environment.gatewayUrl, token: envLink.environment.gatewayToken }
-      : null
+    // Resolve gateway from the agent's linked environment
+    const agentGw = await resolveAgentGateway(agent.id)
+    const gateway = agentGw ? { url: agentGw.url, token: agentGw.token } : null
 
     // Inject tool awareness preamble — lists all available tools at runtime
     // This is injected here (not in the agent's stored prompt) so it always reflects
@@ -485,8 +482,7 @@ async function runWatchers() {
   }
 
   const watchers = await prisma.agent.findMany({
-    where:   { type: { not: 'human' } },
-    include: { environments: { include: { environment: true }, take: 1 } },
+    where: { type: { not: 'human' } },
   })
 
   for (const agent of watchers) {
@@ -508,10 +504,8 @@ async function runWatchers() {
 
     const systemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a monitoring agent.'
     const modelId = await resolveModelId(cfg.llm)
-    const envLink = agent.environments?.[0]
-    const gateway = envLink?.environment?.gatewayUrl && envLink?.environment?.gatewayToken
-      ? { url: envLink.environment.gatewayUrl, token: envLink.environment.gatewayToken }
-      : null
+    const agentGw = await resolveAgentGateway(agent.id)
+    const gateway = agentGw ? { url: agentGw.url, token: agentGw.token } : null
 
     // Pre-fetch all context the agent needs — no API calls from the agent side
     const [contextNotes, snapshot, systemRooms] = await Promise.all([

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -522,6 +522,15 @@ async function runWatchers() {
 
     const wikiContext = buildWikiContext(contextNotes)
 
+    // Inject tool awareness preamble into watcher system prompt — same as task runner
+    const watcherToolList = [
+      ...MANAGEMENT_TOOL_DEFS.map((t: any) => `- ${t.name}: ${t.description.split('\n')[0]}`),
+      ...(gateway ? ['- (gateway tools available: kubectl_get, shell_exec, and others connected via environment gateway)'] : []),
+    ].join('\n')
+    const watcherToolsPreamble = await getPrompt('system.task-runner-tools')
+    const watcherInjectedPreamble = watcherToolsPreamble.replace('{{toolList}}', watcherToolList)
+    const watcherSystemPrompt = watcherInjectedPreamble + '\n\n' + systemPrompt + wikiContext
+
     // Build system room context block so agents know where to post
     const roomLines = Object.entries({
       health:      systemRooms['system.room.health'],
@@ -546,7 +555,7 @@ async function runWatchers() {
       taskPlan:        null,
       agentId:         agent.id,
       agentName:       agent.name,
-      systemPrompt:    systemPrompt + wikiContext,
+      systemPrompt:    watcherSystemPrompt,
       modelId,
       gateway,
       managementTools: {


### PR DESCRIPTION
## Summary

- **Agent-level tool resolution**: tools now follow the agent, not the execution context. A new `agent-gateway.ts` utility resolves an agent's gateway from its linked `AgentEnvironment`. All execution paths (chat rooms, task runner, watcher) call this instead of each managing it independently.
- **Chat rooms now get gateway tools**: when an agent has an environment linked (e.g. Atlas, Pulse → Talos Cluster), those gateway tools (kubectl_get, shell_exec, etc.) are included in the chat room tool call alongside ORION management tools. Previously chat rooms only ever had 3 hardcoded tools regardless of agent configuration.
- **Build fix**: removed unescaped backticks in Atlas seed prompt template literal that broke the Next.js build after #271 merged.
- **Prisma client regenerated**: resolves `taskId` type error in chat_messages route.

## Before

- Chat rooms: all agents got 3 tools, period
- Task runner: fetched gateway inline from `agent.environments[0]`
- Watcher: same inline fetch

## After

- All paths call `resolveAgentGateway(agentId)` — one source of truth
- Agents with linked environments get those gateway tools in every context, including chat rooms
- Pulse and Atlas can now run `kubectl_get` directly from a chat conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)