### PR TITLE
fix: publish tool_call messages via SSE so they appear in real-time

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -257,9 +257,9 @@ async function callOpenAIChat(
 
       console.log(`[room-agents] tool result: ${result}`)
 
-      // Save as structured tool_call message — rendered as blue card in chat UI
+      // Save as structured tool_call message and publish via SSE so it appears in real-time
       const safeOutput = result.replace(/(?:token|secret|password|key)\s*[=:]\s*\S+/gi, (m) => m.split(/[=:]/)[0] + ': [REDACTED]')
-      await prisma.chatMessage.create({
+      const toolMsg = await prisma.chatMessage.create({
         data: {
           roomId:      toolContext!.roomId,
           agentId:     toolContext!.agentId,
@@ -267,7 +267,17 @@ async function callOpenAIChat(
           content:     tc.function.name,
           attachments: { tool: tc.function.name, input: tc.function.arguments ?? '', output: safeOutput.slice(0, 2000) } as any,
         },
-      }).catch(() => {})
+      }).catch(() => null)
+      if (toolMsg) {
+        await publishChatMessage(toolContext!.roomId, {
+          id:          toolMsg.id,
+          senderType:  'tool_call',
+          content:     tc.function.name,
+          attachments: { tool: tc.function.name, input: tc.function.arguments ?? '', output: safeOutput.slice(0, 2000) },
+          sender:      { type: 'agent', id: toolContext!.agentId, name: agentName },
+          createdAt:   toolMsg.createdAt instanceof Date ? toolMsg.createdAt.toISOString() : toolMsg.createdAt,
+        })
+      }
 
       messages.push({ role: 'tool', content: result, tool_call_id: tc.id, name: tc.function.name })
     }


### PR DESCRIPTION
## Summary
- Tool call messages were saved to DB but never published to Redis, causing them to only appear after a page reload
- Now each `tool_call` message is published immediately after saving via `publishChatMessage`, so they stream into the chat in real-time alongside the agent's typing indicator
- Only change: `apps/web/src/lib/room-agents.ts` — capture the result of `prisma.chatMessage.create` and call `publishChatMessage` with the structured tool call data

## Test plan
- [ ] Trigger a tool call in a chat room (e.g. ask Atlas to run kubectl)
- [ ] Confirm the blue tool call card appears in real-time without a page reload
- [ ] Confirm the agent's text reply still follows normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)