### PR TITLE
fix: dream mode type error + Claude MCP tool harness + learning loop

### DIFF
--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -1,0 +1,120 @@
+/**
+ * ORION MCP Server — exposes the tool registry to Claude via the
+ * Model Context Protocol (MCP) streamable-HTTP transport.
+ *
+ * The orion-claude sidecar writes a per-request .mcp.json pointing here,
+ * so Claude can call ORION tools natively instead of going around the system.
+ *
+ * Auth: x-mcp-token header (ORION_MCP_TOKEN env var, same secret in both containers).
+ * Context: agentId and roomId are passed as query params per request.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getToolsForContext, executeRegisteredTool } from '@/lib/tool-registry'
+import { prisma } from '@/lib/db'
+
+const MCP_TOKEN = process.env.ORION_MCP_TOKEN
+
+type JsonRpcRequest = {
+  jsonrpc: string
+  id?: string | number | null
+  method: string
+  params?: unknown
+}
+
+function ok(id: unknown, result: unknown) {
+  return NextResponse.json({ jsonrpc: '2.0', id, result })
+}
+
+function err(id: unknown, code: number, message: string) {
+  return NextResponse.json({ jsonrpc: '2.0', id, error: { code, message } })
+}
+
+export async function POST(req: NextRequest) {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  if (MCP_TOKEN) {
+    const token = req.headers.get('x-mcp-token')
+    if (token !== MCP_TOKEN) {
+      return NextResponse.json(
+        { jsonrpc: '2.0', error: { code: -32001, message: 'Unauthorized' }, id: null },
+        { status: 401 },
+      )
+    }
+  }
+
+  // ── Per-request context (agent and room for tool execution) ───────────────
+  const { searchParams } = new URL(req.url)
+  const agentId = searchParams.get('agentId') ?? undefined
+  const roomId  = searchParams.get('roomId')  ?? undefined
+
+  // ── Parse body ───────────────────────────────────────────────────────────
+  let body: JsonRpcRequest
+  try {
+    body = await req.json()
+  } catch {
+    return err(null, -32700, 'Parse error')
+  }
+
+  const { id, method, params } = body
+
+  // MCP notifications have no id and expect no response body
+  if (id === undefined || id === null) {
+    return new NextResponse(null, { status: 202 })
+  }
+
+  // ── Dispatch ──────────────────────────────────────────────────────────────
+  switch (method) {
+    // Handshake
+    case 'initialize':
+      return ok(id, {
+        protocolVersion: '2024-11-05',
+        capabilities:    { tools: {} },
+        serverInfo:      { name: 'orion', version: '1.0.0' },
+      })
+
+    case 'ping':
+      return ok(id, {})
+
+    // Tool discovery
+    case 'tools/list': {
+      const tools = getToolsForContext('chat')
+      return ok(id, {
+        tools: tools.map(t => ({
+          name:        t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      })
+    }
+
+    // Tool execution
+    case 'tools/call': {
+      const p        = params as { name?: string; arguments?: Record<string, unknown> } | undefined
+      const toolName = p?.name
+      const toolArgs = p?.arguments ?? {}
+
+      if (!toolName) return err(id, -32602, 'Missing required param: name')
+
+      try {
+        const result = await executeRegisteredTool(toolName, toolArgs, {
+          agentId,
+          roomId,
+          prisma,
+        })
+        return ok(id, {
+          content: [{ type: 'text', text: result }],
+          isError: false,
+        })
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        return ok(id, {
+          content: [{ type: 'text', text: `Error: ${msg}` }],
+          isError: true,
+        })
+      }
+    }
+
+    default:
+      return err(id, -32601, `Method not found: ${method}`)
+  }
+}

--- a/apps/web/src/lib/dream.ts
+++ b/apps/web/src/lib/dream.ts
@@ -35,7 +35,7 @@ const MAX_NOTE_AGE_DAYS      = 90   // never auto-delete notes newer than this
 
 async function getDreamModelId(): Promise<string> {
   const dreamModel = await prisma.systemSetting.findUnique({ where: { key: 'dream.model' } })
-  if (dreamModel?.value) return dreamModel.value
+  if (dreamModel?.value && typeof dreamModel.value === 'string') return dreamModel.value
 
   // Fall back to system default
   const { getDefaultModelId } = await import('./default-model')

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -453,8 +453,11 @@ export async function triggerRoomAgentReplies(
           reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext)
         } else {
           // claude / claude:<model> — routed through orion-claude sidecar
+          // hasTools is forced false: the sidecar /run/collect endpoint does not support
+          // tool execution — passing true causes the model to attempt tool calls that the
+          // CLI cannot handle, resulting in a non-zero exit and HTTP 500.
           const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext)
+          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, false)
           if (reply === null) {
             // Claude is unavailable — post a message on the agent's behalf rather than silently skipping
             console.warn(`[room-agents] ${agent.name}: Claude unavailable, posting unavailability notice`)

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -45,13 +45,22 @@ type ChatMsg = { role: 'system' | 'user' | 'assistant'; content: string }
  * otherParticipants lists the names of other agents/users in the room so the
  * model knows who it can @mention to continue the conversation.
  */
-function buildSystemPrompt(agentName: string, agentBasePrompt: string, otherParticipants: string[], hasTools = false): string {
+function buildSystemPrompt(
+  agentName: string,
+  agentBasePrompt: string,
+  otherParticipants: string[],
+  hasTools: false | 'legacy' | 'mcp' = false,
+): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
     : 'You are the only agent in this chat.'
   const mentionHint = otherParticipants.length > 0
     ? `To address or continue the conversation with another participant, use @TheirName in your reply (e.g. "@${otherParticipants[0]} what do you think?"). This will notify them and invite their response.`
     : ''
+  const toolAddendum =
+    hasTools === 'mcp'    ? '\n\n## ORION Tools\nYou have ORION management tools available via MCP. Use them — do not describe hypothetical actions when you can call a tool to get real data.' :
+    hasTools === 'legacy' ? TOOLS_SYSTEM_ADDENDUM :
+    ''
   return `IMPORTANT — YOUR ROLE:
 You are ${agentName}. You are ONE participant in a group chat.
 ${othersLine}
@@ -66,7 +75,7 @@ Rules you must follow without exception:
 7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT
 
 ---
-${agentBasePrompt}${hasTools ? TOOLS_SYSTEM_ADDENDUM : ''}`
+${agentBasePrompt}${toolAddendum}`
 }
 
 /**
@@ -87,7 +96,9 @@ function buildChatMessages(history: HistoryEntry[], latestMessage: string): Chat
   return messages
 }
 
-/** Claude Code SDK — OAuth credentials, same path as streamClaudeResponse */
+/** Claude Code SDK — OAuth credentials, routed through orion-claude sidecar.
+ *  When agentId + roomId are supplied, the sidecar writes a per-request .mcp.json
+ *  so Claude can call ORION tools natively via MCP instead of going around the system. */
 async function callClaude(
   agentName: string,
   agentBasePrompt: string,
@@ -96,8 +107,12 @@ async function callClaude(
   latestMessage: string,
   modelId?: string,
   hasTools = false,
+  agentId?: string,
+  roomId?: string,
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
+  const useMcp = hasTools && !!agentId && !!roomId
+  const toolMode: false | 'legacy' | 'mcp' = useMcp ? 'mcp' : hasTools ? 'legacy' : false
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, toolMode)
   const historyBlock = history.length
     ? history.map(e => `${e.name}: ${e.content}`).join('\n') + '\n\n'
     : ''
@@ -108,11 +123,12 @@ async function callClaude(
     body:    JSON.stringify({
       prompt,
       systemPrompt: sys,
-      allowedTools: [],
-      maxTurns:     1,
+      // MCP context: sidecar writes .mcp.json and gives Claude up to 10 turns
+      ...(useMcp ? { agentId, roomId, maxTurns: 10 } : { maxTurns: 1 }),
       ...(modelId ? { model: modelId } : {}),
     }),
-    signal: AbortSignal.timeout(120_000),
+    // MCP tool calls can take longer — allow 5 min for tool-using sessions
+    signal: AbortSignal.timeout(useMcp ? 300_000 : 120_000),
   }).catch((e: Error) => { console.error(`[room-agents] orion-claude fetch failed: ${e.message}`); return null })
   if (!res?.ok) {
     console.error(`[room-agents] orion-claude /run/collect returned HTTP ${res?.status}`)
@@ -452,12 +468,11 @@ export async function triggerRoomAgentReplies(
           }
           reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext)
         } else {
-          // claude / claude:<model> — routed through orion-claude sidecar
-          // hasTools is forced false: the sidecar /run/collect endpoint does not support
-          // tool execution — passing true causes the model to attempt tool calls that the
-          // CLI cannot handle, resulting in a non-zero exit and HTTP 500.
+          // claude / claude:<model> — routed through orion-claude sidecar.
+          // When tools are enabled, the sidecar writes a per-request .mcp.json so Claude
+          // calls ORION tools natively via MCP (ORION is the harness, Claude is the brain).
           const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, false)
+          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext, agent.id, roomId)
           if (reply === null) {
             // Claude is unavailable — post a message on the agent's behalf rather than silently skipping
             console.warn(`[room-agents] ${agent.name}: Claude unavailable, posting unavailability notice`)

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -40,6 +40,7 @@ export interface ToolDefinition {
 export interface ToolExecutionContext {
   agentId?: string
   taskId?: string
+  roomId?: string
   environmentId?: string
   userId?: string
   prisma: typeof prisma

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,6 +45,13 @@ LOCALHOST_JOIN_TOKEN=change-me-generate-with-openssl-rand-hex-32
 # Set if using Claude API key auth instead of OAuth
 ANTHROPIC_API_KEY=
 
+# ── MCP service token — shared between orion and orion-claude ──────────────────
+# Authenticates the claude sidecar → ORION MCP server so Claude can call ORION
+# tools natively (ORION is the harness, Claude is the brain).
+# Required for tool calling to work in chat rooms and task runs.
+# Generate: openssl rand -hex 32
+ORION_MCP_TOKEN=change-me-generate-with-openssl-rand-hex-32
+
 # ── Redis (for distributed rate limiting) ──────────────────────────────────────
 # Use one of these connection methods:
 #   1. REDIS_URL — standard Redis URL (e.g., redis://host:6379/0)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       # Claude Code sidecar URL (for OAuth bootstrap and credential status)
       ORION_CLAUDE_URL: ${ORION_CLAUDE_URL:-http://orion-claude:3100}
+      # MCP service token — shared with orion-claude so Claude can call ORION tools via MCP
+      ORION_MCP_TOKEN: ${ORION_MCP_TOKEN:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - orion-claude-creds:/claude-creds
@@ -295,6 +297,8 @@ services:
     environment:
       PORT: 3100
       CLAUDE_HOME: /root/.claude
+      ORION_URL: http://orion:3000
+      ORION_MCP_TOKEN: ${ORION_MCP_TOKEN:-}
     deploy:
       resources:
         limits:

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -364,9 +364,53 @@ const server = http.createServer(async (req, res) => {
   }
 })
 
+// ── Token refresh watchdog ────────────────────────────────────────────────────
+// Checks every 30 minutes. If the token expires within 2 hours, runs
+// `claude auth refresh` to get a fresh token before it goes invalid.
+
+function scheduleTokenRefresh() {
+  const CHECK_INTERVAL_MS = 30 * 60 * 1000   // 30 min
+  const REFRESH_THRESHOLD_MS = 2 * 60 * 60 * 1000 // refresh if expiry < 2h away
+
+  function check() {
+    const status = getCredStatus()
+    if (!status.authenticated) {
+      console.warn('[orion-claude] token-watchdog: not authenticated, skipping refresh check')
+      return
+    }
+    if (!status.expiresAt) return  // no expiry info — nothing to do
+
+    const expiresAt = new Date(status.expiresAt).getTime()
+    const now = Date.now()
+    const ttl = expiresAt - now
+
+    if (ttl < REFRESH_THRESHOLD_MS) {
+      console.log(`[orion-claude] token-watchdog: token expires in ${Math.round(ttl / 60000)}min — refreshing`)
+      execFile('claude', ['auth', 'refresh'], { env: process.env, timeout: 30000 }, (err, stdout, stderr) => {
+        if (err) {
+          console.error('[orion-claude] token-watchdog: refresh failed:', err.message, stderr?.slice(0, 200))
+        } else {
+          console.log('[orion-claude] token-watchdog: refresh succeeded')
+          // Copy refreshed credentials to shared volume if present
+          const sharedPath = '/claude-creds/.credentials.json'
+          try {
+            fs.mkdirSync('/claude-creds', { recursive: true })
+            fs.copyFileSync(CREDS_PATH, sharedPath)
+          } catch {}
+        }
+      })
+    }
+  }
+
+  // Run once at startup, then on interval
+  check()
+  setInterval(check, CHECK_INTERVAL_MS)
+}
+
 server.listen(PORT, () => {
   console.log(`[orion-claude] Listening on :${PORT}`)
   console.log(`[orion-claude] Credentials path: ${CREDS_PATH}`)
   const status = getCredStatus()
   console.log(`[orion-claude] Auth status: ${JSON.stringify(status)}`)
+  scheduleTokenRefresh()
 })

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -19,12 +19,15 @@
 
 const http       = require('http')
 const fs         = require('fs')
+const os         = require('os')
 const path       = require('path')
 const pty        = require('node-pty')
 const { execFile } = require('child_process')
 
-const PORT       = parseInt(process.env.PORT || '3100', 10)
+const PORT        = parseInt(process.env.PORT || '3100', 10)
 const CLAUDE_HOME = process.env.CLAUDE_HOME || '/root/.claude'
+const ORION_URL   = process.env.ORION_URL   || 'http://orion:3000'
+const MCP_TOKEN   = process.env.ORION_MCP_TOKEN || ''
 const CREDS_PATH = path.join(CLAUDE_HOME, '.credentials.json')
 
 // ── Login state ───────────────────────────────────────────────────────────────
@@ -76,25 +79,64 @@ function sanitizeMaxTurns(maxTurns, fallback = 20) {
 }
 
 /**
+ * Write a temporary directory containing .mcp.json so the claude CLI can call
+ * ORION tools via MCP for this specific agent+room combination.
+ * Returns the temp dir path — caller must clean it up after execFile completes.
+ */
+function writeMcpDir(agentId, roomId) {
+  const url = `${ORION_URL}/api/mcp?agentId=${encodeURIComponent(agentId)}&roomId=${encodeURIComponent(roomId)}`
+  const config = {
+    mcpServers: {
+      orion: {
+        type: 'http',
+        url,
+        ...(MCP_TOKEN ? { headers: { 'x-mcp-token': MCP_TOKEN } } : {}),
+      },
+    },
+  }
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orion-mcp-'))
+  fs.writeFileSync(path.join(tmpDir, '.mcp.json'), JSON.stringify(config, null, 2))
+  return tmpDir
+}
+
+/**
  * Call the `claude` CLI as a subprocess — same approach as the Discord bot.
  * Strips ANTHROPIC_API_KEY and CLAUDECODE from env to force OAuth credential use.
+ * When agentId + roomId are provided, writes a .mcp.json so Claude can call
+ * ORION tools natively — ORION is the harness, Claude is the brain.
  */
-function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 120000 } = {}) {
+function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 120000, agentId, roomId } = {}) {
   return new Promise((resolve, reject) => {
-    const safeModel = sanitizeModel(model)
+    const safeModel       = sanitizeModel(model)
     const safeSystemPrompt = sanitizeSystemPrompt(systemPrompt)
-    const safeMaxTurns = sanitizeMaxTurns(maxTurns, 20)
+    const useMcp          = !!(agentId && roomId)
+    const safeMaxTurns    = sanitizeMaxTurns(maxTurns, useMcp ? 10 : 1)
 
     const args = ['-p', String(prompt), '--output-format', 'json']
     if (safeModel)        args.push('--model', safeModel)
     if (safeSystemPrompt) args.push('--append-system-prompt', safeSystemPrompt)
-    if (safeMaxTurns)     args.push('--max-turns', String(safeMaxTurns))
+    args.push('--max-turns', String(safeMaxTurns))
 
     const env = Object.fromEntries(
       Object.entries(process.env).filter(([k]) => k !== 'ANTHROPIC_API_KEY' && k !== 'CLAUDECODE')
     )
 
-    const child = execFile('claude', args, { env, timeout, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+    // Per-request MCP dir: claude picks up .mcp.json from cwd
+    let tmpDir = null
+    let cwd    = undefined
+    if (useMcp) {
+      try {
+        tmpDir = writeMcpDir(agentId, roomId)
+        cwd    = tmpDir
+        console.log(`[orion-claude] MCP enabled — agent=${agentId} room=${roomId} url=${ORION_URL}/api/mcp`)
+      } catch (e) {
+        console.error('[orion-claude] Failed to write MCP config, falling back to no-tools:', e.message)
+      }
+    }
+
+    const child = execFile('claude', args, { env, timeout, maxBuffer: 10 * 1024 * 1024, cwd }, (err, stdout, stderr) => {
+      // Always clean up the temp dir
+      if (tmpDir) { try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch {} }
       if (err) {
         console.error('[orion-claude] claude CLI error:', err.message, stderr?.slice(0, 300))
         return reject(err)
@@ -340,11 +382,14 @@ const server = http.createServer(async (req, res) => {
       try { opts = JSON.parse(body || '{}') } catch { return json(res, 400, { error: 'Invalid JSON' }) }
 
       try {
+        const useMcp = !!(opts.agentId && opts.roomId)
         const stdout = await runClaude(String(opts.prompt || ''), {
           systemPrompt: opts.systemPrompt,
           model:        opts.model,
-          maxTurns:     opts.maxTurns ?? 1,
-          timeout:      120000,
+          maxTurns:     opts.maxTurns ?? (useMcp ? 10 : 1),
+          timeout:      useMcp ? 300000 : 120000,
+          agentId:      opts.agentId,
+          roomId:       opts.roomId,
         })
         let text = stdout.trim()
         try {

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -452,10 +452,47 @@ function scheduleTokenRefresh() {
   setInterval(check, CHECK_INTERVAL_MS)
 }
 
+// ── Bootstrap Claude Code global MCP settings ────────────────────────────────
+// Writes ~/.claude.json with the ORION MCP server so Claude Code always has
+// ORION as its tool harness — both for task runs and fallback during chat.
+// The per-request .mcp.json in chat rooms merges on top with agentId/roomId.
+
+function bootstrapMcpSettings() {
+  if (!ORION_URL || !MCP_TOKEN) {
+    console.log('[orion-claude] bootstrap-mcp: ORION_URL or ORION_MCP_TOKEN not set — skipping global MCP config')
+    return
+  }
+
+  const claudeJsonPath = path.join(CLAUDE_HOME, 'claude.json')
+
+  let existing = {}
+  try {
+    existing = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'))
+  } catch { /* first run or missing — start fresh */ }
+
+  // Merge: preserve all existing settings, upsert only the orion MCP entry
+  const updated = {
+    ...existing,
+    mcpServers: {
+      ...(existing.mcpServers ?? {}),
+      orion: {
+        type: 'http',
+        url:  `${ORION_URL}/api/mcp`,
+        headers: { 'x-mcp-token': MCP_TOKEN },
+      },
+    },
+  }
+
+  fs.mkdirSync(CLAUDE_HOME, { recursive: true })
+  fs.writeFileSync(claudeJsonPath, JSON.stringify(updated, null, 2), 'utf8')
+  console.log(`[orion-claude] bootstrap-mcp: ORION MCP server registered in ${claudeJsonPath}`)
+}
+
 server.listen(PORT, () => {
   console.log(`[orion-claude] Listening on :${PORT}`)
   console.log(`[orion-claude] Credentials path: ${CREDS_PATH}`)
   const status = getCredStatus()
   console.log(`[orion-claude] Auth status: ${JSON.stringify(status)}`)
+  bootstrapMcpSettings()
   scheduleTokenRefresh()
 })


### PR DESCRIPTION
## Summary

- **Fix build-breaking type error** in `dream.ts` — `SystemSetting.value` is `JsonValue`, not `string`; added `typeof` guard in `getDreamModelId()`
- **Knowledge write with immediate embedding** — `knowledge_write` tool creates/updates Notes and calls `embedNote()` so they are vector-searchable instantly
- **Dream mode** — background memory consolidation (`dream.ts`): extraction scans recent ChatMessages/TaskEvents every 2h, batches to LLM, writes Notes; pruning reviews stale notes every 24h; started from `worker.ts`; configurable model via `dream.model` SystemSetting with fallback to system default
- **Claude unavailability notice** — when `callClaude` returns null, the agent posts a message on its own behalf instead of silently doing nothing
- **Fix group chat 500** — Claude was attempting ORION tool calls through the sidecar which has no tool execution loop; forced `hasTools=false` as a stopgap (superseded by MCP below)
- **OAuth token auto-refresh** — sidecar watchdog checks every 30min, calls `claude auth refresh` if token expires within 2h
- **Claude calls ORION tools via MCP** — ORION is now the harness, Claude is the brain:
  - New `/api/mcp` route: MCP streamable-HTTP server exposing the tool registry to Claude
  - `orion-claude` sidecar writes a per-request `.mcp.json` (temp dir as cwd) before spawning `claude` so Claude calls ORION tools natively via MCP protocol
  - At startup, sidecar bootstraps `~/.claude.json` with the base ORION MCP URL for task runs
  - Max turns 1 → 10 for MCP sessions; timeout 2min → 5min
  - `ToolExecutionContext` gains `roomId` field
  - `buildSystemPrompt` gets `'mcp'` mode: generic tool hint instead of listing names (MCP injects the real list)
- **`ORION_MCP_TOKEN`** — shared secret added to both services in `docker-compose.yml`, documented in `.env.example`

## Test plan

- [ ] Build passes (dream.ts type error resolved)
- [ ] Worker starts dream scheduler — check logs for `[dream]` entries after 2h
- [ ] `@Claude` in group chat responds without HTTP 500
- [ ] Claude calls an ORION tool (`orion_get_snapshot`) in group chat — verify via sidecar logs showing `MCP enabled`
- [ ] sidecar startup log shows `bootstrap-mcp: ORION MCP server registered`
- [ ] Token auto-refresh fires when token expiry < 2h

🤖 Generated with [Claude Code](https://claude.com/claude-code)