### PR TITLE
fix: Gitea merge empty-body crash + persist GitOps PRs from agent tool

### DIFF
--- a/apps/web/src/lib/git-provider/gitea-provider.ts
+++ b/apps/web/src/lib/git-provider/gitea-provider.ts
@@ -51,7 +51,10 @@ export class GiteaGitProvider implements GitProvider {
       try { detail = await res.text() } catch { /* ignore */ }
       throw new Error(`Gitea ${init.method ?? 'GET'} ${path} → ${res.status}: ${detail}`)
     }
-    return res.json() as Promise<T>
+    // Some Gitea endpoints (e.g. POST .../merge) return HTTP 200 with an empty body
+    const text = await res.text()
+    if (!text) return undefined as T
+    return JSON.parse(text) as T
   }
 
   // ── Repos ──────────────────────────────────────────────────────────────────
@@ -168,6 +171,11 @@ export class GiteaGitProvider implements GitProvider {
   async getPR(owner: string, repo: string, prNumber: number): Promise<GitPR> {
     const pr = await this.fetch<GiteaPR>(`/repos/${owner}/${repo}/pulls/${prNumber}`)
     return toGitPR(pr)
+  }
+
+  async listOpenPRs(owner: string, repo: string): Promise<GitPR[]> {
+    const prs = await this.fetch<GiteaPR[]>(`/repos/${owner}/${repo}/pulls?state=open&limit=50`)
+    return (prs ?? []).map(toGitPR)
   }
 
   async mergePR(owner: string, repo: string, prNumber: number, message?: string): Promise<void> {

--- a/apps/web/src/lib/git-provider/github-provider.ts
+++ b/apps/web/src/lib/git-provider/github-provider.ts
@@ -183,6 +183,11 @@ export class GitHubGitProvider implements GitProvider {
     return toGitPR(pr)
   }
 
+  async listOpenPRs(owner: string, repo: string): Promise<import('./index').GitPR[]> {
+    const prs = await this.fetch<GHPR[]>(`/repos/${owner}/${repo}/pulls?state=open&per_page=50`)
+    return (prs ?? []).map(toGitPR)
+  }
+
   async mergePR(owner: string, repo: string, prNumber: number, message?: string): Promise<void> {
     await this.fetch(`/repos/${owner}/${repo}/pulls/${prNumber}/merge`, {
       method: 'PUT',

--- a/apps/web/src/lib/git-provider/gitlab-provider.ts
+++ b/apps/web/src/lib/git-provider/gitlab-provider.ts
@@ -176,6 +176,13 @@ export class GitLabGitProvider implements GitProvider {
     return toGitPR(mr)
   }
 
+  async listOpenPRs(owner: string, repo: string): Promise<import('./index').GitPR[]> {
+    const mrs = await this.fetch<GLMR[]>(
+      `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&per_page=50`,
+    )
+    return (mrs ?? []).map(toGitPR)
+  }
+
   async mergePR(owner: string, repo: string, prNumber: number, message?: string): Promise<void> {
     await this.fetch(
       `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}/merge`,

--- a/apps/web/src/lib/git-provider/index.ts
+++ b/apps/web/src/lib/git-provider/index.ts
@@ -81,6 +81,7 @@ export interface GitProvider {
   createPR(opts: CreatePROptions): Promise<GitPR>
   mergePR(owner: string, repo: string, prNumber: number, message?: string): Promise<void>
   getPR(owner: string, repo: string, prNumber: number): Promise<GitPR>
+  listOpenPRs(owner: string, repo: string): Promise<GitPR[]>
 
   // Webhooks
   ensureWebhook(owner: string, repo: string, callbackUrl: string, secret: string): Promise<void>

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -636,6 +636,22 @@ async function handleProposeGitops(args: unknown, ctx: ToolExecutionContext): Pr
       ? `auto-merged (${result.classification.reason})`
       : `opened for review — ${result.classification.reason}`
 
+    // Persist the PR so the dashboard can surface pending reviews
+    await ctx.prisma.gitOpsPR.create({
+      data: {
+        environmentId: env.id,
+        prNumber:  result.prNumber,
+        title:     title!,
+        operation: result.classification.operation,
+        decision:  result.classification.decision,
+        status:    result.merged ? 'merged' : 'open',
+        prUrl:     result.prUrl,
+        reasoning: reasoning ?? null,
+        branch:    result.branch,
+        mergedAt:  result.merged ? new Date() : null,
+      },
+    }).catch(() => {}) // non-fatal — PR already exists in Gitea even if DB write fails
+
     await auditLog(ctx.agentId ?? ctx.userId, `🔀 GitOps PR #${result.prNumber} ${action} — **${title}**`)
     return `PR #${result.prNumber} ${action}. URL: ${result.prUrl}`
   } catch (e) {


### PR DESCRIPTION
## Summary

- **Crash fix**: Gitea's `POST .../merge` endpoint returns HTTP 200 with Content-Length 0 (not 204). The `fetch()` helper was calling `res.json()` unconditionally on all non-204 successes, throwing "Unexpected end of JSON input". Changed to `res.text()` first, then parse only if non-empty.
- **listOpenPRs**: Added to Gitea, GitHub, and GitLab providers + the `GitProvider` interface so ORION can query pending review PRs from the git host.
- **PR tracking**: `handleProposeGitops` in `tool-registry.ts` now writes to the `GitOpsPR` table after creating a PR. Previously, only the HTTP `/api/gitops/propose` route persisted PR records — agent-tool invocations were invisible to the dashboard.

## Test plan

- [ ] Call `orion_propose_gitops` for an auto-merge operation — should succeed without "Unexpected end of JSON input"
- [ ] Confirm created PR appears in `/api/gitops/prs` response
- [ ] For review-required PRs, confirm row in `GitOpsPR` with `status = 'open'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)