### PR TITLE
feat: orion_list_secrets tool — discover registered Vault ExternalSecrets

### DIFF
--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -2166,3 +2166,80 @@ Use this after completing or investigating any task. Structure content for maxim
     return `Knowledge ${action}: "${note.title}" (id: ${note.id}, folder: ${folder}, embedded: ${embedded})`
   },
 })
+
+// ── Vault / Managed Secrets ───────────────────────────────────────────────────
+
+async function handleListSecrets(args: unknown, ctx: ToolExecutionContext): Promise<string> {
+  const { environment, namespace, status, tag } = parseArgs(args) as {
+    environment?: string
+    namespace?: string
+    status?: string
+    tag?: string
+  }
+
+  let environmentId: string | undefined
+  if (environment) {
+    const env = await ctx.prisma.environment.findFirst({
+      where: { name: { contains: environment, mode: 'insensitive' } },
+      select: { id: true },
+    })
+    if (!env) return `Error: no environment matching "${environment}". Omit to list secrets from all environments.`
+    environmentId = env.id
+  }
+
+  const secrets = await ctx.prisma.managedSecret.findMany({
+    where: {
+      ...(environmentId ? { environmentId } : {}),
+      ...(namespace     ? { namespace }     : {}),
+      ...(status        ? { status }        : {}),
+    },
+    include: { environment: { select: { name: true } } },
+    orderBy: [{ environment: { name: 'asc' } }, { namespace: 'asc' }, { name: 'asc' }],
+    take: 100,
+  })
+
+  const filtered = tag
+    ? secrets.filter((s: any) => Array.isArray(s.tags) && s.tags.includes(tag))
+    : secrets
+
+  if (!filtered.length) return 'No managed secrets found matching the given filters.'
+
+  return JSON.stringify(
+    filtered.map((s: any) => ({
+      id:             s.id,
+      name:           s.name,                    // ExternalSecret / K8s Secret name
+      environment:    s.environment.name,
+      namespace:      s.namespace,
+      description:    s.description ?? null,
+      vaultPath:      s.remoteRef,               // Vault path — e.g. "secret/data/myapp/db"
+      targetSecret:   s.targetSecretName ?? s.name,  // K8s Secret name to mount/reference
+      // Only the K8s key names — how to reference this secret in pod specs / secretKeyRef.
+      // Vault-internal key names are not exposed.
+      k8sKeys:        (s.dataKeys as Array<{ secretKey: string }> ?? []).map(k => k.secretKey),
+      refreshInterval: s.refreshInterval,
+      status:         s.status,                  // "draft" | "applied" | "error"
+      statusMessage:  s.status === 'error' ? (s.statusMessage ?? null) : null,
+      tags:           s.tags ?? [],
+      appliedAt:      s.appliedAt?.toISOString() ?? null,
+    })),
+    null, 2
+  )
+}
+
+registerTool({
+  name: 'orion_list_secrets',
+  description: 'List Vault secrets registered in ORION as managed ExternalSecrets. Returns metadata only — Vault path, target K8s Secret name, the K8s key names you can reference in pod specs, and sync status. Never returns actual secret values or Vault-internal key names.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      environment: { type: 'string', description: 'Filter by environment name (partial match). Omit for all environments.' },
+      namespace:   { type: 'string', description: 'Filter by Kubernetes namespace.' },
+      status:      { type: 'string', description: 'Filter by sync status: draft, applied, error.' },
+      tag:         { type: 'string', description: 'Filter by a single tag value.' },
+    },
+  },
+  tier: 'read',
+  parallelSafe: true,
+  availableIn: 'both',
+  handler: handleListSecrets,
+})


### PR DESCRIPTION
## Summary
Adds `orion_list_secrets` to the tool registry so agents can see what Vault secrets are registered in ORION without exposing sensitive data.

## What it returns
- Secret name, namespace, environment
- Vault path (the `remoteRef` — e.g. `secret/data/myapp/db`)
- K8s Secret name to use in `secretKeyRef` / volume mounts
- **K8s key names only** — what to put in `secretKeyRef.key`. Vault-internal key names are intentionally omitted.
- Sync status (draft / applied / error) and error message if failed
- Tags, refresh interval, applied timestamp

## What it does NOT return
- Actual secret values
- Vault-internal key names (the field names inside the Vault secret)

## Filters
`environment`, `namespace`, `status`, `tag` — all optional.

## Availability
`availableIn: 'both'` — accessible via MCP (Claude) and registry (Nexus/OpenAI agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)