### PR TITLE
feat: make agent chat tool round limit configurable via admin settings

### DIFF
--- a/apps/web/src/app/(app)/admin/settings/page.tsx
+++ b/apps/web/src/app/(app)/admin/settings/page.tsx
@@ -15,6 +15,7 @@ interface Settings {
   'app.description': string
   'ai.default-model': string
   'chat.historyLimit': number
+  'agent.chat.maxToolRounds': number
   'features.notes': boolean
   'features.backups': boolean
 }
@@ -24,6 +25,7 @@ const DEFAULTS: Settings = {
   'app.description': '',
   'ai.default-model': 'claude',
   'chat.historyLimit': 10,
+  'agent.chat.maxToolRounds': 15,
   'features.notes': true,
   'features.backups': true,
 }
@@ -46,6 +48,7 @@ export default function SettingsPage() {
         ...data,
         // API stores all values as strings — coerce back to their correct types
         'chat.historyLimit': parseInt(data['chat.historyLimit']) || s['chat.historyLimit'],
+        'agent.chat.maxToolRounds': parseInt(data['agent.chat.maxToolRounds']) || s['agent.chat.maxToolRounds'],
         'features.notes': data['features.notes'] === undefined ? s['features.notes'] : data['features.notes'] === 'true',
         'features.backups': data['features.backups'] === undefined ? s['features.backups'] : data['features.backups'] === 'true',
       }))
@@ -152,6 +155,18 @@ export default function SettingsPage() {
             max={100}
             value={settings['chat.historyLimit']}
             onChange={e => set('chat.historyLimit', parseInt(e.target.value) || 10)}
+            className="w-32 px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
+          />
+        </SettingRow>
+
+        {/* Max tool rounds */}
+        <SettingRow label="Max Agent Tool Rounds" description="How many tool calls a chat room agent can make before it must reply. Increase if agents time out mid-task.">
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={settings['agent.chat.maxToolRounds']}
+            onChange={e => set('agent.chat.maxToolRounds', parseInt(e.target.value) || 15)}
             className="w-32 px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
           />
         </SettingRow>

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -208,7 +208,8 @@ async function callOpenAIChat(
   const orionToolNames: Set<string> = new Set(ORION_TOOL_DEFINITIONS.map(d => d.function.name))
 
   // Tool-call loop — keep going until the model produces a text reply
-  const MAX_TOOL_ROUNDS = 5
+  const maxToolRoundsSetting = await prisma.systemSetting.findUnique({ where: { key: 'agent.chat.maxToolRounds' } })
+  const MAX_TOOL_ROUNDS = parseInt(String(maxToolRoundsSetting?.value ?? '15'), 10) || 15
   for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
     const body: Record<string, unknown> = { model, stream: false, messages }
     if (allTools) body.tools = allTools


### PR DESCRIPTION
## Summary
- `MAX_TOOL_ROUNDS` in `room-agents.ts` is now read from `SystemSetting` key `agent.chat.maxToolRounds` (default: 15) instead of hardcoded
- Added a **Max Agent Tool Rounds** field to Admin → General Settings so it can be tuned without a redeployment
- No migration needed — uses existing `SystemSetting` upsert pattern; falls back to 15 if the key is absent

## Why
Agents like Nexus orient themselves with several ORION/kubectl reads before acting. The old hardcoded limit of 5 caused them to silently time out mid-task. The right number varies by workload, so it should be operator-configurable.

## Test plan
- [ ] Admin → Settings shows "Max Agent Tool Rounds" field defaulting to 15
- [ ] Change to a different value, save, confirm agent loop respects it
- [ ] Nexus completes a multi-tool task without hitting the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)