### PR TITLE
feat: agent write_secret tool + ORION edit-values modal for ESO secrets

### DIFF
--- a/apps/web/src/app/api/environments/[id]/secrets/[secretId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/secrets/[secretId]/route.ts
@@ -1,12 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth'
 import { prisma } from '@/lib/db'
+import { writeVaultSecret } from '@/lib/vault'
 
 type Params = { params: Promise<{ id: string; secretId: string }> }
 
 /**
  * PATCH /api/environments/:id/secrets/:secretId
- * Update a managed secret (description, tags, refresh interval, key mappings, etc.)
+ * Update a managed secret. If secretValues are provided, writes them to Vault
+ * and marks the secret as applied.
+ *
+ * Body (all optional):
+ *   description, namespace, secretStore, secretStoreKind, remoteRef,
+ *   targetSecretName, refreshInterval, dataKeys, tags, status, statusMessage
+ *   secretValues: Array<{ vaultKey: string; value: string; k8sKey: string }>
+ *     — written directly to Vault, NEVER stored in the database
  */
 export async function PATCH(req: NextRequest, { params }: Params) {
   const user = await getCurrentUser()
@@ -15,21 +23,79 @@ export async function PATCH(req: NextRequest, { params }: Params) {
   const { secretId } = await params
   const body = await req.json().catch(() => ({})) as Record<string, unknown>
 
+  // secretValues carries actual secret data — ephemeral, never persisted
+  type SecretValueRow = { vaultKey: string; value: string; k8sKey: string }
+  const secretValues: SecretValueRow[] = Array.isArray(body.secretValues)
+    ? (body.secretValues as SecretValueRow[]).filter(r => r.vaultKey?.trim() && r.value !== undefined)
+    : []
+
   try {
+    // If secretValues are provided, write them to Vault first
+    if (secretValues.length > 0) {
+      // Resolve the Vault path: use updated remoteRef from body, or fall back to current record
+      let vaultPath = body.remoteRef ? String(body.remoteRef) : null
+      if (!vaultPath) {
+        const existing = await prisma.managedSecret.findUnique({ where: { id: secretId }, select: { remoteRef: true } })
+        if (!existing) return NextResponse.json({ error: 'Secret not found' }, { status: 404 })
+        vaultPath = existing.remoteRef
+      }
+
+      try {
+        const vaultData: Record<string, string> = {}
+        for (const row of secretValues) {
+          vaultData[row.vaultKey.trim()] = String(row.value)
+        }
+        await writeVaultSecret(vaultPath, vaultData)
+      } catch (e) {
+        return NextResponse.json(
+          { error: `Failed to write to Vault: ${e instanceof Error ? e.message : String(e)}` },
+          { status: 502 },
+        )
+      }
+
+      // Derive updated key mappings from the new secretValues
+      const newDataKeys = secretValues.map(r => ({
+        remoteKey: r.vaultKey.trim(),
+        secretKey: r.k8sKey?.trim() || r.vaultKey.trim(),
+      }))
+
+      const secret = await prisma.managedSecret.update({
+        where: { id: secretId },
+        data: {
+          ...(body.description      !== undefined && { description:      body.description ? String(body.description) : null }),
+          ...(body.namespace        !== undefined && { namespace:        String(body.namespace) }),
+          ...(body.secretStore      !== undefined && { secretStore:      String(body.secretStore) }),
+          ...(body.secretStoreKind  !== undefined && { secretStoreKind:  String(body.secretStoreKind) }),
+          ...(body.remoteRef        !== undefined && { remoteRef:        String(body.remoteRef) }),
+          ...(body.targetSecretName !== undefined && { targetSecretName: body.targetSecretName ? String(body.targetSecretName) : null }),
+          ...(body.refreshInterval  !== undefined && { refreshInterval:  String(body.refreshInterval) }),
+          ...(body.tags             !== undefined && { tags:             (body.tags ?? []) as object }),
+          // Always update dataKeys and mark as applied when values are written
+          dataKeys:  newDataKeys,
+          status:    'applied',
+          appliedAt: new Date(),
+          statusMessage: null,
+        },
+        include: { creator: { select: { id: true, username: true, name: true } } },
+      })
+      return NextResponse.json(secret)
+    }
+
+    // No secretValues — metadata-only update
     const secret = await prisma.managedSecret.update({
       where: { id: secretId },
       data: {
-        ...(body.description     !== undefined && { description:     body.description ? String(body.description) : null }),
-        ...(body.namespace       !== undefined && { namespace:       String(body.namespace) }),
-        ...(body.secretStore     !== undefined && { secretStore:     String(body.secretStore) }),
-        ...(body.secretStoreKind !== undefined && { secretStoreKind: String(body.secretStoreKind) }),
-        ...(body.remoteRef       !== undefined && { remoteRef:       String(body.remoteRef) }),
+        ...(body.description      !== undefined && { description:      body.description ? String(body.description) : null }),
+        ...(body.namespace        !== undefined && { namespace:        String(body.namespace) }),
+        ...(body.secretStore      !== undefined && { secretStore:      String(body.secretStore) }),
+        ...(body.secretStoreKind  !== undefined && { secretStoreKind:  String(body.secretStoreKind) }),
+        ...(body.remoteRef        !== undefined && { remoteRef:        String(body.remoteRef) }),
         ...(body.targetSecretName !== undefined && { targetSecretName: body.targetSecretName ? String(body.targetSecretName) : null }),
-        ...(body.refreshInterval !== undefined && { refreshInterval: String(body.refreshInterval) }),
-        ...(body.dataKeys !== undefined && { dataKeys: (body.dataKeys ?? []) as object }),
-        ...(body.tags    !== undefined && { tags: (body.tags ?? []) as object }),
-        ...(body.status          !== undefined && { status: String(body.status) }),
-        ...(body.statusMessage   !== undefined && { statusMessage: body.statusMessage ? String(body.statusMessage) : null }),
+        ...(body.refreshInterval  !== undefined && { refreshInterval:  String(body.refreshInterval) }),
+        ...(body.dataKeys         !== undefined && { dataKeys:         (body.dataKeys ?? []) as object }),
+        ...(body.tags             !== undefined && { tags:             (body.tags ?? []) as object }),
+        ...(body.status           !== undefined && { status:           String(body.status) }),
+        ...(body.statusMessage    !== undefined && { statusMessage:    body.statusMessage ? String(body.statusMessage) : null }),
       },
       include: { creator: { select: { id: true, username: true, name: true } } },
     })

--- a/apps/web/src/app/api/environments/[id]/secrets/route.ts
+++ b/apps/web/src/app/api/environments/[id]/secrets/route.ts
@@ -1,47 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { decrypt } from '@/lib/encryption'
+import { writeVaultSecret } from '@/lib/vault'
 
 type Params = { params: Promise<{ id: string }> }
-
-// ── Vault helper ──────────────────────────────────────────────────────────────
-
-const VAULT_ADDR = process.env.VAULT_ADDR ?? 'http://vault:8200'
-
-/**
- * Write key/value pairs to Vault KV v2 at the given path.
- * The path may be supplied as "foo/bar" or with the full prefix "secret/data/foo/bar" —
- * we normalise either form before calling the API.
- * Values are NEVER stored in the database.
- */
-async function writeVaultSecret(
-  kvPath: string,
-  data: Record<string, string>,
-): Promise<void> {
-  // Retrieve the encrypted admin token from SystemSetting
-  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.adminToken' } })
-  if (!setting?.value) throw new Error('Vault admin token not configured — has the Vault setup wizard been completed?')
-  const token = decrypt(String(setting.value))
-
-  // Normalise: strip "secret/data/" prefix if the user included it
-  const normalised = kvPath.replace(/^secret\/data\//, '')
-
-  const res = await fetch(`${VAULT_ADDR}/v1/secret/data/${normalised}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Vault-Token': token,
-    },
-    body: JSON.stringify({ data }),
-    signal: AbortSignal.timeout(10_000),
-  })
-
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { errors?: string[] }
-    throw new Error(`Vault responded ${res.status}: ${body.errors?.join(', ') ?? 'unknown error'}`)
-  }
-}
 
 // ── Route handlers ────────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { RefreshCw, ServerCrash, Server, Database, KeyRound, HardDrive, FileText, GitBranch, Plus, X, Trash2, ChevronDown, ChevronUp } from 'lucide-react'
+import { RefreshCw, ServerCrash, Server, Database, KeyRound, HardDrive, FileText, GitBranch, Plus, X, Trash2, ChevronDown, ChevronUp, Pencil } from 'lucide-react'
 import { IngressPage } from '@/components/ingress/IngressPage'
 import { GitOpsPage } from '@/components/gitops/GitOpsPage'
 import { NodeGrid } from '@/components/infrastructure/NodeGrid'
@@ -224,6 +224,11 @@ function SecretsTab({ envId, loading, setLoading, error, setError }: {
   const [secretValues, setSecretValues] = useState<Array<{ vaultKey: string; value: string; k8sKey: string }>>([
     { vaultKey: '', value: '', k8sKey: '' },
   ])
+  // Edit modal state — update values on an existing secret
+  const [editSecret, setEditSecret] = useState<ManagedSecret | null>(null)
+  const [editValues, setEditValues] = useState<Array<{ vaultKey: string; value: string; k8sKey: string }>>([])
+  const [editSaving, setEditSaving] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!envId) return
@@ -293,6 +298,40 @@ function SecretsTab({ envId, loading, setLoading, error, setError }: {
       if (expandedId === id) setExpandedId(null)
     } finally {
       setDeleting(null)
+    }
+  }
+
+  const openEditModal = (s: ManagedSecret) => {
+    // Pre-populate key names from dataKeys; values start blank (never stored)
+    setEditValues(
+      s.dataKeys.length > 0
+        ? s.dataKeys.map(k => ({ vaultKey: k.remoteKey, value: '', k8sKey: k.secretKey }))
+        : [{ vaultKey: '', value: '', k8sKey: '' }]
+    )
+    setEditError(null)
+    setEditSecret(s)
+  }
+
+  const handleEditSave = async () => {
+    if (!editSecret) return
+    const validRows = editValues.filter(r => r.vaultKey.trim() && r.value.trim())
+    if (validRows.length === 0) { setEditError('Enter at least one key and value'); return }
+
+    setEditSaving(true); setEditError(null)
+    try {
+      const res = await fetch(`/api/environments/${envId}/secrets/${editSecret.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secretValues: validRows }),
+      })
+      const data = await res.json()
+      if (!res.ok) { setEditError((data as { error?: string }).error ?? `HTTP ${res.status}`); return }
+      setEditSecret(null)
+      await load()
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setEditSaving(false)
     }
   }
 
@@ -373,6 +412,13 @@ function SecretsTab({ envId, loading, setLoading, error, setError }: {
                     <div className="flex items-center justify-end gap-1">
                       {expandedId === s.id ? <ChevronUp size={12} className="text-text-muted" /> : <ChevronDown size={12} className="text-text-muted" />}
                       <button
+                        onClick={e => { e.stopPropagation(); openEditModal(s) }}
+                        className="p-1 rounded text-text-muted hover:text-accent transition-colors"
+                        title="Update secret values in Vault"
+                      >
+                        <Pencil size={12} />
+                      </button>
+                      <button
                         onClick={e => { e.stopPropagation(); handleDelete(s.id) }}
                         disabled={deleting === s.id}
                         className="p-1 rounded text-text-muted hover:text-status-error transition-colors disabled:opacity-40"
@@ -434,6 +480,99 @@ function SecretsTab({ envId, loading, setLoading, error, setError }: {
           </tbody>
         </table>
       </div>
+
+      {/* Edit Secret Values Modal */}
+      {editSecret && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={() => setEditSecret(null)}>
+          <div
+            className="w-full max-w-lg bg-bg-sidebar border border-border-subtle rounded-xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-4 border-b border-border-subtle flex-shrink-0">
+              <div className="flex items-center gap-2">
+                <Pencil size={14} className="text-accent" />
+                <span className="text-sm font-semibold text-text-primary">Update Secret Values</span>
+                <span className="font-mono text-xs text-text-muted">· {editSecret.name}</span>
+              </div>
+              <button onClick={() => setEditSecret(null)} className="p-1 rounded text-text-muted hover:text-text-primary"><X size={16} /></button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+              <div className="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2.5 text-[10px] text-text-muted leading-relaxed">
+                Values are written <span className="text-accent font-semibold">directly to Vault</span> at <span className="font-mono text-text-secondary">{editSecret.remoteRef}</span> and are never stored in ORION.
+                Current values are in Vault — enter new values to overwrite them.
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-text-muted">Secret Values</p>
+                  <button
+                    onClick={() => setEditValues(prev => [...prev, { vaultKey: '', value: '', k8sKey: '' }])}
+                    className="inline-flex items-center gap-1 text-[10px] text-accent hover:text-accent/80 transition-colors"
+                  >
+                    <Plus size={10} /> Add key
+                  </button>
+                </div>
+                <div className="space-y-1.5">
+                  <div className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2 text-[10px] text-text-muted px-0.5">
+                    <span>Vault key</span>
+                    <span>New value <span className="text-accent">*</span></span>
+                    <span>K8s key (optional)</span>
+                    <span />
+                  </div>
+                  {editValues.map((row, i) => (
+                    <div key={i} className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2 items-center">
+                      <input
+                        className="w-full px-2.5 py-1.5 rounded border border-border-visible bg-bg-raised text-xs text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                        placeholder="password"
+                        value={row.vaultKey}
+                        onChange={e => setEditValues(prev => prev.map((r, idx) => idx === i ? { ...r, vaultKey: e.target.value } : r))}
+                      />
+                      <input
+                        className="w-full px-2.5 py-1.5 rounded border border-border-visible bg-bg-raised text-xs text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                        type="password"
+                        placeholder="new value"
+                        value={row.value}
+                        onChange={e => setEditValues(prev => prev.map((r, idx) => idx === i ? { ...r, value: e.target.value } : r))}
+                        autoComplete="new-password"
+                      />
+                      <input
+                        className="w-full px-2.5 py-1.5 rounded border border-border-visible bg-bg-raised text-xs text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                        placeholder={row.vaultKey || 'DB_PASSWORD'}
+                        value={row.k8sKey}
+                        onChange={e => setEditValues(prev => prev.map((r, idx) => idx === i ? { ...r, k8sKey: e.target.value } : r))}
+                      />
+                      <button
+                        onClick={() => setEditValues(prev => prev.filter((_, idx) => idx !== i))}
+                        disabled={editValues.length === 1}
+                        className="p-1 rounded text-text-muted hover:text-status-error transition-colors disabled:opacity-30"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {editError && (
+              <div className="px-5 py-2 border-t border-status-error/30 bg-status-error/10 text-xs text-status-error flex items-center gap-2 flex-shrink-0">
+                <ServerCrash size={12} />
+                <span>{editError}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-border-subtle flex-shrink-0">
+              <button onClick={() => setEditSecret(null)} className="px-3 py-1.5 rounded text-xs border border-border-subtle text-text-muted hover:text-text-primary transition-colors">
+                Cancel
+              </button>
+              <button onClick={handleEditSave} disabled={editSaving} className="px-4 py-1.5 rounded text-xs bg-accent/15 text-accent hover:bg-accent/25 border border-accent/30 disabled:opacity-50 flex items-center gap-1.5 transition-colors">
+                {editSaving ? <RefreshCw size={11} className="animate-spin" /> : <KeyRound size={11} />}
+                {editSaving ? 'Writing to Vault…' : 'Write to Vault'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Add Secret Modal */}
       {showModal && (

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -16,6 +16,7 @@
  */
 
 import { prisma } from './db'
+import { writeVaultSecret } from './vault'
 
 // ── Tool definitions (OpenAI function-call format) ────────────────────────────
 
@@ -130,7 +131,28 @@ export const ORION_TOOL_DEFINITIONS = [
         required: ['taskId'],
       },
     },
-  }
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'write_secret',
+      description: 'Create a skeleton External Secret in ORION backed by Vault. Writes PLACEHOLDER values to Vault so the human can fill in the real values inside ORION (Infrastructure > External Secrets > pencil icon). Use this when asked to scaffold, create, or set up a secret for a deployment.',
+      parameters: {
+        type: 'object',
+        properties: {
+          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in (e.g. "homelab-k3s")' },
+          name:             { type: 'string', description: 'Human-readable label for the ExternalSecret (e.g. "gitea-db-secret")' },
+          vaultPath:        { type: 'string', description: 'Vault KV v2 path relative to the "secret" mount (e.g. "gitea/db"). No "secret/data/" prefix.' },
+          keyNames:         { type: 'array', items: { type: 'string' }, description: 'List of secret key names to scaffold (e.g. ["DB_PASSWORD", "DB_USER"]). PLACEHOLDER values will be written to Vault.' },
+          namespace:        { type: 'string', description: 'Kubernetes namespace where the Secret will live (default: "default")' },
+          description:      { type: 'string', description: 'What this secret is for and who uses it (optional)' },
+          targetSecretName: { type: 'string', description: 'K8s Secret name (defaults to the ExternalSecret name)' },
+          refreshInterval:  { type: 'string', description: 'ESO sync interval, e.g. "1h", "15m" (default: "1h")' },
+        },
+        required: ['environmentName', 'name', 'vaultPath', 'keyNames'],
+      },
+    },
+  },
 ] as const
 
 // ── Tool execution ────────────────────────────────────────────────────────────
@@ -288,6 +310,68 @@ export async function executeTool(
         return `Task "${updated.title}" (${taskId}): status=${updated.status}, assigned=${updated.assignedAgent ?? 'unassigned'}${args.note ? ', note appended' : ''}`
       }
 
+      case 'write_secret': {
+        const environmentName = String(args.environmentName ?? '').trim()
+        const name            = String(args.name ?? '').trim()
+        const vaultPath       = String(args.vaultPath ?? '').trim()
+        const keyNames        = Array.isArray(args.keyNames) ? (args.keyNames as unknown[]).map(String).filter(Boolean) : []
+
+        if (!environmentName) return 'Error: environmentName is required'
+        if (!name)            return 'Error: name is required'
+        if (!vaultPath)       return 'Error: vaultPath is required'
+        if (keyNames.length === 0) return 'Error: keyNames must contain at least one key'
+
+        // Resolve environment by name
+        const env = await prisma.environment.findUnique({ where: { name: environmentName } })
+        if (!env) return `Error: environment "${environmentName}" not found. Use orion_get_snapshot to see available environments.`
+
+        const namespace       = String(args.namespace       ?? 'default').trim() || 'default'
+        const description     = args.description     ? String(args.description).trim()     : null
+        const targetSecretName = args.targetSecretName ? String(args.targetSecretName).trim() || null : null
+        const refreshInterval  = String(args.refreshInterval ?? '1h').trim() || '1h'
+
+        // Write PLACEHOLDER values to Vault for each key
+        const placeholderData: Record<string, string> = {}
+        for (const key of keyNames) placeholderData[key] = 'PLACEHOLDER'
+
+        try {
+          await writeVaultSecret(vaultPath, placeholderData)
+        } catch (e) {
+          return `Error: failed to write placeholder to Vault: ${e instanceof Error ? e.message : String(e)}`
+        }
+
+        // Persist metadata (status=draft — human must fill real values in ORION)
+        const dataKeys = keyNames.map(k => ({ remoteKey: k, secretKey: k }))
+        const secret = await prisma.managedSecret.create({
+          data: {
+            environmentId:    env.id,
+            createdBy:        context.callerAgentId,
+            name,
+            namespace,
+            description,
+            secretStore:      'vault-backend',
+            secretStoreKind:  'ClusterSecretStore',
+            remoteRef:        vaultPath,
+            targetSecretName,
+            refreshInterval,
+            dataKeys,
+            tags:             [],
+            status:           'draft',
+          },
+        })
+
+        return [
+          `Secret shell created (id: ${secret.id}):`,
+          `  Name:      ${secret.name}`,
+          `  Vault path: secret/data/${vaultPath}`,
+          `  Keys:      ${keyNames.join(', ')}`,
+          `  Namespace: ${namespace}`,
+          `  Status:    draft (PLACEHOLDER values written — real values needed)`,
+          ``,
+          `Next step: open Infrastructure > External Secrets in environment "${environmentName}", find "${name}", and click the pencil icon to enter the real values. ORION will write them to Vault and mark the secret as applied.`,
+        ].join('\n')
+      }
+
       default:
         return `Error: unknown tool "${toolName}"`
     }
@@ -314,6 +398,6 @@ You have access to these tools. Use them — do not pretend to perform an action
 - **update_task**: Update an existing task by ID (status, title, description, priority).
 - **orion_manage_task**: Assign a task to an agent, change status, or append a feed note.
 - **create_agent**: Create a new AI agent and invite it to this chat room.
-
+- **write_secret**: Scaffold an External Secret in ORION backed by Vault — writes PLACEHOLDER values so the human can fill in real values via the ORION UI.
 
 When you use a tool, report the result back clearly (e.g. "Done — PR #42 opened: 'feat: deploy Tailscale Operator'").`

--- a/apps/web/src/lib/vault.ts
+++ b/apps/web/src/lib/vault.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared Vault KV v2 write helper.
+ * Used by both the secrets API routes and the agent tool executor.
+ */
+
+import { prisma } from './db'
+import { decrypt } from './encryption'
+
+const VAULT_ADDR = process.env.VAULT_ADDR ?? 'http://vault:8200'
+
+/**
+ * Write key/value pairs to Vault KV v2 at the given path.
+ * The path may be "foo/bar" or with the full prefix "secret/data/foo/bar" —
+ * either form is normalised before calling the API.
+ * Values are NEVER stored in the database.
+ */
+export async function writeVaultSecret(
+  kvPath: string,
+  data: Record<string, string>,
+): Promise<void> {
+  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.adminToken' } })
+  if (!setting?.value) throw new Error('Vault admin token not configured — has the Vault setup wizard been completed?')
+  const token = decrypt(String(setting.value))
+
+  // Normalise: strip "secret/data/" prefix if the caller included it
+  const normalised = kvPath.replace(/^secret\/data\//, '')
+
+  const res = await fetch(`${VAULT_ADDR}/v1/secret/data/${normalised}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Vault-Token': token,
+    },
+    body: JSON.stringify({ data }),
+    signal: AbortSignal.timeout(10_000),
+  })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { errors?: string[] }
+    throw new Error(`Vault responded ${res.status}: ${body.errors?.join(', ') ?? 'unknown error'}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `writeVaultSecret` into `lib/vault.ts` — shared between API routes and agent tools
- `PATCH /secrets/:id` now accepts `secretValues` — writes them to Vault and marks the secret as `applied`
- Add pencil-icon **Edit Values** modal in Infrastructure > External Secrets: pre-populates key names from stored `dataKeys`, blank value fields (values are never stored), writes to Vault on submit
- Add `write_secret` agent tool: scaffolds an ExternalSecret shell with `PLACEHOLDER` values in Vault so the human can fill real values via the ORION edit modal

## Workflow
1. Agent calls `write_secret` with environment, name, vault path, and key names
2. Agent writes `PLACEHOLDER` for each key to Vault and creates a `ManagedSecret` record (status: `draft`)
3. Human opens Infrastructure > External Secrets, clicks the pencil icon on the row
4. Edit modal opens with key names pre-filled, human enters real values
5. ORION writes values to Vault, status flips to `applied`
6. ESO syncs the K8s Secret automatically on next refresh

## Test plan
- [ ] Agent can call `write_secret` and a draft secret appears in the UI
- [ ] Pencil icon opens edit modal with key names pre-populated
- [ ] Submitting real values writes to Vault and status changes to `applied`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)