### PR TITLE
feat: route claude:* agents through orion-claude sidecar

### DIFF
--- a/apps/web/src/lib/agent-runner/claude-runner.ts
+++ b/apps/web/src/lib/agent-runner/claude-runner.ts
@@ -1,0 +1,65 @@
+import type { AgentRunner, AgentEvent, TaskRunContext } from './types'
+import { getPrompt, interpolate } from '@/lib/system-prompts'
+
+const CLAUDE_URL = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
+
+/**
+ * Claude runner — routes claude:* model IDs through the orion-claude sidecar.
+ *
+ * The sidecar runs the Claude Code CLI with OAuth credentials (never a bare API key).
+ * When agentId is provided, the sidecar writes a per-request .mcp.json so Claude
+ * can call ORION tools natively via MCP — same tool access as any other agent.
+ *
+ * This runner never calls api.anthropic.com directly.
+ */
+export const claudeRunner: AgentRunner = {
+  async *run(ctx: TaskRunContext): AsyncGenerator<AgentEvent> {
+    // Strip "claude:" prefix to get the raw model name (e.g. claude-sonnet-4-6)
+    const modelName = ctx.modelId.startsWith('claude:')
+      ? ctx.modelId.slice('claude:'.length)
+      : ctx.modelId
+
+    const taskTemplate = await getPrompt('system.task-execution')
+    const taskPrompt = interpolate(taskTemplate, {
+      taskTitle:       ctx.taskTitle,
+      taskDescription: ctx.taskDescription ? `Description: ${ctx.taskDescription}` : '',
+      taskPlan:        ctx.taskPlan ? `\nImplementation plan:\n${ctx.taskPlan}` : '',
+    })
+
+    try {
+      const res = await fetch(`${CLAUDE_URL}/run/collect`, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt:       taskPrompt,
+          systemPrompt: ctx.systemPrompt,
+          model:        modelName,
+          agentId:      ctx.agentId,
+          maxTurns:     20,
+        }),
+        signal: AbortSignal.timeout(300_000),
+      })
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        yield { type: 'error', error: `orion-claude sidecar returned HTTP ${res.status}: ${body}` }
+        return
+      }
+
+      const data = await res.json() as { text?: string; error?: string }
+
+      if (data.error) {
+        yield { type: 'error', error: data.error }
+        return
+      }
+
+      if (data.text) {
+        yield { type: 'text', content: data.text }
+      }
+
+      yield { type: 'done' }
+    } catch (err) {
+      yield { type: 'error', error: err instanceof Error ? err.message : String(err) }
+    }
+  },
+}

--- a/apps/web/src/lib/agent-runner/index.ts
+++ b/apps/web/src/lib/agent-runner/index.ts
@@ -2,15 +2,16 @@ import type { AgentRunner } from './types'
 import { openaiRunner } from './openai-runner'
 import { ollamaRunner } from './ollama-runner'
 import { dispatcherRunner } from './dispatcher-runner'
+import { claudeRunner } from './claude-runner'
 
 /**
  * Returns the appropriate runner for a given modelId.
- * All runners use the same OpenAI-compatible tool loop pattern for LLM-agnostic tool execution.
- * claude:* or 'claude' -> openaiRunner (Anthropic API via OpenAI-compatible endpoint)
+ * claude:* or 'claude' -> claudeRunner (orion-claude sidecar, OAuth — never direct API)
  * ollama:* or ext:* -> dispatcherRunner
+ * Default -> openaiRunner (OpenAI-compatible endpoint)
  */
 export function createRunner(modelId: string): AgentRunner {
-  if (modelId.startsWith('claude:') || modelId === 'claude') return openaiRunner
+  if (modelId.startsWith('claude:') || modelId === 'claude') return claudeRunner
   if (modelId.startsWith('ollama:') || modelId.startsWith('ext:')) return dispatcherRunner
   // Default to OpenAI-compatible runner for unknown/legacy model IDs
   return openaiRunner

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -80,11 +80,14 @@ function sanitizeMaxTurns(maxTurns, fallback = 20) {
 
 /**
  * Write a temporary directory containing .mcp.json so the claude CLI can call
- * ORION tools via MCP for this specific agent+room combination.
+ * ORION tools via MCP for this agent. roomId is optional — task runners supply
+ * only agentId; chat rooms supply both agentId and roomId.
  * Returns the temp dir path — caller must clean it up after execFile completes.
  */
 function writeMcpDir(agentId, roomId) {
-  const url = `${ORION_URL}/api/mcp?agentId=${encodeURIComponent(agentId)}&roomId=${encodeURIComponent(roomId)}`
+  const params = new URLSearchParams({ agentId })
+  if (roomId) params.set('roomId', roomId)
+  const url = `${ORION_URL}/api/mcp?${params.toString()}`
   const config = {
     mcpServers: {
       orion: {
@@ -102,14 +105,14 @@ function writeMcpDir(agentId, roomId) {
 /**
  * Call the `claude` CLI as a subprocess — same approach as the Discord bot.
  * Strips ANTHROPIC_API_KEY and CLAUDECODE from env to force OAuth credential use.
- * When agentId + roomId are provided, writes a .mcp.json so Claude can call
- * ORION tools natively — ORION is the harness, Claude is the brain.
+ * When agentId is provided, writes a per-request .mcp.json so Claude can call
+ * ORION tools natively via MCP. roomId is optional (chat rooms only).
  */
 function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 120000, agentId, roomId } = {}) {
   return new Promise((resolve, reject) => {
     const safeModel       = sanitizeModel(model)
     const safeSystemPrompt = sanitizeSystemPrompt(systemPrompt)
-    const useMcp          = !!(agentId && roomId)
+    const useMcp          = !!agentId
     const safeMaxTurns    = sanitizeMaxTurns(maxTurns, useMcp ? 10 : 1)
 
     const args = ['-p', String(prompt), '--output-format', 'json']
@@ -128,7 +131,7 @@ function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 12000
       try {
         tmpDir = writeMcpDir(agentId, roomId)
         cwd    = tmpDir
-        console.log(`[orion-claude] MCP enabled — agent=${agentId} room=${roomId} url=${ORION_URL}/api/mcp`)
+        console.log(`[orion-claude] MCP enabled — agent=${agentId}${roomId ? ` room=${roomId}` : ''} url=${ORION_URL}/api/mcp`)
       } catch (e) {
         console.error('[orion-claude] Failed to write MCP config, falling back to no-tools:', e.message)
       }
@@ -382,7 +385,7 @@ const server = http.createServer(async (req, res) => {
       try { opts = JSON.parse(body || '{}') } catch { return json(res, 400, { error: 'Invalid JSON' }) }
 
       try {
-        const useMcp = !!(opts.agentId && opts.roomId)
+        const useMcp = !!opts.agentId
         const stdout = await runClaude(String(opts.prompt || ''), {
           systemPrompt: opts.systemPrompt,
           model:        opts.model,


### PR DESCRIPTION
## Summary

- **New `claude-runner.ts`**: Routes `claude:*` model IDs to the `orion-claude` sidecar (`/run/collect`) instead of calling `api.anthropic.com` directly. With `agentId` supplied, the sidecar writes a per-request `.mcp.json` so Claude gets full ORION MCP tool access — same as any other agent.
- **`agent-runner/index.ts`**: `claude:*` and `'claude'` now route to `claudeRunner` instead of `openaiRunner`.
- **`deploy/orion-claude/server.js`**: Made `roomId` optional in `writeMcpDir`. Changed `useMcp` gate from `!!(agentId && roomId)` to `!!agentId` — task runners now get MCP tools with only `agentId`, no `roomId` required.

## Why

Watcher agents (Mentor, Claude) were getting 401 errors because `createRunner('claude:...')` returned `openaiRunner`, which called `resolveOpenAIConfig` and routed to `https://api.anthropic.com` with an empty `ANTHROPIC_API_KEY`. Claude should **always** go through the OAuth CLI sidecar — never a bare API key.

## Test plan

- [ ] Deploy updated container image
- [ ] Verify watcher agents (Mentor, Claude) no longer get 401 errors in logs
- [ ] Verify task runner with a `claude:*` agent completes successfully
- [ ] Verify Claude in a chat room still has ORION MCP tool access

🤖 Generated with [Claude Code](https://claude.com/claude-code)