### PR TITLE
fix: rewrite Gitea internal html_url to public URL for PR links

### DIFF
--- a/apps/web/src/lib/git-provider/gitea-provider.ts
+++ b/apps/web/src/lib/git-provider/gitea-provider.ts
@@ -19,16 +19,22 @@ interface GiteaProviderOptions {
   url: string
   token: string
   webhookSecret?: string
+  /** Public-facing base URL used for PR links in the UI (e.g. https://gitea.khalisio.com).
+   *  Defaults to `url` when omitted. Needed when ORION calls Gitea via an internal
+   *  Docker/K8s hostname — Gitea echoes that hostname back in html_url. */
+  publicUrl?: string
 }
 
 export class GiteaGitProvider implements GitProvider {
   readonly type = 'gitea' as const
   private readonly url: string
+  private readonly publicUrl: string
   private readonly token: string
   private readonly webhookSecret?: string
 
   constructor(opts: GiteaProviderOptions) {
     this.url = opts.url.replace(/\/$/, '')
+    this.publicUrl = (opts.publicUrl ?? opts.url).replace(/\/$/, '')
     this.token = opts.token
     this.webhookSecret = opts.webhookSecret
   }
@@ -165,17 +171,17 @@ export class GiteaGitProvider implements GitProvider {
       method: 'POST',
       body: JSON.stringify(body),
     })
-    return toGitPR(pr)
+    return toGitPR(pr, this.url, this.publicUrl)
   }
 
   async getPR(owner: string, repo: string, prNumber: number): Promise<GitPR> {
     const pr = await this.fetch<GiteaPR>(`/repos/${owner}/${repo}/pulls/${prNumber}`)
-    return toGitPR(pr)
+    return toGitPR(pr, this.url, this.publicUrl)
   }
 
   async listOpenPRs(owner: string, repo: string): Promise<GitPR[]> {
     const prs = await this.fetch<GiteaPR[]>(`/repos/${owner}/${repo}/pulls?state=open&limit=50`)
-    return (prs ?? []).map(toGitPR)
+    return (prs ?? []).map(p => toGitPR(p, this.url, this.publicUrl))
   }
 
   async mergePR(owner: string, repo: string, prNumber: number, message?: string): Promise<void> {
@@ -207,7 +213,7 @@ export class GiteaGitProvider implements GitProvider {
   // ── Utilities ──────────────────────────────────────────────────────────────
 
   getPRUrl(owner: string, repo: string, prNumber: number): string {
-    return `${this.url}/${owner}/${repo}/pulls/${prNumber}`
+    return `${this.publicUrl}/${owner}/${repo}/pulls/${prNumber}`
   }
 
   verifyWebhookSignature(rawBody: string, headers: Record<string, string>, secret: string): boolean {
@@ -299,13 +305,19 @@ function toGitRepo(r: GiteaRepo): GitRepo {
   }
 }
 
-function toGitPR(p: GiteaPR): GitPR {
+function toGitPR(p: GiteaPR, internalUrl?: string, publicUrl?: string): GitPR {
+  // Gitea echoes the request hostname back in html_url when called via an internal
+  // network address. Rewrite to the public URL so links work in the browser.
+  let htmlUrl = p.html_url
+  if (internalUrl && publicUrl && internalUrl !== publicUrl) {
+    htmlUrl = htmlUrl.replace(internalUrl, publicUrl)
+  }
   return {
     number: p.number,
     title: p.title,
     body: p.body,
     state: p.merged ? 'merged' : p.state,
-    htmlUrl: p.html_url,
+    htmlUrl,
     headBranch: p.head.ref,
     baseBranch: p.base.ref,
     merged: p.merged,

--- a/apps/web/src/lib/git-provider/index.ts
+++ b/apps/web/src/lib/git-provider/index.ts
@@ -102,6 +102,9 @@ export interface GitProviderConfig {
   type: GitProviderType
   /** API base URL — omit for gitea-bundled (uses http://gitea:3000) and github (uses api.github.com) */
   url?: string
+  /** Public-facing URL for Gitea PR links in the UI. Only needed when `url` is an
+   *  internal hostname (e.g. http://gitea:3000). Defaults to `url` when omitted. */
+  publicUrl?: string
   /** API token / PAT */
   token: string
   /** Default org or user namespace for repo operations */
@@ -117,12 +120,14 @@ export function createProvider(config: GitProviderConfig): GitProvider {
     case 'gitea-bundled':
       return new GiteaGitProvider({
         url: 'http://gitea:3000',
+        publicUrl: config.publicUrl ?? process.env.GITEA_PUBLIC_URL,
         token: config.token,
         webhookSecret: config.webhookSecret,
       })
     case 'gitea':
       return new GiteaGitProvider({
         url: config.url ?? 'http://gitea:3000',
+        publicUrl: config.publicUrl ?? process.env.GITEA_PUBLIC_URL,
         token: config.token,
         webhookSecret: config.webhookSecret,
       })
@@ -166,6 +171,7 @@ export async function getGitProvider(): Promise<GitProvider> {
   // Backwards-compat fallback: env vars
   _cached = new GiteaGitProvider({
     url: process.env.GITEA_URL ?? 'http://gitea:3000',
+    publicUrl: process.env.GITEA_PUBLIC_URL,
     token: process.env.GITEA_ADMIN_TOKEN ?? '',
     webhookSecret: process.env.GITEA_WEBHOOK_SECRET,
   })

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,6 +7,9 @@ MANAGEMENT_IP=192.168.1.10
 # your internal and public domains interactively
 ORION_DOMAIN=orion.internal
 GITEA_DOMAIN=gitea.internal
+# Public URL for Gitea PR links shown in ORION UI (must be reachable from the browser).
+# Defaults to https://<GITEA_DOMAIN> in docker-compose — override only if they differ.
+GITEA_PUBLIC_URL=
 VAULT_DOMAIN=vault.internal
 
 # ── ORION ─────────────────────────────────────────────────────────────────────

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       # Git provider — configured via first-run wizard (stored in DB).
       # These env vars are used as fallback before the wizard completes.
       GITEA_URL: http://gitea:3000
+      GITEA_PUBLIC_URL: https://${GITEA_DOMAIN:-gitea.khalisio.com}
       GITEA_ADMIN_TOKEN: ${GITEA_ADMIN_TOKEN:-}
       GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-}
       GITEA_ADMIN_PASSWORD: ${GITEA_ADMIN_PASSWORD:-}


### PR DESCRIPTION
## Summary
- Gitea returns `html_url=http://gitea:3000/...` in API responses when called via the internal Docker network hostname. This was stored as `prUrl` in `GitOpsPR`, causing the "view" button in the UI to navigate to an unreachable URL and land on the ORION setup page.
- Added `publicUrl` option to `GiteaProviderOptions` and `GitProviderConfig`. The `toGitPR()` function rewrites any internal URL prefix to the public URL before returning.
- `docker-compose.yml` passes `GITEA_PUBLIC_URL=https://<GITEA_DOMAIN>` to ORION automatically for bundled Gitea deployments.

## Test plan
- [ ] Merge and redeploy — click "view" on a GitOps PR in Infrastructure → GitOps tab
- [ ] Confirm link opens `https://gitea.khalisio.com/...` instead of the setup page
- [ ] New PRs created by agents also get the correct public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)