### PR TITLE
fix: use node-pty for claude auth login so OAuth URL is captured

### DIFF
--- a/deploy/orion-claude/Dockerfile
+++ b/deploy/orion-claude/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20-alpine
 
+# node-pty requires native compilation
+RUN apk add --no-cache python3 make g++ libc6-compat
+
 # Install claude CLI globally
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/deploy/orion-claude/package.json
+++ b/deploy/orion-claude/package.json
@@ -3,5 +3,7 @@
   "version": "1.0.0",
   "description": "Persistent Claude Code service for ORION — handles OAuth and task execution",
   "main": "server.js",
-  "dependencies": {}
+  "dependencies": {
+    "node-pty": "^1.0.0"
+  }
 }

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -18,9 +18,9 @@
  */
 
 const http  = require('http')
-const { spawn } = require('child_process')
 const fs    = require('fs')
 const path  = require('path')
+const pty   = require('node-pty')
 
 const PORT       = parseInt(process.env.PORT || '3100', 10)
 const CLAUDE_HOME = process.env.CLAUDE_HOME || '/root/.claude'
@@ -37,6 +37,11 @@ function resetLogin() {
   loginProc   = null
   loginOutput = ''
   loginStatus = 'idle'
+}
+
+// Strip ANSI escape sequences from PTY output for clean URL extraction
+function stripAnsi(str) {
+  return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '').replace(/[\x00-\x09\x0b-\x1f\x7f]/g, '')
 }
 
 function extractUrl(text) {
@@ -119,30 +124,29 @@ const server = http.createServer(async (req, res) => {
       resetLogin()
       loginStatus = 'starting'
 
-      console.log('[orion-claude] Starting claude login...')
+      console.log('[orion-claude] Starting claude auth login (PTY)...')
 
-      loginProc = spawn('claude', ['login'], {
-        env:   { ...process.env, HOME: '/root', TERM: 'dumb' },
-        stdio: ['pipe', 'pipe', 'pipe'],
+      // Use a PTY so claude CLI sees a real terminal and displays the OAuth URL
+      loginProc = pty.spawn('claude', ['auth', 'login'], {
+        name: 'xterm-color',
+        cols: 120,
+        rows: 30,
+        env: { ...process.env, HOME: '/root', TERM: 'xterm-color', COLORTERM: 'truecolor' },
       })
 
-      loginProc.stdout.on('data', (chunk) => {
-        loginOutput += chunk.toString()
+      loginProc.onData((chunk) => {
+        const clean = stripAnsi(chunk)
+        loginOutput += clean
         if (loginStatus === 'starting' && extractUrl(loginOutput)) {
           loginStatus = 'waiting'
           console.log('[orion-claude] Auth URL captured, waiting for code')
         }
-        console.log('[stdout]', chunk.toString().trim())
+        process.stdout.write('[pty] ' + clean.trim() + '\n')
       })
 
-      loginProc.stderr.on('data', (chunk) => {
-        loginOutput += chunk.toString()
-        console.log('[stderr]', chunk.toString().trim())
-      })
-
-      loginProc.on('close', (code) => {
-        console.log('[orion-claude] claude login exited with code', code)
-        if (code === 0) {
+      loginProc.onExit(({ exitCode }) => {
+        console.log('[orion-claude] claude auth login exited with code', exitCode)
+        if (exitCode === 0) {
           loginStatus = 'done'
           // Copy credentials to shared volume path if needed
           const sharedPath = '/claude-creds/.credentials.json'
@@ -157,12 +161,6 @@ const server = http.createServer(async (req, res) => {
           loginStatus = 'error'
         }
         loginProc = null
-      })
-
-      loginProc.on('error', (err) => {
-        loginOutput += `\nProcess error: ${err.message}\n`
-        loginStatus = 'error'
-        loginProc   = null
       })
 
       // Wait up to 5s for the URL to appear before responding
@@ -192,8 +190,8 @@ const server = http.createServer(async (req, res) => {
         return json(res, 400, { error: 'No login in progress — start one first' })
       }
 
-      console.log('[orion-claude] Sending code to claude stdin...')
-      loginProc.stdin.write(code.trim() + '\n')
+      console.log('[orion-claude] Sending code to PTY...')
+      loginProc.write(code.trim() + '\r')
       loginStatus = 'completing'
 
       // Give claude a moment to process

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -181,9 +181,15 @@ const server = http.createServer(async (req, res) => {
     if (method === 'POST' && url === '/auth/code') {
       const body = await readBody(req)
       const { code } = JSON.parse(body || '{}')
+      const normalizedCode = String(code || '').trim()
 
-      if (!code?.trim()) {
+      if (!normalizedCode) {
         return json(res, 400, { error: 'code is required' })
+      }
+
+      // Accept only expected device/auth code characters to avoid PTY/control injection.
+      if (!/^[A-Za-z0-9_-]{4,128}$/.test(normalizedCode)) {
+        return json(res, 400, { error: 'Invalid code format' })
       }
 
       if (!loginProc) {
@@ -191,7 +197,7 @@ const server = http.createServer(async (req, res) => {
       }
 
       console.log('[orion-claude] Sending code to PTY...')
-      loginProc.write(code.trim() + '\r')
+      loginProc.write(normalizedCode + '\r')
       loginStatus = 'completing'
 
       // Give claude a moment to process


### PR DESCRIPTION
## Summary

- `claude auth login` requires a real TTY — without one it exits immediately with "Not logged in"
- Replaced `child_process.spawn` with `node-pty` so the CLI sees a pseudo-terminal and emits the OAuth URL
- Added `node-pty` to `package.json` and native build deps (`python3`, `make`, `g++`) to the Alpine Dockerfile
- ANSI escape sequences are stripped from PTY output before URL extraction

## Test plan
- [ ] Rebuild and restart `orion-claude` container
- [ ] Hit `POST /auth/login` — confirm response has `status: "waiting"` and a valid `authUrl`
- [ ] Complete OAuth flow end-to-end via the Admin → Claude OAuth panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)