### PR TITLE
feat: sampling params for external models + Claude MCP tools in rooms

### DIFF
--- a/apps/web/prisma/migrations/4_external_model_sampling_params/migration.sql
+++ b/apps/web/prisma/migrations/4_external_model_sampling_params/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "ExternalModel" ADD COLUMN "topP"          DOUBLE PRECISION;
+ALTER TABLE "ExternalModel" ADD COLUMN "minP"          DOUBLE PRECISION;
+ALTER TABLE "ExternalModel" ADD COLUMN "repeatPenalty" DOUBLE PRECISION;
+ALTER TABLE "ExternalModel" ADD COLUMN "seed"          INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -439,10 +439,14 @@ model ExternalModel {
   apiKey      String?  @db.Text
   modelId     String
   enabled     Boolean  @default(true)
-  timeoutSecs Int      @default(120)
-  maxTokens   Int?
-  temperature Float?
-  createdAt   DateTime @default(now())
+  timeoutSecs   Int      @default(120)
+  maxTokens     Int?
+  temperature   Float?
+  topP          Float?
+  minP          Float?
+  repeatPenalty Float?
+  seed          Int?
+  createdAt     DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
 

--- a/apps/web/src/app/(app)/admin/models/page.tsx
+++ b/apps/web/src/app/(app)/admin/models/page.tsx
@@ -13,6 +13,10 @@ interface ExternalModel {
   timeoutSecs: number
   maxTokens: number | null
   temperature: number | null
+  topP: number | null
+  minP: number | null
+  repeatPenalty: number | null
+  seed: number | null
 }
 
 interface Health {
@@ -30,9 +34,13 @@ interface ModelForm {
   timeoutSecs: number
   maxTokens: number | null
   temperature: number | null
+  topP: number | null
+  minP: number | null
+  repeatPenalty: number | null
+  seed: number | null
 }
 
-const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120, maxTokens: null, temperature: null }
+const EMPTY_FORM: ModelForm = { name: '', provider: 'openai', baseUrl: '', apiKey: '', modelId: '', enabled: true, timeoutSecs: 120, maxTokens: null, temperature: null, topP: null, minP: null, repeatPenalty: null, seed: null }
 
 const PROVIDER_LABELS: Record<string, string> = {
   openai: 'OpenAI Compatible',
@@ -95,7 +103,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
   const isNew = model === null
   const [form, setForm] = useState<ModelForm>(
     model
-      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120, maxTokens: model.maxTokens ?? null, temperature: model.temperature ?? null }
+      ? { name: model.name, provider: model.provider, baseUrl: model.baseUrl, apiKey: '', modelId: model.modelId, enabled: model.enabled, timeoutSecs: model.timeoutSecs ?? 120, maxTokens: model.maxTokens ?? null, temperature: model.temperature ?? null, topP: model.topP ?? null, minP: model.minP ?? null, repeatPenalty: model.repeatPenalty ?? null, seed: model.seed ?? null }
       : EMPTY_FORM
   )
   const [saving, setSaving]         = useState(false)
@@ -111,7 +119,7 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
     if (!form.name || !form.baseUrl || !form.modelId) { setError('Name, Base URL, and Model ID are required.'); return }
     setSaving(true); setError(null)
     try {
-      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs, maxTokens: form.maxTokens, temperature: form.temperature }
+      const payload = { name: form.name, provider: form.provider, baseUrl: form.baseUrl, apiKey: form.apiKey || undefined, modelId: form.modelId, enabled: form.enabled, timeoutSecs: form.timeoutSecs, maxTokens: form.maxTokens, temperature: form.temperature, topP: form.topP, minP: form.minP, repeatPenalty: form.repeatPenalty, seed: form.seed }
       const res = model
         ? await fetch(`/api/admin/models/${model.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
         : await fetch('/api/admin/models', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -252,6 +260,64 @@ function ModelModal({ model, health, onClose, onSaved, onDeleted }: ModelModalPr
                   setForm(f => ({ ...f, temperature: e.target.value === '' ? null : Math.min(2, Math.max(0, isNaN(v) ? 0 : v)) }))
                 }}
                 placeholder="model default"
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Top-P (blank = model default)">
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={form.topP ?? ''}
+                onChange={e => {
+                  const v = parseFloat(e.target.value)
+                  setForm(f => ({ ...f, topP: e.target.value === '' ? null : Math.min(1, Math.max(0, isNaN(v) ? 1 : v)) }))
+                }}
+                placeholder="model default"
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Min-P — Ollama only (blank = off)">
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={form.minP ?? ''}
+                onChange={e => {
+                  const v = parseFloat(e.target.value)
+                  setForm(f => ({ ...f, minP: e.target.value === '' ? null : Math.min(1, Math.max(0, isNaN(v) ? 0 : v)) }))
+                }}
+                placeholder="off"
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Repeat Penalty — Ollama only (blank = off)">
+              <input
+                type="number"
+                min={1}
+                max={2}
+                step={0.05}
+                value={form.repeatPenalty ?? ''}
+                onChange={e => {
+                  const v = parseFloat(e.target.value)
+                  setForm(f => ({ ...f, repeatPenalty: e.target.value === '' ? null : Math.min(2, Math.max(1, isNaN(v) ? 1 : v)) }))
+                }}
+                placeholder="off"
+                className={inputCls}
+              />
+            </FormField>
+            <FormField label="Seed (blank = random)">
+              <input
+                type="number"
+                min={0}
+                value={form.seed ?? ''}
+                onChange={e => {
+                  const v = parseInt(e.target.value)
+                  setForm(f => ({ ...f, seed: e.target.value === '' ? null : (isNaN(v) ? null : Math.max(0, v)) }))
+                }}
+                placeholder="random"
                 className={inputCls}
               />
             </FormField>

--- a/apps/web/src/app/api/admin/models/[id]/route.ts
+++ b/apps/web/src/app/api/admin/models/[id]/route.ts
@@ -22,7 +22,11 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (body.enabled     !== undefined) updateData.enabled     = body.enabled
   if (body.timeoutSecs !== undefined) updateData.timeoutSecs = body.timeoutSecs
   if ('maxTokens' in body)            updateData.maxTokens   = body.maxTokens   // null clears the cap
-  if ('temperature' in body)          updateData.temperature = body.temperature // null = model default
+  if ('temperature'   in body) updateData.temperature   = body.temperature
+  if ('topP'          in body) updateData.topP          = body.topP
+  if ('minP'          in body) updateData.minP          = body.minP
+  if ('repeatPenalty' in body) updateData.repeatPenalty = body.repeatPenalty
+  if ('seed'          in body) updateData.seed          = body.seed
   if (body.apiKey)                    updateData.apiKey      = body.apiKey
 
   const model = await prisma.externalModel.update({

--- a/apps/web/src/app/api/admin/models/route.ts
+++ b/apps/web/src/app/api/admin/models/route.ts
@@ -29,8 +29,12 @@ export async function POST(req: NextRequest) {
       apiKey:      body.apiKey ?? null,
       modelId:     body.modelId,
       enabled:     body.enabled ?? true,
-      timeoutSecs: body.timeoutSecs ?? 120,
-      temperature: body.temperature ?? null,
+      timeoutSecs:   body.timeoutSecs ?? 120,
+      temperature:   body.temperature   ?? null,
+      topP:          body.topP          ?? null,
+      minP:          body.minP          ?? null,
+      repeatPenalty: body.repeatPenalty ?? null,
+      seed:          body.seed          ?? null,
     },
   })
 

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -252,6 +252,23 @@ interface OllamaMsg {
   tool_calls?: Array<{ function: { name: string; arguments: string | Record<string, unknown> } }>
 }
 
+/** Build Ollama options object — only includes fields that are explicitly set. */
+function buildOllamaOptions(
+  temperature?: number,
+  topP?: number,
+  minP?: number,
+  repeatPenalty?: number,
+  seed?: number,
+): Record<string, number> | undefined {
+  const opts: Record<string, number> = {}
+  if (temperature   !== undefined) opts.temperature    = temperature
+  if (topP          !== undefined) opts.top_p          = topP
+  if (minP          !== undefined) opts.min_p          = minP
+  if (repeatPenalty !== undefined) opts.repeat_penalty = repeatPenalty
+  if (seed          !== undefined) opts.seed           = seed
+  return Object.keys(opts).length ? opts : undefined
+}
+
 async function* streamOllamaToolLoop(
   prompt: string,
   conversationId: string,
@@ -265,6 +282,10 @@ async function* streamOllamaToolLoop(
   abortSignal?: AbortSignal,
   userId?: string,
   temperature?: number,
+  topP?: number,
+  minP?: number,
+  repeatPenalty?: number,
+  seed?: number,
 ): AsyncGenerator<StreamChunk> {
   const { GatewayClient: _GC } = await import('./agent-runner/gateway-client')
   void _GC
@@ -272,13 +293,21 @@ async function* streamOllamaToolLoop(
   let ollamaUrl = baseUrl
   let timeoutSecs = 120
   let resolvedTemp = temperature
+  let resolvedTopP = topP
+  let resolvedMinP = minP
+  let resolvedRepeatPenalty = repeatPenalty
+  let resolvedSeed = seed
   if (!ollamaUrl) {
     const extModel = await prisma.externalModel.findFirst({ where: { provider: 'ollama', modelId: model, enabled: true } })
       ?? await prisma.externalModel.findFirst({ where: { provider: 'ollama', enabled: true } })
     if (!extModel?.baseUrl) { yield { type: 'error', error: 'No Ollama model configured' }; return }
     ollamaUrl = extModel.baseUrl
     timeoutSecs = extModel.timeoutSecs ?? 120
-    if (resolvedTemp === undefined && extModel.temperature != null) resolvedTemp = extModel.temperature
+    if (resolvedTemp         === undefined && extModel.temperature   != null) resolvedTemp         = extModel.temperature
+    if (resolvedTopP         === undefined && extModel.topP          != null) resolvedTopP         = extModel.topP
+    if (resolvedMinP         === undefined && extModel.minP          != null) resolvedMinP         = extModel.minP
+    if (resolvedRepeatPenalty=== undefined && extModel.repeatPenalty != null) resolvedRepeatPenalty= extModel.repeatPenalty
+    if (resolvedSeed         === undefined && extModel.seed          != null) resolvedSeed         = extModel.seed
   }
 
   // Synthetic management tools — handled locally, never forwarded to the gateway
@@ -360,7 +389,7 @@ async function* streamOllamaToolLoop(
       const res = await fetch(`${ollamaUrl}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model, messages, stream: false, tools: ollamaToolDefs, ...(resolvedTemp !== undefined && { options: { temperature: resolvedTemp } }) }),
+        body: JSON.stringify({ model, messages, stream: false, tools: ollamaToolDefs, options: buildOllamaOptions(resolvedTemp, resolvedTopP, resolvedMinP, resolvedRepeatPenalty, resolvedSeed) }),
         signal: fetchSignal,
       })
       if (!res.ok) throw new Error(`Ollama ${res.status}: ${await res.text()}`)
@@ -545,6 +574,10 @@ export async function* streamAgentChat(
     let provider = 'ollama'
     let apiKey: string | undefined
     let extTemperature: number | undefined
+    let extTopP: number | undefined
+    let extMinP: number | undefined
+    let extRepeatPenalty: number | undefined
+    let extSeed: number | undefined
 
     if (llm.startsWith('ext:')) {
       const extId = llm.slice('ext:'.length)
@@ -555,7 +588,11 @@ export async function* streamAgentChat(
       timeoutSecs = extModel.timeoutSecs ?? 120
       provider = extModel.provider   // 'ollama' | 'openai' | 'custom' | etc.
       apiKey = extModel.apiKey ?? undefined
-      if (extModel.temperature != null) extTemperature = extModel.temperature
+      if (extModel.temperature   != null) extTemperature   = extModel.temperature
+      if (extModel.topP          != null) extTopP          = extModel.topP
+      if (extModel.minP          != null) extMinP          = extModel.minP
+      if (extModel.repeatPenalty != null) extRepeatPenalty = extModel.repeatPenalty
+      if (extModel.seed          != null) extSeed          = extModel.seed
     } else {
       model = llm.slice('ollama:'.length)
     }
@@ -572,9 +609,9 @@ export async function* streamAgentChat(
       const activeTasks = await getActiveTasksSection()
       if (gw) {
         const systemPrompt = await getSystemPrompt(gw.tools.map(t => t.name), agentSystemPrompt + activeTasks, conversationId, knowledgeContext)
-        yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId, extTemperature)
+        yield* streamOllamaToolLoop(prompt, conversationId, systemPrompt, trimmedHistory, model, baseUrl, gw.tools, gw.gc, gw.environmentId, undefined, userId, extTemperature, extTopP, extMinP, extRepeatPenalty, extSeed)
       } else {
-        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix + kcSection, trimmedHistory, model, baseUrl, timeoutSecs, undefined, extTemperature)
+        yield* streamOllamaAgentChat(prompt, conversationId, agentSystemPrompt + activeTasks + noGwSuffix + kcSection, trimmedHistory, model, baseUrl, timeoutSecs, undefined, extTemperature, extTopP, extMinP, extRepeatPenalty, extSeed)
       }
     } else {
       // OpenAI-compatible endpoint (custom / openai / llama.cpp / etc.)
@@ -602,7 +639,7 @@ ${readClusterContext()}${kcSection}`
         prompt, conversationId, openAISystemPrompt, trimmedHistory,
         model!, baseUrl!, apiKey,
         gw?.tools ?? [], gw?.gc ?? null, gw?.environmentId,
-        undefined, userId, extTemperature,
+        undefined, userId, extTemperature, extTopP, extSeed,
       )
     }
     return
@@ -646,6 +683,10 @@ async function* streamOllamaAgentChat(
   resolvedTimeoutSecs?: number,
   abortSignal?: AbortSignal,
   resolvedTemperature?: number,
+  resolvedTopP?: number,
+  resolvedMinP?: number,
+  resolvedRepeatPenalty?: number,
+  resolvedSeed?: number,
 ): AsyncGenerator<StreamChunk> {
   let ollamaUrl = resolvedBaseUrl
   let timeoutSecs = resolvedTimeoutSecs ?? 120
@@ -659,7 +700,11 @@ async function* streamOllamaAgentChat(
     if (!extModel) throw new Error('No Ollama model configured — add one in Admin → Models')
     ollamaUrl = extModel.baseUrl
     timeoutSecs = extModel.timeoutSecs ?? 120
-    if (resolvedTemp === undefined && extModel.temperature != null) resolvedTemp = extModel.temperature
+    if (resolvedTemp          === undefined && extModel.temperature   != null) resolvedTemp          = extModel.temperature
+    if (resolvedTopP          === undefined && extModel.topP          != null) resolvedTopP          = extModel.topP
+    if (resolvedMinP          === undefined && extModel.minP          != null) resolvedMinP          = extModel.minP
+    if (resolvedRepeatPenalty === undefined && extModel.repeatPenalty != null) resolvedRepeatPenalty = extModel.repeatPenalty
+    if (resolvedSeed          === undefined && extModel.seed          != null) resolvedSeed          = extModel.seed
   }
   const start = Date.now()
   let totalText = ''
@@ -679,7 +724,7 @@ async function* streamOllamaAgentChat(
     const res = await fetch(`${ollamaUrl}/api/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, messages, stream: true, ...(resolvedTemp !== undefined && { options: { temperature: resolvedTemp } }) }),
+      body: JSON.stringify({ model, messages, stream: true, options: buildOllamaOptions(resolvedTemp, resolvedTopP, resolvedMinP, resolvedRepeatPenalty, resolvedSeed) }),
       signal: fetchSignal,
     })
 
@@ -1069,6 +1114,8 @@ async function* streamOpenAIChatCore(
   abortSignal?: AbortSignal,
   userId?: string,
   temperature?: number,
+  topP?: number,
+  seed?: number,
 ): AsyncGenerator<StreamChunk> {
   const start = Date.now()
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
@@ -1238,8 +1285,10 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
     // Agentic loop — handles tool calls until model returns a final text response
     for (let turn = 0; turn < 10; turn++) {
       const body: Record<string, unknown> = { model, messages, stream: true }
-      if (openaiTools.length) body.tools = openaiTools
+      if (openaiTools.length)        body.tools       = openaiTools
       if (temperature !== undefined) body.temperature = temperature
+      if (topP        !== undefined) body.top_p       = topP
+      if (seed        !== undefined) body.seed        = seed
 
       const timeoutSignal = AbortSignal.timeout(120_000)
       const fetchSignal = abortSignal ? AbortSignal.any([abortSignal, timeoutSignal]) : timeoutSignal

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -110,7 +110,9 @@ async function callClaude(
   agentId?: string,
   roomId?: string,
 ): Promise<string | null> {
-  const useMcp = hasTools && !!agentId && !!roomId
+  // Always enable MCP when in a room context — Claude should have the same tool access
+  // as OpenAI-compatible agents. maxTurns controls depth; hasTools controls prompt framing.
+  const useMcp = !!agentId && !!roomId
   const toolMode: false | 'legacy' | 'mcp' = useMcp ? 'mcp' : hasTools ? 'legacy' : false
   const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, toolMode)
   const historyBlock = history.length
@@ -123,8 +125,9 @@ async function callClaude(
     body:    JSON.stringify({
       prompt,
       systemPrompt: sys,
-      // MCP context: sidecar writes .mcp.json and gives Claude up to 10 turns
-      ...(useMcp ? { agentId, roomId, maxTurns: 10 } : { maxTurns: 1 }),
+      // MCP context: always enabled in rooms so Claude has the same tools as other agents.
+      // maxTurns: 10 when tools explicitly enabled on agent, 3 otherwise (conversational mode).
+      ...(useMcp ? { agentId, roomId, maxTurns: hasTools ? 10 : 3 } : { maxTurns: 1 }),
       ...(modelId ? { model: modelId } : {}),
     }),
     // MCP tool calls can take longer — allow 5 min for tool-using sessions


### PR DESCRIPTION
## Summary
- **4 new sampling parameters** in Admin → Models: Top-P, Min-P (Ollama only), Repeat Penalty (Ollama only), Seed
- **Claude tool access fix**: Claude agents in chat rooms now always have access to ORION MCP tools, matching OpenAI-compatible agents

## Sampling Parameters
All stored in `ExternalModel`, all nullable (blank = model default):

| Field | Range | Works with |
|---|---|---|
| `topP` | 0–1 | Ollama + OpenAI-compat |
| `minP` | 0–1 | Ollama only |
| `repeatPenalty` | 1–2 | Ollama only |
| `seed` | 0+ | Ollama + OpenAI-compat |

Ollama params go into `options: {}` block. OpenAI-compat gets `top_p` and `seed` at body top level.

## Claude MCP Fix
Previously `useMcp = hasTools && !!agentId && !!roomId` — if an agent didn't have `contextConfig.tools: true`, Claude had no tool access at all in chat rooms, while OpenAI agents always got `getToolsForContext('chat')`.

Now `useMcp = !!agentId && !!roomId` — Claude always connects to the ORION MCP server in room context. `maxTurns` is 10 when tools explicitly enabled, 3 for conversational mode, keeping latency reasonable for simple replies.

## Test plan
- [ ] Open Admin → Models, edit an Ollama model — confirm Top-P, Min-P, Repeat Penalty, Seed fields appear
- [ ] Set `seed=42`, save, re-open — confirm value persists
- [ ] Leave all blank — confirm null stored, model defaults used
- [ ] Trigger a Claude agent reply in a chat room — confirm it has access to `orion_list_tasks`, `orion_get_snapshot` etc.
- [ ] Claude with tools disabled: confirm it still replies (3-turn max vs 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)