### PR TITLE
feat: PreToolUse hook to enforce one-branch-one-PR workflow

### DIFF
--- a/.claude/hooks/check-merged-pr.sh
+++ b/.claude/hooks/check-merged-pr.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PreToolUse hook — blocks git push when the current branch already has a merged PR.
+#
+# Why: Claude Code was repeatedly pushing new commits to branches whose PRs had
+# already been merged into main, causing commits to pile up on stale branches
+# and breaking the one-branch-one-PR workflow.
+#
+# When blocked, the deny reason and additionalContext are surfaced to Claude so
+# it automatically creates a new branch from main instead.
+
+set -euo pipefail
+
+HOOK_INPUT=$(cat)
+COMMAND=$(echo "$HOOK_INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept git push commands
+if [[ ! "$COMMAND" =~ ^git[[:space:]]+push ]]; then
+  exit 0
+fi
+
+# Determine the branch being pushed
+BRANCH=$(git -C "$(dirname "$0")/../.." rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# Nothing to check on detached HEAD or main/master
+if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" || "$BRANCH" =~ ^(main|master)$ ]]; then
+  exit 0
+fi
+
+# gh CLI required — skip gracefully if not available
+if ! command -v gh &>/dev/null; then
+  exit 0
+fi
+
+# Check PR state for this branch
+PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null || echo "NONE")
+
+if [[ "$PR_STATE" == "MERGED" ]]; then
+  PR_URL=$(gh pr view "$BRANCH" --json url --jq '.url' 2>/dev/null || echo "")
+  jq -n \
+    --arg branch "$BRANCH" \
+    --arg url "$PR_URL" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: ("Branch \"" + $branch + "\" already has a merged PR — push blocked."),
+        additionalContext: ("The PR for branch \"" + $branch + "\" has been merged (" + $url + "). Do NOT push more commits to this branch. Create a fresh branch from main for the next piece of work:\n  git checkout -b feat/<new-name> origin/main\nThen commit and push the new branch and open a new PR.")
+      }
+    }'
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git push*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/orion/.claude/hooks/check-merged-pr.sh",
+            "timeout": 10,
+            "statusMessage": "Checking if branch PR is already merged..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` Claude Code hook that intercepts every `git push` command
- Calls `gh pr view <branch>` to check if the branch's PR is already merged
- If merged: returns `permissionDecision: deny` with an `additionalContext` message telling Claude to create a new branch from main instead
- If open, closed, or no PR: allows the push through normally

## Why
Claude kept pushing new commits to branches whose PRs had already been merged into main (e.g. pushing secrets work to `feat/everyone-mention` after PR #302 merged), violating the one-branch-one-PR rule.

## Files
- `.claude/hooks/check-merged-pr.sh` — the hook script (executable)
- `.claude/settings.json` — wires it to `PreToolUse` with matcher `Bash(git push*)`

## Test plan
- [ ] On a branch with a merged PR: `git push` is blocked, Claude creates a new branch
- [ ] On a branch with an open PR: `git push` proceeds normally
- [ ] On main: `git push` proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)