### PR TITLE
feat: agent context injection, plan-first for local LLMs, mTLS vault-proxy

### DIFF
--- a/apps/web/src/app/api/setup/vault/route.ts
+++ b/apps/web/src/app/api/setup/vault/route.ts
@@ -14,8 +14,8 @@ import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
 import { generateVaultProxyCerts } from '@/lib/vault-proxy'
 import { encrypt, encryptJson } from '@/lib/encryption'
+import { VAULT_ADDR, vaultFetch } from '@/lib/vault'
 
-const VAULT_ADDR       = process.env.VAULT_ADDR ?? 'http://vault:8200'
 const UNSEAL_SHARES    = 5
 const UNSEAL_THRESHOLD = 3
 
@@ -43,9 +43,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const healthRes = await fetch(`${VAULT_ADDR}/v1/sys/health`, {
-      signal: AbortSignal.timeout(5000),
-    })
+    const healthRes = await vaultFetch(`${VAULT_ADDR}/v1/sys/health`)
     const health = await healthRes.json()
 
     if (health.initialized) {
@@ -56,11 +54,10 @@ export async function POST(req: NextRequest) {
     }
 
     // Initialize Vault
-    const initRes = await fetch(`${VAULT_ADDR}/v1/sys/init`, {
+    const initRes = await vaultFetch(`${VAULT_ADDR}/v1/sys/init`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ secret_shares: UNSEAL_SHARES, secret_threshold: UNSEAL_THRESHOLD }),
-      signal: AbortSignal.timeout(15000),
     })
 
     if (!initRes.ok) {
@@ -77,25 +74,23 @@ export async function POST(req: NextRequest) {
     // Unseal with threshold keys
     await Promise.all(
       thresholdKeys.map((key: string) =>
-        fetch(`${VAULT_ADDR}/v1/sys/unseal`, {
+        vaultFetch(`${VAULT_ADDR}/v1/sys/unseal`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ key }),
-          signal: AbortSignal.timeout(5000),
         })
       )
     )
 
     // Create scoped admin policy
-    await fetch(`${VAULT_ADDR}/v1/sys/policies/acl/orion-admin`, {
+    await vaultFetch(`${VAULT_ADDR}/v1/sys/policies/acl/orion-admin`, {
       method: 'PUT',
       headers: { 'X-Vault-Token': root_token, 'Content-Type': 'application/json' },
       body: JSON.stringify({ policy: ORION_ADMIN_POLICY }),
-      signal: AbortSignal.timeout(5000),
     })
 
     // Mint a 1-year renewable admin token bound to that policy
-    const adminTokenRes = await fetch(`${VAULT_ADDR}/v1/auth/token/create`, {
+    const adminTokenRes = await vaultFetch(`${VAULT_ADDR}/v1/auth/token/create`, {
       method: 'POST',
       headers: { 'X-Vault-Token': root_token, 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -104,7 +99,6 @@ export async function POST(req: NextRequest) {
         ttl: '8760h',
         renewable: true,
       }),
-      signal: AbortSignal.timeout(5000),
     })
     if (!adminTokenRes.ok) {
       const errText = await adminTokenRes.text()
@@ -116,10 +110,9 @@ export async function POST(req: NextRequest) {
     const { auth: { client_token: adminToken } } = await adminTokenRes.json()
 
     // Revoke root token — never persisted
-    await fetch(`${VAULT_ADDR}/v1/auth/token/revoke-self`, {
+    await vaultFetch(`${VAULT_ADDR}/v1/auth/token/revoke-self`, {
       method: 'POST',
       headers: { 'X-Vault-Token': root_token },
-      signal: AbortSignal.timeout(5000),
     })
 
     // Store unseal keys + admin token encrypted in DB — no files written to disk

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -1,0 +1,115 @@
+/**
+ * Pre-flight context injection for room agents.
+ *
+ * Before each LLM call, this module assembles two context blocks:
+ *
+ * 1. ORION snapshot — agents, active tasks, recent events.
+ *    Cached in-process for 2 minutes so agents don't need to call
+ *    orion_get_snapshot on every message.
+ *
+ * 2. Knowledge base — semantically relevant notes from the vector store.
+ *    Embedding query is the latest user message. Silently skipped if no
+ *    embedding provider is configured.
+ *
+ * The combined block is injected into every agent's system prompt so the
+ * model arrives pre-oriented and can answer most questions without any
+ * tool calls.
+ */
+
+import { prisma } from './db'
+import { retrieveKnowledgeContext } from './embeddings'
+
+// ── In-process snapshot cache ────────────────────────────────────────────────
+
+const SNAPSHOT_TTL_MS = 2 * 60 * 1000  // 2 minutes
+
+let snapshotCache: { text: string; expiresAt: number } | null = null
+
+async function fetchSnapshot(): Promise<string> {
+  const now = Date.now()
+  if (snapshotCache && snapshotCache.expiresAt > now) {
+    return snapshotCache.text
+  }
+
+  try {
+    const [agents, tasks, events] = await Promise.all([
+      prisma.agent.findMany({ orderBy: { name: 'asc' } }),
+      prisma.task.findMany({
+        where: { status: { in: ['pending', 'in_progress', 'blocked'] } },
+        orderBy: { updatedAt: 'desc' },
+        take: 20,
+        include: { agent: { select: { name: true } } },
+      }),
+      prisma.taskEvent.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        include: { task: { select: { title: true } } },
+      }),
+    ])
+
+    const activeAgents = agents.filter(
+      (a: any) => (a.metadata as Record<string, unknown> | null)?.archived !== true,
+    )
+    const agentLines = activeAgents
+      .map((a: any) => `  ${a.name} (${a.status})${a.role ? ' — ' + a.role : ''}`)
+      .join('\n')
+    const taskLines = tasks
+      .map(
+        (t: any) =>
+          `  [${t.id}] ${t.title} — ${t.status}, assigned: ${t.agent?.name ?? 'unassigned'}`,
+      )
+      .join('\n')
+    const eventLines = events
+      .map((e: any) => `  [${e.taskId}] ${e.task?.title ?? '?'}: ${e.eventType}`)
+      .join('\n')
+
+    const text = [
+      `## ORION State (cached ${new Date().toISOString()})`,
+      `**Agents (${activeAgents.length}):**`,
+      agentLines || '  none',
+      '',
+      `**Active Tasks (${tasks.length}):**`,
+      taskLines || '  none',
+      '',
+      `**Recent Events:**`,
+      eventLines || '  none',
+    ].join('\n')
+
+    snapshotCache = { text, expiresAt: now + SNAPSHOT_TTL_MS }
+    return text
+  } catch (err) {
+    // Never block an LLM call over a snapshot failure
+    console.warn('[agent-context] snapshot fetch failed:', err)
+    return ''
+  }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Build a context block to prepend to an agent's system prompt.
+ *
+ * @param query - The latest user message, used as the vector search query.
+ * @returns A formatted markdown string (may be empty if both sources fail).
+ */
+export async function buildAgentContext(query: string): Promise<string> {
+  const [snapshot, knowledge] = await Promise.all([
+    fetchSnapshot(),
+    retrieveKnowledgeContext(query, 3, 0.4),
+  ])
+
+  const parts: string[] = []
+  if (snapshot) parts.push(snapshot)
+  if (knowledge) {
+    parts.push('## Relevant Knowledge Base Notes')
+    parts.push(knowledge)
+  }
+
+  if (parts.length === 0) return ''
+  return '\n\n---\n' + parts.join('\n\n') + '\n---'
+}
+
+/** Explicitly invalidate the snapshot cache (call after write operations). */
+export function invalidateSnapshotCache(): void {
+  snapshotCache = null
+}

--- a/apps/web/src/lib/agent-runner/claude-runner.ts
+++ b/apps/web/src/lib/agent-runner/claude-runner.ts
@@ -1,0 +1,65 @@
+import type { AgentRunner, AgentEvent, TaskRunContext } from './types'
+import { getPrompt, interpolate } from '@/lib/system-prompts'
+
+const CLAUDE_URL = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
+
+/**
+ * Claude runner — routes claude:* model IDs through the orion-claude sidecar.
+ *
+ * The sidecar runs the Claude Code CLI with OAuth credentials (never a bare API key).
+ * When agentId is provided, the sidecar writes a per-request .mcp.json so Claude
+ * can call ORION tools natively via MCP — same tool access as any other agent.
+ *
+ * This runner never calls api.anthropic.com directly.
+ */
+export const claudeRunner: AgentRunner = {
+  async *run(ctx: TaskRunContext): AsyncGenerator<AgentEvent> {
+    // Strip "claude:" prefix to get the raw model name (e.g. claude-sonnet-4-6)
+    const modelName = ctx.modelId.startsWith('claude:')
+      ? ctx.modelId.slice('claude:'.length)
+      : ctx.modelId
+
+    const taskTemplate = await getPrompt('system.task-execution')
+    const taskPrompt = interpolate(taskTemplate, {
+      taskTitle:       ctx.taskTitle,
+      taskDescription: ctx.taskDescription ? `Description: ${ctx.taskDescription}` : '',
+      taskPlan:        ctx.taskPlan ? `\nImplementation plan:\n${ctx.taskPlan}` : '',
+    })
+
+    try {
+      const res = await fetch(`${CLAUDE_URL}/run/collect`, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt:       taskPrompt,
+          systemPrompt: ctx.systemPrompt,
+          model:        modelName,
+          agentId:      ctx.agentId,
+          maxTurns:     20,
+        }),
+        signal: AbortSignal.timeout(300_000),
+      })
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        yield { type: 'error', error: `orion-claude sidecar returned HTTP ${res.status}: ${body}` }
+        return
+      }
+
+      const data = await res.json() as { text?: string; error?: string }
+
+      if (data.error) {
+        yield { type: 'error', error: data.error }
+        return
+      }
+
+      if (data.text) {
+        yield { type: 'text', content: data.text }
+      }
+
+      yield { type: 'done' }
+    } catch (err) {
+      yield { type: 'error', error: err instanceof Error ? err.message : String(err) }
+    }
+  },
+}

--- a/apps/web/src/lib/agent-runner/index.ts
+++ b/apps/web/src/lib/agent-runner/index.ts
@@ -1,20 +1,44 @@
-import type { AgentRunner } from './types'
+import type { AgentRunner, TaskRunContext, AgentEvent } from './types'
 import { openaiRunner } from './openai-runner'
 import { ollamaRunner } from './ollama-runner'
 import { dispatcherRunner } from './dispatcher-runner'
 import { claudeRunner } from './claude-runner'
+import { buildAgentContext } from '../agent-context'
 
 /**
- * Returns the appropriate runner for a given modelId.
+ * Wraps a runner so every execution gets ORION snapshot + vector knowledge
+ * injected into the system prompt automatically — regardless of which caller
+ * invoked the runner (task runner, watcher, etc.).
+ *
+ * The query used for vector search is the task title + description, which
+ * gives semantically relevant notes without the agent needing to ask.
+ */
+function withContext(runner: AgentRunner): AgentRunner {
+  return {
+    async *run(ctx: TaskRunContext): AsyncGenerator<AgentEvent> {
+      const query = [ctx.taskTitle, ctx.taskDescription ?? ''].join(' ').trim()
+      const contextBlock = await buildAgentContext(query)
+      const enrichedCtx: TaskRunContext = contextBlock
+        ? { ...ctx, systemPrompt: ctx.systemPrompt + contextBlock }
+        : ctx
+      yield* runner.run(enrichedCtx)
+    },
+  }
+}
+
+/**
+ * Returns the appropriate runner for a given modelId, pre-wrapped with
+ * automatic context injection (ORION snapshot + vector search).
  * claude:* or 'claude' -> claudeRunner (orion-claude sidecar, OAuth — never direct API)
  * ollama:* or ext:* -> dispatcherRunner
  * Default -> openaiRunner (OpenAI-compatible endpoint)
  */
 export function createRunner(modelId: string): AgentRunner {
-  if (modelId.startsWith('claude:') || modelId === 'claude') return claudeRunner
-  if (modelId.startsWith('ollama:') || modelId.startsWith('ext:')) return dispatcherRunner
-  // Default to OpenAI-compatible runner for unknown/legacy model IDs
-  return openaiRunner
+  let base: AgentRunner
+  if (modelId.startsWith('claude:') || modelId === 'claude') base = claudeRunner
+  else if (modelId.startsWith('ollama:') || modelId.startsWith('ext:')) base = dispatcherRunner
+  else base = openaiRunner
+  return withContext(base)
 }
 
 export type { AgentRunner, AgentEvent, TaskRunContext, GatewayTool } from './types'

--- a/apps/web/src/lib/agent-runner/index.ts
+++ b/apps/web/src/lib/agent-runner/index.ts
@@ -2,15 +2,16 @@ import type { AgentRunner } from './types'
 import { openaiRunner } from './openai-runner'
 import { ollamaRunner } from './ollama-runner'
 import { dispatcherRunner } from './dispatcher-runner'
+import { claudeRunner } from './claude-runner'
 
 /**
  * Returns the appropriate runner for a given modelId.
- * All runners use the same OpenAI-compatible tool loop pattern for LLM-agnostic tool execution.
- * claude:* or 'claude' -> openaiRunner (Anthropic API via OpenAI-compatible endpoint)
+ * claude:* or 'claude' -> claudeRunner (orion-claude sidecar, OAuth — never direct API)
  * ollama:* or ext:* -> dispatcherRunner
+ * Default -> openaiRunner (OpenAI-compatible endpoint)
  */
 export function createRunner(modelId: string): AgentRunner {
-  if (modelId.startsWith('claude:') || modelId === 'claude') return openaiRunner
+  if (modelId.startsWith('claude:') || modelId === 'claude') return claudeRunner
   if (modelId.startsWith('ollama:') || modelId.startsWith('ext:')) return dispatcherRunner
   // Default to OpenAI-compatible runner for unknown/legacy model IDs
   return openaiRunner

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -28,9 +28,9 @@ import { prisma } from './db'
 import { decrypt } from './encryption'
 import { bootstrapEnvironmentRepo } from './gitops'
 import { getGitProvider } from './git-provider'
+import { VAULT_ADDR, vaultFetch } from './vault'
 
 const ORION_URL       = process.env.NEXTAUTH_URL  ?? 'http://localhost:3000'
-const VAULT_ADDR      = process.env.VAULT_ADDR    ?? 'http://vault:8200'
 const MANAGEMENT_IP   = process.env.MANAGEMENT_IP ?? 'localhost'
 
 export type BootstrapEvent =
@@ -362,11 +362,10 @@ async function vaultRequest(
   method: string = 'GET',
   body?: unknown,
 ): Promise<{ ok: boolean; status: number; data: unknown }> {
-  const res = await fetch(`${VAULT_ADDR}/v1/${path}`, {
+  const res = await vaultFetch(`${VAULT_ADDR}/v1/${path}`, {
     method,
     headers: { 'X-Vault-Token': token, 'Content-Type': 'application/json' },
     body: body ? JSON.stringify(body) : undefined,
-    signal: AbortSignal.timeout(10000),
   })
   const data = res.status !== 204 ? await res.json().catch(() => ({})) : {}
   return { ok: res.ok, status: res.status, data }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -45,11 +45,24 @@ type ChatMsg = { role: 'system' | 'user' | 'assistant'; content: string }
  * otherParticipants lists the names of other agents/users in the room so the
  * model knows who it can @mention to continue the conversation.
  */
+const LOCAL_MODEL_PLAN_FIRST = `
+
+## Plan Before You Act
+
+Before calling any tool:
+1. State what you already know
+2. State what you still need
+3. List the exact sequence of tool calls you will make
+
+Then execute that plan — one tool at a time, in order. Do not call the same tool twice. Do not improvise mid-plan. If a step fails, report it and stop — do not retry or chain to a different tool hoping for a better result.`
+
 function buildSystemPrompt(
   agentName: string,
   agentBasePrompt: string,
   otherParticipants: string[],
   hasTools: boolean | 'legacy' | 'mcp' = false,
+  /** True for non-Claude (Ollama/OpenAI-compat) models — injects plan-first constraint */
+  localModel = false,
 ): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
@@ -61,6 +74,7 @@ function buildSystemPrompt(
     hasTools === 'mcp'              ? '\n\n## ORION Tools\nYou have ORION management tools available via MCP. Use them — do not describe hypothetical actions when you can call a tool to get real data.' :
     hasTools === 'legacy' || hasTools === true ? TOOLS_SYSTEM_ADDENDUM :
     ''
+  const planFirst = localModel && hasTools ? LOCAL_MODEL_PLAN_FIRST : ''
   return `IMPORTANT — YOUR ROLE:
 You are ${agentName}. You are ONE participant in a group chat.
 ${othersLine}
@@ -75,7 +89,7 @@ Rules you must follow without exception:
 7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT
 
 ---
-${agentBasePrompt}${toolAddendum}`
+${agentBasePrompt}${toolAddendum}${planFirst}`
 }
 
 /**
@@ -153,7 +167,7 @@ async function callOllamaChat(
   baseUrl: string,
   hasTools = false,
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const res = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
@@ -191,7 +205,7 @@ async function callOpenAIChat(
   gatewayTools?: GatewayTool[],
 ): Promise<string | null> {
   const hasTools = !!toolContext
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -20,6 +20,7 @@ import { ORION_TOOL_DEFINITIONS, TOOLS_SYSTEM_ADDENDUM, executeTool } from './ag
 import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
+import { buildAgentContext, invalidateSnapshotCache } from './agent-context'
 import type { AgentGateway } from './agent-gateway'
 import type { GatewayTool } from './agent-runner/types'
 
@@ -443,9 +444,14 @@ export async function triggerRoomAgentReplies(
       const toolsEnabled  = !!(contextConfig.tools)
 
       // Base persona description — identity constraint is added by buildSystemPrompt()
-      const agentBasePrompt = rawPrompt
+      const personaPrompt = rawPrompt
         ? `${agent.role ? `Role: ${agent.role}\n\n` : ''}${rawPrompt}`
         : `${agent.role ? `Role: ${agent.role}\n\n` : ''}${agent.description ?? ''}`
+
+      // Inject pre-fetched context (ORION snapshot + vector search) so agents arrive
+      // pre-oriented and don't need to call orion_get_snapshot on every message.
+      const agentContext = await buildAgentContext(latestTurn)
+      const agentBasePrompt = agentContext ? personaPrompt + agentContext : personaPrompt
 
       // Names of other agents/users in the room so the model can @mention them
       const otherParticipants = agentMembers

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -126,8 +126,9 @@ async function callClaude(
       prompt,
       systemPrompt: sys,
       // MCP context: always enabled in rooms so Claude has the same tools as other agents.
-      // maxTurns: 10 when tools explicitly enabled on agent, 3 otherwise (conversational mode).
-      ...(useMcp ? { agentId, roomId, maxTurns: hasTools ? 10 : 3 } : { maxTurns: 1 }),
+      // maxTurns: 5 when tools explicitly enabled on agent, 3 otherwise (conversational mode).
+      // Reduced from 10 → 5: Qwen/tool-using models burn turns on exploration; cap keeps them focused.
+      ...(useMcp ? { agentId, roomId, maxTurns: hasTools ? 5 : 3 } : { maxTurns: 1 }),
       ...(modelId ? { model: modelId } : {}),
     }),
     // MCP tool calls can take longer — allow 5 min for tool-using sessions

--- a/apps/web/src/lib/vault.ts
+++ b/apps/web/src/lib/vault.ts
@@ -3,10 +3,82 @@
  * Used by both the secrets API routes and the agent tool executor.
  */
 
+import https from 'node:https'
+import fs from 'node:fs'
 import { prisma } from './db'
 import { decrypt } from './encryption'
 
-const VAULT_ADDR = process.env.VAULT_ADDR ?? 'http://vault:8200'
+export const VAULT_ADDR = process.env.VAULT_ADDR ?? 'http://vault:8200'
+
+// ── mTLS agent ────────────────────────────────────────────────────────────────
+// When VAULT_CACERT / VAULT_CLIENT_CERT / VAULT_CLIENT_KEY are set, all Vault
+// calls go through the Envoy proxy with mutual TLS. Falls back to plain fetch
+// when the env vars are absent (e.g. local dev pointing directly at Vault HTTP).
+
+let _agent: https.Agent | undefined | null = null   // null = not yet initialised
+
+function getVaultAgent(): https.Agent | undefined {
+  if (_agent !== null) return _agent
+  const caPath   = process.env.VAULT_CACERT
+  const certPath = process.env.VAULT_CLIENT_CERT
+  const keyPath  = process.env.VAULT_CLIENT_KEY
+  if (!caPath && !certPath) { _agent = undefined; return undefined }
+  _agent = new https.Agent({
+    ca:   caPath   ? fs.readFileSync(caPath)   : undefined,
+    cert: certPath ? fs.readFileSync(certPath) : undefined,
+    key:  keyPath  ? fs.readFileSync(keyPath)  : undefined,
+    rejectUnauthorized: !!caPath,
+  })
+  return _agent
+}
+
+/**
+ * Drop-in replacement for `fetch()` that adds mTLS when Vault certs are
+ * configured. Returns a standard `Response` so callers need no changes.
+ */
+export function vaultFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const agent = getVaultAgent()
+  if (!agent) return fetch(url, options)
+
+  // Native fetch() in Node.js doesn't accept an https.Agent directly.
+  // Use node:https.request and wrap the result in a Response.
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const body   = options.body ? String(options.body) : undefined
+    const reqOpts: https.RequestOptions = {
+      hostname: parsed.hostname,
+      port:     parsed.port || 443,
+      path:     parsed.pathname + parsed.search,
+      method:   (options.method ?? 'GET').toUpperCase(),
+      headers:  options.headers as Record<string, string> | undefined,
+      agent,
+      timeout:  10_000,
+    }
+
+    const req = https.request(reqOpts, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => {
+        const buffer = Buffer.concat(chunks)
+        const text   = buffer.toString('utf8')
+        const status = res.statusCode ?? 500
+        // Construct a Response-compatible object
+        resolve(new Response(text, {
+          status,
+          headers: res.headers as Record<string, string>,
+        }))
+      })
+    })
+
+    req.on('error', reject)
+    req.on('timeout', () => { req.destroy(); reject(new Error('Vault request timed out')) })
+
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+// ── Secret writer ─────────────────────────────────────────────────────────────
 
 /**
  * Write key/value pairs to Vault KV v2 at the given path.
@@ -25,14 +97,13 @@ export async function writeVaultSecret(
   // Normalise: strip "secret/data/" prefix if the caller included it
   const normalised = kvPath.replace(/^secret\/data\//, '')
 
-  const res = await fetch(`${VAULT_ADDR}/v1/secret/data/${normalised}`, {
+  const res = await vaultFetch(`${VAULT_ADDR}/v1/secret/data/${normalised}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-Vault-Token': token,
     },
     body: JSON.stringify({ data }),
-    signal: AbortSignal.timeout(10_000),
   })
 
   if (!res.ok) {

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -16,7 +16,6 @@ import { getSystemRooms } from './lib/seed-system-epic'
 import { getPrompt } from './lib/system-prompts'
 import { resolveAgentGateway } from './lib/agent-gateway'
 import { getAgentsMd } from './lib/agents-md'
-import { retrieveKnowledgeContext } from './lib/embeddings'
 import { startDream } from './lib/dream'
 
 const POLL_INTERVAL_MS = 15_000
@@ -219,23 +218,6 @@ async function runTask(taskId: string): Promise<void> {
     const agentGw = await resolveAgentGateway(agent.id)
     const gateway = agentGw ? { url: agentGw.url, token: agentGw.token } : null
 
-    // Retrieve semantically relevant knowledge context (RAG) for this task
-    let ragContext = ''
-    try {
-      if (agentGw?.environmentId) {
-        const ragResult = await retrieveKnowledgeContext(
-          `${task.title} ${task.description ?? ''}`.trim(),
-          8,
-          0.65,
-        )
-        if (ragResult) {
-          ragContext = '\n\n## Retrieved Knowledge\n' + ragResult
-        }
-      }
-    } catch (ragErr) {
-      err(`[rag] context retrieval failed: ${ragErr}`)
-    }
-
     // Inject tool awareness preamble — lists all available tools at runtime
     // This is injected here (not in the agent's stored prompt) so it always reflects
     // the current tool set, not a stale snapshot from when the agent was created.
@@ -254,7 +236,9 @@ async function runTask(taskId: string): Promise<void> {
       ? `\n\n## Environment-Specific Instructions (from AGENTS.md)\n${agentsMd}`
       : ''
 
-    let systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + agentsMdSection + wikiContext + ragContext
+    // Note: ORION snapshot + vector RAG are injected automatically by withContext()
+    // inside createRunner() — no need to fetch them here.
+    let systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + agentsMdSection + wikiContext
 
     // Prepend plan-before-execute instruction if configured on this agent
     if (contextConfig.planBeforeExecute === true) {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,6 +5,23 @@ COMPOSE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$COMPOSE_DIR"
 
 echo "=== ORION Deploy ==="
+
+# ── Generate ORION mTLS client cert for vault-proxy if not present ────────────
+CERTS_DIR="$COMPOSE_DIR/vault-proxy/certs"
+if [ -f "$CERTS_DIR/ca.crt" ] && [ -f "$CERTS_DIR/ca.key" ] && [ ! -f "$CERTS_DIR/orion-client.crt" ]; then
+  echo "Generating ORION mTLS client cert for vault-proxy..."
+  openssl genrsa -out "$CERTS_DIR/orion-client.key" 4096 2>/dev/null
+  openssl req -new -key "$CERTS_DIR/orion-client.key" \
+    -out "$CERTS_DIR/orion-client.csr" \
+    -subj "/CN=orion-client/O=ORION" 2>/dev/null
+  openssl x509 -req \
+    -in "$CERTS_DIR/orion-client.csr" \
+    -CA "$CERTS_DIR/ca.crt" -CAkey "$CERTS_DIR/ca.key" -CAserial "$CERTS_DIR/ca.srl" \
+    -out "$CERTS_DIR/orion-client.crt" -days 3650 -sha256 2>/dev/null
+  rm -f "$CERTS_DIR/orion-client.csr"
+  echo "ORION client cert generated."
+fi
+
 echo "Pulling latest images from ghcr.io..."
 
 # Pull images (handles image tag rotation from ghcr.io)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,8 +19,11 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       ORION_ENCRYPTION_KEY: ${ORION_ENCRYPTION_KEY}
       ORION_UNSEALER_TOKEN: ${ORION_UNSEALER_TOKEN}
-      VAULT_ADDR: http://vault:8200
+      VAULT_ADDR: https://vault-proxy:8200
       VAULT_TOKEN: ${VAULT_TOKEN}
+      VAULT_CACERT: /vault-proxy-certs/ca.crt
+      VAULT_CLIENT_CERT: /vault-proxy-certs/orion-client.crt
+      VAULT_CLIENT_KEY: /vault-proxy-certs/orion-client.key
       # Git provider — configured via first-run wizard (stored in DB).
       # These env vars are used as fallback before the wizard completes.
       GITEA_URL: http://gitea:3000

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -80,11 +80,14 @@ function sanitizeMaxTurns(maxTurns, fallback = 20) {
 
 /**
  * Write a temporary directory containing .mcp.json so the claude CLI can call
- * ORION tools via MCP for this specific agent+room combination.
+ * ORION tools via MCP for this agent. roomId is optional — task runners supply
+ * only agentId; chat rooms supply both agentId and roomId.
  * Returns the temp dir path — caller must clean it up after execFile completes.
  */
 function writeMcpDir(agentId, roomId) {
-  const url = `${ORION_URL}/api/mcp?agentId=${encodeURIComponent(agentId)}&roomId=${encodeURIComponent(roomId)}`
+  const params = new URLSearchParams({ agentId })
+  if (roomId) params.set('roomId', roomId)
+  const url = `${ORION_URL}/api/mcp?${params.toString()}`
   const config = {
     mcpServers: {
       orion: {
@@ -102,14 +105,14 @@ function writeMcpDir(agentId, roomId) {
 /**
  * Call the `claude` CLI as a subprocess — same approach as the Discord bot.
  * Strips ANTHROPIC_API_KEY and CLAUDECODE from env to force OAuth credential use.
- * When agentId + roomId are provided, writes a .mcp.json so Claude can call
- * ORION tools natively — ORION is the harness, Claude is the brain.
+ * When agentId is provided, writes a per-request .mcp.json so Claude can call
+ * ORION tools natively via MCP. roomId is optional (chat rooms only).
  */
 function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 120000, agentId, roomId } = {}) {
   return new Promise((resolve, reject) => {
     const safeModel       = sanitizeModel(model)
     const safeSystemPrompt = sanitizeSystemPrompt(systemPrompt)
-    const useMcp          = !!(agentId && roomId)
+    const useMcp          = !!agentId
     const safeMaxTurns    = sanitizeMaxTurns(maxTurns, useMcp ? 10 : 1)
 
     const args = ['-p', String(prompt), '--output-format', 'json']
@@ -128,7 +131,7 @@ function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 12000
       try {
         tmpDir = writeMcpDir(agentId, roomId)
         cwd    = tmpDir
-        console.log(`[orion-claude] MCP enabled — agent=${agentId} room=${roomId} url=${ORION_URL}/api/mcp`)
+        console.log(`[orion-claude] MCP enabled — agent=${agentId}${roomId ? ` room=${roomId}` : ''} url=${ORION_URL}/api/mcp`)
       } catch (e) {
         console.error('[orion-claude] Failed to write MCP config, falling back to no-tools:', e.message)
       }
@@ -382,7 +385,7 @@ const server = http.createServer(async (req, res) => {
       try { opts = JSON.parse(body || '{}') } catch { return json(res, 400, { error: 'Invalid JSON' }) }
 
       try {
-        const useMcp = !!(opts.agentId && opts.roomId)
+        const useMcp = !!opts.agentId
         const stdout = await runClaude(String(opts.prompt || ''), {
           systemPrompt: opts.systemPrompt,
           model:        opts.model,

--- a/deploy/vault-proxy/envoy.yaml
+++ b/deploy/vault-proxy/envoy.yaml
@@ -17,7 +17,7 @@ static_resources:
             validation_context:
               trusted_ca: { filename: /certs/ca.crt }
       filters:
-      # 1. Reject anything not from the LAN before spending any resources on it
+      # 1. Reject anything not from the LAN or Docker bridge before spending any resources on it
       - name: envoy.filters.network.rbac
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
@@ -32,6 +32,13 @@ static_resources:
                 - remote_ip:
                     address_prefix: 10.2.2.0
                     prefix_len: 24
+              allow-docker:
+                permissions:
+                - any: true
+                principals:
+                - remote_ip:
+                    address_prefix: 172.18.0.0
+                    prefix_len: 16
       # 2. Rate-limit: max 100 new connections/s from any single source
       - name: envoy.filters.network.local_ratelimit
         typed_config:


### PR DESCRIPTION
## Summary

- **mTLS for ORION→Vault**: Routes all Vault traffic through vault-proxy with Envoy mTLS (Docker network + client cert). Adds `vaultFetch()` with `node:https.Agent`, regenerated server cert with SANs, auto-generates `orion-client.crt` in `deploy.sh`
- **claude:\* agents via orion-claude sidecar**: `agent-runner/index.ts` now routes `claude:*` to `claudeRunner` instead of `openaiRunner` — Claude agents no longer hit the Anthropic API directly
- **Pre-flight context injection**: New `agent-context.ts` module injects ORION snapshot (2-min in-process cache) + vector RAG into every agent execution path — task runner, watcher, and chat rooms — via `withContext()` wrapper in `createRunner()` and `buildAgentContext()` in `room-agents.ts`. Agents arrive pre-oriented without calling `orion_get_snapshot`
- **Plan-first constraint for local LLMs**: `buildSystemPrompt()` injects a plan-before-act block for all Ollama/OpenAI-compat agents when tools are enabled — covers current Qwen agents and any future local models automatically
- **maxTurns 10→5 for tool-using chat rooms**: Prevents Qwen from burning turns on exploration

## Test plan

- [ ] Verify vault-proxy mTLS: `docker logs deploy-orion-web-1 | grep vault` — no connection errors
- [ ] Verify Claude agents respond in chat rooms (check `orion-claude` sidecar logs)
- [ ] Send a message to a Qwen agent with tools enabled — confirm it states a plan before calling tools
- [ ] Check task runner logs — agents should not call `orion_get_snapshot` on first turn
- [ ] Confirm vector RAG fires when embedding provider is configured (`[agent-context]` log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)