### PR TITLE
fix: show Claude models when authenticated via orion-claude OAuth

### DIFF
--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
   let claude = false
   try {
     const { existsSync, readFileSync } = await import('fs')
-    const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.claude'
+    const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.credentials.json'
     if (existsSync(credPath)) {
       const raw = readFileSync(credPath, 'utf8')
       const parsed = JSON.parse(raw)

--- a/apps/web/src/app/api/models/route.ts
+++ b/apps/web/src/app/api/models/route.ts
@@ -1,7 +1,15 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { existsSync } from 'fs'
 
 export const dynamic = 'force-dynamic'
+
+function claudeAvailable(): boolean {
+  if (process.env.ANTHROPIC_API_KEY) return true
+  // OAuth via orion-claude sidecar — check credentials file on shared volume
+  const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.credentials.json'
+  return existsSync(credPath)
+}
 
 export interface AppModel {
   id: string        // "claude:claude-sonnet-4-6" | "gemini:..." | "ext:<cuid>"
@@ -36,8 +44,8 @@ export async function GET() {
   const isDefault = (id: string) => id === defaultModelId
 
   const builtIns: AppModel[] = [
-    ...(process.env.ANTHROPIC_API_KEY ? CLAUDE_MODELS(isDefault) : []),
-    ...(process.env.GEMINI_API_KEY    ? GEMINI_MODELS(isDefault)  : []),
+    ...(claudeAvailable()           ? CLAUDE_MODELS(isDefault) : []),
+    ...(process.env.GEMINI_API_KEY  ? GEMINI_MODELS(isDefault) : []),
   ]
 
   const extMapped: AppModel[] = external.map((m: any) => ({


### PR DESCRIPTION
## Summary

- `/api/models` was gating Claude models behind `ANTHROPIC_API_KEY` — now also checks for the credentials file written by the orion-claude OAuth flow, so Haiku/Sonnet/Opus appear in the model list once authenticated
- `/api/health` was checking `/claude-creds/.claude` (wrong path — that's a directory) instead of `/claude-creds/.credentials.json`, so the Claude health indicator was always red

## Test plan
- [ ] Complete OAuth flow via Admin → Claude OAuth
- [ ] Admin → Models: Claude Haiku/Sonnet/Opus should now show as available
- [ ] Health endpoint should show `claude: true` after authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)