### PR TITLE
feat: add Claude Code OAuth bootstrap to admin panel

### DIFF
--- a/apps/web/src/app/(app)/admin/claude/page.tsx
+++ b/apps/web/src/app/(app)/admin/claude/page.tsx
@@ -1,133 +1,164 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
-import { CheckCircle, XCircle, AlertCircle, RefreshCw, LogIn, ClipboardPaste } from 'lucide-react'
+import { CheckCircle, XCircle, AlertCircle, RefreshCw, LogIn, ClipboardPaste, Send, X } from 'lucide-react'
 
 interface CredStatus {
-  configured: boolean
+  authenticated: boolean
   valid: boolean
   expiresAt: string | null
   reason: string | null
 }
 
-interface Job {
-  id: string
-  status: string
-  logs: string
+interface PollData {
+  status: 'idle' | 'starting' | 'waiting' | 'completing' | 'done' | 'error'
+  authUrl: string | null
+  output: string
+  creds?: CredStatus
 }
 
 export default function ClaudeOAuthPage() {
-  const [status, setStatus] = useState<CredStatus | null>(null)
-  const [tab, setTab] = useState<'oauth' | 'paste'>('oauth')
-  const [pasteValue, setPasteValue] = useState('')
-  const [pasteError, setPasteError] = useState<string | null>(null)
-  const [pasteSaving, setPasteSaving] = useState(false)
-  const [pasteSaved, setPasteSaved] = useState(false)
-  const [job, setJob] = useState<Job | null>(null)
-  const [starting, setStarting] = useState(false)
+  const [status, setStatus]       = useState<CredStatus | null>(null)
+  const [tab, setTab]             = useState<'oauth' | 'paste'>('oauth')
+  const [poll, setPoll]           = useState<PollData | null>(null)
+  const [code, setCode]           = useState('')
+  const [starting, setStarting]   = useState(false)
+  const [sending, setSending]     = useState(false)
+  const [pasteVal, setPasteVal]   = useState('')
+  const [pasteErr, setPasteErr]   = useState<string | null>(null)
+  const [pasteBusy, setPasteBusy] = useState(false)
+  const [pasteDone, setPasteDone] = useState(false)
+  const [svcErr, setSvcErr]       = useState<string | null>(null)
   const logRef = useRef<HTMLPreElement>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const loadStatus = () =>
-    fetch('/api/admin/claude/status')
-      .then(r => r.json())
-      .then(setStatus)
-      .catch(() => {})
+  const loadStatus = async () => {
+    const res = await fetch('/api/admin/claude/status').catch(() => null)
+    if (res?.ok) setStatus(await res.json())
+  }
 
   useEffect(() => { loadStatus() }, [])
-
-  // Poll job logs while running
-  useEffect(() => {
-    if (!job || job.status === 'completed' || job.status === 'failed') return
-    const t = setInterval(() => {
-      fetch(`/api/jobs/${job.id}`)
-        .then(r => r.json())
-        .then((j: Job) => {
-          setJob(j)
-          if (j.status === 'completed') { loadStatus(); clearInterval(t) }
-        })
-        .catch(() => {})
-    }, 1500)
-    return () => clearInterval(t)
-  }, [job])
 
   // Auto-scroll logs
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
-  }, [job?.logs])
+  }, [poll?.output])
 
-  const startOAuth = async () => {
+  // Poll while login is in progress
+  useEffect(() => {
+    if (!poll || poll.status === 'done' || poll.status === 'error' || poll.status === 'idle') {
+      if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+      if (poll?.status === 'done') loadStatus()
+      return
+    }
+    if (pollRef.current) return
+    pollRef.current = setInterval(async () => {
+      const res = await fetch('/api/admin/claude/oauth?action=poll').catch(() => null)
+      if (res?.ok) {
+        const data: PollData = await res.json()
+        setPoll(data)
+      }
+    }, 1500)
+    return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }
+  }, [poll?.status])
+
+  const startLogin = async () => {
     setStarting(true)
-    setJob(null)
-    const res = await fetch('/api/admin/claude/oauth', { method: 'POST' })
-    const data = await res.json()
-    setJob({ id: data.jobId, status: 'running', logs: '' })
+    setSvcErr(null)
+    setPoll(null)
+    setCode('')
+    const res = await fetch('/api/admin/claude/oauth?action=login', { method: 'POST' }).catch(() => null)
+    if (!res || !res.ok) {
+      setSvcErr('Claude Code service is not reachable. Make sure orion-claude is running.')
+      setStarting(false)
+      return
+    }
+    const data: PollData = await res.json()
+    setPoll(data)
     setStarting(false)
   }
 
-  const savePaste = async () => {
-    setPasteError(null)
-    setPasteSaving(true)
-    const res = await fetch('/api/admin/claude/credentials', {
-      method: 'POST',
+  const submitCode = async () => {
+    if (!code.trim()) return
+    setSending(true)
+    const res = await fetch('/api/admin/claude/oauth?action=code', {
+      method:  'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ credentials: pasteValue }),
-    })
-    const data = await res.json()
-    if (res.ok) {
-      setPasteSaved(true)
-      setPasteValue('')
-      setTimeout(() => setPasteSaved(false), 3000)
-      loadStatus()
-    } else {
-      setPasteError(data.error ?? 'Failed to save')
+      body:    JSON.stringify({ code: code.trim() }),
+    }).catch(() => null)
+    if (res?.ok) {
+      const data: PollData = await res.json()
+      setPoll(prev => prev ? { ...prev, ...data } : data)
     }
-    setPasteSaving(false)
+    setSending(false)
   }
 
-  // Extract any URL from logs for display
-  const authUrl = job?.logs?.match(/https:\/\/[^\s]+/)?.[0]
+  const cancelLogin = async () => {
+    await fetch('/api/admin/claude/oauth?action=cancel', { method: 'POST' }).catch(() => {})
+    setPoll(null)
+    setCode('')
+  }
+
+  const savePaste = async () => {
+    setPasteErr(null)
+    setPasteBusy(true)
+    const res = await fetch('/api/admin/claude/credentials', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ credentials: pasteVal }),
+    }).catch(() => null)
+    if (!res || !res.ok) {
+      const d = await res?.json().catch(() => ({}))
+      setPasteErr(d?.error ?? 'Failed to save')
+    } else {
+      setPasteDone(true)
+      setPasteVal('')
+      setTimeout(() => setPasteDone(false), 3000)
+      loadStatus()
+    }
+    setPasteBusy(false)
+  }
+
+  const isRunning = poll && poll.status !== 'done' && poll.status !== 'error' && poll.status !== 'idle'
 
   return (
     <div className="p-6 space-y-6 max-w-2xl">
       <div>
-        <h1 className="text-lg font-semibold text-text-primary">Claude Code OAuth</h1>
+        <h1 className="text-lg font-semibold text-text-primary">Claude Code</h1>
         <p className="text-sm text-text-muted mt-0.5">
-          Authenticate Claude Code so agents can use it as a runner for tasks and conversations.
+          Authenticate the Claude Code service so agents can use it as a task runner.
         </p>
       </div>
 
-      {/* Status card */}
-      <div className="rounded-lg border border-border-subtle bg-bg-card p-4">
-        <div className="flex items-center gap-3">
-          {!status ? (
-            <RefreshCw size={16} className="text-text-muted animate-spin" />
-          ) : status.valid ? (
-            <CheckCircle size={16} className="text-status-healthy" />
-          ) : status.configured ? (
-            <AlertCircle size={16} className="text-status-warning" />
-          ) : (
-            <XCircle size={16} className="text-status-error" />
-          )}
-          <div>
-            <p className="text-sm font-medium text-text-primary">
-              {!status ? 'Checking...' : status.valid ? 'Connected' : status.configured ? 'Token expired' : 'Not configured'}
+      {/* Status */}
+      <div className="rounded-lg border border-border-subtle bg-bg-card p-4 flex items-center gap-3">
+        {!status ? (
+          <RefreshCw size={16} className="text-text-muted animate-spin" />
+        ) : status.valid ? (
+          <CheckCircle size={16} className="text-status-healthy flex-shrink-0" />
+        ) : status.authenticated ? (
+          <AlertCircle size={16} className="text-status-warning flex-shrink-0" />
+        ) : (
+          <XCircle size={16} className="text-status-error flex-shrink-0" />
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-text-primary">
+            {!status ? 'Checking...'
+              : status.valid ? 'Connected'
+              : status.authenticated ? 'Token expired'
+              : 'Not authenticated'}
+          </p>
+          {status?.expiresAt && (
+            <p className="text-xs text-text-muted mt-0.5">
+              Expires {new Date(status.expiresAt).toLocaleDateString(undefined, { dateStyle: 'medium' })}
             </p>
-            {status?.expiresAt && (
-              <p className="text-xs text-text-muted mt-0.5">
-                Expires {new Date(status.expiresAt).toLocaleDateString(undefined, { dateStyle: 'medium' })}
-              </p>
-            )}
-            {status?.reason && !status.valid && (
-              <p className="text-xs text-text-muted mt-0.5">{status.reason}</p>
-            )}
-          </div>
-          <button
-            onClick={loadStatus}
-            className="ml-auto text-text-muted hover:text-text-primary transition-colors"
-            title="Refresh status"
-          >
-            <RefreshCw size={13} />
-          </button>
+          )}
+          {status?.reason && !status.valid && (
+            <p className="text-xs text-text-muted mt-0.5">{status.reason}</p>
+          )}
         </div>
+        <button onClick={loadStatus} className="text-text-muted hover:text-text-primary transition-colors">
+          <RefreshCw size={13} />
+        </button>
       </div>
 
       {/* Tabs */}
@@ -137,103 +168,143 @@ export default function ClaudeOAuthPage() {
             key={t}
             onClick={() => setTab(t)}
             className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-              tab === t
-                ? 'border-accent text-accent'
-                : 'border-transparent text-text-secondary hover:text-text-primary'
+              tab === t ? 'border-accent text-accent' : 'border-transparent text-text-secondary hover:text-text-primary'
             }`}
           >
-            {t === 'oauth' ? (
-              <span className="flex items-center gap-1.5"><LogIn size={13} />OAuth Flow</span>
-            ) : (
-              <span className="flex items-center gap-1.5"><ClipboardPaste size={13} />Paste Credentials</span>
-            )}
+            {t === 'oauth'
+              ? <span className="flex items-center gap-1.5"><LogIn size={13} />OAuth Flow</span>
+              : <span className="flex items-center gap-1.5"><ClipboardPaste size={13} />Paste Credentials</span>}
           </button>
         ))}
       </div>
 
+      {/* OAuth tab */}
       {tab === 'oauth' && (
         <div className="space-y-4">
           <p className="text-sm text-text-secondary">
-            Runs <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude login</code> inside the{' '}
-            <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude-refresh</code> container.
-            A browser auth URL will appear below — open it, log in, and credentials will be saved automatically.
+            Starts <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude login</code> inside
+            the <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">orion-claude</code> service.
+            Visit the URL that appears, then paste the authorization code back here.
           </p>
 
-          <button
-            onClick={startOAuth}
-            disabled={starting || job?.status === 'running'}
-            className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
-          >
-            {starting || job?.status === 'running' ? (
-              <><RefreshCw size={13} className="animate-spin" />Running...</>
-            ) : (
-              <><LogIn size={13} />Start OAuth Flow</>
-            )}
-          </button>
-
-          {job && (
-            <div className="rounded-lg border border-border-subtle overflow-hidden">
-              <div className="px-3 py-2 border-b border-border-subtle bg-bg-raised flex items-center justify-between">
-                <span className="text-xs font-mono text-text-muted">Output</span>
-                <span className={`text-xs font-medium ${
-                  job.status === 'completed' ? 'text-status-healthy' :
-                  job.status === 'failed'    ? 'text-status-error' :
-                  'text-status-warning'
-                }`}>{job.status}</span>
-              </div>
-              <pre
-                ref={logRef}
-                className="p-3 text-xs font-mono text-text-secondary whitespace-pre-wrap max-h-64 overflow-y-auto bg-bg-page"
-              >{job.logs || '…'}</pre>
+          {svcErr && (
+            <div className="rounded border border-status-error/40 bg-status-error/10 px-4 py-3 text-sm text-status-error">
+              {svcErr}
             </div>
           )}
 
-          {authUrl && job?.status === 'running' && (
-            <div className="rounded-lg border border-accent/30 bg-accent/5 p-4">
-              <p className="text-sm font-medium text-text-primary mb-2">Open this URL to authenticate:</p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={startLogin}
+              disabled={starting || !!isRunning}
+              className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+            >
+              {starting ? <RefreshCw size={13} className="animate-spin" /> : <LogIn size={13} />}
+              {starting ? 'Starting...' : isRunning ? 'Login in progress...' : 'Start Login'}
+            </button>
+            {isRunning && (
+              <button
+                onClick={cancelLogin}
+                className="flex items-center gap-2 px-3 py-2 rounded border border-border-subtle text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
+                <X size={13} /> Cancel
+              </button>
+            )}
+          </div>
+
+          {/* Log output */}
+          {poll && (
+            <div className="rounded-lg border border-border-subtle overflow-hidden">
+              <div className="px-3 py-2 border-b border-border-subtle bg-bg-raised flex items-center justify-between">
+                <span className="text-xs font-mono text-text-muted">claude login output</span>
+                <span className={`text-xs font-medium ${
+                  poll.status === 'done'      ? 'text-status-healthy' :
+                  poll.status === 'error'     ? 'text-status-error' :
+                  poll.status === 'waiting'   ? 'text-status-warning' :
+                  'text-text-muted'
+                }`}>{poll.status}</span>
+              </div>
+              <pre
+                ref={logRef}
+                className="p-3 text-xs font-mono text-text-secondary whitespace-pre-wrap max-h-48 overflow-y-auto bg-bg-page"
+              >{poll.output || 'Starting…'}</pre>
+            </div>
+          )}
+
+          {/* Auth URL callout */}
+          {poll?.authUrl && poll.status !== 'done' && (
+            <div className="rounded-lg border border-accent/30 bg-accent/5 p-4 space-y-2">
+              <p className="text-sm font-medium text-text-primary">1. Open this URL in your browser:</p>
               <a
-                href={authUrl}
+                href={poll.authUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-accent underline break-all"
+                className="block text-sm text-accent underline break-all font-mono"
               >
-                {authUrl}
+                {poll.authUrl}
               </a>
+              <p className="text-sm text-text-secondary pt-1">
+                2. Authorize, then paste the code you receive below:
+              </p>
+            </div>
+          )}
+
+          {/* Code input — shown once we have the URL */}
+          {poll?.authUrl && poll.status !== 'done' && poll.status !== 'error' && (
+            <div className="flex gap-2">
+              <input
+                value={code}
+                onChange={e => setCode(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && !sending && submitCode()}
+                placeholder="Paste authorization code here…"
+                className="flex-1 px-3 py-2 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors font-mono"
+              />
+              <button
+                onClick={submitCode}
+                disabled={!code.trim() || sending}
+                className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+              >
+                {sending ? <RefreshCw size={13} className="animate-spin" /> : <Send size={13} />}
+                Submit
+              </button>
+            </div>
+          )}
+
+          {poll?.status === 'done' && (
+            <div className="rounded-lg border border-status-healthy/30 bg-status-healthy/5 px-4 py-3 flex items-center gap-2">
+              <CheckCircle size={14} className="text-status-healthy flex-shrink-0" />
+              <p className="text-sm text-status-healthy">Authentication complete. Claude Code is ready.</p>
             </div>
           )}
         </div>
       )}
 
+      {/* Paste tab */}
       {tab === 'paste' && (
         <div className="space-y-4">
           <p className="text-sm text-text-secondary">
             Run <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude login</code> on any
-            machine, then paste the contents of{' '}
-            <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">~/.claude/.credentials.json</code> below.
+            machine with Claude Code installed, then paste the contents of{' '}
+            <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">~/.claude/.credentials.json</code>.
           </p>
-
           <textarea
-            value={pasteValue}
-            onChange={e => setPasteValue(e.target.value)}
+            value={pasteVal}
+            onChange={e => setPasteVal(e.target.value)}
             placeholder={'{\n  "claudeAiOauth": {\n    "accessToken": "...",\n    "expiresAt": 1234567890\n  }\n}'}
             rows={10}
             className="w-full px-3 py-2 text-xs font-mono bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-none"
           />
-
-          {pasteError && (
-            <p className="text-sm text-status-error">{pasteError}</p>
-          )}
-
+          {pasteErr && <p className="text-sm text-status-error">{pasteErr}</p>}
           <div className="flex items-center gap-3">
             <button
               onClick={savePaste}
-              disabled={!pasteValue.trim() || pasteSaving}
+              disabled={!pasteVal.trim() || pasteBusy}
               className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
             >
-              {pasteSaving ? <RefreshCw size={13} className="animate-spin" /> : <ClipboardPaste size={13} />}
-              {pasteSaving ? 'Saving...' : 'Save Credentials'}
+              {pasteBusy ? <RefreshCw size={13} className="animate-spin" /> : <ClipboardPaste size={13} />}
+              {pasteBusy ? 'Saving...' : 'Save Credentials'}
             </button>
-            {pasteSaved && <span className="text-sm text-status-healthy">Saved successfully</span>}
+            {pasteDone && <span className="text-sm text-status-healthy">Saved successfully</span>}
           </div>
         </div>
       )}

--- a/apps/web/src/app/(app)/admin/claude/page.tsx
+++ b/apps/web/src/app/(app)/admin/claude/page.tsx
@@ -1,0 +1,242 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { CheckCircle, XCircle, AlertCircle, RefreshCw, LogIn, ClipboardPaste } from 'lucide-react'
+
+interface CredStatus {
+  configured: boolean
+  valid: boolean
+  expiresAt: string | null
+  reason: string | null
+}
+
+interface Job {
+  id: string
+  status: string
+  logs: string
+}
+
+export default function ClaudeOAuthPage() {
+  const [status, setStatus] = useState<CredStatus | null>(null)
+  const [tab, setTab] = useState<'oauth' | 'paste'>('oauth')
+  const [pasteValue, setPasteValue] = useState('')
+  const [pasteError, setPasteError] = useState<string | null>(null)
+  const [pasteSaving, setPasteSaving] = useState(false)
+  const [pasteSaved, setPasteSaved] = useState(false)
+  const [job, setJob] = useState<Job | null>(null)
+  const [starting, setStarting] = useState(false)
+  const logRef = useRef<HTMLPreElement>(null)
+
+  const loadStatus = () =>
+    fetch('/api/admin/claude/status')
+      .then(r => r.json())
+      .then(setStatus)
+      .catch(() => {})
+
+  useEffect(() => { loadStatus() }, [])
+
+  // Poll job logs while running
+  useEffect(() => {
+    if (!job || job.status === 'completed' || job.status === 'failed') return
+    const t = setInterval(() => {
+      fetch(`/api/jobs/${job.id}`)
+        .then(r => r.json())
+        .then((j: Job) => {
+          setJob(j)
+          if (j.status === 'completed') { loadStatus(); clearInterval(t) }
+        })
+        .catch(() => {})
+    }, 1500)
+    return () => clearInterval(t)
+  }, [job])
+
+  // Auto-scroll logs
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [job?.logs])
+
+  const startOAuth = async () => {
+    setStarting(true)
+    setJob(null)
+    const res = await fetch('/api/admin/claude/oauth', { method: 'POST' })
+    const data = await res.json()
+    setJob({ id: data.jobId, status: 'running', logs: '' })
+    setStarting(false)
+  }
+
+  const savePaste = async () => {
+    setPasteError(null)
+    setPasteSaving(true)
+    const res = await fetch('/api/admin/claude/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credentials: pasteValue }),
+    })
+    const data = await res.json()
+    if (res.ok) {
+      setPasteSaved(true)
+      setPasteValue('')
+      setTimeout(() => setPasteSaved(false), 3000)
+      loadStatus()
+    } else {
+      setPasteError(data.error ?? 'Failed to save')
+    }
+    setPasteSaving(false)
+  }
+
+  // Extract any URL from logs for display
+  const authUrl = job?.logs?.match(/https:\/\/[^\s]+/)?.[0]
+
+  return (
+    <div className="p-6 space-y-6 max-w-2xl">
+      <div>
+        <h1 className="text-lg font-semibold text-text-primary">Claude Code OAuth</h1>
+        <p className="text-sm text-text-muted mt-0.5">
+          Authenticate Claude Code so agents can use it as a runner for tasks and conversations.
+        </p>
+      </div>
+
+      {/* Status card */}
+      <div className="rounded-lg border border-border-subtle bg-bg-card p-4">
+        <div className="flex items-center gap-3">
+          {!status ? (
+            <RefreshCw size={16} className="text-text-muted animate-spin" />
+          ) : status.valid ? (
+            <CheckCircle size={16} className="text-status-healthy" />
+          ) : status.configured ? (
+            <AlertCircle size={16} className="text-status-warning" />
+          ) : (
+            <XCircle size={16} className="text-status-error" />
+          )}
+          <div>
+            <p className="text-sm font-medium text-text-primary">
+              {!status ? 'Checking...' : status.valid ? 'Connected' : status.configured ? 'Token expired' : 'Not configured'}
+            </p>
+            {status?.expiresAt && (
+              <p className="text-xs text-text-muted mt-0.5">
+                Expires {new Date(status.expiresAt).toLocaleDateString(undefined, { dateStyle: 'medium' })}
+              </p>
+            )}
+            {status?.reason && !status.valid && (
+              <p className="text-xs text-text-muted mt-0.5">{status.reason}</p>
+            )}
+          </div>
+          <button
+            onClick={loadStatus}
+            className="ml-auto text-text-muted hover:text-text-primary transition-colors"
+            title="Refresh status"
+          >
+            <RefreshCw size={13} />
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border-subtle">
+        {(['oauth', 'paste'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              tab === t
+                ? 'border-accent text-accent'
+                : 'border-transparent text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {t === 'oauth' ? (
+              <span className="flex items-center gap-1.5"><LogIn size={13} />OAuth Flow</span>
+            ) : (
+              <span className="flex items-center gap-1.5"><ClipboardPaste size={13} />Paste Credentials</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'oauth' && (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            Runs <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude login</code> inside the{' '}
+            <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude-refresh</code> container.
+            A browser auth URL will appear below — open it, log in, and credentials will be saved automatically.
+          </p>
+
+          <button
+            onClick={startOAuth}
+            disabled={starting || job?.status === 'running'}
+            className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+          >
+            {starting || job?.status === 'running' ? (
+              <><RefreshCw size={13} className="animate-spin" />Running...</>
+            ) : (
+              <><LogIn size={13} />Start OAuth Flow</>
+            )}
+          </button>
+
+          {job && (
+            <div className="rounded-lg border border-border-subtle overflow-hidden">
+              <div className="px-3 py-2 border-b border-border-subtle bg-bg-raised flex items-center justify-between">
+                <span className="text-xs font-mono text-text-muted">Output</span>
+                <span className={`text-xs font-medium ${
+                  job.status === 'completed' ? 'text-status-healthy' :
+                  job.status === 'failed'    ? 'text-status-error' :
+                  'text-status-warning'
+                }`}>{job.status}</span>
+              </div>
+              <pre
+                ref={logRef}
+                className="p-3 text-xs font-mono text-text-secondary whitespace-pre-wrap max-h-64 overflow-y-auto bg-bg-page"
+              >{job.logs || '…'}</pre>
+            </div>
+          )}
+
+          {authUrl && job?.status === 'running' && (
+            <div className="rounded-lg border border-accent/30 bg-accent/5 p-4">
+              <p className="text-sm font-medium text-text-primary mb-2">Open this URL to authenticate:</p>
+              <a
+                href={authUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-accent underline break-all"
+              >
+                {authUrl}
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === 'paste' && (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            Run <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">claude login</code> on any
+            machine, then paste the contents of{' '}
+            <code className="text-xs bg-bg-raised px-1 py-0.5 rounded">~/.claude/.credentials.json</code> below.
+          </p>
+
+          <textarea
+            value={pasteValue}
+            onChange={e => setPasteValue(e.target.value)}
+            placeholder={'{\n  "claudeAiOauth": {\n    "accessToken": "...",\n    "expiresAt": 1234567890\n  }\n}'}
+            rows={10}
+            className="w-full px-3 py-2 text-xs font-mono bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-none"
+          />
+
+          {pasteError && (
+            <p className="text-sm text-status-error">{pasteError}</p>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={savePaste}
+              disabled={!pasteValue.trim() || pasteSaving}
+              className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+            >
+              {pasteSaving ? <RefreshCw size={13} className="animate-spin" /> : <ClipboardPaste size={13} />}
+              {pasteSaving ? 'Saving...' : 'Save Credentials'}
+            </button>
+            {pasteSaved && <span className="text-sm text-status-healthy">Saved successfully</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/admin/layout.tsx
+++ b/apps/web/src/app/(app)/admin/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare } from 'lucide-react'
+import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare, KeyRound } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 
 const adminNav = [
@@ -14,6 +14,7 @@ const adminNav = [
   { href: '/admin/approvals',     icon: ShieldAlert,     label: 'Approvals'     },
   { href: '/admin/sso',           icon: ShieldCheck,     label: 'SSO'           },
   { href: '/admin/prompts',        icon: MessageSquare,   label: 'Prompts'       },
+  { href: '/admin/claude',         icon: KeyRound,        label: 'Claude OAuth'  },
   { href: '/admin/audit',         icon: ScrollText,      label: 'Audit Log'     },
 ]
 

--- a/apps/web/src/app/api/admin/claude/credentials/route.ts
+++ b/apps/web/src/app/api/admin/claude/credentials/route.ts
@@ -1,8 +1,17 @@
+/**
+ * POST /api/admin/claude/credentials
+ * Paste-based credential bootstrap — forwards directly to the orion-claude
+ * service which stores them in its own /root/.claude volume.
+ *
+ * Also writes to /claude-creds/.credentials.json (the path the web container
+ * reads via getOAuthToken) for immediate availability without restart.
+ */
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import fs from 'fs'
 
-const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+const CLAUDE_URL  = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
+const LOCAL_CREDS = '/claude-creds/.credentials.json'
 
 export async function POST(req: NextRequest) {
   await requireAdmin()
@@ -24,8 +33,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'JSON must contain claudeAiOauth.accessToken' }, { status: 400 })
   }
 
-  fs.mkdirSync('/claude-creds/.claude', { recursive: true })
-  fs.writeFileSync(CREDS_PATH, JSON.stringify(parsed, null, 2), 'utf8')
+  // Write to local volume for immediate web-process pickup
+  try {
+    fs.mkdirSync('/claude-creds', { recursive: true })
+    fs.writeFileSync(LOCAL_CREDS, JSON.stringify(parsed, null, 2), 'utf8')
+  } catch { /* volume may not be writable in all environments */ }
+
+  // Also send to orion-claude service so it stores in its native /root/.claude
+  try {
+    await fetch(`${CLAUDE_URL}/auth/credentials`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ credentials: parsed }),
+      signal:  AbortSignal.timeout(5000),
+    })
+  } catch { /* service may not be up yet */ }
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/admin/claude/credentials/route.ts
+++ b/apps/web/src/app/api/admin/claude/credentials/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import fs from 'fs'
+
+const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+
+export async function POST(req: NextRequest) {
+  await requireAdmin()
+
+  const body = await req.json().catch(() => null)
+  const raw: string | undefined = body?.credentials
+
+  if (!raw) return NextResponse.json({ error: 'credentials field required' }, { status: 400 })
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = typeof raw === 'string' ? JSON.parse(raw) : raw
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const token = (parsed?.claudeAiOauth as Record<string, unknown> | undefined)?.accessToken
+  if (!token) {
+    return NextResponse.json({ error: 'JSON must contain claudeAiOauth.accessToken' }, { status: 400 })
+  }
+
+  fs.mkdirSync('/claude-creds/.claude', { recursive: true })
+  fs.writeFileSync(CREDS_PATH, JSON.stringify(parsed, null, 2), 'utf8')
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/admin/claude/oauth/route.ts
+++ b/apps/web/src/app/api/admin/claude/oauth/route.ts
@@ -1,102 +1,67 @@
 /**
- * POST /api/admin/claude/oauth
+ * Claude Code OAuth proxy routes
  *
- * Starts the Claude Code OAuth flow by running `claude login` inside the
- * claude-refresh container via Docker exec. Returns a BackgroundJob ID that
- * the UI can poll for log output (which includes the auth URL to visit).
- *
- * On completion, `claude login` writes credentials to /root/.claude in the
- * claude-refresh container, and the refresh script copies them to the shared
- * /claude-creds volume — which the web container also mounts.
+ * POST /api/admin/claude/oauth/login   — start the login flow on the orion-claude service
+ * POST /api/admin/claude/oauth/code    — forward the pasted code to the running login process
+ * GET  /api/admin/claude/oauth/poll    — poll login progress and output
+ * POST /api/admin/claude/oauth/cancel  — cancel any running login
  */
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
-import { prisma } from '@/lib/db'
-import { spawn } from 'child_process'
 
-// Name of the claude-refresh container (matches docker-compose service name)
-const REFRESH_CONTAINER = process.env.CLAUDE_REFRESH_CONTAINER ?? 'deploy-claude-refresh-1'
-const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+const CLAUDE_URL = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
 
-export async function POST() {
-  await requireAdmin()
-
-  const job = await prisma.backgroundJob.create({
-    data: {
-      type: 'claude-oauth',
-      title: 'Claude Code OAuth Login',
-      status: 'running',
-      logs: 'Starting Claude OAuth flow...\n',
-    },
+async function proxy(path: string, method: string, body?: unknown) {
+  const res = await fetch(`${CLAUDE_URL}${path}`, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body:    body ? JSON.stringify(body) : undefined,
+    signal:  AbortSignal.timeout(10_000),
   })
-
-  // Run async — do not await
-  runOAuthFlow(job.id).catch(async (err) => {
-    await prisma.backgroundJob.update({
-      where: { id: job.id },
-      data: { status: 'failed', logs: { set: `Error: ${err instanceof Error ? err.message : String(err)}\n` } },
-    }).catch(() => {})
-  })
-
-  return NextResponse.json({ jobId: job.id })
+  return res.json()
 }
 
-async function runOAuthFlow(jobId: string) {
-  const appendLog = async (line: string) => {
-    const current = await prisma.backgroundJob.findUnique({ where: { id: jobId }, select: { logs: true } })
-    const prev = typeof current?.logs === 'string' ? current.logs : ''
-    await prisma.backgroundJob.update({
-      where: { id: jobId },
-      data: { logs: prev + line },
-    }).catch(() => {})
-  }
+export async function POST(req: NextRequest) {
+  await requireAdmin()
 
-  await appendLog(`Executing: docker exec ${REFRESH_CONTAINER} claude login\n`)
-  await appendLog('Waiting for auth URL — this may take a few seconds...\n\n')
+  const url    = new URL(req.url)
+  const action = url.searchParams.get('action') ?? 'login'
 
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn('docker', ['exec', '-i', REFRESH_CONTAINER, 'claude', 'login'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-
-    const handle = async (data: Buffer) => {
-      const text = data.toString()
-      await appendLog(text)
+  try {
+    if (action === 'login') {
+      const data = await proxy('/auth/login', 'POST')
+      return NextResponse.json(data)
     }
 
-    proc.stdout.on('data', handle)
-    proc.stderr.on('data', handle)
+    if (action === 'code') {
+      const body = await req.json().catch(() => ({}))
+      const data = await proxy('/auth/code', 'POST', { code: body.code })
+      return NextResponse.json(data)
+    }
 
-    proc.on('close', async (code) => {
-      if (code === 0) {
-        await appendLog('\n✓ Login completed. Copying credentials to shared volume...\n')
+    if (action === 'cancel') {
+      const data = await proxy('/auth/cancel', 'POST')
+      return NextResponse.json(data)
+    }
 
-        // claude login writes to /root/.claude in the refresh container.
-        // The refresh script already copies to /claude-creds on each loop,
-        // but we trigger a copy immediately via docker exec.
-        const copy = spawn('docker', [
-          'exec', REFRESH_CONTAINER,
-          'sh', '-c',
-          `mkdir -p /claude-creds/.claude && cp /root/.claude/.credentials.json ${CREDS_PATH}`,
-        ])
-        await new Promise<void>(r => copy.on('close', () => r()))
-        await appendLog('✓ Credentials saved. Claude Code is ready.\n')
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+  } catch {
+    return NextResponse.json({ error: 'Claude Code service unreachable' }, { status: 503 })
+  }
+}
 
-        await prisma.backgroundJob.update({
-          where: { id: jobId },
-          data: { status: 'completed' },
-        }).catch(() => {})
-        resolve()
-      } else {
-        await appendLog(`\n✗ claude login exited with code ${code}\n`)
-        await prisma.backgroundJob.update({
-          where: { id: jobId },
-          data: { status: 'failed' },
-        }).catch(() => {})
-        reject(new Error(`Exit code ${code}`))
-      }
-    })
+export async function GET(req: NextRequest) {
+  await requireAdmin()
+  const url    = new URL(req.url)
+  const action = url.searchParams.get('action') ?? 'poll'
 
-    proc.on('error', reject)
-  })
+  try {
+    if (action === 'poll') {
+      const data = await proxy('/auth/poll', 'GET')
+      return NextResponse.json(data)
+    }
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+  } catch {
+    return NextResponse.json({ error: 'Claude Code service unreachable' }, { status: 503 })
+  }
 }

--- a/apps/web/src/app/api/admin/claude/oauth/route.ts
+++ b/apps/web/src/app/api/admin/claude/oauth/route.ts
@@ -1,0 +1,102 @@
+/**
+ * POST /api/admin/claude/oauth
+ *
+ * Starts the Claude Code OAuth flow by running `claude login` inside the
+ * claude-refresh container via Docker exec. Returns a BackgroundJob ID that
+ * the UI can poll for log output (which includes the auth URL to visit).
+ *
+ * On completion, `claude login` writes credentials to /root/.claude in the
+ * claude-refresh container, and the refresh script copies them to the shared
+ * /claude-creds volume — which the web container also mounts.
+ */
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { spawn } from 'child_process'
+
+// Name of the claude-refresh container (matches docker-compose service name)
+const REFRESH_CONTAINER = process.env.CLAUDE_REFRESH_CONTAINER ?? 'deploy-claude-refresh-1'
+const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+
+export async function POST() {
+  await requireAdmin()
+
+  const job = await prisma.backgroundJob.create({
+    data: {
+      type: 'claude-oauth',
+      title: 'Claude Code OAuth Login',
+      status: 'running',
+      logs: 'Starting Claude OAuth flow...\n',
+    },
+  })
+
+  // Run async — do not await
+  runOAuthFlow(job.id).catch(async (err) => {
+    await prisma.backgroundJob.update({
+      where: { id: job.id },
+      data: { status: 'failed', logs: { set: `Error: ${err instanceof Error ? err.message : String(err)}\n` } },
+    }).catch(() => {})
+  })
+
+  return NextResponse.json({ jobId: job.id })
+}
+
+async function runOAuthFlow(jobId: string) {
+  const appendLog = async (line: string) => {
+    const current = await prisma.backgroundJob.findUnique({ where: { id: jobId }, select: { logs: true } })
+    const prev = typeof current?.logs === 'string' ? current.logs : ''
+    await prisma.backgroundJob.update({
+      where: { id: jobId },
+      data: { logs: prev + line },
+    }).catch(() => {})
+  }
+
+  await appendLog(`Executing: docker exec ${REFRESH_CONTAINER} claude login\n`)
+  await appendLog('Waiting for auth URL — this may take a few seconds...\n\n')
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn('docker', ['exec', '-i', REFRESH_CONTAINER, 'claude', 'login'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    const handle = async (data: Buffer) => {
+      const text = data.toString()
+      await appendLog(text)
+    }
+
+    proc.stdout.on('data', handle)
+    proc.stderr.on('data', handle)
+
+    proc.on('close', async (code) => {
+      if (code === 0) {
+        await appendLog('\n✓ Login completed. Copying credentials to shared volume...\n')
+
+        // claude login writes to /root/.claude in the refresh container.
+        // The refresh script already copies to /claude-creds on each loop,
+        // but we trigger a copy immediately via docker exec.
+        const copy = spawn('docker', [
+          'exec', REFRESH_CONTAINER,
+          'sh', '-c',
+          `mkdir -p /claude-creds/.claude && cp /root/.claude/.credentials.json ${CREDS_PATH}`,
+        ])
+        await new Promise<void>(r => copy.on('close', () => r()))
+        await appendLog('✓ Credentials saved. Claude Code is ready.\n')
+
+        await prisma.backgroundJob.update({
+          where: { id: jobId },
+          data: { status: 'completed' },
+        }).catch(() => {})
+        resolve()
+      } else {
+        await appendLog(`\n✗ claude login exited with code ${code}\n`)
+        await prisma.backgroundJob.update({
+          where: { id: jobId },
+          data: { status: 'failed' },
+        }).catch(() => {})
+        reject(new Error(`Exit code ${code}`))
+      }
+    })
+
+    proc.on('error', reject)
+  })
+}

--- a/apps/web/src/app/api/admin/claude/status/route.ts
+++ b/apps/web/src/app/api/admin/claude/status/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import fs from 'fs'
+
+const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+
+export async function GET() {
+  await requireAdmin()
+
+  try {
+    const raw = fs.readFileSync(CREDS_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    const oauth = parsed?.claudeAiOauth
+    const accessToken: string | undefined = oauth?.accessToken
+    const expiresAt: number | undefined = oauth?.expiresAt
+
+    if (!accessToken) {
+      return NextResponse.json({ configured: true, valid: false, reason: 'No access token found' })
+    }
+
+    const now = Date.now()
+    const valid = !expiresAt || expiresAt > now
+
+    return NextResponse.json({
+      configured: true,
+      valid,
+      expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+      reason: valid ? null : 'Token expired',
+    })
+  } catch {
+    return NextResponse.json({ configured: false, valid: false, reason: 'Credentials file not found' })
+  }
+}

--- a/apps/web/src/app/api/admin/claude/status/route.ts
+++ b/apps/web/src/app/api/admin/claude/status/route.ts
@@ -1,33 +1,15 @@
 import { NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
-import fs from 'fs'
 
-const CREDS_PATH = '/claude-creds/.claude/.credentials.json'
+const CLAUDE_URL = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
 
 export async function GET() {
   await requireAdmin()
-
   try {
-    const raw = fs.readFileSync(CREDS_PATH, 'utf8')
-    const parsed = JSON.parse(raw)
-    const oauth = parsed?.claudeAiOauth
-    const accessToken: string | undefined = oauth?.accessToken
-    const expiresAt: number | undefined = oauth?.expiresAt
-
-    if (!accessToken) {
-      return NextResponse.json({ configured: true, valid: false, reason: 'No access token found' })
-    }
-
-    const now = Date.now()
-    const valid = !expiresAt || expiresAt > now
-
-    return NextResponse.json({
-      configured: true,
-      valid,
-      expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
-      reason: valid ? null : 'Token expired',
-    })
+    const res = await fetch(`${CLAUDE_URL}/auth/status`, { signal: AbortSignal.timeout(5000) })
+    const data = await res.json()
+    return NextResponse.json(data)
   } catch {
-    return NextResponse.json({ configured: false, valid: false, reason: 'Credentials file not found' })
+    return NextResponse.json({ authenticated: false, valid: false, reason: 'Claude Code service unreachable' })
   }
 }

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -125,6 +125,7 @@ function getOAuthToken(): string | null {
     process.env.CLAUDE_CREDENTIALS_PATH
       ? path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
       : null,
+    '/claude-creds/.claude/.credentials.json', // shared volume written by admin bootstrap or claude-refresh
     '/tmp/claude-home/.claude/.credentials.json',
   ].filter(Boolean) as string[]
   for (const p of candidates) {

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -1,9 +1,7 @@
 import fs from 'fs'
-import path from 'path'
 import { prisma } from './db'
 import { getPrompt, interpolate } from './system-prompts'
 import { generateEmbedding, vectorSearch } from './embeddings'
-import type { SDKAssistantMessage, SDKResultMessage } from '@anthropic-ai/claude-code'
 import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './management-tools'
 
 async function getActiveTasksSection(): Promise<string> {
@@ -93,51 +91,6 @@ export interface StreamChunk {
   error?: string
 }
 
-// Collect all text from a query() response into a single string
-type AnyMsg = { type: string; message?: { content: Array<{ type: string; text?: string }> }; subtype?: string; result?: string }
-
-async function collectQueryText(response: AsyncIterable<unknown>): Promise<string> {
-  let text = ''
-  for await (const raw of response) {
-    const msg = raw as AnyMsg
-    if (msg.type === 'assistant' && msg.message) {
-      for (const block of msg.message.content) {
-        if (block.type === 'text' && block.text) text += block.text
-      }
-    } else if (msg.type === 'result' && msg.subtype === 'success' && msg.result && !text.includes(msg.result.trim())) {
-      text += msg.result
-    }
-  }
-  return text.trim()
-}
-
-function getOAuthToken(): string | null {
-  // Try the CLAUDE_CREDENTIALS env var first (raw JSON blob set by ESO)
-  if (process.env.CLAUDE_CREDENTIALS) {
-    try {
-      const parsed = JSON.parse(process.env.CLAUDE_CREDENTIALS)
-      const token = parsed?.claudeAiOauth?.accessToken
-      if (token) return token
-    } catch { /* fall through */ }
-  }
-  // Fall back to mounted credentials file
-  const candidates = [
-    process.env.CLAUDE_CREDENTIALS_PATH
-      ? path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
-      : null,
-    '/claude-creds/.credentials.json',       // orion-claude volume (native /root/.claude mount)
-    '/claude-creds/.claude/.credentials.json', // legacy path from claude-refresh
-    '/tmp/claude-home/.claude/.credentials.json',
-  ].filter(Boolean) as string[]
-  for (const p of candidates) {
-    try {
-      const parsed = JSON.parse(fs.readFileSync(p, 'utf8'))
-      const token = parsed?.claudeAiOauth?.accessToken
-      if (token) return token
-    } catch { /* try next */ }
-  }
-  return null
-}
 
 export interface AgentContextConfig {
   maxTurns?: number        // default 6 for agent chats
@@ -1627,17 +1580,14 @@ ${transcript}`,
     }
   } catch { /* Ollama unavailable — fall through to Claude */ }
 
-  // Fallback: use Claude Code SDK (costs quota)
+  // Fallback: use orion-claude service (Claude Code SDK — token stays in the sidecar)
   try {
-    if (process.env.CLAUDE_CREDENTIALS_PATH) {
-      const srcCreds = path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
-      const dest = '/tmp/claude-home/.claude/.credentials.json'
-      fs.mkdirSync(path.dirname(dest), { recursive: true })
-      if (fs.existsSync(srcCreds)) fs.copyFileSync(srcCreds, dest)
-    }
-    const { query } = await import('@anthropic-ai/claude-code')
-    const response = query({
-      prompt: `Create a detailed conversation summary that captures:
+    const claudeUrl = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
+    const res = await fetch(`${claudeUrl}/run/collect`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({
+        prompt: `Create a detailed conversation summary that captures:
 - Key facts discovered or established (names, values, configurations)
 - Decisions made and the reasoning behind them
 - Important context about systems, services, or state
@@ -1646,13 +1596,18 @@ ${transcript}`,
 Be specific with details. Use 5-8 sentences if needed for completeness:
 
 ${transcript}`,
-      options: { allowedTools: [], maxTurns: 1, customSystemPrompt: 'You are a conversation summarizer. Produce a detailed factual summary that preserves important context and facts.' },
+        systemPrompt: 'You are a conversation summarizer. Produce a detailed factual summary that preserves important context and facts.',
+        allowedTools: [],
+        maxTurns: 1,
+      }),
+      signal: AbortSignal.timeout(60_000),
     })
-    const summary = await collectQueryText(response as AsyncIterable<unknown>)
-    return summary || null
-  } catch {
-    return null
-  }
+    if (res.ok) {
+      const data = await res.json() as { text?: string }
+      return data.text?.trim() || null
+    }
+  } catch { /* orion-claude unreachable */ }
+  return null
 }
 
 export async function* streamClaudeResponse(
@@ -1670,20 +1625,9 @@ export async function* streamClaudeResponse(
   let totalText = ''
   const toolCallLog: Array<{ tool: string; input: string; output?: string }> = []
 
+  const claudeUrl = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
+
   try {
-    const { query } = await import('@anthropic-ai/claude-code')
-
-    // Claude Code needs a writable HOME to store state (.claude.json).
-    // The Secret volume is read-only, so copy creds to /tmp and point HOME there.
-    if (process.env.CLAUDE_CREDENTIALS_PATH) {
-      const srcCreds = path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
-      const claudeHome = '/tmp/claude-home'
-      const destDir = path.join(claudeHome, '.claude')
-      fs.mkdirSync(destDir, { recursive: true })
-      try { fs.copyFileSync(srcCreds, path.join(destDir, '.credentials.json')) } catch { /* ignore if missing */ }
-      process.env.HOME = claudeHome
-    }
-
     const baseSystemPrompt = agentSystemPrompt ?? (planTarget
       ? await getPlanningSystemPrompt(planTarget.type)
       : await getSystemPrompt([], undefined, conversationId, knowledgeContext))
@@ -1695,79 +1639,137 @@ export async function* streamClaudeResponse(
       ? previousMessages.map(m => `${m.role}: ${m.content}`).join('\n\n') + `\n\nuser: ${prompt}`
       : prompt
 
-    // ── Phase 1: Sonnet — gathers info with tools, produces the draft plan ─────
-    const response = query({
-      prompt: fullPrompt,
-      options: {
-        allowedTools: ALLOWED_TOOLS,
-        customSystemPrompt: systemPrompt,
-        maxTurns: overrides?.maxTurns ?? 20,
-        ...(overrides?.allowedTools !== undefined && { allowedTools: overrides.allowedTools }),
+    // ── Phase 1: stream via orion-claude service (SDK token stays in the sidecar) ─
+    const runRes = await fetch(`${claudeUrl}/run`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({
+        prompt:       fullPrompt,
+        systemPrompt,
+        allowedTools: overrides?.allowedTools ?? ALLOWED_TOOLS,
+        maxTurns:     overrides?.maxTurns ?? 20,
         ...(overrides?.model && { model: overrides.model }),
-      },
+      }),
+      signal: abortSignal ?? AbortSignal.timeout(300_000),
     })
 
-    for await (const msg of response) {
-      if (abortSignal?.aborted) break
+    if (!runRes.ok || !runRes.body) {
+      throw new Error(`orion-claude /run returned ${runRes.status}`)
+    }
+
+    // Read NDJSON stream — each line is one raw SDK event
+    const reader  = runRes.body.getReader()
+    const decoder = new TextDecoder()
+    let   buf     = ''
+
+    const processLine = (line: string) => {
+      if (!line.trim()) return
+      let msg: Record<string, unknown>
+      try { msg = JSON.parse(line) } catch { return }
+
       if (msg.type === 'assistant') {
-        const assistantMsg = msg as SDKAssistantMessage
-        for (const block of assistantMsg.message.content) {
-          if (block.type === 'text') {
+        const content = (msg as any).message?.content as Array<{ type: string; text?: string; id?: string; name?: string; input?: unknown }> ?? []
+        for (const block of content) {
+          if (block.type === 'text' && block.text) {
             totalText += block.text
-            yield { type: 'text', content: block.text }
+            // Note: can't yield inside a regular function — batched below
           } else if (block.type === 'tool_use') {
-            const toolInput = JSON.stringify(block.input)
+            const toolInput = JSON.stringify(block.input ?? {})
             toolsUsed.push(`${block.name}(${toolInput})`)
-            toolCallLog.push({ tool: block.name, input: toolInput })
-            yield { type: 'tool_call', tool: block.name, input: toolInput }
-          }
-        }
-      } else if (msg.type === 'user') {
-        const userMsg = msg as { type: 'user'; message: { role: 'user'; content: unknown[] } }
-        for (const block of userMsg.message.content as Array<{ type: string; content?: unknown }>) {
-          if (block.type === 'tool_result') {
-            const result = Array.isArray(block.content)
-              ? (block.content as Array<{ type: string; text?: string }>).map(c => c.type === 'text' ? c.text : '').join('')
-              : String(block.content ?? '')
-            if (toolCallLog.length > 0) toolCallLog[toolCallLog.length - 1].output = result
-            yield { type: 'tool_result', output: result }
+            toolCallLog.push({ tool: block.name!, input: toolInput })
           }
         }
       } else if (msg.type === 'result') {
-        const resultMsg = msg as SDKResultMessage
-        const subtype = (resultMsg as { subtype?: string }).subtype
-        const resultText = subtype === 'success' ? (resultMsg as { result: string }).result : undefined
-        process.stderr.write(`[claude] result: subtype=${subtype} result_len=${resultText?.length ?? 0}\n`)
-        if (resultText && resultText.trim() && !totalText.includes(resultText.trim())) {
+        const subtype    = (msg as any).subtype as string | undefined
+        const resultText = subtype === 'success' ? (msg as any).result as string : undefined
+        if (resultText?.trim() && !totalText.includes(resultText.trim())) {
           totalText += (totalText ? '\n\n' : '') + resultText
-          yield { type: 'text', content: resultText }
         }
       }
     }
 
-    // ── Phase 2 (planning only): Opus reviews the Sonnet draft ────────────────
+    // Streaming yield loop — process lines and yield events as they arrive
+    while (true) {
+      if (abortSignal?.aborted) break
+      const { done, value } = await reader.read()
+      if (done) { if (buf.trim()) processLine(buf); break }
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop()!
+      for (const line of lines) {
+        if (!line.trim()) continue
+        let msg: Record<string, unknown>
+        try { msg = JSON.parse(line) } catch { continue }
+
+        if (msg.type === 'error') {
+          throw new Error((msg as any).error ?? 'Unknown error from orion-claude')
+        }
+
+        if (msg.type === 'assistant') {
+          const content = (msg as any).message?.content as Array<{ type: string; text?: string; name?: string; input?: unknown }> ?? []
+          for (const block of content) {
+            if (block.type === 'text' && block.text) {
+              totalText += block.text
+              yield { type: 'text', content: block.text }
+            } else if (block.type === 'tool_use') {
+              const toolInput = JSON.stringify(block.input ?? {})
+              toolsUsed.push(`${block.name}(${toolInput})`)
+              toolCallLog.push({ tool: block.name!, input: toolInput })
+              yield { type: 'tool_call', tool: block.name!, input: toolInput }
+            }
+          }
+        } else if (msg.type === 'user') {
+          const content = (msg as any).message?.content as Array<{ type: string; content?: unknown }> ?? []
+          for (const block of content) {
+            if (block.type === 'tool_result') {
+              const result = Array.isArray(block.content)
+                ? (block.content as Array<{ type: string; text?: string }>).map(c => c.type === 'text' ? c.text : '').join('')
+                : String(block.content ?? '')
+              if (toolCallLog.length > 0) toolCallLog[toolCallLog.length - 1].output = result
+              yield { type: 'tool_result', output: result }
+            }
+          }
+        } else if (msg.type === 'result') {
+          const subtype    = (msg as any).subtype as string | undefined
+          const resultText = subtype === 'success' ? (msg as any).result as string : undefined
+          process.stderr.write(`[claude] result: subtype=${subtype} result_len=${resultText?.length ?? 0}\n`)
+          if (resultText?.trim() && !totalText.includes(resultText.trim())) {
+            totalText += (totalText ? '\n\n' : '') + resultText
+            yield { type: 'text', content: resultText }
+          }
+        }
+      }
+    }
+
+    // ── Phase 2 (planning only): Opus reviews the Sonnet draft via orion-claude ─
     let opusReview = ''
     if (planTarget && totalText.trim()) {
       const separator = '\n\n---\n\n*Reviewing with Opus...*\n\n'
       yield { type: 'text', content: separator }
 
-      const opusReviewText = await collectQueryText(query({
-        prompt: `Review this draft plan and output the final, improved version. Work only from the text below — do not attempt to run any commands or gather additional information. Fill gaps, sharpen implementation steps, remove vagueness, and ensure the plan is complete and actionable. Output the final plan directly with no preamble and no open-ended questions at the end.
+      const reviewRes = await fetch(`${claudeUrl}/run/collect`, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({
+          prompt: `Review this draft plan and output the final, improved version. Work only from the text below — do not attempt to run any commands or gather additional information. Fill gaps, sharpen implementation steps, remove vagueness, and ensure the plan is complete and actionable. Output the final plan directly with no preamble and no open-ended questions at the end.
 
 Draft plan to review:
 
 ${totalText}`,
-        options: {
+          systemPrompt: await getPrompt('system.plan-review'),
           allowedTools: [],
-          customSystemPrompt: await getPrompt('system.plan-review'),
-          maxTurns: 1,
-          model: 'claude-opus-4-6',
-        },
-      }))
+          maxTurns:     1,
+          model:        'claude-opus-4-6',
+        }),
+        signal: AbortSignal.timeout(120_000),
+      }).catch(() => null)
 
-      if (opusReviewText) {
-        opusReview = opusReviewText
-        yield { type: 'text', content: opusReviewText }
+      if (reviewRes?.ok) {
+        const d = await reviewRes.json() as { text?: string }
+        if (d.text) {
+          opusReview = d.text
+          yield { type: 'text', content: d.text }
+        }
       }
     }
 

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -125,7 +125,8 @@ function getOAuthToken(): string | null {
     process.env.CLAUDE_CREDENTIALS_PATH
       ? path.join(process.env.CLAUDE_CREDENTIALS_PATH, '.claude', '.credentials.json')
       : null,
-    '/claude-creds/.claude/.credentials.json', // shared volume written by admin bootstrap or claude-refresh
+    '/claude-creds/.credentials.json',       // orion-claude volume (native /root/.claude mount)
+    '/claude-creds/.claude/.credentials.json', // legacy path from claude-refresh
     '/tmp/claude-home/.claude/.credentials.json',
   ].filter(Boolean) as string[]
   for (const p of candidates) {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       REDIS_SENTINEL_NODES: ${REDIS_SENTINEL_NODES:-redis-sentinel-1:26379,redis-sentinel-2:26380,redis-sentinel-3:26381}
       REDIS_SENTINEL_PASSWORD: ${REDIS_SENTINEL_PASSWORD:-}
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      # Claude Code sidecar URL (for OAuth bootstrap and credential status)
+      ORION_CLAUDE_URL: ${ORION_CLAUDE_URL:-http://orion-claude:3100}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - orion-claude-creds:/claude-creds
@@ -278,6 +280,26 @@ services:
         limits:
           cpus: '0.5'
           memory: 256M
+
+  # ── Claude Code Service ────────────────────────────────────────────────────
+  # Persistent Claude Code sidecar. Handles OAuth login interactively and
+  # stores credentials in the shared orion-claude-creds volume.
+  # ORION web reads credentials from /claude-creds (same volume).
+  orion-claude:
+    build:
+      context: ./orion-claude
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    volumes:
+      - orion-claude-creds:/root/.claude   # native claude credentials directory
+    environment:
+      PORT: 3100
+      CLAUDE_HOME: /root/.claude
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
 
   # ── Claude Creds Refresh ───────────────────────────────────────────────────
   claude-refresh:

--- a/deploy/orion-claude/Dockerfile
+++ b/deploy/orion-claude/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+# Install claude CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create claude home — credentials volume will be mounted here
+RUN mkdir -p /root/.claude
+
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY server.js ./
+
+EXPOSE 3100
+CMD ["node", "server.js"]

--- a/deploy/orion-claude/package.json
+++ b/deploy/orion-claude/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "orion-claude",
+  "version": "1.0.0",
+  "description": "Persistent Claude Code service for ORION — handles OAuth and task execution",
+  "main": "server.js",
+  "dependencies": {}
+}

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -1,22 +1,20 @@
 /**
  * orion-claude — persistent Claude Code sidecar for ORION
  *
- * Wraps the `claude` CLI with an HTTP API so ORION can:
- *   - Check auth status
- *   - Initiate the OAuth login flow and capture the auth URL
- *   - Accept the pasted authorization code and forward it to claude's stdin
- *   - Poll login progress
- *
- * Credentials are stored in /root/.claude (the volume mount point).
- * ORION web reads from the same volume at /claude-creds.
+ * All Claude Code SDK calls go through this service. The OAuth token
+ * never leaves this container — ORION sends prompts here, we run them
+ * with the SDK, and stream results back as NDJSON.
  *
  * Endpoints:
- *   GET  /health          — liveness probe
- *   GET  /auth/status     — credential validity + expiry
- *   POST /auth/login      — start claude login, return auth URL when available
- *   POST /auth/code       — send code to running login process via stdin
- *   GET  /auth/poll       — poll login output + status
- *   POST /auth/cancel     — kill any running login process
+ *   GET  /health             — liveness probe
+ *   GET  /auth/status        — credential validity + expiry
+ *   POST /auth/login         — start claude login, return auth URL when available
+ *   POST /auth/code          — send code to running login process via stdin
+ *   GET  /auth/poll          — poll login output + status
+ *   POST /auth/cancel        — kill any running login process
+ *   POST /auth/credentials   — store pasted credentials directly
+ *   POST /run                — execute a query(), stream SDK events as NDJSON
+ *   POST /run/collect        — execute a query(), return full text as JSON (for summarizer/review)
  */
 
 const http  = require('http')
@@ -235,6 +233,76 @@ const server = http.createServer(async (req, res) => {
       fs.writeFileSync(CREDS_PATH, JSON.stringify(credentials, null, 2), 'utf8')
       console.log('[orion-claude] Credentials stored via paste')
       return json(res, 200, { ok: true })
+    }
+
+    // ── POST /run ────────────────────────────────────────────────────────────
+    // Execute a Claude Code query and stream SDK events back as NDJSON.
+    // Each line is one JSON-serialised SDK event (assistant / user / result / error).
+    if (method === 'POST' && url === '/run') {
+      const body = await readBody(req)
+      let opts
+      try { opts = JSON.parse(body || '{}') } catch { return json(res, 400, { error: 'Invalid JSON' }) }
+
+      res.writeHead(200, {
+        'Content-Type': 'application/x-ndjson',
+        'Transfer-Encoding': 'chunked',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+      })
+
+      try {
+        const { query } = await import('@anthropic-ai/claude-code')
+        const response = query({
+          prompt: String(opts.prompt || ''),
+          options: {
+            allowedTools:     opts.allowedTools ?? [],
+            maxTurns:         opts.maxTurns     ?? 20,
+            ...(opts.systemPrompt && { customSystemPrompt: opts.systemPrompt }),
+            ...(opts.model        && { model: opts.model }),
+          },
+        })
+        for await (const event of response) {
+          res.write(JSON.stringify(event) + '\n')
+        }
+      } catch (err) {
+        try { res.write(JSON.stringify({ type: 'error', error: err instanceof Error ? err.message : String(err) }) + '\n') } catch {}
+      }
+      return res.end()
+    }
+
+    // ── POST /run/collect ────────────────────────────────────────────────────
+    // Like /run but buffers the full text and returns it as JSON.
+    // Used by the plan-reviewer and conversation summariser.
+    if (method === 'POST' && url === '/run/collect') {
+      const body = await readBody(req)
+      let opts
+      try { opts = JSON.parse(body || '{}') } catch { return json(res, 400, { error: 'Invalid JSON' }) }
+
+      try {
+        const { query } = await import('@anthropic-ai/claude-code')
+        const response = query({
+          prompt: String(opts.prompt || ''),
+          options: {
+            allowedTools:     opts.allowedTools ?? [],
+            maxTurns:         opts.maxTurns     ?? 1,
+            ...(opts.systemPrompt && { customSystemPrompt: opts.systemPrompt }),
+            ...(opts.model        && { model: opts.model }),
+          },
+        })
+        let text = ''
+        for await (const event of response) {
+          if (event.type === 'assistant') {
+            for (const block of event.message?.content ?? []) {
+              if (block.type === 'text') text += block.text
+            }
+          } else if (event.type === 'result' && event.subtype === 'success') {
+            if (event.result && !text.includes(event.result.trim())) text += (text ? '\n\n' : '') + event.result
+          }
+        }
+        return json(res, 200, { text })
+      } catch (err) {
+        return json(res, 500, { error: err instanceof Error ? err.message : String(err) })
+      }
     }
 
     json(res, 404, { error: 'Not found' })

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -1,0 +1,252 @@
+/**
+ * orion-claude — persistent Claude Code sidecar for ORION
+ *
+ * Wraps the `claude` CLI with an HTTP API so ORION can:
+ *   - Check auth status
+ *   - Initiate the OAuth login flow and capture the auth URL
+ *   - Accept the pasted authorization code and forward it to claude's stdin
+ *   - Poll login progress
+ *
+ * Credentials are stored in /root/.claude (the volume mount point).
+ * ORION web reads from the same volume at /claude-creds.
+ *
+ * Endpoints:
+ *   GET  /health          — liveness probe
+ *   GET  /auth/status     — credential validity + expiry
+ *   POST /auth/login      — start claude login, return auth URL when available
+ *   POST /auth/code       — send code to running login process via stdin
+ *   GET  /auth/poll       — poll login output + status
+ *   POST /auth/cancel     — kill any running login process
+ */
+
+const http  = require('http')
+const { spawn } = require('child_process')
+const fs    = require('fs')
+const path  = require('path')
+
+const PORT       = parseInt(process.env.PORT || '3100', 10)
+const CLAUDE_HOME = process.env.CLAUDE_HOME || '/root/.claude'
+const CREDS_PATH = path.join(CLAUDE_HOME, '.credentials.json')
+
+// ── Login state ───────────────────────────────────────────────────────────────
+
+let loginProc   = null   // child_process
+let loginOutput = ''     // accumulated stdout+stderr
+let loginStatus = 'idle' // idle | starting | waiting | completing | done | error
+
+function resetLogin() {
+  if (loginProc) { try { loginProc.kill() } catch {} }
+  loginProc   = null
+  loginOutput = ''
+  loginStatus = 'idle'
+}
+
+function extractUrl(text) {
+  const m = text.match(/https:\/\/[^\s\n]+/)
+  return m ? m[0] : null
+}
+
+// ── Auth helpers ──────────────────────────────────────────────────────────────
+
+function getCredStatus() {
+  try {
+    const raw    = fs.readFileSync(CREDS_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    const oauth  = parsed?.claudeAiOauth
+    const token  = oauth?.accessToken
+    const exp    = oauth?.expiresAt
+
+    if (!token) return { authenticated: false, valid: false, reason: 'No access token' }
+
+    const valid = !exp || exp > Date.now()
+    return {
+      authenticated: true,
+      valid,
+      expiresAt: exp ? new Date(exp).toISOString() : null,
+      reason: valid ? null : 'Token expired',
+    }
+  } catch {
+    return { authenticated: false, valid: false, reason: 'No credentials file' }
+  }
+}
+
+// ── HTTP server ───────────────────────────────────────────────────────────────
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    req.on('data', chunk => { data += chunk })
+    req.on('end',  () => resolve(data))
+    req.on('error', reject)
+  })
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' })
+  res.end(JSON.stringify(body))
+}
+
+const server = http.createServer(async (req, res) => {
+  const url    = req.url.split('?')[0]
+  const method = req.method
+
+  // CORS preflight
+  if (method === 'OPTIONS') {
+    res.writeHead(204, { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET,POST', 'Access-Control-Allow-Headers': 'Content-Type' })
+    return res.end()
+  }
+
+  try {
+    // ── GET /health ──────────────────────────────────────────────────────────
+    if (method === 'GET' && url === '/health') {
+      return json(res, 200, { ok: true })
+    }
+
+    // ── GET /auth/status ─────────────────────────────────────────────────────
+    if (method === 'GET' && url === '/auth/status') {
+      return json(res, 200, getCredStatus())
+    }
+
+    // ── POST /auth/login ─────────────────────────────────────────────────────
+    if (method === 'POST' && url === '/auth/login') {
+      // If already running, return current state
+      if (loginProc && loginStatus !== 'done' && loginStatus !== 'error') {
+        return json(res, 200, {
+          status:    loginStatus,
+          authUrl:   extractUrl(loginOutput),
+          output:    loginOutput,
+        })
+      }
+
+      resetLogin()
+      loginStatus = 'starting'
+
+      console.log('[orion-claude] Starting claude login...')
+
+      loginProc = spawn('claude', ['login'], {
+        env:   { ...process.env, HOME: '/root', TERM: 'dumb' },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+
+      loginProc.stdout.on('data', (chunk) => {
+        loginOutput += chunk.toString()
+        if (loginStatus === 'starting' && extractUrl(loginOutput)) {
+          loginStatus = 'waiting'
+          console.log('[orion-claude] Auth URL captured, waiting for code')
+        }
+        console.log('[stdout]', chunk.toString().trim())
+      })
+
+      loginProc.stderr.on('data', (chunk) => {
+        loginOutput += chunk.toString()
+        console.log('[stderr]', chunk.toString().trim())
+      })
+
+      loginProc.on('close', (code) => {
+        console.log('[orion-claude] claude login exited with code', code)
+        if (code === 0) {
+          loginStatus = 'done'
+          // Copy credentials to shared volume path if needed
+          const sharedPath = '/claude-creds/.credentials.json'
+          try {
+            fs.mkdirSync('/claude-creds', { recursive: true })
+            fs.copyFileSync(CREDS_PATH, sharedPath)
+            console.log('[orion-claude] Credentials copied to shared volume')
+          } catch (e) {
+            console.log('[orion-claude] Could not copy to shared volume:', e.message)
+          }
+        } else if (loginStatus !== 'done') {
+          loginStatus = 'error'
+        }
+        loginProc = null
+      })
+
+      loginProc.on('error', (err) => {
+        loginOutput += `\nProcess error: ${err.message}\n`
+        loginStatus = 'error'
+        loginProc   = null
+      })
+
+      // Wait up to 5s for the URL to appear before responding
+      let waited = 0
+      while (!extractUrl(loginOutput) && waited < 5000 && loginStatus !== 'error') {
+        await new Promise(r => setTimeout(r, 200))
+        waited += 200
+      }
+
+      return json(res, 200, {
+        status:  loginStatus,
+        authUrl: extractUrl(loginOutput),
+        output:  loginOutput,
+      })
+    }
+
+    // ── POST /auth/code ──────────────────────────────────────────────────────
+    if (method === 'POST' && url === '/auth/code') {
+      const body = await readBody(req)
+      const { code } = JSON.parse(body || '{}')
+
+      if (!code?.trim()) {
+        return json(res, 400, { error: 'code is required' })
+      }
+
+      if (!loginProc) {
+        return json(res, 400, { error: 'No login in progress — start one first' })
+      }
+
+      console.log('[orion-claude] Sending code to claude stdin...')
+      loginProc.stdin.write(code.trim() + '\n')
+      loginStatus = 'completing'
+
+      // Give claude a moment to process
+      await new Promise(r => setTimeout(r, 1000))
+
+      return json(res, 200, {
+        status: loginStatus,
+        output: loginOutput,
+      })
+    }
+
+    // ── GET /auth/poll ───────────────────────────────────────────────────────
+    if (method === 'GET' && url === '/auth/poll') {
+      return json(res, 200, {
+        status:  loginStatus,
+        authUrl: extractUrl(loginOutput),
+        output:  loginOutput,
+        creds:   getCredStatus(),
+      })
+    }
+
+    // ── POST /auth/cancel ────────────────────────────────────────────────────
+    if (method === 'POST' && url === '/auth/cancel') {
+      resetLogin()
+      return json(res, 200, { ok: true })
+    }
+
+    // ── POST /auth/credentials ───────────────────────────────────────────────
+    // Store pasted credentials directly to /root/.claude/.credentials.json
+    if (method === 'POST' && url === '/auth/credentials') {
+      const body = await readBody(req)
+      const { credentials } = JSON.parse(body || '{}')
+      if (!credentials?.claudeAiOauth?.accessToken) {
+        return json(res, 400, { error: 'credentials.claudeAiOauth.accessToken required' })
+      }
+      fs.mkdirSync(CLAUDE_HOME, { recursive: true })
+      fs.writeFileSync(CREDS_PATH, JSON.stringify(credentials, null, 2), 'utf8')
+      console.log('[orion-claude] Credentials stored via paste')
+      return json(res, 200, { ok: true })
+    }
+
+    json(res, 404, { error: 'Not found' })
+  } catch (err) {
+    console.error('[orion-claude] Error:', err)
+    json(res, 500, { error: err.message })
+  }
+})
+
+server.listen(PORT, () => {
+  console.log(`[orion-claude] Listening on :${PORT}`)
+  console.log(`[orion-claude] Credentials path: ${CREDS_PATH}`)
+  const status = getCredStatus()
+  console.log(`[orion-claude] Auth status: ${JSON.stringify(status)}`)
+})


### PR DESCRIPTION
## Summary
- New **Admin → Claude OAuth** page with two setup paths:
  - **OAuth Flow**: clicks "Start OAuth Flow" → ORION runs `claude login` inside the `claude-refresh` container via docker exec → auth URL appears in the log output → admin visits URL → credentials saved to shared volume automatically
  - **Paste Credentials**: admin runs `claude login` locally, pastes `~/.claude/.credentials.json` contents into a textarea → saved directly to the shared volume
- Status card shows connected / expired / not configured with expiry date
- `getOAuthToken()` now includes `/claude-creds/.claude/.credentials.json` as a candidate path so the web container picks up credentials without needing `CLAUDE_CREDENTIALS_PATH` set

## How the shared volume works
`orion-claude-creds` Docker volume is mounted at `/claude-creds` in both the `orion` and `claude-refresh` containers. Credentials written there survive restarts and are picked up by both the web app (for SDK calls) and the refresh loop (for token renewal).

## Test plan
- [ ] Admin → Claude OAuth shows status card
- [ ] "Start OAuth Flow" creates a BackgroundJob, logs stream in real-time, auth URL highlighted
- [ ] After completing auth, status card shows "Connected"
- [ ] Paste flow: paste valid credentials JSON → status flips to Connected
- [ ] `getOAuthToken()` returns a token when `/claude-creds/.claude/.credentials.json` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)