### PR TITLE
feat: tool lifecycle hook system with pre/post hooks

### DIFF
--- a/apps/web/src/lib/agent-runner/ollama-runner.ts
+++ b/apps/web/src/lib/agent-runner/ollama-runner.ts
@@ -3,6 +3,7 @@ import { GatewayClient } from './gateway-client'
 import { getPrompt, interpolate } from '@/lib/system-prompts'
 import { validateToolArgs } from '@/lib/tool-registry'
 import { checkToolPermission } from '@/lib/tool-permissions'
+import { runPreHooks, runPostHooks } from '@/lib/tool-hooks'
 
 interface OllamaMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
@@ -127,18 +128,47 @@ export const ollamaRunner: AgentRunner = {
               continue
             }
 
+            // Pre-hook — may block or modify args
+            const preDecision = await runPreHooks({
+              event: 'pre',
+              toolName: fn.name,
+              args: parsedArgs,
+              agentId: ctx.agentId,
+              taskId: ctx.taskId,
+              environmentId: ctx.environmentId,
+            })
+            if (preDecision.action === 'block') {
+              result = `Blocked by pre-hook: ${preDecision.reason ?? 'no reason given'}`
+              yield { type: 'tool_result', tool: fn.name, result }
+              messages.push({ role: 'tool', content: result })
+              continue
+            }
+
+            const effectiveArgs = preDecision.action === 'modify' ? preDecision.modifiedArgs : parsedArgs
+            const effectiveArgsRaw = preDecision.action === 'modify' ? JSON.stringify(effectiveArgs) : argsRaw
+
             if (ctx.managementTools && ctx.managementTools.definitions.some(d => d.name === fn.name)) {
-              result = await ctx.managementTools.execute(fn.name, argsRaw)
+              result = await ctx.managementTools.execute(fn.name, effectiveArgsRaw)
             } else if (gateway) {
               try {
-                const args = JSON.parse(argsRaw)
-                result = await gateway.executeTool(fn.name, args)
+                result = await gateway.executeTool(fn.name, effectiveArgs as Record<string, unknown>)
               } catch (err) {
                 result = `Error: ${err instanceof Error ? err.message : String(err)}`
               }
             } else {
               result = 'No gateway connected — cannot execute tools'
             }
+
+            // Post-hook — audit, redact, cost tracking
+            await runPostHooks({
+              event: 'post',
+              toolName: fn.name,
+              args: effectiveArgs,
+              result,
+              agentId: ctx.agentId,
+              taskId: ctx.taskId,
+              environmentId: ctx.environmentId,
+            })
 
             yield { type: 'tool_result', tool: fn.name, result }
             messages.push({ role: 'tool', content: result })

--- a/apps/web/src/lib/agent-runner/openai-runner.ts
+++ b/apps/web/src/lib/agent-runner/openai-runner.ts
@@ -3,6 +3,7 @@ import { GatewayClient } from './gateway-client'
 import { getPrompt, interpolate } from '@/lib/system-prompts'
 import { validateToolArgs } from '@/lib/tool-registry'
 import { checkToolPermission } from '@/lib/tool-permissions'
+import { runPreHooks, runPostHooks } from '@/lib/tool-hooks'
 
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
@@ -136,18 +137,47 @@ export const openaiRunner: AgentRunner = {
               continue
             }
 
+            // Pre-hook — may block or modify args
+            const preDecision = await runPreHooks({
+              event: 'pre',
+              toolName: fn.name,
+              args: parsedArgs,
+              agentId: ctx.agentId,
+              taskId: ctx.taskId,
+              environmentId: ctx.environmentId,
+            })
+            if (preDecision.action === 'block') {
+              result = `Blocked by pre-hook: ${preDecision.reason ?? 'no reason given'}`
+              yield { type: 'tool_result', tool: fn.name, result }
+              messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result })
+              continue
+            }
+
+            const effectiveArgs = preDecision.action === 'modify' ? preDecision.modifiedArgs : parsedArgs
+            const effectiveArgsRaw = preDecision.action === 'modify' ? JSON.stringify(effectiveArgs) : argsRaw
+
             if (ctx.managementTools && ctx.managementTools.definitions.some(d => d.name === fn.name)) {
-              result = await ctx.managementTools.execute(fn.name, argsRaw)
+              result = await ctx.managementTools.execute(fn.name, effectiveArgsRaw)
             } else if (gateway) {
               try {
-                const args = JSON.parse(argsRaw)
-                result = await gateway.executeTool(fn.name, args)
+                result = await gateway.executeTool(fn.name, effectiveArgs as Record<string, unknown>)
               } catch (err) {
                 result = `Error: ${err instanceof Error ? err.message : String(err)}`
               }
             } else {
               result = 'No gateway connected — cannot execute tools'
             }
+
+            // Post-hook — audit, redact, cost tracking
+            await runPostHooks({
+              event: 'post',
+              toolName: fn.name,
+              args: effectiveArgs,
+              result,
+              agentId: ctx.agentId,
+              taskId: ctx.taskId,
+              environmentId: ctx.environmentId,
+            })
 
             yield { type: 'tool_result', tool: fn.name, result }
             messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result })

--- a/apps/web/src/lib/tool-hooks.ts
+++ b/apps/web/src/lib/tool-hooks.ts
@@ -1,0 +1,103 @@
+import { redactSensitive } from '@/lib/redact'
+
+export type HookEvent = 'pre' | 'post'
+
+export interface HookContext {
+  event: HookEvent
+  toolName: string
+  args: unknown
+  result?: string        // only for 'post' hooks
+  agentId?: string
+  taskId?: string
+  environmentId?: string
+}
+
+export interface HookDecision {
+  action: 'allow' | 'block' | 'modify'
+  reason?: string
+  modifiedArgs?: unknown  // only if action === 'modify'
+}
+
+export type ToolHookFn = (ctx: HookContext) => Promise<HookDecision>
+
+// Hook registry — built-in hooks registered at module load
+const preHooks: ToolHookFn[] = []
+const postHooks: ToolHookFn[] = []
+
+export function registerPreHook(fn: ToolHookFn) { preHooks.push(fn) }
+export function registerPostHook(fn: ToolHookFn) { postHooks.push(fn) }
+
+export async function runPreHooks(ctx: HookContext): Promise<HookDecision> {
+  for (const hook of preHooks) {
+    const decision = await hook(ctx)
+    if (decision.action !== 'allow') return decision
+  }
+  return { action: 'allow' }
+}
+
+export async function runPostHooks(ctx: HookContext): Promise<void> {
+  for (const hook of postHooks) {
+    try { await hook(ctx) } catch (e) { console.warn('[hook] post-hook error:', e) }
+  }
+}
+
+// ─── Built-in Hooks ───────────────────────────────────────────────────────────
+
+// 1. audit-log (post hook): Log every tool call + result summary
+registerPostHook(async (ctx) => {
+  console.log(JSON.stringify({
+    hook: 'audit-log',
+    ts: new Date().toISOString(),
+    agent: ctx.agentId,
+    task: ctx.taskId,
+    tool: ctx.toolName,
+    resultLen: ctx.result?.length ?? 0,
+  }))
+  return { action: 'allow' }
+})
+
+// 2. secret-redact (post hook): Strip secrets from tool results before storage
+registerPostHook(async (ctx) => {
+  if (ctx.result) {
+    ctx.result = redactSensitive(ctx.result)
+  }
+  return { action: 'allow' }
+})
+
+// 3. destructive-gate (pre hook): Audit trail for destructive patterns
+const DESTRUCTIVE_PATTERNS = [
+  /kubectl.*delete/i,
+  /helm.*uninstall/i,
+  /rm\s+-rf/i,
+  /talos.*reset/i,
+]
+
+registerPreHook(async (ctx) => {
+  const argsStr = JSON.stringify(ctx.args ?? '')
+  const isDestructive = DESTRUCTIVE_PATTERNS.some(p =>
+    p.test(ctx.toolName) || p.test(argsStr)
+  )
+  if (isDestructive) {
+    // Log and allow — the permission system in tool-permissions.ts handles blocking
+    // This hook just adds an audit trail for destructive patterns
+    console.warn(`[destructive-gate] Destructive pattern detected: ${ctx.toolName} by agent ${ctx.agentId}`)
+  }
+  return { action: 'allow' }
+})
+
+// 4. cost-tracker (post hook): Track token usage per agent+task
+const agentCostMap = new Map<string, number>()
+const COST_WARN_THRESHOLD = 500_000
+
+registerPostHook(async (ctx) => {
+  if (ctx.agentId && ctx.result) {
+    const key = `${ctx.agentId}:${ctx.taskId}`
+    const current = agentCostMap.get(key) ?? 0
+    const updated = current + ctx.result.length
+    agentCostMap.set(key, updated)
+    if (updated > COST_WARN_THRESHOLD && current <= COST_WARN_THRESHOLD) {
+      console.warn(`[cost-tracker] Agent ${ctx.agentId} task ${ctx.taskId} has consumed ${updated} chars of tool output`)
+    }
+  }
+  return { action: 'allow' }
+})


### PR DESCRIPTION
## Summary

- Creates `lib/tool-hooks.ts` — a hook registry with `registerPreHook`/`registerPostHook`, `runPreHooks`/`runPostHooks`, and `allow`/`block`/`modify` decisions
- Wired into `openai-runner` and `ollama-runner` around every tool call: pre-hook runs before execution (can block with message to LLM), post-hook runs after (audit/redact/track)
- Adds `environmentId` to `TaskRunContext` so hooks have full execution context
- Four built-in hooks registered at startup:
  - **audit-log** (post): structured JSON log of every tool call + result length
  - **secret-redact** (post): strips secrets from tool results before they persist
  - **destructive-gate** (pre): warns on `kubectl delete` / `helm uninstall` / `rm -rf` patterns
  - **cost-tracker** (post): per-agent:task char counter, warns at 500k chars

## Why

Without lifecycle hooks, adding cross-cutting concerns (auditing, redaction, cost tracking, safety gates) requires modifying the runner directly. The hook system makes these first-class extension points — new hooks can be registered without touching the execution loop. It also provides the foundation for future per-agent hooks stored in `agent.metadata`.

## Test plan
- [ ] Check logs after a task runs — confirm structured `audit-log` JSON entries appear
- [ ] Assign a task that calls a tool with a secret in the result — confirm it's redacted in stored `TaskEvent`
- [ ] Write a pre-hook that blocks a specific tool — confirm the LLM receives the block message and self-corrects

🤖 Generated with [Claude Code](https://claude.com/claude-code)