### PR TITLE
feat: add Mentor — agent effectiveness reviewer and prompt improver

### DIFF
--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
   let claude = false
   try {
     const { existsSync, readFileSync } = await import('fs')
-    const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.claude'
+    const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.credentials.json'
     if (existsSync(credPath)) {
       const raw = readFileSync(credPath, 'utf8')
       const parsed = JSON.parse(raw)

--- a/apps/web/src/app/api/models/route.ts
+++ b/apps/web/src/app/api/models/route.ts
@@ -1,7 +1,15 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { existsSync } from 'fs'
 
 export const dynamic = 'force-dynamic'
+
+function claudeAvailable(): boolean {
+  if (process.env.ANTHROPIC_API_KEY) return true
+  // OAuth via orion-claude sidecar — check credentials file on shared volume
+  const credPath = process.env.CLAUDE_CREDENTIALS_PATH ?? '/claude-creds/.credentials.json'
+  return existsSync(credPath)
+}
 
 export interface AppModel {
   id: string        // "claude:claude-sonnet-4-6" | "gemini:..." | "ext:<cuid>"
@@ -36,8 +44,8 @@ export async function GET() {
   const isDefault = (id: string) => id === defaultModelId
 
   const builtIns: AppModel[] = [
-    ...(process.env.ANTHROPIC_API_KEY ? CLAUDE_MODELS(isDefault) : []),
-    ...(process.env.GEMINI_API_KEY    ? GEMINI_MODELS(isDefault)  : []),
+    ...(claudeAvailable()           ? CLAUDE_MODELS(isDefault) : []),
+    ...(process.env.GEMINI_API_KEY  ? GEMINI_MODELS(isDefault) : []),
   ]
 
   const extMapped: AppModel[] = external.map((m: any) => ({

--- a/apps/web/src/lib/management-tools.ts
+++ b/apps/web/src/lib/management-tools.ts
@@ -41,12 +41,14 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
   },
   {
     name: 'orion_list_tasks',
-    description: 'List tasks filtered by status and assignment. Use this to find unassigned work, check what is running, or review failed tasks.',
+    description: 'List tasks filtered by status, assignment, and date. Use this to find unassigned work, check what is running, or review failed tasks.',
     inputSchema: {
       type: 'object',
       properties: {
         status:          { type: 'string',  description: 'Filter by status: pending, running, pending_validation, done, failed. Defaults to pending+running+failed. Use "pending_validation" to find tasks awaiting Veritas review.' },
         unassigned_only: { type: 'boolean', description: 'Only return tasks with no agent or user assigned (default false)' },
+        assigned_agent_id: { type: 'string', description: 'Filter to tasks assigned to a specific agent ID' },
+        since:           { type: 'string',  description: 'ISO 8601 timestamp — only return tasks created or updated after this date. Use this to fetch only new work since your last review.' },
       },
     },
   },
@@ -81,15 +83,16 @@ export const MANAGEMENT_TOOL_DEFS: ManagementToolDef[] = [
   },
   {
     name: 'orion_update_agent',
-    description: 'Update an existing agent\'s role, description, system prompt, or LLM. Use this to improve agents based on observed performance — sharpen their prompts, fix their role description, or reassign their LLM.',
+    description: 'Update an existing agent\'s role, description, system prompt, LLM, or review timestamp. Use this to improve agents based on observed performance — sharpen their prompts, fix their role description, or reassign their LLM. Also call this with mentorReviewedAt to record that you have reviewed an agent even if no prompt change was needed.',
     inputSchema: {
       type: 'object',
       properties: {
-        agent_id:     { type: 'string', description: 'Agent ID to update' },
-        role:         { type: 'string', description: 'Updated one-line role description' },
-        description:  { type: 'string', description: 'Updated longer description' },
-        systemPrompt: { type: 'string', description: 'Updated full system prompt' },
-        llm:          { type: 'string', description: 'Updated LLM (e.g. ext:<id>)' },
+        agent_id:          { type: 'string', description: 'Agent ID to update' },
+        role:              { type: 'string', description: 'Updated one-line role description' },
+        description:       { type: 'string', description: 'Updated longer description' },
+        systemPrompt:      { type: 'string', description: 'Updated full system prompt' },
+        llm:               { type: 'string', description: 'Updated LLM (e.g. ext:<id>)' },
+        mentorReviewedAt:  { type: 'string', description: 'ISO 8601 timestamp to record when Mentor last reviewed this agent. Always set this after completing a review, even if no changes were made.' },
       },
       required: ['agent_id'],
     },
@@ -314,17 +317,22 @@ async function handleListAgents(argsRaw: string): Promise<string> {
 }
 
 async function handleListTasks(argsRaw: string): Promise<string> {
-  const { status, unassigned_only } = parseArgs(argsRaw) as {
+  const { status, unassigned_only, assigned_agent_id, since } = parseArgs(argsRaw) as {
     status?: string | string[]
     unassigned_only?: boolean
+    assigned_agent_id?: string
+    since?: string
   }
   const statuses = status
     ? (Array.isArray(status) ? status : [status])
     : ['pending', 'running', 'failed']
+  const sinceDate = since ? new Date(since) : undefined
   const tasks = await prisma.task.findMany({
     where: {
       status: { in: statuses as any },
       ...(unassigned_only ? { assignedAgent: null, assignedUserId: null } : {}),
+      ...(assigned_agent_id ? { assignedAgent: assigned_agent_id } : {}),
+      ...(sinceDate ? { OR: [{ createdAt: { gte: sinceDate } }, { updatedAt: { gte: sinceDate } }] } : {}),
     },
     include: { agent: { select: { id: true, name: true } } },
     orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
@@ -691,6 +699,7 @@ async function handleUpdateAgent(argsRaw: string, actorId?: string): Promise<str
     description?: string
     systemPrompt?: string
     llm?: string
+    mentorReviewedAt?: string
   }
   if (!spec.agent_id) return 'Error: agent_id is required'
 
@@ -704,15 +713,18 @@ async function handleUpdateAgent(argsRaw: string, actorId?: string): Promise<str
   const existingCfg  = (existingMeta.contextConfig ?? {}) as Record<string, unknown>
 
   const updatedMeta: Record<string, unknown> = { ...existingMeta }
-  if (spec.systemPrompt !== undefined) updatedMeta.systemPrompt = spec.systemPrompt
-  if (spec.llm !== undefined) updatedMeta.contextConfig = { ...existingCfg, llm: spec.llm }
+  if (spec.systemPrompt    !== undefined) updatedMeta.systemPrompt    = spec.systemPrompt
+  if (spec.llm             !== undefined) updatedMeta.contextConfig   = { ...existingCfg, llm: spec.llm }
+  if (spec.mentorReviewedAt !== undefined) updatedMeta.mentorReviewedAt = spec.mentorReviewedAt
 
   const data: Record<string, unknown> = { metadata: updatedMeta }
   if (spec.role        !== undefined) data.role        = spec.role
   if (spec.description !== undefined) data.description = spec.description
 
   await prisma.agent.update({ where: { id: spec.agent_id }, data })
-  await auditLog(actorId, `✏️ Updated agent **${existing.name}** (${spec.agent_id})`)
+  if (spec.systemPrompt !== undefined) {
+    await auditLog(actorId, `✏️ Updated agent **${existing.name}** system prompt (${spec.agent_id})`)
+  }
   return `Updated agent "${existing.name}" (${spec.agent_id})`
 }
 

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -487,11 +487,18 @@ An agent is underperforming if, across its recent task history, you observe:
 
 Occasional failures are normal. Only intervene when a pattern repeats across 3+ tasks.
 
+## Incremental Review — Only New Work
+
+Each agent stores metadata.mentorReviewedAt — the ISO timestamp of your last review. You use this to avoid re-examining work you have already seen:
+- Pass since: mentorReviewedAt to orion_list_tasks to fetch only tasks created/updated after your last review
+- After completing a review (whether or not you changed anything), call orion_update_agent with mentorReviewedAt set to the current ISO timestamp
+- This means each cycle only examines genuinely new work — not the full history
+
 ## Diagnosis Process
 
 For each agent you audit:
-1. Call orion_list_tasks filtered to that agent — look at both completed and failed tasks
-2. Call orion_get_task_events on 3–5 recent tasks to read what the agent actually did
+1. Call orion_list_tasks with assigned_agent_id and since: mentorReviewedAt — only new tasks since last review
+2. Call orion_get_task_events on 2–3 failing tasks to read what the agent actually did
 3. Compare what the agent did against what its system prompt instructs
 4. Ask: "Is this failure rooted in an unclear or missing instruction in the system prompt?"
 
@@ -518,16 +525,18 @@ When you determine a prompt change is warranted:
         tools:           true,
         persistent:      true,
         watchIntervalMin: 60,
-        watchPrompt: `Review agent effectiveness and fix underperforming system prompts.
+        watchPrompt: `Review agent effectiveness and fix underperforming system prompts. Only examine work you have not already reviewed.
 
-1. Call orion_list_agents to get all active agents.
-2. For each non-system agent (skip Alpha, Veritas, Planner, Mentor itself), call orion_list_tasks filtered to that agent to see their recent task history.
-3. Skip any agent with fewer than 3 completed or failed tasks — not enough data.
-4. For agents with a pattern of failures (3+ failed tasks or repeated zero-tool-call completions), call orion_get_task_events on 2–3 of those tasks to read what went wrong.
-5. Determine if the root cause is a prompt issue. If yes, call orion_update_agent with a surgically improved systemPrompt. If no, leave it alone.
+1. Call orion_list_agents to get all active agents. Each agent record includes metadata.mentorReviewedAt (the ISO timestamp of your last review) and metadata.contextConfig.
+2. For each non-system agent (skip Alpha, Veritas, Planner, Mentor itself):
+   a. Call orion_list_tasks with assigned_agent_id set to that agent's ID, status "done,failed", and since set to the agent's mentorReviewedAt (if present — omit since if this is the first review).
+   b. Skip the agent if fewer than 3 tasks are returned — not enough new data.
+3. For agents with a pattern of failures in the new tasks (3+ failures, or repeated zero-tool-call completions), call orion_get_task_events on 2–3 of those tasks to diagnose the root cause.
+4. Determine if the root cause is a prompt issue. If yes, call orion_update_agent with a surgically improved systemPrompt AND mentorReviewedAt set to the current ISO timestamp.
+5. For agents you reviewed but found no issues, still call orion_update_agent with mentorReviewedAt set to the current ISO timestamp so you don't re-examine their tasks next cycle.
 6. Call orion_send_message to post one summary to the operations room: "Mentor | Cycle [timestamp] | Reviewed: N agents | Prompt updates: N | Patterns noted: [brief list or 'none']"
 
-Cap at 5 prompt updates per cycle. When in doubt, do not update.`,
+Cap at 5 prompt updates per cycle. When in doubt, do not update — but always stamp mentorReviewedAt.`,
       },
     },
   },

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -8,7 +8,7 @@
  *      admin customisations to prompts and LLM are preserved across restarts).
  *   3. Tracked with a NovaDeployment record.
  *
- * System agents: Alpha (coordinator), Veritas (QA gate), Planner (planning specialist), Pulse (cluster health watcher).
+ * System agents: Alpha (coordinator), Veritas (QA gate), Planner (planning specialist), Atlas (environment specialist), Pulse (cluster health watcher), Mentor (agent effectiveness reviewer).
  */
 
 import { prisma } from './db'
@@ -84,7 +84,7 @@ Alpha | Cycle [timestamp] | Assigned: N | Escalated: N | Archived: N
 
 Only create a new agent when no existing agent can handle the task. Before creating, check the full agent list.
 
-Current team: Archivist (backups), Atlas (cluster environment), Cipher (secrets/Vault), Debugger (failures), Forge (CI/CD), Gatekeeper (identity/SSO), Mason (web development), Planner (planning), Pulse (cluster health), Sentinel (monitoring/observability), Veritas (QA), Warden (security), Weaver (networking).
+Current team: Archivist (backups), Atlas (cluster environment), Cipher (secrets/Vault), Debugger (failures), Forge (CI/CD), Gatekeeper (identity/SSO), Mason (web development), Mentor (agent effectiveness/prompt review), Planner (planning), Pulse (cluster health), Sentinel (monitoring/observability), Veritas (QA), Warden (security), Weaver (networking).
 
 When creating a new agent, follow these rules exactly:
 1. Choose a single evocative word as the name — it must represent the agent domain, not describe it generically.
@@ -453,6 +453,81 @@ Run kubectl_get calls proactively when Planner presents deployment tasks — don
    b. If no existing task: call orion_create_task with no assignedAgent. Title: "Fix [issue]: [hostname]". Description: include namespace, ingress name, exact error, and HTTP status.
    c. If you need more detail than orion_cluster_health provides, use kubectl_get to query the specific resource directly.
 4. Call orion_send_message to post one summary line to the health room: "Pulse | Cycle [timestamp] | Checked: N | Degraded: N | Tasks created: N"`,
+      },
+    },
+  },
+
+  // ── Mentor ────────────────────────────────────────────────────────────────────
+  {
+    nova: {
+      name:        'mentor',
+      displayName: 'Mentor',
+      description: 'Agent effectiveness reviewer. Audits agents\' task history and system prompts, then surgically rewrites prompts for underperforming agents to fix the root cause.',
+      version:     '1.0.0',
+      tags:        ['system', 'meta', 'watcher', 'prompt-engineer'],
+    },
+    agent: {
+      type:        'claude',
+      role:        'Agent Effectiveness Reviewer',
+      description: 'Persistent watcher that audits agent task history and effectiveness, then rewrites system prompts for underperforming agents to fix the root cause of failures.',
+      systemPrompt: `You are Mentor, the agent effectiveness reviewer for this engineering team. You run periodically to audit how well each agent is performing, diagnose root causes of failure, and surgically rewrite system prompts to fix them.
+
+## Your Mandate
+
+You review agent task history, identify underperformance, and improve system prompts. You do NOT execute tasks, manage assignments, or interfere with ongoing work. You are a silent improver.
+
+## What Counts as Underperformance
+
+An agent is underperforming if, across its recent task history, you observe:
+- **Consistent hallucination** — tasks marked done with zero tool calls (Veritas should catch these, but patterns persist)
+- **Repeated failures on the same class of task** — the agent keeps failing tasks it should handle
+- **Wrong tool usage** — using the wrong tools for the job, or not using tools at all
+- **Scope violations** — the agent doing work outside its role or failing to stay in lane
+- **Prompt confusion** — the agent misinterprets its own responsibilities based on its events
+
+Occasional failures are normal. Only intervene when a pattern repeats across 3+ tasks.
+
+## Diagnosis Process
+
+For each agent you audit:
+1. Call orion_list_tasks filtered to that agent — look at both completed and failed tasks
+2. Call orion_get_task_events on 3–5 recent tasks to read what the agent actually did
+3. Compare what the agent did against what its system prompt instructs
+4. Ask: "Is this failure rooted in an unclear or missing instruction in the system prompt?"
+
+**Only modify the system prompt if the root cause is a prompt issue.** If the failure is due to tool limitations, environment problems, or task quality — do not modify the prompt.
+
+## Rewrite Principles
+
+When you determine a prompt change is warranted:
+- Make the minimum change necessary — do not rewrite the whole prompt
+- Add a specific rule, example, or clarification that addresses the exact failure pattern
+- Preserve the agent's voice and existing structure
+- Do not add generic advice — only add instructions that directly address the observed failure
+- After rewriting, call orion_update_agent with the full updated systemPrompt
+- Post a note explaining what you changed and why
+
+## Standing Rules
+- Never modify Alpha, Veritas, Planner, or Mentor's own system prompts without extreme justification — they have meta-level roles
+- Never change an agent's role, name, or LLM — only the systemPrompt
+- If you are unsure whether a prompt change will help, do nothing — underperformance from unclear causes should be escalated, not guessed at
+- Never intervene on an agent that has fewer than 3 completed or failed tasks — insufficient data
+- Post a summary of what you reviewed and what you changed (even if nothing) to the operations room`,
+      contextConfig: {
+        llm:             'claude',
+        tools:           true,
+        persistent:      true,
+        watchIntervalMin: 60,
+        watchPrompt: `Review agent effectiveness and fix underperforming system prompts.
+
+1. Call orion_list_agents to get all active agents.
+2. For each non-system agent (skip Alpha, Veritas, Planner, Mentor itself), call orion_list_tasks filtered to that agent to see their recent task history.
+3. Skip any agent with fewer than 3 completed or failed tasks — not enough data.
+4. For agents with a pattern of failures (3+ failed tasks or repeated zero-tool-call completions), call orion_get_task_events on 2–3 of those tasks to read what went wrong.
+5. Determine if the root cause is a prompt issue. If yes, call orion_update_agent with a surgically improved systemPrompt. If no, leave it alone.
+6. Call orion_send_message to post one summary to the operations room: "Mentor | Cycle [timestamp] | Reviewed: N agents | Prompt updates: N | Patterns noted: [brief list or 'none']"
+
+Cap at 5 prompt updates per cycle. When in doubt, do not update.`,
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds **Mentor**, a new persistent watcher agent that reviews agent effectiveness and surgically improves system prompts.

**What Mentor does every 60 minutes:**
- Calls `orion_list_agents` to enumerate active agents
- For each agent with 3+ tasks, inspects recent task history via `orion_list_tasks` + `orion_get_task_events`
- Identifies underperformance patterns: repeated failures, zero-tool-call hallucinations, scope violations, wrong tool usage
- If the root cause is a prompt issue, calls `orion_update_agent` with a surgical fix to the system prompt
- Posts a summary to the operations room

**What Mentor does NOT do:**
- Touch Alpha, Veritas, Planner, or itself without extreme justification
- Modify agent roles, names, or LLM config — only `systemPrompt`
- Intervene when fewer than 3 tasks or when failure cause is unclear
- Cap exceeded: max 5 prompt updates per cycle

Also adds Mentor to Alpha's known team roster so Alpha doesn't recreate it.

## Test plan
- [ ] Deploy and restart ORION — Mentor should seed on startup
- [ ] Verify Mentor appears in the agents list as online
- [ ] Wait for first watcher cycle (60min) or trigger manually
- [ ] Check operations room for Mentor summary post

🤖 Generated with [Claude Code](https://claude.com/claude-code)