### PR TITLE
feat: render tool calls as blue cards in chat rooms

### DIFF
--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   Users, Bot, User as UserIcon,
-  Hash, Send, X, Loader2, Plus, LogOut, AtSign, BookmarkCheck,
+  Hash, Send, X, Loader2, Plus, LogOut, AtSign, BookmarkCheck, Terminal,
 } from 'lucide-react'
 
 /** Render message content with @mention highlighting */
@@ -27,11 +27,17 @@ interface RoomMember {
   user?: { id: string; username: string; name: string } | null
 }
 
+interface ToolCallAttachment {
+  tool: string
+  input: string
+  output?: string
+}
+
 interface RoomMessage {
   id: string
   senderType: string
   content: string
-  attachments: unknown[]
+  attachments: ToolCallAttachment | unknown[] | null
   sender: { type: string; id: string | null; name: string }
   createdAt: string
 }
@@ -430,6 +436,24 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               >
                 {msg.senderType === 'system' ? (
                   <div className="text-[10px] text-text-muted py-1">{msg.content}</div>
+                ) : msg.senderType === 'tool_call' ? (
+                  (() => {
+                    const tc = msg.attachments as ToolCallAttachment
+                    return (
+                      <div className="w-full rounded-lg border border-status-info/30 bg-status-info/5 text-xs overflow-hidden">
+                        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-status-info/20 bg-status-info/10">
+                          <Terminal size={12} className="text-status-info" />
+                          <span className="font-mono text-status-info">{tc?.tool ?? msg.content}</span>
+                        </div>
+                        {tc?.input && (
+                          <div className="px-3 py-2 font-mono text-text-secondary break-all">{tc.input}</div>
+                        )}
+                        {tc?.output && (
+                          <div className="px-3 py-2 border-t border-status-info/20 font-mono text-text-muted whitespace-pre-wrap max-h-48 overflow-y-auto">{tc.output}</div>
+                        )}
+                      </div>
+                    )
+                  })()
                 ) : (
                   <div className={`rounded-lg px-3 py-2 ${msg.sender?.type === 'human' || msg.sender?.type === 'user' ? 'bg-accent/20 text-text-primary' : 'bg-bg-raised border border-border-subtle text-text-primary'}`}>
                     <div className="flex items-center gap-1.5 mb-1">

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -242,12 +242,6 @@ async function callOpenAIChat(
       try { args = JSON.parse(tc.function.arguments) } catch { /* ignore */ }
       console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
-      // Post tool call to the room so participants can see what the agent is doing
-      const argsSummary = String(tc.function.arguments ?? '').slice(0, 200)
-      await prisma.chatMessage.create({
-        data: { roomId: toolContext!.roomId, agentId: toolContext!.agentId, senderType: 'agent', content: `🔧 \`${tc.function.name}\`(${argsSummary})` },
-      }).catch(() => {})
-
       let result: string
       if (orionToolNames.has(tc.function.name)) {
         result = await executeTool(tc.function.name, args, {
@@ -263,10 +257,16 @@ async function callOpenAIChat(
 
       console.log(`[room-agents] tool result: ${result}`)
 
-      // Post truncated result to the room (redact any secrets before display)
-      const safeResult = result.replace(/(?:token|secret|password|key)\s*[=:]\s*\S+/gi, (m) => m.split(/[=:]/)[0] + ': [REDACTED]')
+      // Save as structured tool_call message — rendered as blue card in chat UI
+      const safeOutput = result.replace(/(?:token|secret|password|key)\s*[=:]\s*\S+/gi, (m) => m.split(/[=:]/)[0] + ': [REDACTED]')
       await prisma.chatMessage.create({
-        data: { roomId: toolContext!.roomId, agentId: toolContext!.agentId, senderType: 'agent', content: `↩ \`${tc.function.name}\`: ${safeResult.slice(0, 500)}` },
+        data: {
+          roomId:      toolContext!.roomId,
+          agentId:     toolContext!.agentId,
+          senderType:  'tool_call',
+          content:     tc.function.name,
+          attachments: { tool: tc.function.name, input: tc.function.arguments ?? '', output: safeOutput.slice(0, 2000) } as any,
+        },
       }).catch(() => {})
 
       messages.push({ role: 'tool', content: result, tool_call_id: tc.id, name: tc.function.name })


### PR DESCRIPTION
## Summary

When agents invoke tools in a chat room (e.g. Atlas running `kubectl_get`), the tool call and its output are now saved as a structured `senderType: 'tool_call'` message and rendered as a blue-bordered card — the same style used in the Claude direct-chat UI via `MessageBubble`.

## Before

Tool calls posted two plain agent text messages: `🔧 tool(args)` and `↩ tool: result`. No visual distinction from regular agent messages.

## After

Single structured message saved with `attachments: { tool, input, output }`. `RoomChat` renders it as:
- Blue border/background card (`status-info` color tokens)  
- Terminal icon + tool name in header
- Monospace input block
- Scrollable monospace output (max 2000 chars, secrets redacted)

Identical look to the existing `MessageBubble` tool call rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)