### PR TITLE
fix: type errors in room-agents and tool-registry from MCP PR

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -49,7 +49,7 @@ function buildSystemPrompt(
   agentName: string,
   agentBasePrompt: string,
   otherParticipants: string[],
-  hasTools: false | 'legacy' | 'mcp' = false,
+  hasTools: boolean | 'legacy' | 'mcp' = false,
 ): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
@@ -58,8 +58,8 @@ function buildSystemPrompt(
     ? `To address or continue the conversation with another participant, use @TheirName in your reply (e.g. "@${otherParticipants[0]} what do you think?"). This will notify them and invite their response.`
     : ''
   const toolAddendum =
-    hasTools === 'mcp'    ? '\n\n## ORION Tools\nYou have ORION management tools available via MCP. Use them — do not describe hypothetical actions when you can call a tool to get real data.' :
-    hasTools === 'legacy' ? TOOLS_SYSTEM_ADDENDUM :
+    hasTools === 'mcp'              ? '\n\n## ORION Tools\nYou have ORION management tools available via MCP. Use them — do not describe hypothetical actions when you can call a tool to get real data.' :
+    hasTools === 'legacy' || hasTools === true ? TOOLS_SYSTEM_ADDENDUM :
     ''
   return `IMPORTANT — YOUR ROLE:
 You are ${agentName}. You are ONE participant in a group chat.

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -1948,7 +1948,7 @@ Use this after completing or investigating any task. Structure content for maxim
         data: {
           content:   content.trim(),
           folder:    folder.trim(),
-          tags:      tags ? tags : existing.tags,
+          tags:      tags ? tags : (existing.tags ?? undefined),
           updatedAt: new Date(),
         },
       })


### PR DESCRIPTION
## Summary

Two type errors introduced by the MCP PR that weren't caught locally:

- **`room-agents.ts`** — `buildSystemPrompt` parameter narrowed to `false | 'legacy' | 'mcp'` but `callOllamaChat` and `callOpenAIChat` still pass plain `boolean`. Widened to `boolean | 'legacy' | 'mcp'`; `true` maps to legacy behaviour.
- **`tool-registry.ts`** — `knowledge_write` tool passes `existing.tags` (Prisma `JsonValue`) to `note.update({ tags })` which expects `NullableJsonNullValueInput | InputJsonValue | undefined`. Fixed with `?? undefined` to strip the null.

Ran `tsc --noEmit` locally — zero errors.

## Test plan
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)