### PR TITLE
fix: prevent archived agents from appearing in or responding in chat rooms

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
@@ -28,6 +28,14 @@ export async function POST(
   })
   if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
 
+  // Block archived agents from being invited
+  if (agentId) {
+    const agent = await prisma.agent.findUnique({ where: { id: agentId }, select: { metadata: true } })
+    if ((agent?.metadata as Record<string, unknown> | null)?.archived === true) {
+      return NextResponse.json({ error: 'Cannot invite an archived agent' }, { status: 400 })
+    }
+  }
+
   // Check if already a member
   const already = room.members.find((m: any) =>
     (userId && m.userId === userId) || (agentId && m.agentId === agentId)

--- a/apps/web/src/app/api/chatrooms/[id]/members/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/members/route.ts
@@ -28,7 +28,7 @@ export async function GET(
     orderBy: { username: 'asc' },
   })
   const allAgents = await prisma.agent.findMany({
-    select: { id: true, name: true, type: true },
+    select: { id: true, name: true, type: true, metadata: true },
     orderBy: { name: 'asc' },
   })
 
@@ -36,7 +36,11 @@ export async function GET(
   const memberAgentIds = room.members.map((m: any) => m.agentId).filter(Boolean) as string[]
 
   const availableUsers = allUsers.filter((u: any) => u.id !== session.user.id && !memberUserIds.includes(u.id))
-  const availableAgents = allAgents.filter((a: any) => !memberAgentIds.includes(a.id))
+  const availableAgents = allAgents.filter((a: any) => {
+    if (memberAgentIds.includes(a.id)) return false
+    if ((a.metadata as Record<string, unknown> | null)?.archived === true) return false
+    return true
+  }).map(({ metadata: _m, ...rest }: any) => rest)
 
   return NextResponse.json({ users: availableUsers, agents: availableAgents })
 }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -333,7 +333,10 @@ export async function triggerRoomAgentReplies(
     },
   })
 
-  const agentMembers = (room?.members ?? []).map((m: any) => m.agent!).filter(Boolean)
+  const agentMembers = (room?.members ?? [])
+    .map((m: any) => m.agent!)
+    .filter(Boolean)
+    .filter((a: any) => (a.metadata as Record<string, unknown> | null)?.archived !== true)
   if (agentMembers.length === 0) return
 
   const mentionedNames  = parseMentions(triggerContent)


### PR DESCRIPTION
## Summary
- **Invite dropdown** (`members/route.ts`): now filters out agents with `metadata.archived === true` so they never appear as options
- **Invite endpoint** (`invite/route.ts`): guards against directly POSTing an archived agent's ID — returns 400
- **Room message processing** (`room-agents.ts`): skips archived agents when building the list of agents to trigger, so they can't respond even if they're already a member

## Root cause
Archiving is stored as `metadata.archived = true` (a JSON field). All three paths that handle chat room membership/participation were checking other fields (watchPrompt, member lists) but none checked the archived flag.

## Test plan
- [ ] Archived agent should not appear in the invite dropdown
- [ ] Directly inviting an archived agent ID via API returns 400
- [ ] If an archived agent is already a member, it stays silent — does not respond to messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)