### PR TITLE
feat: add security monitoring API routes

### DIFF
--- a/apps/web/src/app/api/monitoring/security/actions/route.ts
+++ b/apps/web/src/app/api/monitoring/security/actions/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const { action, ...params } = body as { action: string; [key: string]: unknown }
+
+  const gatewayUrl = process.env.GATEWAY_URL
+  const gatewayToken = process.env.GATEWAY_TOKEN
+
+  if (!gatewayUrl || !gatewayToken) {
+    return NextResponse.json({ error: 'Gateway not configured' }, { status: 503 })
+  }
+
+  let toolName = ''
+  let toolArgs: Record<string, unknown> = {}
+
+  switch (action) {
+    case 'block_ip':
+      toolName = 'crowdsec_block_ip'
+      toolArgs = { ip: params.ip, reason: params.reason || 'Blocked via ORION' }
+      break
+    case 'quarantine_device':
+      // Route to CrowdSec for IP block
+      toolName = 'crowdsec_block_ip'
+      toolArgs = { ip: params.ip, reason: params.deviceId ? `Quarantine: ${params.deviceId}` : 'Quarantine' }
+      break
+    case 'investigate':
+      toolName = 'elk_flow_search'
+      toolArgs = { query: params.ip ? `src_ip:${params.ip}` : '*', limit: 20 }
+      break
+    default:
+      return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 })
+  }
+
+  const res = await fetch(`${gatewayUrl}/tools/execute`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${gatewayToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: toolName, arguments: toolArgs }),
+  })
+
+  const result = await res.json()
+  if (!res.ok) {
+    return NextResponse.json({ error: result.error || result }, { status: res.status })
+  }
+
+  return NextResponse.json({ success: true, result })
+}

--- a/apps/web/src/app/api/monitoring/security/alerts/ack/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/ack/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const { ids }: { ids: string[] } = body
+
+  if (!ids || !Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json({ error: 'ids array required' }, { status: 400 })
+  }
+
+  const acknowledgedAt = new Date()
+
+  await prisma.securityEvent.updateMany({
+    where: { id: { in: ids } },
+    data: { acknowledged: true, acknowledgedAt },
+  })
+
+  return NextResponse.json({ acknowledged: ids.length })
+}

--- a/apps/web/src/app/api/monitoring/security/alerts/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const type = searchParams.get('type') || undefined
+  const severity = searchParams.get('severity') ? parseInt(searchParams.get('severity')!) : undefined
+  const minutes = searchParams.get('minutes') ? parseInt(searchParams.get('minutes')!) : 60
+  const acknowledged = searchParams.get('acknowledged') === 'true'
+  const page = searchParams.get('page') ? parseInt(searchParams.get('page')!) : 1
+  const limit = searchParams.get('limit') ? parseInt(searchParams.get('limit')!) : 20
+
+  const envId = process.env.ENVIRONMENT_ID || ''
+
+  const where: Record<string, unknown> = {}
+  if (envId) where.environmentId = envId
+  if (type) where.type = type
+  if (severity) where.severity = { gte: severity }
+  if (typeof acknowledged === 'boolean') where.acknowledged = acknowledged
+
+  const cutoff = new Date(Date.now() - minutes * 60 * 1000)
+  ;(where as any).createdAt = { ...where.createdAt, gte: cutoff }
+
+  const [events, total] = await Promise.all([
+    prisma.securityEvent.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.securityEvent.count({ where }),
+  ])
+
+  return NextResponse.json({
+    events: events.map(a => ({
+      id: a.id,
+      type: a.type,
+      source: a.source,
+      severity: a.severity,
+      title: a.title,
+      description: a.description,
+      acknowledged: a.acknowledged,
+      acknowledgedAt: a.acknowledgedAt,
+      createdAt: a.createdAt,
+    })),
+    pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/flows/route.ts
+++ b/apps/web/src/app/api/monitoring/security/flows/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('q') || '*'
+  const limit = searchParams.get('limit') ? parseInt(searchParams.get('limit')!) : 50
+  const index = searchParams.get('index') || 'netflow-*'
+
+  // Get Gateway URL from environment
+  const gatewayUrl = process.env.GATEWAY_URL
+  if (!gatewayUrl) {
+    return NextResponse.json({ error: 'Gateway URL not configured' }, { status: 503 })
+  }
+
+  const gatewayToken = process.env.GATEWAY_TOKEN
+  if (!gatewayToken) {
+    return NextResponse.json({ error: 'Gateway token not configured' }, { status: 503 })
+  }
+
+  // Call Gateway's elk_flow_search tool via REST API
+  const res = await fetch(`${gatewayUrl}/tools/execute`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${gatewayToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: 'elk_flow_search',
+      arguments: { query, limit },
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    return NextResponse.json({ error: text }, { status: res.status })
+  }
+
+  const data = await res.json()
+  return NextResponse.json({ flows: data })
+}

--- a/apps/web/src/app/api/monitoring/security/overview/route.ts
+++ b/apps/web/src/app/api/monitoring/security/overview/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const envId = process.env.ENVIRONMENT_ID || ''
+
+  // Fetch recent security events
+  const recentAlerts = await prisma.securityEvent.findMany({
+    where: envId ? { environmentId: envId, acknowledged: false } : undefined,
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+    include: { environment: true },
+  })
+
+  // Count by type and severity
+  const typeCounts = await prisma.securityEvent.groupBy({
+    by: ['type'],
+    where: envId ? { environmentId: envId } : undefined,
+    _count: true,
+  })
+
+  const severityDist = await prisma.securityEvent.groupBy({
+    by: ['severity'],
+    where: envId ? { environmentId: envId } : undefined,
+    _count: { id: true },
+    orderBy: { severity: 'desc' },
+    take: 5,
+  })
+
+  const criticalCount = recentAlerts.filter(a => a.severity >= 80).length
+  const highCount = recentAlerts.filter(a => a.severity >= 50 && a.severity < 80).length
+  const totalUnack = recentAlerts.length
+
+  // Risk score: 0-100 based on threat volume and severity
+  const riskScore = Math.min(100, Math.max(0,
+    criticalCount * 25 + highCount * 10 + totalUnack * 2
+  ))
+
+  return NextResponse.json({
+    riskScore,
+    activeThreats: recentAlerts.length,
+    criticalCount,
+    highCount,
+    recentAlerts: recentAlerts.map(a => ({
+      id: a.id,
+      type: a.type,
+      source: a.source,
+      severity: a.severity,
+      title: a.title,
+      acknowledged: a.acknowledged,
+      createdAt: a.createdAt,
+    })),
+    blockCount: (typeCounts.find(t => t.type === 'crowdsec_block')?._count ?? 0) as number,
+    anomalyCount: (typeCounts.find(t => t.type === 'anomaly')?._count ?? 0) as number,
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/stream/route.ts
+++ b/apps/web/src/app/api/monitoring/security/stream/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export const streamTimeout = 0
+
+export function GET(request: NextRequest) {
+  const { signal } = request
+
+  const headers = {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(`\n\n: connected\n\n`)
+
+      const interval = setInterval(() => {
+        controller.enqueue(`: heartbeat\n\n`)
+      }, 15000)
+
+      signal.addEventListener('abort', () => {
+        clearInterval(interval)
+        controller.close()
+      })
+
+      // Poll for new events every 5 seconds
+      const pollInterval = setInterval(async () => {
+        try {
+          const { prisma } = await import('@/lib/db')
+          const events = await prisma.securityEvent.findMany({
+            where: { acknowledged: false },
+            orderBy: { createdAt: 'desc' },
+            take: 5,
+          })
+
+          if (events.length > 0) {
+            controller.enqueue(`data: ${JSON.stringify(events)}\n\n`)
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : 'poll error'
+          controller.enqueue(`data: {"error":"${msg}"}\n\n`)
+        }
+      }, 5000)
+
+      signal.addEventListener('abort', () => {
+        clearInterval(interval)
+        clearInterval(pollInterval)
+      })
+    },
+  })
+
+  return new NextResponse(stream, { headers })
+}


### PR DESCRIPTION
## Summary

Create REST API endpoints for security monitoring under `/api/monitoring/security/`:

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/overview` | GET | Risk score, active threats, block/anomaly counts |
| `/alerts` | GET | Paginated, filterable security events (type, severity, time window, acknowledged) |
| `/alerts/ack` | POST | Bulk acknowledge security events |
| `/flows` | GET | Proxy NetFlow data from Elasticsearch via Gateway |
| `/actions` | POST | Route security actions (block_ip, quarantine, investigate) |
| `/stream` | GET | SSE stream for real-time security events |

Each route uses `dynamic = 'force-dynamic'` and follows existing Next.js API patterns.

## Files Changed
- `apps/web/src/app/api/monitoring/security/overview/route.ts` — NEW
- `apps/web/src/app/api/monitoring/security/alerts/route.ts` — NEW
- `apps/web/src/app/api/monitoring/security/alerts/ack/route.ts` — NEW
- `apps/web/src/app/api/monitoring/security/flows/route.ts` — NEW
- `apps/web/src/app/api/monitoring/security/actions/route.ts` — NEW
- `apps/web/src/app/api/monitoring/security/stream/route.ts` — NEW

---
Phase 6 of the Observability Platform implementation plan.
Depends on PR #325 (SecurityEvent Prisma model).