### PR TITLE
feat: AGENTS.md layering and planBeforeExecute flag

### DIFF
--- a/apps/web/src/lib/agents-md.ts
+++ b/apps/web/src/lib/agents-md.ts
@@ -1,0 +1,55 @@
+/**
+ * AGENTS.md Loader
+ *
+ * Reads an AGENTS.md file from the root of an environment's linked Gitea repo
+ * and caches the result per environment for 5 minutes.
+ *
+ * Supports file-based agent instruction layering — operators can commit
+ * agent instructions alongside their infrastructure code, version-controlled
+ * and reviewable in PRs (same pattern as Codex / Claude Code AGENTS.md support).
+ */
+
+import { prisma } from './db'
+import { getFileContent } from './gitea'
+
+// Cache AGENTS.md content per environment, TTL 5 minutes
+const cache = new Map<string, { content: string; fetchedAt: number }>()
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Fetch AGENTS.md from the environment's linked Gitea repo.
+ * Returns the file content as a string, or null if:
+ *   - The environment has no linked repo
+ *   - The file does not exist in the repo
+ *   - Any error occurs during fetch
+ *
+ * Results are cached per environmentId for 5 minutes.
+ */
+export async function getAgentsMd(environmentId: string): Promise<string | null> {
+  const cached = cache.get(environmentId)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.content || null
+  }
+
+  try {
+    // Get the environment's Gitea repo info
+    const env = await prisma.environment.findUnique({
+      where: { id: environmentId },
+      select: { gitOwner: true, gitRepo: true },
+    })
+    if (!env?.gitOwner || !env?.gitRepo) return null
+
+    // Read AGENTS.md from the repo root via the Gitea file content API
+    const content = await getFileContent(env.gitOwner, env.gitRepo, 'AGENTS.md')
+
+    cache.set(environmentId, { content: content ?? '', fetchedAt: Date.now() })
+    return content
+  } catch {
+    return null
+  }
+}
+
+/** Invalidate cached AGENTS.md for an environment (e.g. after a push webhook). */
+export function invalidateAgentsMdCache(environmentId: string) {
+  cache.delete(environmentId)
+}

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -433,6 +433,21 @@ Rules:
   },
 
   {
+    key: 'system.task-plan-prefix',
+    name: 'Task Plan Prefix',
+    category: 'system',
+    description: 'Prepended to a task agent\'s system prompt when planBeforeExecute is enabled. Requires the agent to output a structured plan before taking any actions.',
+    content: `Before taking any actions, first output your complete plan inside <plan> tags:
+
+<plan>
+List each step you will take, what tool you will call, and what you expect to happen.
+Only proceed to execution after the plan is complete.
+</plan>
+
+Now execute your plan step by step.`,
+  },
+
+  {
     key: 'system.agent-creation',
     name: 'Agent Creation Planning System Prompt',
     category: 'system',

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -15,6 +15,7 @@ import { MANAGEMENT_TOOL_DEFS, executeManagedTool } from './lib/management-tools
 import { getSystemRooms } from './lib/seed-system-epic'
 import { getPrompt } from './lib/system-prompts'
 import { resolveAgentGateway } from './lib/agent-gateway'
+import { getAgentsMd } from './lib/agents-md'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -225,7 +226,22 @@ async function runTask(taskId: string): Promise<void> {
     ].join('\n')
     const toolsPreamble = await getPrompt('system.task-runner-tools')
     const injectedPreamble = toolsPreamble.replace('{{toolList}}', toolList)
-    const systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + wikiContext
+
+    // Fetch AGENTS.md from the environment's Gitea repo (if linked)
+    const agentsMd = agentGw?.environmentId
+      ? await getAgentsMd(agentGw.environmentId)
+      : null
+    const agentsMdSection = agentsMd
+      ? `\n\n## Environment-Specific Instructions (from AGENTS.md)\n${agentsMd}`
+      : ''
+
+    let systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + agentsMdSection + wikiContext
+
+    // Prepend plan-before-execute instruction if configured on this agent
+    if (contextConfig.planBeforeExecute === true) {
+      const planPrefix = await getPrompt('system.task-plan-prefix')
+      systemPrompt = planPrefix + '\n\n' + systemPrompt
+    }
 
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
 
@@ -587,7 +603,16 @@ async function runWatchers() {
     ].join('\n')
     const watcherToolsPreamble = await getPrompt('system.task-runner-tools')
     const watcherInjectedPreamble = watcherToolsPreamble.replace('{{toolList}}', watcherToolList)
-    const watcherSystemPrompt = watcherInjectedPreamble + '\n\n' + systemPrompt + wikiContext
+
+    // Fetch AGENTS.md from the environment's Gitea repo (if linked)
+    const watcherAgentsMd = agentGw?.environmentId
+      ? await getAgentsMd(agentGw.environmentId)
+      : null
+    const watcherAgentsMdSection = watcherAgentsMd
+      ? `\n\n## Environment-Specific Instructions (from AGENTS.md)\n${watcherAgentsMd}`
+      : ''
+
+    const watcherSystemPrompt = watcherInjectedPreamble + '\n\n' + systemPrompt + watcherAgentsMdSection + wikiContext
 
     // Build system room context block so agents know where to post
     const roomLines = Object.entries({


### PR DESCRIPTION
## Summary

- **AGENTS.md layering**: reads `AGENTS.md` from the root of each environment's linked Gitea repo and injects its content into agent system prompts as `## Environment-Specific Instructions`. Cached per environment with 5-minute TTL, silent on missing file. Applied to both `runTask()` and `runWatchers()`.
- **planBeforeExecute flag**: setting `contextConfig.planBeforeExecute: true` on an agent prepends a structured planning instruction to the task system prompt, requiring the agent to output a `<plan>` before taking any actions. No new DB schema — just a prompt prefix keyed off an existing contextConfig field.
- **agent-gateway**: adds `environmentId` to `AgentGateway` interface so callers can access the linked environment ID without a second DB query.

## Why

Codex, Cursor, and Claude Code all support file-based instruction layering for a reason: instructions version-controlled alongside infrastructure are reviewable in PRs, team-shareable, and automatically scoped to the right environment. AGENTS.md gives cluster operators that same capability without needing to touch ORION's DB.

`planBeforeExecute` delivers structured planning before action at near-zero implementation cost — no dual-model orchestration, no new state machine.

## Test plan
- [ ] Add an `AGENTS.md` to a managed environment's Gitea repo, trigger a task — confirm `## Environment-Specific Instructions` appears in the task system prompt (visible in task events)
- [ ] Set `contextConfig.planBeforeExecute: true` on an agent, assign a task — confirm the agent outputs `<plan>...</plan>` before the first tool call
- [ ] Remove `AGENTS.md` from repo — confirm ORION silently continues (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)