### PR TITLE
feat: bundle monitoring manifests for bootstrap deployment

### DIFF
--- a/deploy/monitoring/elastiflow/deployment.yaml
+++ b/deploy/monitoring/elastiflow/deployment.yaml
@@ -1,0 +1,118 @@
+---
+# Elastiflow — ORION Phase 3
+# NetFlow/IPFIX/sFlow collector for network monitoring
+# Adapted from ansible for RPi 4 homelab (single replica, amd64)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elastiflow
+  namespace: monitoring
+  labels:
+    app: elastiflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elastiflow
+  template:
+    metadata:
+      labels:
+        app: elastiflow
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: elastiflow
+          image: elastiflow/unified-flow-collector:6.3.0
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 2055
+              protocol: UDP
+              name: netflow
+            - containerPort: 6343
+              protocol: UDP
+              name: sflow
+            - containerPort: 4739
+              protocol: UDP
+              name: ipfix
+          env:
+            - name: EF_FLOW_SERVER_UDP_IP
+              value: "0.0.0.0"
+            - name: EF_FLOW_SERVER_UDP_PORT
+              value: "2055"
+            - name: EF_OUTPUT_ELASTICSEARCH_ENABLE
+              value: "true"
+            - name: EF_OUTPUT_ELASTICSEARCH_ECS_ENABLE
+              value: "true"
+            - name: EF_OUTPUT_ELASTICSEARCH_ADDRESSES
+              value: "http://elasticsearch-client.elk:9200"
+            - name: EF_OUTPUT_ELASTICSEARCH_USERNAME
+              value: "elastic"
+            - name: EF_OUTPUT_ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-credentials
+                  key: password
+            - name: EF_FLOW_DECODER_NETFLOW_ENABLE
+              value: "true"
+            - name: EF_FLOW_DECODER_SFLOW_ENABLE
+              value: "true"
+            - name: EF_FLOW_DECODER_IPFIX_ENABLE
+              value: "true"
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+---
+# Service for Elastiflow
+apiVersion: v1
+kind: Service
+metadata:
+  name: elastiflow
+  namespace: monitoring
+  labels:
+    app: elastiflow
+spec:
+  type: NodePort
+  selector:
+    app: elastiflow
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    - name: netflow
+      port: 2055
+      targetPort: 2055
+      protocol: UDP
+    - name: sflow
+      port: 6343
+      targetPort: 6343
+      protocol: UDP
+    - name: ipfix
+      port: 4739
+      targetPort: 4739
+      protocol: UDP
+---
+# IngressRoute for Elastiflow web UI
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: elastiflow
+  namespace: monitoring
+  labels:
+    app: elastiflow
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`netflow.khalis.corp`)
+      kind: Rule
+      services:
+        - name: elastiflow
+          port: 8080
+          namespace: monitoring

--- a/deploy/monitoring/elk/elasticsearch-deployment.yaml
+++ b/deploy/monitoring/elk/elasticsearch-deployment.yaml
@@ -1,0 +1,115 @@
+---
+# Elasticsearch StatefulSet — ORION Phase 3
+# Adapted from ansible for RPi 4 8GB homelab (2 replicas, amd64)
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: elk
+  labels:
+    app: elasticsearch
+spec:
+  serviceName: elasticsearch
+  replicas: 2
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      initContainers:
+        - name: increase-vm-max-map
+          image: busybox
+          command: ["sysctl", "-w", "vm.max_map_count=262144"]
+          securityContext:
+            privileged: true
+            runAsUser: 0
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+          ports:
+            - containerPort: 9200
+              name: http
+            - containerPort: 9300
+              name: transport
+          env:
+            - name: cluster.name
+              value: "orion-elasticsearch"
+            - name: node.name
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: discovery.seed_hosts
+              value: "elasticsearch-0.elasticsearch.elk,elasticsearch-1.elasticsearch.elk"
+            - name: cluster.initial_master_nodes
+              value: "elasticsearch-0,elasticsearch-1"
+            - name: ES_JAVA_OPTS
+              value: "-Xms1g -Xmx1g"
+            - name: xpack.security.enabled
+              value: "true"
+            - name: xpack.security.http.ssl.enabled
+              value: "false"
+            - name: ELASTIC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-credentials
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "1000m"
+            limits:
+              memory: "2Gi"
+              cpu: "2000m"
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 50Gi
+---
+# Headless service for StatefulSet pod DNS
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: elk
+spec:
+  clusterIP: None
+  selector:
+    app: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200
+    - name: transport
+      port: 9300
+      targetPort: 9300
+---
+# Client service for Kibana, Logstash, Elastiflow to reach ES
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-client
+  namespace: elk
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: 9200

--- a/deploy/monitoring/elk/kibana-deployment.yaml
+++ b/deploy/monitoring/elk/kibana-deployment.yaml
@@ -1,0 +1,83 @@
+---
+# Kibana Deployment — ORION Phase 3
+# Adapted from ansible for RPi 4 homelab (2 replicas, amd64)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: elk
+  labels:
+    app: kibana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:8.11.3
+          ports:
+            - containerPort: 5601
+              name: http
+          env:
+            - name: ELASTICSEARCH_HOSTS
+              value: "http://elasticsearch-client:9200"
+            - name: ELASTICSEARCH_USERNAME
+              value: "elastic"
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-credentials
+                  key: password
+            - name: XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY
+              value: "a7a6311933d3503b89bc2dbc36572c33a6c10925682e591bffcab6911c06786d"
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+---
+# Kibana service
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: elk
+  labels:
+    app: kibana
+spec:
+  selector:
+    app: kibana
+  ports:
+    - name: http
+      port: 5601
+      targetPort: 5601
+---
+# IngressRoute for Kibana — Traefik IngressRoute
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: kibana-internal
+  namespace: elk
+  labels:
+    app: kibana
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`siem.khalis.corp`)
+      kind: Rule
+      services:
+        - name: kibana
+          port: 5601
+          namespace: elk

--- a/deploy/monitoring/elk/logstash-configmap.yaml
+++ b/deploy/monitoring/elk/logstash-configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logstash-config
+  namespace: elk
+  labels:
+    app: logstash
+data:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    path.config: /usr/share/logstash/pipeline
+  logstash.conf: |
+    input {
+      # NetFlow v5/v9/v10 (IPFIX) input
+      udp {
+        port => 2055
+        codec => netflow {
+          versions => [5, 9, 10]
+        }
+        type => "netflow"
+      }
+
+      # sFlow input
+      udp {
+        port => 6343
+        codec => netflow {
+          versions => [10]
+          target => "sflow"
+        }
+        type => "sflow"
+      }
+
+      # Syslog input
+      udp {
+        port => 514
+        type => "syslog"
+      }
+
+      # Beats input
+      beats {
+        port => 5044
+      }
+    }
+
+    filter {
+      # NetFlow enrichment
+      if [type] == "netflow" {
+        if [ipv4_src_addr] {
+          geoip {
+            source => "ipv4_src_addr"
+            target => "geoip_src"
+          }
+        }
+        if [ipv4_dst_addr] {
+          geoip {
+            source => "ipv4_dst_addr"
+            target => "geoip_dst"
+          }
+        }
+
+        mutate {
+          convert {
+            "in_bytes" => "integer"
+            "in_pkts" => "integer"
+            "out_bytes" => "integer"
+            "out_pkts" => "integer"
+          }
+        }
+      }
+
+      # Syslog filtering
+      if [type] == "syslog" {
+        grok {
+          match => { "message" => "%{SYSLOGLINE}" }
+        }
+        date {
+          match => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+        }
+      }
+    }
+
+    output {
+      elasticsearch {
+        hosts => ["http://elasticsearch-client:9200"]
+        index => "%{[type]}-%{+YYYY.MM.dd}"
+        user => "elastic"
+        password => "orion-elk-default"
+      }
+    }

--- a/deploy/monitoring/elk/logstash-deployment.yaml
+++ b/deploy/monitoring/elk/logstash-deployment.yaml
@@ -1,0 +1,102 @@
+---
+# Logstash Deployment — ORION Phase 3
+# Adapts ansible config for RPi 4 homelab (2 replicas, amd64)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logstash
+  namespace: elk
+  labels:
+    app: logstash
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: logstash
+  template:
+    metadata:
+      labels:
+        app: logstash
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: logstash
+          image: docker.elastic.co/logstash/logstash:8.11.3
+          ports:
+            - containerPort: 5044
+              name: beats
+            - containerPort: 5000
+              name: tcp
+            - containerPort: 5000
+              protocol: UDP
+              name: udp
+            - containerPort: 514
+              name: syslog
+              protocol: UDP
+            - containerPort: 2055
+              name: netflow
+              protocol: UDP
+            - containerPort: 6343
+              name: sflow
+              protocol: UDP
+          volumeMounts:
+            - name: config
+              mountPath: /usr/share/logstash/pipeline/logstash.conf
+              subPath: logstash.conf
+            - name: config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+          env:
+            - name: LS_JAVA_OPTS
+              value: "-Xmx1g -Xms1g"
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+      volumes:
+        - name: config
+          configMap:
+            name: logstash-config
+---
+# Service for Logstash (NodePort for external collectors)
+apiVersion: v1
+kind: Service
+metadata:
+  name: logstash
+  namespace: elk
+  labels:
+    app: logstash
+spec:
+  type: NodePort
+  selector:
+    app: logstash
+  ports:
+    - name: beats
+      port: 5044
+      targetPort: 5044
+    - name: tcp
+      port: 5000
+      targetPort: 5000
+    - name: udp
+      port: 5000
+      targetPort: 5000
+      protocol: UDP
+    - name: syslog
+      port: 514
+      targetPort: 514
+      protocol: UDP
+      nodePort: 30514
+    - name: netflow
+      port: 2055
+      targetPort: 2055
+      protocol: UDP
+      nodePort: 30055
+    - name: sflow
+      port: 6343
+      targetPort: 6343
+      protocol: UDP
+      nodePort: 30343

--- a/deploy/monitoring/elk/namespace.yaml
+++ b/deploy/monitoring/elk/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: elk

--- a/deploy/monitoring/elk/secret.yaml
+++ b/deploy/monitoring/elk/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elasticsearch-credentials
+  namespace: elk
+stringData:
+  password: "orion-elk-default"

--- a/deploy/monitoring/grafana/values.yaml
+++ b/deploy/monitoring/grafana/values.yaml
@@ -1,0 +1,64 @@
+# ORION Phase 3 — Standalone Grafana values
+# Connects to VictoriaMetrics as datasource
+# Single replica, amd64 only (RPi 4 homelab)
+
+replicas: 1
+
+nodeSelector:
+  kubernetes.io/arch: amd64
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 256Mi
+
+persistence:
+  enabled: true
+  storageClassName: longhorn
+  size: 5Gi
+
+adminUser: admin
+adminPasswordFromEnv: GRAFANA_ADMIN_PASSWORD
+
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: VictoriaMetrics
+        type: prometheus
+        access: proxy
+        url: http://vmsingle-vmsingle.victoria-metrics:8429
+        isDefault: true
+        editable: false
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://vmalert-vmalert.victoria-metrics:3100
+        editable: false
+
+dashboards:
+  default:
+    gdev:
+      enabled: true
+
+grafana.ini:
+  server:
+    root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana"
+    serve_from_sub_path: true
+  log:
+    level: warn
+  security:
+    allow_embedding: false
+
+service:
+  type: ClusterIP
+  ports:
+    grafana:
+      port: 80
+      targetPort: 3000
+
+serviceAccount:
+  create: true
+  name: grafana

--- a/deploy/monitoring/namespace.yaml
+++ b/deploy/monitoring/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/deploy/monitoring/networkpolicy.yaml
+++ b/deploy/monitoring/networkpolicy.yaml
@@ -1,0 +1,35 @@
+# ORION Phase 3 — Restrict Elasticsearch access
+# Only allow ingress from the elk namespace itself (Logstash, Kibana)
+# and the monitoring namespace (Elastiflow, ELK stack components)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: elk-restrict
+  namespace: elk
+spec:
+  podSelector:
+    matchLabels:
+      app: elasticsearch
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow from any pod in the elk namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: elk
+      ports:
+        - protocol: TCP
+          port: 9200
+        - protocol: TCP
+          port: 9300
+        - protocol: TCP
+          port: 5601
+    # Allow from monitoring namespace (Elastiflow)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9200

--- a/deploy/monitoring/ntopng/daemonset.yaml
+++ b/deploy/monitoring/ntopng/daemonset.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ntopng
+  namespace: monitoring
+  labels:
+    app: ntopng
+spec:
+  selector:
+    matchLabels:
+      app: ntopng
+  template:
+    metadata:
+      labels:
+        app: ntopng
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: homelab-master
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: ntopng
+          image: ghcr.io/ntop/ntopng:latest
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          ports:
+            - containerPort: 3000
+              hostPort: 3000
+              name: web
+            - containerPort: 9101
+              hostPort: 9101
+              name: prometheus
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          env:
+            - name: NTOPNG_ARGS
+              value: "-w 3000 --http-uuid ntopng --interface 0 --disable-featured-tasks"
+          volumeMounts:
+            - name: data
+              mountPath: /opt/ntop
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/deploy/monitoring/ntopng/ingress.yaml
+++ b/deploy/monitoring/ntopng/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ntopng
+  namespace: monitoring
+  labels:
+    app: ntopng
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`ntopng.khalis.corp`)
+      kind: Rule
+      services:
+        - name: ntopng
+          port: 3000
+          namespace: monitoring

--- a/deploy/monitoring/ntopng/service.yaml
+++ b/deploy/monitoring/ntopng/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ntopng
+  namespace: monitoring
+  labels:
+    app: ntopng
+spec:
+  type: ClusterIP
+  selector:
+    app: ntopng
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: web
+    - port: 9101
+      targetPort: 9101
+      name: prometheus

--- a/deploy/monitoring/victoria-metrics/namespace.yaml
+++ b/deploy/monitoring/victoria-metrics/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: victoria-metrics

--- a/deploy/monitoring/victoria-metrics/values.yaml
+++ b/deploy/monitoring/victoria-metrics/values.yaml
@@ -1,0 +1,154 @@
+# VictoriaMetrics K8s Stack Configuration — ORION Phase 3
+# Adapted for RPi 4 8GB (amd64 only) homelab environment
+# Version: 0.60.1
+
+# VictoriaMetrics Single (not cluster mode)
+vmsingle:
+  enabled: true
+  spec:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    retentionPeriod: "72h"
+    replicaCount: 1
+    storage:
+      storageClassName: longhorn
+      resources:
+        requests:
+          storage: 50Gi
+      accessModes:
+        - ReadWriteOnce
+    resources:
+      limits:
+        memory: 2560Mi
+      requests:
+        cpu: 10m
+        memory: 2560Mi
+    extraArgs:
+      loggerLevel: WARN
+
+# Disable cluster mode
+vmcluster:
+  enabled: false
+
+# VM Agent for metrics collection
+vmagent:
+  enabled: true
+  spec:
+    replicaCount: 1
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    resources:
+      limits:
+        memory: 1024Mi
+      requests:
+        cpu: 10m
+        memory: 1024Mi
+    extraArgs:
+      loggerLevel: WARN
+
+# VM Alert for alerting rules
+vmalert:
+  enabled: true
+  spec:
+    replicaCount: 1
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    extraArgs:
+      loggerLevel: WARN
+
+# AlertManager for alert routing
+alertmanager:
+  enabled: true
+  spec:
+    replicaCount: 1
+    nodeSelector:
+      kubernetes.io/arch: amd64
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    logLevel: WARN
+
+# Grafana for visualization
+grafana:
+  enabled: true
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  sidecar:
+    dashboards:
+      enabled: true
+      searchNamespace: kube-system
+    datasources:
+      enabled: true
+  adminPasswordFromEnv: ADMIN_PASSWORD
+  replicas: 1
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 256Mi
+  persistence:
+    enabled: true
+    storageClassName: longhorn
+    size: 5Gi
+  grafana.ini:
+    log:
+      level: warn
+    security:
+      allow_embedding: false
+    plugins:
+      - grafana-lokiexplore-app
+
+# Prometheus Node Exporter
+prometheus-node-exporter:
+  enabled: true
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+# Kube State Metrics
+kube-state-metrics:
+  enabled: true
+  replicas: 1
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+
+# Default dashboards
+defaultDashboardsEnabled: true
+defaultDashboardsTimezone: utc
+
+# VM Operator
+victoria-metrics-operator:
+  operator:
+    enable_converter_ownership: true
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+  logLevel: ERROR
+
+# CRDs
+crds:
+  enabled: true
+
+# Service monitors
+serviceMonitor:
+  enabled: true


### PR DESCRIPTION
## Summary

Add bundled Kubernetes manifests for deploying monitoring stacks during bootstrap:

- Namespace definitions (monitoring, victoria-metrics, elk)
- VictoriaMetrics Helm values for k8s stack
- Grafana Helm values with VictoriaMetrics datasource
- ntopng DaemonSet (hostNetwork, privileged) with service + ingress
- ELK stack (Elasticsearch StatefulSet, Logstash, Kibana, configmap)
- Elastiflow NetFlow collector
- Network policy restricting ELK access

All manifests are amd64-only with resource limits appropriate for RPi 4 8GB homelab.

## Files Added
- `deploy/monitoring/namespace.yaml`
- `deploy/monitoring/victoria-metrics/namespace.yaml`
- `deploy/monitoring/victoria-metrics/values.yaml`
- `deploy/monitoring/grafana/values.yaml`
- `deploy/monitoring/ntopng/daemonset.yaml`
- `deploy/monitoring/ntopng/service.yaml`
- `deploy/monitoring/ntopng/ingress.yaml`
- `deploy/monitoring/elk/namespace.yaml`
- `deploy/monitoring/elk/secret.yaml`
- `deploy/monitoring/elk/elasticsearch-deployment.yaml`
- `deploy/monitoring/elk/logstash-configmap.yaml`
- `deploy/monitoring/elk/logstash-deployment.yaml`
- `deploy/monitoring/elk/kibana-deployment.yaml`
- `deploy/monitoring/elastiflow/deployment.yaml`
- `deploy/monitoring/networkpolicy.yaml`

---
Phase 3 of the Observability Platform implementation plan.