### PR TITLE
feat: add GET /api/tasks/:id/stream SSE endpoint for live task progress

### DIFF
--- a/apps/web/src/app/api/tasks/[id]/stream/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/stream/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/db'
+import { createSSEStream } from '@/lib/sse'
+
+const POLL_INTERVAL_MS = 2_000
+const TERMINAL_STATES  = new Set(['completed', 'failed', 'cancelled'])
+
+/**
+ * GET /api/tasks/:id/stream
+ *
+ * Server-Sent Events stream for live task progress. Polls the DB every 2s
+ * and emits three event types:
+ *
+ *  event: task_event  — a new TaskEvent row (tool_call, tool_result, text, status_change…)
+ *  event: status      — the task's current status string (emitted on each status change)
+ *  event: done        — task reached a terminal state; stream closes automatically
+ *
+ * Clients can pass `?after=<eventId>` to resume from a known position so they
+ * don't replay events they've already processed.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const taskId = params.id
+  const afterParam = req.nextUrl.searchParams.get('after') ?? undefined
+
+  // Verify the task exists before opening the stream
+  const task = await prisma.task.findUnique({ where: { id: taskId }, select: { id: true, status: true } })
+  if (!task) {
+    return new Response('Task not found', { status: 404 })
+  }
+
+  // If already terminal, send a single done event and close immediately
+  if (TERMINAL_STATES.has(task.status)) {
+    return createSSEStream((_send, close) => {
+      _send('status', { status: task.status })
+      _send('done',   { status: task.status })
+      close()
+      return () => {}
+    })
+  }
+
+  return createSSEStream((send, close) => {
+    let lastEventId  = afterParam
+    let lastStatus   = task.status
+    let timer: ReturnType<typeof setInterval> | null = null
+
+    const poll = async () => {
+      try {
+        // Fetch new events since the last one we sent
+        const newEvents = await prisma.taskEvent.findMany({
+          where: {
+            taskId,
+            ...(lastEventId ? { id: { gt: lastEventId } } : {}),
+          },
+          orderBy: { createdAt: 'asc' },
+        })
+
+        for (const ev of newEvents) {
+          send('task_event', {
+            id:        ev.id,
+            eventType: ev.eventType,
+            content:   ev.content,
+            agentId:   ev.agentId,
+            createdAt: ev.createdAt,
+          })
+          lastEventId = ev.id
+        }
+
+        // Check for status change
+        const current = await prisma.task.findUnique({
+          where: { id: taskId },
+          select: { status: true },
+        })
+        if (!current) {
+          // Task was deleted
+          send('done', { status: 'deleted' })
+          close()
+          return
+        }
+
+        if (current.status !== lastStatus) {
+          lastStatus = current.status
+          send('status', { status: current.status })
+        }
+
+        if (TERMINAL_STATES.has(current.status)) {
+          send('done', { status: current.status })
+          close()
+        }
+      } catch {
+        // DB hiccup — keep the stream alive, try again next tick
+      }
+    }
+
+    // Initial poll immediately, then on interval
+    poll()
+    timer = setInterval(poll, POLL_INTERVAL_MS)
+
+    // Cleanup function called on stream cancel / client disconnect
+    return () => {
+      if (timer !== null) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- New `GET /api/tasks/:id/stream` route using `createSSEStream` (same pattern as `/api/k8s/stream` and `/api/chat/.../stream`)
- Polls DB every 2s and emits three SSE event types:
  - `task_event` — new `TaskEvent` rows as they appear (tool_call, tool_result, text, status_change, etc.)
  - `status` — emitted whenever the task's status field changes
  - `done` — task reached a terminal state (`completed`/`failed`/`cancelled`); stream closes
- `?after=<eventId>` query param for resumable streams — clients skip already-seen events on reconnect
- Tasks already in a terminal state receive an immediate `status`+`done` event without polling

## Test plan
- [ ] Open `GET /api/tasks/<id>/stream` while a task is running and verify `task_event` events stream in real time
- [ ] Verify `status` event fires when task moves `pending → in_progress → completed`
- [ ] Verify `done` event closes the stream after terminal state
- [ ] Connect with `?after=<eventId>` and verify only events after that ID are replayed
- [ ] Connect to an already-completed task and verify immediate `done` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)