### PR TITLE
feat: disable Gitea self-registration — admin + SSO only

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -128,6 +128,8 @@ services:
       GITEA__admin__DISABLE_REGULAR_ORG_CREATION: "false"
       GITEA__actions__ENABLED: "true"
       GITEA__service__REQUIRE_SIGNIN_VIEW: "false"
+      GITEA__service__DISABLE_REGISTRATION: "true"
+      GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION: "false"
     volumes:
       - gitea-data:/data
     ports:


### PR DESCRIPTION
## Summary
- Set `GITEA__service__DISABLE_REGISTRATION=true` — no one can create accounts via the sign-up form
- Set `GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION=false` — local admin accounts remain functional
- Access is: local admin accounts (provisioned by admin) + Authentik OAuth2 SSO

## Notes
- Authentik OAuth2 integration still needs to be configured in Gitea admin UI (Site Administration > Authentication Sources > Add OAuth2)
- The Gitea ingress was applied separately to the Talos cluster (CrowdSec only, no Authentik forward auth — Gitea handles SSO natively)

## Test plan
- [ ] Sign-up page returns 403 or is hidden
- [ ] Admin login still works at `/user/login`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)