### PR TITLE
feat: add 8 Prisma models for Hooks, Skills, Evals & Observability

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -114,7 +114,10 @@ model Environment {
   ingressPoints IngressPoint[]
   coreDnsDomains Domain[]              @relation("DomainCoreDns")
   novaDeployments NovaDeployment[]
-  managedSecrets  ManagedSecret[]
+  managedSecrets   ManagedSecret[]
+  nebulaInstances  NebulaInstance[]
+  evals            Eval[]
+  agentScores      AgentScore[]
 }
 
 /// Tracks every PR opened by the GitOps loop — open, auto-merged, or awaiting review.
@@ -840,4 +843,149 @@ model ManagedSecret {
 
   @@index([environmentId])
   @@map("managed_secrets")
+}
+
+// ── ORION Hooks, Skills, Evals & Observability (Phase 1) ──────────────────────
+
+model NovaDefinition {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  category    String   // "skill" | "hook"
+  version     String   @default("1.0")
+  title       String
+  description String   @db.Text
+  spec        String   @db.Text // JSON string
+  metadata    String?  @db.Text // JSON string
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  instances   NebulaInstance[]
+
+  @@index([category])
+}
+
+model NebulaInstance {
+  id            String             @id @default(cuid())
+  environmentId String
+  environment   Environment        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  sourceNovaId  String?
+  novaDefinition NovaDefinition?   @relation(fields: [sourceNovaId], references: [id])
+  name          String
+  category      String             // "skill" | "hook"
+  spec          String             @db.Text
+  isForked      Boolean            @default(false)
+  isInstalled   Boolean            @default(true)
+  minimumTier   String?
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
+  hookLogs      HookExecutionLog[]
+  skillLogs     SkillExecutionLog[]
+
+  @@unique([environmentId, name])
+  @@index([environmentId, category, isInstalled])
+}
+
+model HookExecutionLog {
+  id           String             @id @default(cuid())
+  nebulaId     String
+  nebula       NebulaInstance     @relation(fields: [nebulaId], references: [id], onDelete: Cascade)
+  triggerEvent String
+  triggerData  String?            @db.Text
+  actionType   String
+  status       String             @default("running")
+  output       String?            @db.Text
+  startedAt    DateTime           @default(now())
+  completedAt  DateTime?
+  durationMs   Int?
+
+  @@index([nebulaId, startedAt])
+  @@index([status, startedAt])
+}
+
+model SkillExecutionLog {
+  id             String           @id @default(cuid())
+  nebulaId       String
+  nebula         NebulaInstance   @relation(fields: [nebulaId], references: [id], onDelete: Cascade)
+  source         String           // "chat_match" | "hook_trigger" | "manual"
+  contextId      String?
+  matchedPattern String?
+  createdAt      DateTime         @default(now())
+
+  @@index([nebulaId, createdAt])
+}
+
+model AgentTrace {
+  id               String   @id @default(cuid())
+  conversationId   String?
+  taskId           String?
+  step             Int
+  type             String   // "tool_call" | "tool_result" | "skill_injected" | "hook_triggered" | "text_generation" | "error"
+  toolName         String?
+  toolArgs         String?  @db.Text
+  toolResult       String?  @db.Text
+  content          String?  @db.Text
+  skillName        String?
+  hookName         String?
+  durationMs       Int?
+  modelUsed        String?
+  systemPromptHash String?
+  tokensIn         Int?
+  tokensOut        Int?
+  costCents        Decimal? @db.Decimal(10,6)
+  createdAt        DateTime @default(now())
+
+  @@index([conversationId, step])
+  @@index([taskId, step])
+  @@index([type, createdAt])
+  @@index([createdAt])
+}
+
+model Eval {
+  id            String         @id @default(cuid())
+  environmentId String
+  environment   Environment    @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  targetType    String         // "conversation" | "task" | "skill" | "hook"
+  targetId      String
+  evalType      String         // "manual" | "auto_rule" | "auto_llm"
+  evaluator     String?
+  rulesetId     String?
+  scores        String         @db.Text // JSON
+  scoreTotal    Float          // 0-100
+  scoreBreakdown String?       @db.Text // JSON
+  feedback      String?        @db.Text
+  evidence      String?        @db.Text // JSON
+  createdAt     DateTime       @default(now())
+
+  @@index([environmentId, targetType, targetId])
+  @@index([evalType, createdAt])
+}
+
+model Ruleset {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String   @db.Text
+  criteria    String   @db.Text // JSON
+  triggers    String   @db.Text // JSON
+  createdAt   DateTime @default(now())
+
+  @@index([name])
+}
+
+model AgentScore {
+  id            String         @id @default(cuid())
+  environmentId String
+  environment   Environment    @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  targetType    String         // "conversation" | "task" | "skill" | "hook"
+  targetId      String
+  scoreTotal    Float          // 0-100
+  accuracy      Float          // 0-100
+  completeness  Float?         // 0-100
+  safety        Float          // 0-100
+  efficiency    Float?         // 0-100
+  quality       Float?         // 0-100
+  evalCount     Int            @default(0)
+  lastEvalAt    DateTime?
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  @@unique([targetType, targetId])
 }

--- a/apps/web/src/app/(app)/security/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { notFound } from 'next/navigation'
+
+export default function SecurityDetailPage({ params }: { params: { id: string } }) {
+  // Placeholder for future alert detail page
+  return notFound()
+}

--- a/apps/web/src/app/(app)/security/page.tsx
+++ b/apps/web/src/app/(app)/security/page.tsx
@@ -1,0 +1,5 @@
+import SecurityDashboard from '@/components/security/SecurityDashboard'
+
+export default function SecurityPage() {
+  return <SecurityDashboard />
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -5,9 +5,10 @@ import { useState } from 'react'
 import {
   Server, MessageSquare, Bot,
   Bell, ClipboardList,
-  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles,
+  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles, Shield,
 } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
+import { useUnackAlertCount } from '@/hooks/useSecurityAlerts'
 
 const nav = [
   { href: '/infrastructure', icon: Server,  label: 'Infrastructure' },
@@ -15,6 +16,7 @@ const nav = [
   { href: '/tasks',          icon: ClipboardList, label: 'Tasks' },
   { href: '/agents',         icon: Bot,    label: 'Agents' },
   { href: '/alerts',         icon: Bell,   label: 'Alerts' },
+  { href: '/security',       icon: Shield, label: 'Security' },
   { href: '/notes',          icon: BookOpen, label: 'Wiki' },
   { href: '/nova',           icon: Sparkles, label: 'Nova' },
 ]
@@ -23,6 +25,7 @@ export function Sidebar() {
   const pathname = usePathname()
   const [collapsed, setCollapsed] = useState(false)
   const { count: pendingCount } = usePendingTools()
+  const unackCount = useUnackAlertCount()
 
   const NavLink = ({ href, icon: Icon, label, badge }: { href: string; icon: React.ElementType; label: string; badge?: number }) => {
     const active = href === '/' ? pathname === '/' : pathname.startsWith(href)
@@ -53,7 +56,7 @@ export function Sidebar() {
     <aside className={`hidden md:flex flex-col bg-bg-sidebar border-r border-border-subtle transition-all duration-200 flex-shrink-0 ${collapsed ? 'w-16' : 'w-56'}`}>
       {/* Nav */}
       <nav className="flex-1 py-2 overflow-y-auto">
-        {nav.map(item => <NavLink key={item.href} {...item} />)}
+        {nav.map(item => <NavLink key={item.href} {...item} badge={item.href === '/security' ? (unackCount || undefined) : undefined} />)}
       </nav>
 
       {/* Divider + Admin link */}

--- a/apps/web/src/components/security/AlertFeed.tsx
+++ b/apps/web/src/components/security/AlertFeed.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { AlertTriangle, CheckCircle2, XCircle, Loader2, Shield, Globe, Database } from 'lucide-react'
+
+const sourceIcons: Record<string, React.ElementType> = {
+  crowdsec: Shield,
+  ntopng: Globe,
+  wazuh: Database,
+  elk: Database,
+}
+
+const sourceColors: Record<string, string> = {
+  crowdsec: 'text-blue-400',
+  ntopng: 'text-green-400',
+  wazuh: 'text-orange-400',
+  elk: 'text-purple-400',
+}
+
+function SeverityBadge({ severity }: { severity: number }) {
+  let cls = ''
+  let icon = null
+  if (severity >= 80) {
+    cls = 'bg-red-500/20 text-red-400 border-red-500/30'
+    icon = <XCircle size={10} />
+  } else if (severity >= 50) {
+    cls = 'bg-orange-500/20 text-orange-400 border-orange-500/30'
+    icon = <AlertTriangle size={10} />
+  } else if (severity >= 20) {
+    cls = 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+    icon = <AlertTriangle size={10} />
+  } else {
+    cls = 'bg-green-500/20 text-green-400 border-green-500/30'
+    icon = <CheckCircle2 size={10} />
+  }
+
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border ${cls}`}>
+      {icon}
+      {severity}
+    </span>
+  )
+}
+
+export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: any[]; compact?: boolean }) {
+  const [alerts, setAlerts] = useState(initialAlerts || [])
+  const [selected, setSelected] = useState<string[]>([])
+
+  useEffect(() => {
+    const source = new EventSource('/api/monitoring/security/stream')
+
+    source.onmessage = (event) => {
+      const parsed = JSON.parse(event.data)
+      if (Array.isArray(parsed)) {
+        setAlerts(prev => {
+          const all = [...parsed, ...prev]
+          return all.slice(0, 100)
+        })
+      }
+    }
+
+    return () => source.close()
+  }, [])
+
+  async function ackSelected() {
+    if (selected.length === 0) return
+    await fetch('/api/monitoring/security/alerts/ack', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: selected }),
+    })
+    setAlerts(prev => prev.map(a => selected.includes(a.id) ? { ...a, acknowledged: true } : a))
+    setSelected([])
+  }
+
+  if (alerts.length === 0 && !initialAlerts) {
+    return (
+      <div className="p-8 text-center text-text-muted text-sm">
+        <Loader2 size={20} className="animate-spin mx-auto mb-2 text-accent" />
+        Connecting to security stream…
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {selected.length > 0 && (
+        <div className="px-4 py-2 border-b border-border-subtle flex items-center justify-between bg-bg-raised">
+          <span className="text-xs text-text-muted">{selected.length} selected</span>
+          <button onClick={ackSelected} className="text-xs text-accent hover:underline">
+            Acknowledge selected
+          </button>
+        </div>
+      )}
+
+      <div className="divide-y divide-border-subtle">
+        {alerts.map(alert => {
+          const Icon = sourceIcons[alert.source] || Shield
+          return (
+            <div
+              key={alert.id}
+              className={`px-4 py-3 flex items-start gap-3 hover:bg-bg-raised transition-colors ${
+                selected.includes(alert.id) ? 'bg-accent/5' : ''
+              } ${alert.acknowledged ? 'opacity-50' : ''}`}
+            >
+              <input
+                type="checkbox"
+                checked={selected.includes(alert.id)}
+                onChange={() => setSelected(prev =>
+                  prev.includes(alert.id) ? prev.filter(id => id !== alert.id) : [...prev, alert.id]
+                )}
+                className="mt-1 accent-accent"
+              />
+              <Icon size={14} className={`flex-shrink-0 mt-0.5 ${sourceColors[alert.source] || 'text-text-muted'}`} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-text-primary truncate">{alert.title}</span>
+                  <SeverityBadge severity={alert.severity} />
+                </div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[10px] text-text-muted">{alert.source}</span>
+                  <span className="text-[10px] text-text-muted">·</span>
+                  <span className="text-[10px] text-text-muted">{new Date(alert.createdAt).toLocaleString()}</span>
+                </div>
+                {!compact && alert.description && (
+                  <p className="text-xs text-text-muted mt-1 truncate">{alert.description}</p>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/security/FlowTable.tsx
+++ b/apps/web/src/components/security/FlowTable.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { ChevronUp, ChevronDown, Search, Loader2 } from 'lucide-react'
+
+type FlowRow = {
+  src_ip: string
+  dst_ip: string
+  src_port: number
+  dst_port: number
+  protocol: string
+  bytes: number
+  packets: number
+  duration: number
+  timestamp: string
+}
+
+function formatBytes(b: number) {
+  if (b < 1024) return `${b} B`
+  if (b < 1048576) return `${(b / 1024).toFixed(1)} KB`
+  return `${(b / 1048576).toFixed(1)} MB`
+}
+
+export default function FlowTable() {
+  const [flows, setFlows] = useState<FlowRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [sortCol, setSortCol] = useState<keyof FlowRow>('timestamp')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    fetch('/api/monitoring/security/flows?limit=50')
+      .then(r => r.json())
+      .then(d => { setFlows(d.flows || d || []); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 size={20} className="animate-spin text-accent" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-status-error text-sm">Error loading flows: {error}</div>
+    )
+  }
+
+  const filtered = flows.filter(f => {
+    if (!search) return true
+    const q = search.toLowerCase()
+    return Object.values(f).some(v => String(v).toLowerCase().includes(q))
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    const aVal = a[sortCol]
+    const bVal = b[sortCol]
+    if (typeof aVal === 'number') {
+      return sortDir === 'asc' ? aVal - bVal : bVal - aVal
+    }
+    return sortDir === 'asc'
+      ? String(aVal).localeCompare(String(bVal))
+      : String(bVal).localeCompare(String(aVal))
+  })
+
+  return (
+    <div>
+      <div className="px-4 py-3 border-b border-border-subtle">
+        <div className="flex items-center gap-3">
+          <div className="relative flex-1">
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted" />
+            <input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search flows…"
+              className="w-full pl-8 pr-3 py-1.5 text-xs bg-bg-raised border border-border-subtle rounded-md text-text-primary focus:outline-none focus:border-accent"
+            />
+          </div>
+          <span className="text-xs text-text-muted">{sorted.length} flows</span>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border-subtle">
+              {(['src_ip', 'dst_ip', 'protocol', 'bytes', 'packets', 'duration', 'timestamp'] as const).map(col => (
+                <th
+                  key={col}
+                  className="px-4 py-2 text-left text-text-muted font-medium cursor-pointer hover:text-text-primary transition-colors whitespace-nowrap"
+                  onClick={() => {
+                    if (sortCol === col) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+                    else { setSortCol(col); setSortDir('asc') }
+                  }}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.replace('_', ' ')}
+                    {sortCol === col && (
+                      sortDir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />
+                    )}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-subtle">
+            {sorted.slice(0, 50).map((flow, i) => (
+              <tr key={i} className="hover:bg-bg-raised transition-colors">
+                <td className="px-4 py-2 font-mono text-text-primary">{flow.src_ip}</td>
+                <td className="px-4 py-2 font-mono text-text-primary">{flow.dst_ip}</td>
+                <td className="px-4 py-2 text-text-muted">{flow.protocol}</td>
+                <td className="px-4 py-2 text-text-muted">{formatBytes(flow.bytes)}</td>
+                <td className="px-4 py-2 text-text-muted">{flow.packets.toLocaleString()}</td>
+                <td className="px-4 py-2 text-text-muted">{flow.duration}s</td>
+                <td className="px-4 py-2 text-text-muted">{new Date(flow.timestamp).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Shield, AlertTriangle, Activity, Zap, CheckCircle2, Loader2 } from 'lucide-react'
+import AlertFeed from './AlertFeed'
+import FlowTable from './FlowTable'
+
+function RiskScoreGauge({ score }: { score: number }) {
+  const getColor = (s: number) => {
+    if (s >= 75) return 'text-status-error'
+    if (s >= 50) return 'text-status-warning'
+    if (s >= 25) return 'text-yellow-400'
+    return 'text-status-success'
+  }
+  const getLabel = (s: number) => {
+    if (s >= 75) return 'Critical'
+    if (s >= 50) return 'High'
+    if (s >= 25) return 'Medium'
+    return 'Low'
+  }
+
+  return (
+    <div className="bg-bg-surface border border-border-subtle rounded-xl p-5 flex flex-col items-center">
+      <div className="flex items-center gap-2 mb-3">
+        <Shield size={16} className="text-text-muted" />
+        <span className="text-sm font-medium text-text-muted">Risk Score</span>
+      </div>
+      <div className={`text-5xl font-bold ${getColor(score)}`}>{score}</div>
+      <div className={`text-sm font-medium mt-1 ${getColor(score)}`}>{getLabel(score)}</div>
+      <div className="w-full h-2 bg-bg-raised rounded-full mt-3 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${
+            score >= 75 ? 'bg-status-error' : score >= 50 ? 'bg-status-warning' : 'bg-status-success'
+          }`}
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ icon: Icon, label, value, color }: {
+  icon: React.ElementType; label: string; value: number | string; color: string
+}) {
+  return (
+    <div className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon size={14} className={color} />
+        <span className="text-xs text-text-muted">{label}</span>
+      </div>
+      <div className="text-2xl font-bold text-text-primary">{value}</div>
+    </div>
+  )
+}
+
+export default function SecurityDashboard() {
+  const [data, setData] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [tab, setTab] = useState<'overview' | 'alerts' | 'flows'>('overview')
+
+  useEffect(() => {
+    fetch('/api/monitoring/security/overview')
+      .then(r => r.json())
+      .then(d => { setData(d); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-accent" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-status-error text-sm p-4 border border-status-error/20 bg-status-error/5 rounded-lg">
+        Error loading security data: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+          <Shield size={20} className="text-accent" />
+          Security Dashboard
+        </h1>
+        <div className="flex gap-1 bg-bg-raised rounded-lg p-0.5">
+          {(['overview', 'alerts', 'flows'] as const).map(t => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                tab === t ? 'bg-accent text-white' : 'text-text-muted hover:text-text-primary'
+              }`}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {tab === 'overview' && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <RiskScoreGauge score={data?.riskScore ?? 0} />
+            <StatCard icon={AlertTriangle} label="Active Threats" value={data?.activeThreats ?? 0} color="text-status-warning" />
+            <StatCard icon={Activity} label="Blocks" value={data?.blockCount ?? 0} color="text-blue-400" />
+            <StatCard icon={Zap} label="Anomalies" value={data?.anomalyCount ?? 0} color="text-purple-400" />
+          </div>
+          <div className="bg-bg-surface border border-border-subtle rounded-xl">
+            <div className="px-4 py-3 border-b border-border-subtle">
+              <span className="text-sm font-medium text-text-primary">Recent Alerts</span>
+            </div>
+            <AlertFeed initialAlerts={data?.recentAlerts} compact />
+          </div>
+        </div>
+      )}
+
+      {tab === 'alerts' && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl">
+          <div className="px-4 py-3 border-b border-border-subtle">
+            <span className="text-sm font-medium text-text-primary">All Alerts</span>
+          </div>
+          <AlertFeed />
+        </div>
+      )}
+
+      {tab === 'flows' && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl">
+          <div className="px-4 py-3 border-b border-border-subtle">
+            <span className="text-sm font-medium text-text-primary">NetFlow Records</span>
+          </div>
+          <FlowTable />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/security/SecuritySettings.tsx
+++ b/apps/web/src/components/security/SecuritySettings.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { Shield, CheckCircle2, XCircle, Loader2, RefreshCw } from 'lucide-react'
+
+const sources = [
+  { key: 'CROWDSEC_API', name: 'CrowdSec', desc: 'Brute-force & IP blocking', default: 'http://crowdsec-lapi.crowdsec:8080' },
+  { key: 'NTOPNG_API', name: 'ntopng', desc: 'Network traffic analysis', default: 'http://ntopng.monitoring:3000' },
+  { key: 'ELASTICSEARCH_URL', name: 'Elasticsearch', desc: 'Logs & flow data', default: 'http://elasticsearch-client.monitoring:9200' },
+  { key: 'VICTORIA_METRICS_URL', name: 'VictoriaMetrics', desc: 'Metrics time-series DB', default: 'http://victoria-metrics.monitoring:8428' },
+  { key: 'WAZUH_API', name: 'Wazuh', desc: 'Endpoint security & SIEM', default: 'https://wazuh-manager.security:55000' },
+]
+
+export default function SecuritySettings() {
+  const [config, setConfig] = useState<Record<string, string>>({})
+  const [testing, setTesting] = useState<string | null>(null)
+  const [results, setResults] = useState<Record<string, 'ok' | 'error' | null>>({})
+
+  async function testConnection(key: string) {
+    setTesting(key)
+    try {
+      const res = await fetch(`/api/monitoring/security/connections/test?key=${key}`)
+      const data = await res.json()
+      setResults(prev => ({ ...prev, [key]: data.ok ? 'ok' as const : 'error' as const }))
+    } catch {
+      setResults(prev => ({ ...prev, [key]: 'error' as const }))
+    }
+    setTesting(null)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Shield size={20} className="text-accent" />
+        <h2 className="text-base font-semibold text-text-primary">Security Sources</h2>
+      </div>
+      <p className="text-xs text-text-muted">Configure and test connections to security monitoring sources.</p>
+
+      <div className="space-y-3">
+        {sources.map(source => (
+          <div key={source.key} className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+            <div className="flex items-start justify-between mb-2">
+              <div>
+                <div className="text-sm font-medium text-text-primary">{source.name}</div>
+                <div className="text-[11px] text-text-muted">{source.desc}</div>
+              </div>
+              <button
+                onClick={() => testConnection(source.key)}
+                disabled={testing === source.key}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-primary border border-border-subtle rounded-md disabled:opacity-50"
+              >
+                {testing === source.key ? <Loader2 size={12} className="animate-spin" /> :
+                  results[source.key] === 'ok' ? <CheckCircle2 size={12} className="text-status-success" /> :
+                  results[source.key] === 'error' ? <XCircle size={12} className="text-status-error" /> :
+                  <RefreshCw size={12} />}
+                Test
+              </button>
+            </div>
+            <input
+              type="text"
+              value={config[source.key] || source.default}
+              onChange={e => setConfig(prev => ({ ...prev, [source.key]: e.target.value }))}
+              className="w-full px-3 py-1.5 text-xs bg-bg-raised border border-border-subtle rounded-md font-mono text-text-primary focus:outline-none focus:border-accent"
+              placeholder={source.default}
+            />
+          </div>
+        ))}
+      </div>
+
+      <button className="px-4 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 transition-colors">
+        Save Configuration
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useSecurityAlerts.ts
+++ b/apps/web/src/hooks/useSecurityAlerts.ts
@@ -1,0 +1,16 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export function useUnackAlertCount() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    fetch('/api/monitoring/security/alerts?acknowledged=false&minutes=60&limit=1')
+      .then(r => r.json())
+      .then(d => { setCount(d.pagination?.total ?? 0) })
+      .catch(() => {})
+  }, [])
+
+  return count
+}


### PR DESCRIPTION
## Summary

Add 8 new Prisma models for the Hooks, Skills, Evals & Observability platform.

### Models
- **NovaDefinition** — Registry of skill/hook definitions
- **NebulaInstance** — Per-environment instances with execution logs
- **HookExecutionLog** — Hook trigger logs
- **SkillExecutionLog** — Skill match logs
- **AgentTrace** — Observability traces per agent step
- **Eval** — Evaluation records (manual, auto-rule, auto-llm)
- **Ruleset** — Configurable auto-evaluation criteria/triggers
- **AgentScore** — Aggregated scores per target

Also adds reverse relations on Environment for the new models.

---
Phase 1 of Hooks, Skills, Evals & Observability.
Depends on: PR #330 (security UI) for clean base.