### PR TITLE
fix: use vault.rootToken key to retrieve Vault token from SystemSetting

### DIFF
--- a/apps/web/src/lib/vault.ts
+++ b/apps/web/src/lib/vault.ts
@@ -18,8 +18,8 @@ export async function writeVaultSecret(
   kvPath: string,
   data: Record<string, string>,
 ): Promise<void> {
-  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.adminToken' } })
-  if (!setting?.value) throw new Error('Vault admin token not configured — has the Vault setup wizard been completed?')
+  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.rootToken' } })
+  if (!setting?.value) throw new Error('Vault root token not configured — has the Vault setup wizard been completed?')
   const token = decrypt(String(setting.value))
 
   // Normalise: strip "secret/data/" prefix if the caller included it


### PR DESCRIPTION
## Summary
- `writeVaultSecret` in `lib/vault.ts` was looking up `vault.adminToken` but the setup wizard stores the token under `vault.rootToken`
- One-line fix: update the SystemSetting key lookup

## Test plan
- [ ] Agent `write_secret` tool no longer returns "Vault admin token not configured"
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)