### PR TITLE
fix: remove orion_get_snapshot, fix write_secret env name, fix token watchdog

### DIFF
--- a/apps/web/src/app/(app)/admin/settings/SettingsForm.tsx
+++ b/apps/web/src/app/(app)/admin/settings/SettingsForm.tsx
@@ -1,0 +1,286 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Save, RefreshCw, Trash2 } from 'lucide-react'
+
+interface ExternalModel {
+  id:       string
+  name:     string
+  modelId:  string
+  provider: string
+  enabled:  boolean
+}
+
+interface CacheEntry {
+  key:            string
+  label:          string
+  description:    string
+  defaultSeconds: number
+}
+
+interface Props {
+  initialSettings: Record<string, unknown>
+  externalModels:  ExternalModel[]
+  cacheRegistry:   CacheEntry[]
+  saveSettings:    (entries: Array<{ key: string; value: string }>) => Promise<void>
+  flushCaches:     () => Promise<void>
+}
+
+const GENERAL_DEFAULTS = {
+  'app.name':                'ORION',
+  'app.description':         '',
+  'ai.default-model':        'claude',
+  'chat.historyLimit':       10,
+  'agent.chat.maxToolRounds': 15,
+  'features.notes':          true,
+  'features.backups':        true,
+}
+
+type GeneralSettings = typeof GENERAL_DEFAULTS
+
+export function SettingsForm({
+  initialSettings,
+  externalModels,
+  cacheRegistry,
+  saveSettings,
+  flushCaches,
+}: Props) {
+  // ── General settings state ────────────────────────────────────────────────
+  const [general, setGeneral] = useState<GeneralSettings>({
+    'app.name':                String(initialSettings['app.name'] ?? GENERAL_DEFAULTS['app.name']),
+    'app.description':         String(initialSettings['app.description'] ?? ''),
+    'ai.default-model':        String(initialSettings['ai.default-model'] ?? GENERAL_DEFAULTS['ai.default-model']),
+    'chat.historyLimit':       parseInt(String(initialSettings['chat.historyLimit'])) || GENERAL_DEFAULTS['chat.historyLimit'],
+    'agent.chat.maxToolRounds': parseInt(String(initialSettings['agent.chat.maxToolRounds'])) || GENERAL_DEFAULTS['agent.chat.maxToolRounds'],
+    'features.notes':          initialSettings['features.notes'] === undefined
+      ? GENERAL_DEFAULTS['features.notes']
+      : initialSettings['features.notes'] === 'true' || initialSettings['features.notes'] === true,
+    'features.backups':        initialSettings['features.backups'] === undefined
+      ? GENERAL_DEFAULTS['features.backups']
+      : initialSettings['features.backups'] === 'true' || initialSettings['features.backups'] === true,
+  })
+
+  // ── Cache TTL state ───────────────────────────────────────────────────────
+  const [cacheTtls, setCacheTtls] = useState<Record<string, number>>(
+    Object.fromEntries(
+      cacheRegistry.map(c => [
+        c.key,
+        parseInt(String(initialSettings[c.key])) || c.defaultSeconds,
+      ])
+    )
+  )
+
+  // ── Action state ──────────────────────────────────────────────────────────
+  const [isPending, startTransition] = useTransition()
+  const [isFlushing, startFlush]     = useTransition()
+  const [saved, setSaved]            = useState(false)
+  const [flushed, setFlushed]        = useState(false)
+  const [error, setError]            = useState<string | null>(null)
+
+  const setGenField = <K extends keyof GeneralSettings>(key: K, value: GeneralSettings[K]) =>
+    setGeneral(s => ({ ...s, [key]: value }))
+
+  const handleSave = () => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const entries: Array<{ key: string; value: string }> = [
+          ...Object.entries(general).map(([key, value]) => ({ key, value: String(value) })),
+          ...Object.entries(cacheTtls).map(([key, value]) => ({ key, value: String(value) })),
+        ]
+        await saveSettings(entries)
+        setSaved(true)
+        setTimeout(() => setSaved(false), 2500)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to save settings')
+      }
+    })
+  }
+
+  const handleFlush = () => {
+    startFlush(async () => {
+      await flushCaches()
+      setFlushed(true)
+      setTimeout(() => setFlushed(false), 2500)
+    })
+  }
+
+  return (
+    <div className="p-6 space-y-8 max-w-2xl">
+      <div>
+        <h1 className="text-lg font-semibold text-text-primary">General Settings</h1>
+        <p className="text-sm text-text-muted mt-0.5">Application-wide configuration</p>
+      </div>
+
+      {error && (
+        <div className="rounded border border-status-error/40 bg-status-error/10 px-4 py-3 text-sm text-status-error">
+          {error}
+        </div>
+      )}
+
+      {/* ── General ────────────────────────────────────────────────────────── */}
+      <div className="rounded-lg border border-border-subtle bg-bg-card divide-y divide-border-subtle">
+        <SettingRow label="App Name" description="Displayed in the header and browser tab">
+          <input
+            value={general['app.name']}
+            onChange={e => setGenField('app.name', e.target.value)}
+            className="input w-full"
+          />
+        </SettingRow>
+
+        <SettingRow label="App Description" description="Short tagline shown on the dashboard">
+          <input
+            value={general['app.description']}
+            onChange={e => setGenField('app.description', e.target.value)}
+            placeholder="K3s Homelab Dashboard"
+            className="input w-full"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="Default AI Model"
+          description="Model used for AI features. Falls back to the first enabled external model if not set."
+        >
+          <select
+            value={general['ai.default-model']}
+            onChange={e => setGenField('ai.default-model', e.target.value)}
+            className="input w-full"
+          >
+            <option value="claude">Claude (built-in)</option>
+            {externalModels.map(m => (
+              <option key={m.id} value={m.id}>
+                {m.name} ({m.modelId})
+              </option>
+            ))}
+          </select>
+        </SettingRow>
+
+        <SettingRow label="Max History Messages" description="Number of messages to include in chat context">
+          <input
+            type="number" min={1} max={100}
+            value={general['chat.historyLimit']}
+            onChange={e => setGenField('chat.historyLimit', parseInt(e.target.value) || 10)}
+            className="input w-32"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="Max Agent Tool Rounds"
+          description="How many tool calls a chat room agent can make before it must reply."
+        >
+          <input
+            type="number" min={1} max={50}
+            value={general['agent.chat.maxToolRounds']}
+            onChange={e => setGenField('agent.chat.maxToolRounds', parseInt(e.target.value) || 15)}
+            className="input w-32"
+          />
+        </SettingRow>
+
+        <SettingRow label="Enable Notes" description="Show the Notes section in the sidebar">
+          <Toggle value={general['features.notes']} onChange={v => setGenField('features.notes', v)} />
+        </SettingRow>
+
+        <SettingRow label="Enable Backups" description="Show the Backups section in the sidebar">
+          <Toggle value={general['features.backups']} onChange={v => setGenField('features.backups', v)} />
+        </SettingRow>
+      </div>
+
+      {/* ── Cache TTLs ─────────────────────────────────────────────────────── */}
+      <div>
+        <h2 className="text-base font-semibold text-text-primary">Cache Performance</h2>
+        <p className="text-sm text-text-muted mt-0.5">
+          In-process cache lifetimes. Lower values keep data fresher; higher values reduce database load.
+          Changes take effect immediately on save.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border-subtle bg-bg-card divide-y divide-border-subtle">
+        {cacheRegistry.map(c => (
+          <SettingRow
+            key={c.key}
+            label={c.label}
+            description={`${c.description} Default: ${c.defaultSeconds}s.`}
+          >
+            <div className="flex items-center gap-2">
+              <input
+                type="number" min={1}
+                value={cacheTtls[c.key] ?? c.defaultSeconds}
+                onChange={e =>
+                  setCacheTtls(s => ({ ...s, [c.key]: parseInt(e.target.value) || c.defaultSeconds }))
+                }
+                className="input w-28"
+              />
+              <span className="text-xs text-text-muted">seconds</span>
+            </div>
+          </SettingRow>
+        ))}
+      </div>
+
+      {/* ── Actions ────────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          onClick={handleSave}
+          disabled={isPending}
+          className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
+        >
+          {isPending ? <RefreshCw size={14} className="animate-spin" /> : <Save size={14} />}
+          {isPending ? 'Saving…' : 'Save Settings'}
+        </button>
+
+        <button
+          onClick={handleFlush}
+          disabled={isFlushing}
+          title="Clear all in-process caches immediately without changing settings"
+          className="flex items-center gap-2 px-4 py-2 rounded border border-border-subtle bg-bg-raised text-text-secondary text-sm font-medium hover:bg-bg-card transition-colors disabled:opacity-50"
+        >
+          {isFlushing ? <RefreshCw size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          {isFlushing ? 'Flushing…' : 'Flush Caches'}
+        </button>
+
+        {saved  && <span className="text-sm text-status-healthy">Saved — caches flushed</span>}
+        {flushed && !saved && <span className="text-sm text-status-healthy">Caches flushed</span>}
+      </div>
+    </div>
+  )
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function SettingRow({
+  label,
+  description,
+  children,
+}: {
+  label:       string
+  description: string
+  children:    React.ReactNode
+}) {
+  return (
+    <div className="px-4 py-4 flex items-start gap-4">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-text-primary">{label}</p>
+        <p className="text-xs text-text-muted mt-0.5">{description}</p>
+      </div>
+      <div className="w-64 flex-shrink-0">{children}</div>
+    </div>
+  )
+}
+
+function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={value}
+      onClick={() => onChange(!value)}
+      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
+        value ? 'bg-accent' : 'bg-bg-raised border border-border-visible'
+      }`}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+          value ? 'translate-x-6' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  )
+}

--- a/apps/web/src/app/(app)/admin/settings/actions.ts
+++ b/apps/web/src/app/(app)/admin/settings/actions.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { invalidateAll } from '@/lib/system-cache'
+
+/**
+ * Upsert an array of SystemSetting key-value pairs in a single transaction,
+ * then flush all in-process caches so new TTLs take effect immediately.
+ */
+export async function saveSettings(entries: Array<{ key: string; value: string }>) {
+  await requireAdmin()
+
+  await prisma.$transaction(
+    entries.map(({ key, value }) =>
+      prisma.systemSetting.upsert({
+        where:  { key },
+        update: { value: value as any },
+        create: { key,  value: value as any },
+      })
+    )
+  )
+
+  // Flush in-process caches — new TTLs take effect on next access
+  invalidateAll()
+  revalidatePath('/admin/settings')
+}
+
+/**
+ * Flush all in-process caches without changing any settings.
+ * Useful for forcing a refresh after external changes.
+ */
+export async function flushCaches() {
+  await requireAdmin()
+  invalidateAll()
+}

--- a/apps/web/src/app/(app)/admin/settings/page.tsx
+++ b/apps/web/src/app/(app)/admin/settings/page.tsx
@@ -1,242 +1,26 @@
-'use client'
-import { useState, useEffect } from 'react'
-import { Save, RefreshCw } from 'lucide-react'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { CACHE_REGISTRY } from '@/lib/system-cache'
+import { SettingsForm } from './SettingsForm'
+import { saveSettings, flushCaches } from './actions'
 
-interface ExternalModel {
-  id: string
-  name: string
-  modelId: string
-  provider: string
-  enabled: boolean
-}
+export default async function SettingsPage() {
+  await requireAdmin()
 
-interface Settings {
-  'app.name': string
-  'app.description': string
-  'ai.default-model': string
-  'chat.historyLimit': number
-  'agent.chat.maxToolRounds': number
-  'features.notes': boolean
-  'features.backups': boolean
-}
+  const [rows, models] = await Promise.all([
+    prisma.systemSetting.findMany(),
+    prisma.externalModel.findMany({ where: { enabled: true }, orderBy: { name: 'asc' } }),
+  ])
 
-const DEFAULTS: Settings = {
-  'app.name': 'ORION',
-  'app.description': '',
-  'ai.default-model': 'claude',
-  'chat.historyLimit': 10,
-  'agent.chat.maxToolRounds': 15,
-  'features.notes': true,
-  'features.backups': true,
-}
-
-export default function SettingsPage() {
-  const [settings, setSettings] = useState<Settings>(DEFAULTS)
-  const [externalModels, setExternalModels] = useState<ExternalModel[]>([])
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    Promise.all([
-      fetch('/api/admin/settings').then(r => r.json()).catch(() => ({})),
-      fetch('/api/admin/models').then(r => r.json()).catch(() => []),
-    ]).then(([data, modelsData]) => {
-      setSettings(s => ({
-        ...s,
-        ...data,
-        // API stores all values as strings — coerce back to their correct types
-        'chat.historyLimit': parseInt(data['chat.historyLimit']) || s['chat.historyLimit'],
-        'agent.chat.maxToolRounds': parseInt(data['agent.chat.maxToolRounds']) || s['agent.chat.maxToolRounds'],
-        'features.notes': data['features.notes'] === undefined ? s['features.notes'] : data['features.notes'] === 'true',
-        'features.backups': data['features.backups'] === undefined ? s['features.backups'] : data['features.backups'] === 'true',
-      }))
-      setExternalModels((Array.isArray(modelsData) ? modelsData : []).filter((m: ExternalModel) => m.enabled))
-      setLoading(false)
-    })
-  }, [])
-
-  const handleSave = async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      // API takes one key-value pair at a time — save all in parallel
-      const entries = Object.entries(settings) as [string, unknown][]
-      const results = await Promise.all(
-        entries.map(([key, value]) =>
-          fetch('/api/admin/settings', {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ key, value: String(value) }),
-          })
-        )
-      )
-      if (results.some(r => !r.ok)) throw new Error('Failed to save one or more settings')
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Unknown error')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const set = <K extends keyof Settings>(key: K, value: Settings[K]) => {
-    setSettings(s => ({ ...s, [key]: value }))
-  }
-
-  if (loading) {
-    return (
-      <div className="p-6 flex items-center gap-2 text-text-muted text-sm">
-        <RefreshCw size={14} className="animate-spin" />
-        Loading settings...
-      </div>
-    )
-  }
+  const settings = Object.fromEntries(rows.map(r => [r.key, r.value]))
 
   return (
-    <div className="p-6 space-y-6 max-w-2xl">
-      <div>
-        <h1 className="text-lg font-semibold text-text-primary">General Settings</h1>
-        <p className="text-sm text-text-muted mt-0.5">Application-wide configuration</p>
-      </div>
-
-      {error && (
-        <div className="rounded border border-status-error/40 bg-status-error/10 px-4 py-3 text-sm text-status-error">
-          {error}
-        </div>
-      )}
-
-      <div className="rounded-lg border border-border-subtle bg-bg-card divide-y divide-border-subtle">
-        {/* App name */}
-        <SettingRow label="App Name" description="Displayed in the header and browser tab">
-          <input
-            value={settings['app.name']}
-            onChange={e => set('app.name', e.target.value)}
-            className="w-full px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
-          />
-        </SettingRow>
-
-        {/* App description */}
-        <SettingRow label="App Description" description="Short tagline shown on the dashboard">
-          <input
-            value={settings['app.description']}
-            onChange={e => set('app.description', e.target.value)}
-            placeholder="K3s Homelab Dashboard"
-            className="w-full px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors"
-          />
-        </SettingRow>
-
-        {/* Default AI model */}
-        <SettingRow
-          label="Default AI Model"
-          description="Model used for all AI features (generate features, generate tasks, planning). Falls back to the first enabled external model if not set."
-        >
-          <select
-            value={settings['ai.default-model']}
-            onChange={e => set('ai.default-model', e.target.value)}
-            className="w-full px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
-          >
-            <option value="claude">Claude (built-in)</option>
-            {externalModels.map(m => (
-              <option key={m.id} value={m.id}>
-                {m.name} ({m.modelId})
-              </option>
-            ))}
-          </select>
-        </SettingRow>
-
-        {/* History limit */}
-        <SettingRow label="Max History Messages" description="Number of messages to include in chat context">
-          <input
-            type="number"
-            min={1}
-            max={100}
-            value={settings['chat.historyLimit']}
-            onChange={e => set('chat.historyLimit', parseInt(e.target.value) || 10)}
-            className="w-32 px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
-          />
-        </SettingRow>
-
-        {/* Max tool rounds */}
-        <SettingRow label="Max Agent Tool Rounds" description="How many tool calls a chat room agent can make before it must reply. Increase if agents time out mid-task.">
-          <input
-            type="number"
-            min={1}
-            max={50}
-            value={settings['agent.chat.maxToolRounds']}
-            onChange={e => set('agent.chat.maxToolRounds', parseInt(e.target.value) || 15)}
-            className="w-32 px-3 py-1.5 text-sm bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent transition-colors"
-          />
-        </SettingRow>
-
-        {/* Feature toggles */}
-        <SettingRow label="Enable Notes" description="Show the Notes section in the sidebar">
-          <Toggle
-            value={settings['features.notes']}
-            onChange={v => set('features.notes', v)}
-          />
-        </SettingRow>
-
-        <SettingRow label="Enable Backups" description="Show the Backups section in the sidebar">
-          <Toggle
-            value={settings['features.backups']}
-            onChange={v => set('features.backups', v)}
-          />
-        </SettingRow>
-      </div>
-
-      <div className="flex items-center gap-3">
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="flex items-center gap-2 px-4 py-2 rounded bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors disabled:opacity-50"
-        >
-          {saving ? <RefreshCw size={14} className="animate-spin" /> : <Save size={14} />}
-          {saving ? 'Saving...' : 'Save Settings'}
-        </button>
-        {saved && <span className="text-sm text-status-healthy">Saved successfully</span>}
-      </div>
-    </div>
-  )
-}
-
-function SettingRow({
-  label,
-  description,
-  children,
-}: {
-  label: string
-  description: string
-  children: React.ReactNode
-}) {
-  return (
-    <div className="px-4 py-4 flex items-start gap-4">
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-text-primary">{label}</p>
-        <p className="text-xs text-text-muted mt-0.5">{description}</p>
-      </div>
-      <div className="w-64 flex-shrink-0">{children}</div>
-    </div>
-  )
-}
-
-function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
-  return (
-    <button
-      role="switch"
-      aria-checked={value}
-      onClick={() => onChange(!value)}
-      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ${
-        value ? 'bg-accent' : 'bg-bg-raised border border-border-visible'
-      }`}
-    >
-      <span
-        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-          value ? 'translate-x-6' : 'translate-x-1'
-        }`}
-      />
-    </button>
+    <SettingsForm
+      initialSettings={settings}
+      externalModels={models}
+      cacheRegistry={[...CACHE_REGISTRY]}
+      saveSettings={saveSettings}
+      flushCaches={flushCaches}
+    />
   )
 }

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -4,8 +4,7 @@
  * Before each LLM call, this module assembles two context blocks:
  *
  * 1. ORION snapshot — agents, active tasks, recent events.
- *    Cached in-process for 2 minutes so agents don't need to call
- *    orion_get_snapshot on every message.
+ *    Cached via system-cache with a configurable TTL (default 2 min).
  *
  * 2. Knowledge base — semantically relevant notes from the vector store.
  *    Embedding query is the latest user message. Silently skipped if no
@@ -18,19 +17,11 @@
 
 import { prisma } from './db'
 import { retrieveKnowledgeContext } from './embeddings'
+import { getOrFetch, invalidate } from './system-cache'
 
-// ── In-process snapshot cache ────────────────────────────────────────────────
-
-const SNAPSHOT_TTL_MS = 2 * 60 * 1000  // 2 minutes
-
-let snapshotCache: { text: string; expiresAt: number } | null = null
+// ── Snapshot fetcher (pure — no caching, system-cache handles that) ────────────
 
 async function fetchSnapshot(): Promise<string> {
-  const now = Date.now()
-  if (snapshotCache && snapshotCache.expiresAt > now) {
-    return snapshotCache.text
-  }
-
   try {
     const [agents, tasks, events] = await Promise.all([
       prisma.agent.findMany({ orderBy: { name: 'asc' } }),
@@ -63,7 +54,7 @@ async function fetchSnapshot(): Promise<string> {
       .map((e: any) => `  [${e.taskId}] ${e.task?.title ?? '?'}: ${e.eventType}`)
       .join('\n')
 
-    const text = [
+    return [
       `## ORION State (cached ${new Date().toISOString()})`,
       `**Agents (${activeAgents.length}):**`,
       agentLines || '  none',
@@ -74,9 +65,6 @@ async function fetchSnapshot(): Promise<string> {
       `**Recent Events:**`,
       eventLines || '  none',
     ].join('\n')
-
-    snapshotCache = { text, expiresAt: now + SNAPSHOT_TTL_MS }
-    return text
   } catch (err) {
     // Never block an LLM call over a snapshot failure
     console.warn('[agent-context] snapshot fetch failed:', err)
@@ -94,7 +82,7 @@ async function fetchSnapshot(): Promise<string> {
  */
 export async function buildAgentContext(query: string): Promise<string> {
   const [snapshot, knowledge] = await Promise.all([
-    fetchSnapshot(),
+    getOrFetch('snapshot', 'cache.snapshot.ttl', fetchSnapshot).catch(() => ''),
     retrieveKnowledgeContext(query, 3, 0.4),
   ])
 
@@ -111,5 +99,5 @@ export async function buildAgentContext(query: string): Promise<string> {
 
 /** Explicitly invalidate the snapshot cache (call after write operations). */
 export function invalidateSnapshotCache(): void {
-  snapshotCache = null
+  invalidate('snapshot')
 }

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -105,6 +105,18 @@ export const ORION_TOOL_DEFINITIONS = [
   {
     type: 'function' as const,
     function: {
+      name: 'orion_list_environments',
+      description: 'List all ORION environments by name and type. Use this before calling write_secret or any tool that requires an environmentName.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
       name: 'orion_manage_task',
       description: 'Assign a task to an agent, update its status, or append a feed note.',
       parameters: {
@@ -127,7 +139,7 @@ export const ORION_TOOL_DEFINITIONS = [
       parameters: {
         type: 'object',
         properties: {
-          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in. Use orion_get_agents or check available environments — current options are "Talos Cluster" or "localhost".' },
+          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in. If unsure, call orion_list_environments to see available names.' },
           name:             { type: 'string', description: 'Human-readable label for the ExternalSecret (e.g. "gitea-db-secret")' },
           vaultPath:        { type: 'string', description: 'Vault KV v2 path relative to the "secret" mount (e.g. "gitea/db"). No "secret/data/" prefix.' },
           keyNames:         { type: 'array', items: { type: 'string' }, description: 'List of secret key names to scaffold (e.g. ["DB_PASSWORD", "DB_USER"]). PLACEHOLDER values will be written to Vault.' },
@@ -252,6 +264,12 @@ export async function executeTool(
         ).join('\n')
       }
 
+      case 'orion_list_environments': {
+        const envs = await prisma.environment.findMany({ orderBy: { name: 'asc' } })
+        if (envs.length === 0) return 'No environments configured.'
+        return envs.map((e: any) => `  "${e.name}" (type: ${e.type})`).join('\n')
+      }
+
       case 'orion_manage_task': {
         const taskId = String(args.taskId ?? '')
         if (!taskId) return 'Error: taskId is required'
@@ -284,7 +302,11 @@ export async function executeTool(
 
         // Resolve environment by name
         const env = await prisma.environment.findUnique({ where: { name: environmentName } })
-        if (!env) return `Error: environment "${environmentName}" not found. Available environments: "Talos Cluster", "localhost".`
+        if (!env) {
+          const all = await prisma.environment.findMany({ select: { name: true }, orderBy: { name: 'asc' } })
+          const names = all.map((e: { name: string }) => `"${e.name}"`).join(', ')
+          return `Error: environment "${environmentName}" not found. Available environments: ${names || 'none'}.`
+        }
 
         const namespace       = String(args.namespace       ?? 'default').trim() || 'default'
         const description     = args.description     ? String(args.description).trim()     : null
@@ -352,6 +374,7 @@ You have access to these tools. Use them — do not pretend to perform an action
 **Read ORION state:**
 - **orion_get_tasks**: List tasks, optionally filtered by status or assigned agent.
 - **orion_get_agents**: List all active agents and their roles.
+- **orion_list_environments**: List available ORION environments by name. Call this before write_secret.
 
 **Write ORION state:**
 - **create_task**: Log a new task on the board (title, description, priority, status).

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -16,6 +16,7 @@
 
 import { prisma } from './db'
 import { writeVaultSecret } from './vault'
+import { getOrFetch } from './system-cache'
 
 // ── Tool definitions (OpenAI function-call format) ────────────────────────────
 
@@ -148,9 +149,14 @@ export const ORION_TOOL_DEFINITIONS = [
  * from the DB — so the LLM never needs to call a tool to discover them.
  */
 export async function buildToolDefinitions() {
-  const envs = await prisma.environment.findMany({ select: { name: true }, orderBy: { name: 'asc' } })
-  const envNames = envs.map((e: { name: string }) => `"${e.name}"`).join(', ') || 'none configured'
+  return getOrFetch('environments', 'cache.environments.ttl', async () => {
+    const envs = await prisma.environment.findMany({ select: { name: true }, orderBy: { name: 'asc' } })
+    const envNames = envs.map((e: { name: string }) => `"${e.name}"`).join(', ') || 'none configured'
+    return _buildToolDefinitionsWithEnvs(envNames)
+  })
+}
 
+function _buildToolDefinitionsWithEnvs(envNames: string) {
   return ORION_TOOL_DEFINITIONS.map(def => {
     if (def.function.name !== 'write_secret') return def
     return {

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -105,18 +105,6 @@ export const ORION_TOOL_DEFINITIONS = [
   {
     type: 'function' as const,
     function: {
-      name: 'orion_list_environments',
-      description: 'List all ORION environments by name and type. Use this before calling write_secret or any tool that requires an environmentName.',
-      parameters: {
-        type: 'object',
-        properties: {},
-        required: [],
-      },
-    },
-  },
-  {
-    type: 'function' as const,
-    function: {
       name: 'orion_manage_task',
       description: 'Assign a task to an agent, update its status, or append a feed note.',
       parameters: {
@@ -139,7 +127,7 @@ export const ORION_TOOL_DEFINITIONS = [
       parameters: {
         type: 'object',
         properties: {
-          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in. If unsure, call orion_list_environments to see available names.' },
+          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in.' },
           name:             { type: 'string', description: 'Human-readable label for the ExternalSecret (e.g. "gitea-db-secret")' },
           vaultPath:        { type: 'string', description: 'Vault KV v2 path relative to the "secret" mount (e.g. "gitea/db"). No "secret/data/" prefix.' },
           keyNames:         { type: 'array', items: { type: 'string' }, description: 'List of secret key names to scaffold (e.g. ["DB_PASSWORD", "DB_USER"]). PLACEHOLDER values will be written to Vault.' },
@@ -153,6 +141,36 @@ export const ORION_TOOL_DEFINITIONS = [
     },
   },
 ] as const
+
+/**
+ * Returns a copy of ORION_TOOL_DEFINITIONS with the write_secret
+ * environmentName description patched to list actual environment names
+ * from the DB — so the LLM never needs to call a tool to discover them.
+ */
+export async function buildToolDefinitions() {
+  const envs = await prisma.environment.findMany({ select: { name: true }, orderBy: { name: 'asc' } })
+  const envNames = envs.map((e: { name: string }) => `"${e.name}"`).join(', ') || 'none configured'
+
+  return ORION_TOOL_DEFINITIONS.map(def => {
+    if (def.function.name !== 'write_secret') return def
+    return {
+      ...def,
+      function: {
+        ...def.function,
+        parameters: {
+          ...def.function.parameters,
+          properties: {
+            ...def.function.parameters.properties,
+            environmentName: {
+              type: 'string' as const,
+              description: `Name of the ORION environment to create the secret in. Available environments: ${envNames}.`,
+            },
+          },
+        },
+      },
+    }
+  })
+}
 
 // ── Tool execution ────────────────────────────────────────────────────────────
 
@@ -264,12 +282,6 @@ export async function executeTool(
         ).join('\n')
       }
 
-      case 'orion_list_environments': {
-        const envs = await prisma.environment.findMany({ orderBy: { name: 'asc' } })
-        if (envs.length === 0) return 'No environments configured.'
-        return envs.map((e: any) => `  "${e.name}" (type: ${e.type})`).join('\n')
-      }
-
       case 'orion_manage_task': {
         const taskId = String(args.taskId ?? '')
         if (!taskId) return 'Error: taskId is required'
@@ -374,7 +386,6 @@ You have access to these tools. Use them — do not pretend to perform an action
 **Read ORION state:**
 - **orion_get_tasks**: List tasks, optionally filtered by status or assigned agent.
 - **orion_get_agents**: List all active agents and their roles.
-- **orion_list_environments**: List available ORION environments by name. Call this before write_secret.
 
 **Write ORION state:**
 - **create_task**: Log a new task on the board (title, description, priority, status).

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -11,7 +11,6 @@
  *   create_agent        — create a new agent and invite it to the current room
  *   orion_get_tasks     — list tasks (server-side Prisma, no HTTP round-trip)
  *   orion_get_agents    — list agents (server-side Prisma, no HTTP round-trip)
- *   orion_get_snapshot  — full system snapshot: agents + tasks + recent events
  *   orion_manage_task   — assign, update status, or post feed message for a task
  */
 
@@ -106,18 +105,6 @@ export const ORION_TOOL_DEFINITIONS = [
   {
     type: 'function' as const,
     function: {
-      name: 'orion_get_snapshot',
-      description: 'Get a full ORION system snapshot: all agents, pending/in-progress tasks, and recent task events.',
-      parameters: {
-        type: 'object',
-        properties: {},
-        required: [],
-      },
-    },
-  },
-  {
-    type: 'function' as const,
-    function: {
       name: 'orion_manage_task',
       description: 'Assign a task to an agent, update its status, or append a feed note.',
       parameters: {
@@ -140,7 +127,7 @@ export const ORION_TOOL_DEFINITIONS = [
       parameters: {
         type: 'object',
         properties: {
-          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in (e.g. "homelab-k3s")' },
+          environmentName:  { type: 'string', description: 'Name of the ORION environment to create the secret in. Use orion_get_agents or check available environments — current options are "Talos Cluster" or "localhost".' },
           name:             { type: 'string', description: 'Human-readable label for the ExternalSecret (e.g. "gitea-db-secret")' },
           vaultPath:        { type: 'string', description: 'Vault KV v2 path relative to the "secret" mount (e.g. "gitea/db"). No "secret/data/" prefix.' },
           keyNames:         { type: 'array', items: { type: 'string' }, description: 'List of secret key names to scaffold (e.g. ["DB_PASSWORD", "DB_USER"]). PLACEHOLDER values will be written to Vault.' },
@@ -265,32 +252,6 @@ export async function executeTool(
         ).join('\n')
       }
 
-      case 'orion_get_snapshot': {
-        const [agents, tasks, events] = await Promise.all([
-          prisma.agent.findMany({ orderBy: { name: 'asc' } }),
-          prisma.task.findMany({
-            where: { status: { in: ['pending', 'in_progress', 'blocked'] } },
-            orderBy: { updatedAt: 'desc' },
-            take: 30,
-            include: { agent: { select: { name: true } } },
-          }),
-          prisma.taskEvent.findMany({
-            orderBy: { createdAt: 'desc' },
-            take: 10,
-            include: { task: { select: { title: true } } },
-          }),
-        ])
-        const activeAgents = agents.filter((a: any) => (a.metadata as Record<string, unknown> | null)?.archived !== true)
-        const agentLines = activeAgents.map((a: any) => `  ${a.name} (${a.status})${a.role ? ' — ' + a.role : ''}`).join('\n')
-        const taskLines  = tasks.map((t: any) =>
-          `  [${t.id}] ${t.title} — ${t.status}, assigned: ${t.agent?.name ?? 'unassigned'}`
-        ).join('\n')
-        const eventLines = events.map((e: any) =>
-          `  [${e.taskId}] ${e.task?.title ?? '?'}: ${e.eventType}`
-        ).join('\n')
-        return `## Agents (${activeAgents.length})\n${agentLines || '  none'}\n\n## Active Tasks (${tasks.length})\n${taskLines || '  none'}\n\n## Recent Events\n${eventLines || '  none'}`
-      }
-
       case 'orion_manage_task': {
         const taskId = String(args.taskId ?? '')
         if (!taskId) return 'Error: taskId is required'
@@ -323,7 +284,7 @@ export async function executeTool(
 
         // Resolve environment by name
         const env = await prisma.environment.findUnique({ where: { name: environmentName } })
-        if (!env) return `Error: environment "${environmentName}" not found. Use orion_get_snapshot to see available environments.`
+        if (!env) return `Error: environment "${environmentName}" not found. Available environments: "Talos Cluster", "localhost".`
 
         const namespace       = String(args.namespace       ?? 'default').trim() || 'default'
         const description     = args.description     ? String(args.description).trim()     : null
@@ -389,7 +350,6 @@ export const TOOLS_SYSTEM_ADDENDUM = `
 You have access to these tools. Use them — do not pretend to perform an action when you can call a tool instead.
 
 **Read ORION state:**
-- **orion_get_snapshot**: Full system view — all agents, active tasks, recent events. Use this to orient yourself.
 - **orion_get_tasks**: List tasks, optionally filtered by status or assigned agent.
 - **orion_get_agents**: List all active agents and their roles.
 

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -344,6 +344,8 @@ async function resolveOllamaBaseUrl(): Promise<string> {
  * for a room, stop chaining to prevent a runaway loop.
  */
 const MAX_AGENT_MESSAGES_PER_MINUTE = 40
+/** Maximum agent→agent chain hops per human message to prevent infinite loops. */
+const MAX_CHAIN_DEPTH = 4
 
 /**
  * Trigger agent replies for a chat room message (fire-and-forget from POST handler).
@@ -352,16 +354,24 @@ const MAX_AGENT_MESSAGES_PER_MINUTE = 40
  * - @mention present → only mentioned agents reply
  * - No @mention      → all agent members reply
  *
- * After each round, if any saved reply names another agent the chain continues so
- * agents can hold a natural back-and-forth conversation. It stops when:
- *   1. No agent name appears in the last reply (natural end of conversation), or
+ * After each round, chaining continues ONLY on explicit @mentions (bare name
+ * references are ignored — they cause false-positive loops). It stops when:
+ *   1. No @mention appears in the last reply (natural end of conversation), or
  *   2. An agent replies with the single word SILENT, or
- *   3. The room has exceeded MAX_AGENT_MESSAGES_PER_MINUTE (runaway loop guard).
+ *   3. The room has exceeded MAX_AGENT_MESSAGES_PER_MINUTE (rate-limit guard), or
+ *   4. Chain depth exceeds MAX_CHAIN_DEPTH (loop guard).
  */
 export async function triggerRoomAgentReplies(
   roomId: string,
   triggerContent: string,
+  chainDepth = 0,
 ): Promise<void> {
+  // Chain depth guard — stop before agents can loop indefinitely
+  if (chainDepth > MAX_CHAIN_DEPTH) {
+    console.warn(`[room-agents] room ${roomId} hit MAX_CHAIN_DEPTH (${MAX_CHAIN_DEPTH}) — stopping chain`)
+    return
+  }
+
   // Runaway loop guard — count agent messages in this room in the last minute
   const recentAgentCount = await prisma.chatMessage.count({
     where: {
@@ -566,18 +576,18 @@ export async function triggerRoomAgentReplies(
     }
   }
 
-  // Chain: if the last reply names another agent (with or without @), trigger them.
-  // Models often write "Hey Orion" instead of "@Orion", so we check bare names too.
+  // Chain: only on explicit @mentions in the last reply.
+  // Bare name references ("Alpha already handled this") are intentionally ignored —
+  // they cause false-positive loops where agents keep mentioning each other in passing.
   if (lastSavedReply) {
-    const addressed = agentMembers.filter((a: any) => {
-      const pattern = new RegExp(`(?:^|\\s|@)${a.name}\\b`, 'i')
-      return pattern.test(lastSavedReply!)
-    })
+    const mentionedNames = parseMentions(lastSavedReply)
+    const addressed = agentMembers.filter((a: any) =>
+      mentionedNames.some((n: string) => a.name.toLowerCase() === n.toLowerCase()),
+    )
     if (addressed.length > 0) {
-      // Build a synthetic trigger with @mentions so the next round routes correctly
       const syntheticTrigger = addressed.map((a: any) => `@${a.name}`).join(' ')
-      console.log(`[room-agents] chaining to: ${addressed.map((a: any) => a.name).join(', ')}`)
-      await triggerRoomAgentReplies(roomId, syntheticTrigger)
+      console.log(`[room-agents] chaining to: ${addressed.map((a: any) => a.name).join(', ')} (depth ${chainDepth + 1})`)
+      await triggerRoomAgentReplies(roomId, syntheticTrigger, chainDepth + 1)
     }
   }
 }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -16,7 +16,7 @@
 
 import { prisma } from './db'
 import { setTyping, clearTyping } from './typing-state'
-import { ORION_TOOL_DEFINITIONS, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agent-tools'
+import { buildToolDefinitions, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agent-tools'
 import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
@@ -222,7 +222,9 @@ async function callOpenAIChat(
 
   // Legacy agent-tools (create_task, orion_manage_task, etc.) — keep for backward compat.
   // Exclude any that are now in the registry to avoid duplicates.
-  const legacyTools = ORION_TOOL_DEFINITIONS.filter(d => !registryToolNames.has(d.function.name))
+  // buildToolDefinitions() injects real environment names into write_secret description.
+  const allToolDefs = await buildToolDefinitions()
+  const legacyTools = allToolDefs.filter(d => !registryToolNames.has(d.function.name))
   const legacyToolNames: Set<string> = new Set(legacyTools.map(d => d.function.name))
 
   // Merge: registry + legacy + gateway tools

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -220,7 +220,7 @@ async function callOpenAIChat(
   }))
   const registryToolNames: Set<string> = new Set(getToolsForContext('chat').map(t => t.name))
 
-  // Legacy agent-tools (create_task, orion_get_snapshot, etc.) — keep for backward compat.
+  // Legacy agent-tools (create_task, orion_manage_task, etc.) — keep for backward compat.
   // Exclude any that are now in the registry to avoid duplicates.
   const legacyTools = ORION_TOOL_DEFINITIONS.filter(d => !registryToolNames.has(d.function.name))
   const legacyToolNames: Set<string> = new Set(legacyTools.map(d => d.function.name))
@@ -284,7 +284,7 @@ async function callOpenAIChat(
           prisma,
         })
       } else if (legacyToolNames.has(tc.function.name)) {
-        // Legacy agent-tools (create_task, orion_get_snapshot, etc.)
+        // Legacy agent-tools (create_task, orion_manage_task, etc.)
         result = await executeTool(tc.function.name, args, {
           roomId:        toolContext!.roomId,
           callerAgentId: toolContext!.agentId,

--- a/apps/web/src/lib/system-cache.ts
+++ b/apps/web/src/lib/system-cache.ts
@@ -1,0 +1,106 @@
+/**
+ * System cache — in-process TTL cache backed by SystemSetting.
+ *
+ * TTL values are read from SystemSetting and themselves cached for 60 s so
+ * we don't hit the DB on every agent message. Changing a TTL in the settings
+ * page + clicking "Invalidate" makes the new TTL take effect immediately in
+ * the web process. The worker process picks up the new TTL on its next natural
+ * cache expiry (no cross-process signalling).
+ *
+ * Usage:
+ *   const value = await getOrFetch('my-key', 'cache.my.ttl', fetcher)
+ *   invalidate('my-key')   // clear one entry
+ *   invalidateAll()        // clear everything (call after changing TTL settings)
+ */
+
+import { prisma } from './db'
+
+// ── Cache registry ─────────────────────────────────────────────────────────────
+// Single source of truth for both the server cache and the settings UI.
+
+export const CACHE_REGISTRY = [
+  {
+    key:            'cache.snapshot.ttl',
+    label:          'Agent Snapshot',
+    description:    'How long (seconds) to cache the ORION state snapshot injected into every agent prompt. Lower = more current data; higher = fewer DB queries.',
+    defaultSeconds: 120,
+  },
+  {
+    key:            'cache.environments.ttl',
+    label:          'Environment Names',
+    description:    'How long (seconds) to cache environment names injected into write_secret tool descriptions. Environments rarely change so this can be high.',
+    defaultSeconds: 3600,
+  },
+] as const
+
+export type CacheSettingKey = (typeof CACHE_REGISTRY)[number]['key']
+
+const DEFAULT_TTL_MS: Record<string, number> = Object.fromEntries(
+  CACHE_REGISTRY.map(c => [c.key, c.defaultSeconds * 1000])
+)
+
+// ── Internal state ─────────────────────────────────────────────────────────────
+
+type Entry<T> = { value: T; expiresAt: number }
+
+const valueCache = new Map<string, Entry<unknown>>()
+const ttlCache   = new Map<string, Entry<number>>()  // cached TTL values from DB
+
+const TTL_META_TTL_MS = 60_000  // re-read TTL settings at most once per minute
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function readTtlMs(settingKey: string): Promise<number> {
+  const now    = Date.now()
+  const cached = ttlCache.get(settingKey)
+  if (cached && cached.expiresAt > now) return cached.value
+
+  try {
+    const row  = await prisma.systemSetting.findUnique({ where: { key: settingKey } })
+    const secs = row ? Number(row.value) : NaN
+    const ms   = Number.isFinite(secs) && secs > 0
+      ? secs * 1000
+      : (DEFAULT_TTL_MS[settingKey] ?? 120_000)
+    ttlCache.set(settingKey, { value: ms, expiresAt: now + TTL_META_TTL_MS })
+    return ms
+  } catch {
+    return DEFAULT_TTL_MS[settingKey] ?? 120_000
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the cached value for `cacheKey` if still fresh, otherwise calls
+ * `fetcher`, caches the result for the TTL stored in `settingKey`, and returns it.
+ */
+export async function getOrFetch<T>(
+  cacheKey:   string,
+  settingKey: string,
+  fetcher:    () => Promise<T>,
+): Promise<T> {
+  const now    = Date.now()
+  const cached = valueCache.get(cacheKey) as Entry<T> | undefined
+  if (cached && cached.expiresAt > now) return cached.value
+
+  // Read TTL and fetch value in parallel — we need both regardless.
+  const [ttlMs, value] = await Promise.all([readTtlMs(settingKey), fetcher()])
+  valueCache.set(cacheKey, { value, expiresAt: now + ttlMs })
+  return value
+}
+
+/** Clear a single cache entry so the next call re-fetches it. */
+export function invalidate(cacheKey: string): void {
+  valueCache.delete(cacheKey)
+}
+
+/**
+ * Clear all cached values AND all cached TTL settings.
+ * Call this after saving new TTL values so they take effect immediately.
+ * Note: only clears the web-server process cache. The worker process
+ * picks up new TTLs on its next natural expiry.
+ */
+export function invalidateAll(): void {
+  valueCache.clear()
+  ttlCache.clear()
+}

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -433,20 +433,12 @@ function scheduleTokenRefresh() {
     const ttl = expiresAt - now
 
     if (ttl < REFRESH_THRESHOLD_MS) {
-      console.log(`[orion-claude] token-watchdog: token expires in ${Math.round(ttl / 60000)}min — refreshing`)
-      execFile('claude', ['auth', 'refresh'], { env: process.env, timeout: 30000 }, (err, stdout, stderr) => {
-        if (err) {
-          console.error('[orion-claude] token-watchdog: refresh failed:', err.message, stderr?.slice(0, 200))
-        } else {
-          console.log('[orion-claude] token-watchdog: refresh succeeded')
-          // Copy refreshed credentials to shared volume if present
-          const sharedPath = '/claude-creds/.credentials.json'
-          try {
-            fs.mkdirSync('/claude-creds', { recursive: true })
-            fs.copyFileSync(CREDS_PATH, sharedPath)
-          } catch {}
-        }
-      })
+      // Claude CLI has no headless refresh command — log a warning so an admin
+      // knows to re-authenticate via the ORION UI (Settings → Claude Auth).
+      console.warn(
+        `[orion-claude] token-watchdog: token expires in ${Math.round(ttl / 60000)}min — ` +
+        'manual re-authentication required via ORION UI (Settings → Claude Auth)'
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- **Remove `orion_get_snapshot` tool** — context is now pre-injected via `buildAgentContext()` so agents don't need to call it. Agents were calling it on every message anyway (Qwen behavior), wasting a round-trip.
- **Fix `write_secret` environment name** — the example said `"homelab-k3s"` which doesn't exist in the cluster. This caused Nexus to copy the example and fail every `write_secret` call. Now shows actual environments.
- **Fix orion-claude token watchdog** — `claude auth refresh` is not a valid CLI command; watchdog was spamming error logs every 30 min. Replaced with a warning log telling admins to re-auth via ORION UI.

## Test plan
- [ ] Nexus no longer calls `orion_get_snapshot` (tool not offered)
- [ ] `write_secret` succeeds when called with `"Talos Cluster"` or `"localhost"`
- [ ] orion-claude logs no longer show repeated `claude auth refresh` failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)