### PR TITLE
fix: dream.ts getSetting JsonValue not assignable to string

### DIFF
--- a/apps/web/src/lib/dream.ts
+++ b/apps/web/src/lib/dream.ts
@@ -113,7 +113,7 @@ async function callLLM(prompt: string): Promise<string> {
 
 function getSetting(key: string): Promise<string | null> {
   return prisma.systemSetting.findUnique({ where: { key } })
-    .then(r => r?.value ?? null)
+    .then(r => (typeof r?.value === 'string' ? r.value : null))
 }
 
 async function setSetting(key: string, value: string): Promise<void> {


### PR DESCRIPTION
## Summary

- `getSetting()` in `dream.ts` had return type `Promise<string | null>` but `SystemSetting.value` is Prisma's `JsonValue` — build fails with type error at line 115
- Fix: narrow with `typeof r?.value === 'string'` before returning, same pattern used in `getDreamModelId()` on line 38

## Test plan
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)