### PR TITLE
fix: raise MAX_TOOL_ROUNDS from 5 to 15 in chat room agent loop

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -208,7 +208,7 @@ async function callOpenAIChat(
   const orionToolNames: Set<string> = new Set(ORION_TOOL_DEFINITIONS.map(d => d.function.name))
 
   // Tool-call loop — keep going until the model produces a text reply
-  const MAX_TOOL_ROUNDS = 5
+  const MAX_TOOL_ROUNDS = 15
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const body: Record<string, unknown> = { model, stream: false, messages }
     if (allTools) body.tools = allTools


### PR DESCRIPTION
## Summary
`MAX_TOOL_ROUNDS = 5` was too low. Agents that orient themselves before acting (e.g. `orion_get_snapshot` + `kubectl_get pods` + `kubectl_get ingress` + action + verification) exhaust the budget before producing a text reply, returning null silently.

Raised to 15 — enough headroom for exploration + action + verification without being unbounded.

## Test plan
- [ ] Ask Nexus to check cluster state and deploy something — confirm he responds after using multiple tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)