### PR TITLE
fix: managed_secrets migration idempotent FK constraints

### DIFF
--- a/apps/web/prisma/migrations/2_add_managed_secrets/migration.sql
+++ b/apps/web/prisma/migrations/2_add_managed_secrets/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "managed_secrets" (
+CREATE TABLE IF NOT EXISTS "managed_secrets" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -17,18 +17,25 @@ CREATE TABLE "managed_secrets" (
     "appliedAt" TIMESTAMP(3),
     "createdBy" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "managed_secrets_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE INDEX "managed_secrets_environmentId_idx" ON "managed_secrets"("environmentId");
+CREATE INDEX IF NOT EXISTS "managed_secrets_environmentId_idx" ON "managed_secrets"("environmentId");
 
--- AddForeignKey
-ALTER TABLE "managed_secrets" ADD CONSTRAINT "managed_secrets_environmentId_fkey"
-    FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "managed_secrets" ADD CONSTRAINT "managed_secrets_environmentId_fkey"
+    FOREIGN KEY ("environmentId") REFERENCES "Environment"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
--- AddForeignKey
-ALTER TABLE "managed_secrets" ADD CONSTRAINT "managed_secrets_createdBy_fkey"
-    FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+DO $$ BEGIN
+  ALTER TABLE "managed_secrets" ADD CONSTRAINT "managed_secrets_createdBy_fkey"
+    FOREIGN KEY ("createdBy") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
- Rewrites `2_add_managed_secrets` migration SQL to be fully idempotent
- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`
- FK `ALTER TABLE ADD CONSTRAINT` statements wrapped in PL/pgSQL `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;` blocks

## Root Cause
The `managed_secrets` table was manually pre-created via raw SQL before CI ran `prisma migrate deploy`. The FK constraints already existed, so the plain `ALTER TABLE ADD CONSTRAINT` statements threw "constraint already exists" errors. Prisma marked the migration as failed and blocked all further deployments (P3009).

## Fix
This PR makes the migration safe to run on both a clean database and one where the table was pre-applied manually.

The stuck migration record in the live `_prisma_migrations` table has already been cleared (`finished_at` set, `logs` nulled) so `prisma migrate deploy` will re-run this migration cleanly on next deploy.

## Test plan
- [ ] CI build passes (no TypeScript or Prisma errors)
- [ ] `docker compose logs orion` shows "All migrations applied successfully" after deploy
- [ ] `SELECT migration_name, finished_at, logs FROM _prisma_migrations ORDER BY started_at DESC LIMIT 5;` — all rows have `finished_at` set and `logs` null

🤖 Generated with [Claude Code](https://claude.com/claude-code)