### PR TITLE
fix: show tool calls and results in chat room

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -242,6 +242,12 @@ async function callOpenAIChat(
       try { args = JSON.parse(tc.function.arguments) } catch { /* ignore */ }
       console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
+      // Post tool call to the room so participants can see what the agent is doing
+      const argsSummary = String(tc.function.arguments ?? '').slice(0, 200)
+      await prisma.chatMessage.create({
+        data: { roomId: toolContext!.roomId, agentId: toolContext!.agentId, senderType: 'agent', content: `🔧 \`${tc.function.name}\`(${argsSummary})` },
+      }).catch(() => {})
+
       let result: string
       if (orionToolNames.has(tc.function.name)) {
         result = await executeTool(tc.function.name, args, {
@@ -256,6 +262,13 @@ async function callOpenAIChat(
       }
 
       console.log(`[room-agents] tool result: ${result}`)
+
+      // Post truncated result to the room (redact any secrets before display)
+      const safeResult = result.replace(/(?:token|secret|password|key)\s*[=:]\s*\S+/gi, (m) => m.split(/[=:]/)[0] + ': [REDACTED]')
+      await prisma.chatMessage.create({
+        data: { roomId: toolContext!.roomId, agentId: toolContext!.agentId, senderType: 'agent', content: `↩ \`${tc.function.name}\`: ${safeResult.slice(0, 500)}` },
+      }).catch(() => {})
+
       messages.push({ role: 'tool', content: result, tool_call_id: tc.id, name: tc.function.name })
     }
   }


### PR DESCRIPTION
## Summary

When agents in a chat room invoke tools (e.g. `kubectl_get`, `orion_create_task`), the calls and their results are now posted as chat messages — matching the visibility that already exists in the task runner feed.

## Before

Tool calls were `console.log` only. Participants had no way to see what the agent was doing or verify it actually ran the tool (vs hallucinating the output).

## After

Each tool call posts two messages to the room:
- `🔧 \`tool_name\`(args...)` — the call being made
- `↩ \`tool_name\`: result...` — the first 500 chars of the result, with secrets redacted

This means when Atlas runs `kubectl_get`, you can see the raw cluster output in the chat alongside its summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)