### PR TITLE
feat: per-model temperature setting for external models

### DIFF
--- a/apps/web/prisma/migrations/3_external_model_temperature/migration.sql
+++ b/apps/web/prisma/migrations/3_external_model_temperature/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ExternalModel" ADD COLUMN "temperature" DOUBLE PRECISION;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -441,6 +441,7 @@ model ExternalModel {
   enabled     Boolean  @default(true)
   timeoutSecs Int      @default(120)
   maxTokens   Int?
+  temperature Float?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }

--- a/apps/web/src/app/(app)/admin/models/page.tsx
+++ b/apps/web/src/app/(app)/admin/models/page.tsx
@@ -12,6 +12,7 @@ interface ExternalModel {
   enabled: boolean
   timeoutSecs: number
   maxTokens: number | null
+  temperature: number | null
 }
 
 interface Health {
@@ -28,9 +29,10 @@ interface ModelForm {
   enabled: boolean
   timeoutSecs: number
   maxTokens: number | null
+  temperature: number | null
 }
 
-const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120, maxTokens: null }
+const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120, maxTokens: null, temperature: null }
 
 const PROVIDER_LABELS: Record<string, string> = {
   openai: 'OpenAI Compatible',
@@ -93,7 +95,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
   const isNew = model === null
   const [form, setForm] = useState<ModelForm>(
     model
-      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120, maxTokens: model.maxTokens ?? null }
+      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120, maxTokens: model.maxTokens ?? null, temperature: model.temperature ?? null }
       : EMPTY_FORM
   )
   const [saving, setSaving]         = useState(false)
@@ -109,7 +111,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
     if (!form.name || !form.baseUrl || !form.modelId) { setError('Name, Base URL, and Model ID are required.'); return }
     setSaving(true); setError(null)
     try {
-      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs, maxTokens: form.maxTokens }
+      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs, maxTokens: form.maxTokens, temperature: form.temperature }
       const res = model
         ? await fetch(`/api/admin/models/${model.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
         : await fetch('/api/admin/models', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -235,6 +237,21 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
                 value={form.maxTokens ?? ''}
                 onChange={e => setForm(f => ({ ...f, maxTokens: e.target.value ? Math.max(1, parseInt(e.target.value)) : null }))}
                 placeholder="unlimited"
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Temperature (blank = model default)">
+              <input
+                type="number"
+                min={0}
+                max={2}
+                step={0.05}
+                value={form.temperature ?? ''}
+                onChange={e => {
+                  const v = parseFloat(e.target.value)
+                  setForm(f => ({ ...f, temperature: e.target.value === '' ? null : Math.min(2, Math.max(0, isNaN(v) ? 0 : v)) }))
+                }}
+                placeholder="model default"
                 className={inputCls}
               />
             </FormField>

--- a/apps/web/src/app/api/admin/models/[id]/route.ts
+++ b/apps/web/src/app/api/admin/models/[id]/route.ts
@@ -21,7 +21,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (body.modelId     !== undefined) updateData.modelId     = body.modelId
   if (body.enabled     !== undefined) updateData.enabled     = body.enabled
   if (body.timeoutSecs !== undefined) updateData.timeoutSecs = body.timeoutSecs
-  if ('maxTokens' in body)            updateData.maxTokens   = body.maxTokens  // null clears the cap
+  if ('maxTokens' in body)            updateData.maxTokens   = body.maxTokens   // null clears the cap
+  if ('temperature' in body)          updateData.temperature = body.temperature // null = model default
   if (body.apiKey)                    updateData.apiKey      = body.apiKey
 
   const model = await prisma.externalModel.update({

--- a/apps/web/src/app/api/admin/models/route.ts
+++ b/apps/web/src/app/api/admin/models/route.ts
@@ -30,6 +30,7 @@ export async function POST(req: NextRequest) {
       modelId:     body.modelId,
       enabled:     body.enabled ?? true,
       timeoutSecs: body.timeoutSecs ?? 120,
+      temperature: body.temperature ?? null,
     },
   })
 

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -264,18 +264,21 @@ async function* streamOllamaToolLoop(
   environmentId: string,
   abortSignal?: AbortSignal,
   userId?: string,
+  temperature?: number,
 ): AsyncGenerator<StreamChunk> {
   const { GatewayClient: _GC } = await import('./agent-runner/gateway-client')
   void _GC
 
   let ollamaUrl = baseUrl
   let timeoutSecs = 120
+  let resolvedTemp = temperature
   if (!ollamaUrl) {
     const extModel = await prisma.externalModel.findFirst({ where: { provider: 'ollama', modelId: model, enabled: true } })
       ?? await prisma.externalModel.findFirst({ where: { provider: 'ollama', enabled: true } })
     if (!extModel?.baseUrl) { yield { type: 'error', error: 'No Ollama model configured' }; return }
     ollamaUrl = extModel.baseUrl
     timeoutSecs = extModel.timeoutSecs ?? 120
+    if (resolvedTemp === undefined && extModel.temperature != null) resolvedTemp = extModel.temperature
   }
 
   // Synthetic management tools — handled locally, never forwarded to the gateway
@@ -357,7 +360,7 @@ async function* streamOllamaToolLoop(
       const res = await fetch(`${ollamaUrl}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model, messages, stream: false, tools: ollamaToolDefs }),
+        body: JSON.stringify({ model, messages, stream: false, tools: ollamaToolDefs, ...(resolvedTemp !== undefined && { options: { temperature: resolvedTemp } }) }),
         signal: fetchSignal,
       })
       if (!res.ok) throw new Error(`Ollama ${res.status}: ${await res.text()}`)
@@ -541,6 +544,7 @@ export async function* streamAgentChat(
     let timeoutSecs = 120
     let provider = 'ollama'
     let apiKey: string | undefined
+    let extTemperature: number | undefined
 
     if (llm.startsWith('ext:')) {
       const extId = llm.slice('ext:'.length)
@@ -551,6 +555,7 @@ export async function* streamAgentChat(
       timeoutSecs = extModel.timeoutSecs ?? 120
       provider = extModel.provider   // 'ollama' | 'openai' | 'custom' | etc.
       apiKey = extModel.apiKey ?? undefined
+      if (extModel.temperature != null) extTemperature = extModel.temperature
     } else {
       model = llm.slice('ollama:'.length)
     }
@@ -567,9 +572,9 @@ export async function* streamAgentChat(
       const activeTasks = await getActiveTasksSection()
       if (gw) {
         const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt + activeTasks, conversationId, knowledgeContext)
-        yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId)
+        yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId, extTemperature)
       } else {
-        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix + kcSection, trimmedHistory, model, baseUrl, timeoutSecs)
+        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix + kcSection, trimmedHistory, model, baseUrl, timeoutSecs, undefined, extTemperature)
       }
     } else {
       // OpenAI-compatible endpoint (custom / openai / llama.cpp / etc.)
@@ -597,7 +602,7 @@ ${readClusterContext()}${kcSection}`
         prompt, conversationId, openAISystemPrompt, trimmedHistory,
         model!, baseUrl!, apiKey,
         gw?.tools ?? [], gw?.gc ?? null, gw?.environmentId,
-        undefined, userId,
+        undefined, userId, extTemperature,
       )
     }
     return
@@ -637,12 +642,14 @@ async function* streamOllamaAgentChat(
   systemPrompt: string,
   history: Array<{ role: string; content: string }>,
   model: string,
-  resolvedBaseUrl?: string,     // pre-resolved from ext: lookup — skips second DB query
+  resolvedBaseUrl?: string,       // pre-resolved from ext: lookup — skips second DB query
   resolvedTimeoutSecs?: number,
   abortSignal?: AbortSignal,
+  resolvedTemperature?: number,
 ): AsyncGenerator<StreamChunk> {
   let ollamaUrl = resolvedBaseUrl
   let timeoutSecs = resolvedTimeoutSecs ?? 120
+  let resolvedTemp = resolvedTemperature
   if (!ollamaUrl) {
     const extModel = await prisma.externalModel.findFirst({
       where: { provider: 'ollama', modelId: model, enabled: true },
@@ -652,6 +659,7 @@ async function* streamOllamaAgentChat(
     if (!extModel) throw new Error('No Ollama model configured — add one in Admin → Models')
     ollamaUrl = extModel.baseUrl
     timeoutSecs = extModel.timeoutSecs ?? 120
+    if (resolvedTemp === undefined && extModel.temperature != null) resolvedTemp = extModel.temperature
   }
   const start = Date.now()
   let totalText = ''
@@ -671,7 +679,7 @@ async function* streamOllamaAgentChat(
     const res = await fetch(`${ollamaUrl}/api/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, messages, stream: true }),
+      body: JSON.stringify({ model, messages, stream: true, ...(resolvedTemp !== undefined && { options: { temperature: resolvedTemp } }) }),
       signal: fetchSignal,
     })
 
@@ -1060,6 +1068,7 @@ async function* streamOpenAIChatCore(
   environmentId: string | undefined,
   abortSignal?: AbortSignal,
   userId?: string,
+  temperature?: number,
 ): AsyncGenerator<StreamChunk> {
   const start = Date.now()
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
@@ -1230,6 +1239,7 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
     for (let turn = 0; turn < 10; turn++) {
       const body: Record<string, unknown> = { model, messages, stream: true }
       if (openaiTools.length) body.tools = openaiTools
+      if (temperature !== undefined) body.temperature = temperature
 
       const timeoutSignal = AbortSignal.timeout(120_000)
       const fetchSignal = abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal


### PR DESCRIPTION
## Summary
- Adds a `temperature` field to `ExternalModel` (nullable `Float` — blank means model default)
- Exposes it in Admin → Models form with a 0–2 range, step 0.05
- Threads the value through all inference paths: Ollama tool loop, Ollama agent chat, and OpenAI-compatible chat completions
- Prisma migration `3_external_model_temperature` adds the column

## Why
Qwen (and other local models) are prone to hallucination at default temperature. Setting temperature to 0 via the model config is the single biggest lever for reducing confabulation in agentic tasks.

## Test plan
- [ ] Add an Ollama model in Admin → Models — confirm temperature field appears
- [ ] Set temperature to 0, save, confirm value persists on re-open
- [ ] Leave temperature blank — confirm null is stored and model default is used
- [ ] Trigger an agent task using the model — confirm requests include `options.temperature` (Ollama) or `temperature` (OpenAI-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)