### PR TITLE
fix: set createdBy to null in write_secret agent tool

### DIFF
--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -345,7 +345,7 @@ export async function executeTool(
         const secret = await prisma.managedSecret.create({
           data: {
             environmentId:    env.id,
-            createdBy:        context.callerAgentId,
+            createdBy:        null,  // callerAgentId is an Agent ID, not a User ID
             name,
             namespace,
             description,


### PR DESCRIPTION
## Summary
`write_secret` was passing `context.callerAgentId` as `createdBy` on the `ManagedSecret` record. That field has a FK constraint to the `User` table — agent IDs don't exist there, causing a constraint violation on every call.

Fix: set `createdBy: null`. The field is nullable (ON DELETE SET NULL) and is the correct value when an agent (not a human) creates the secret.

## Test plan
- [ ] Agent can call `write_secret` without FK constraint error
- [ ] Secret row appears with `createdBy = null` and creator shown as blank in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)