### PR TITLE
feat: add seed data for NovaDefinitions and Rulesets

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "db:migrate": "prisma migrate deploy"
+    "db:migrate": "prisma migrate deploy",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.0",
@@ -58,6 +59,7 @@
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^1.6.1"
   }
 }

--- a/apps/web/src/lib/default-novas.test.ts
+++ b/apps/web/src/lib/default-novas.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_NOVAS, type NovaDefinitionSeed } from './default-novas'
+import { DEFAULT_RULESETS, type RulesetSeed } from './default-rulesets'
+
+describe('Seed Data', () => {
+  describe('Nova Definitions', () => {
+    it('exports exactly 10 novas (5 skills + 5 hooks)', () => {
+      expect(DEFAULT_NOVAS).toHaveLength(10)
+      const skills = DEFAULT_NOVAS.filter(n => n.category === 'skill')
+      const hooks = DEFAULT_NOVAS.filter(n => n.category === 'hook')
+      expect(skills).toHaveLength(5)
+      expect(hooks).toHaveLength(5)
+    })
+
+    it('all novas have unique names', () => {
+      const names = DEFAULT_NOVAS.map(n => n.name)
+      const unique = new Set(names)
+      expect(unique.size).toBe(names.length)
+    })
+
+    it('all novas have required fields', () => {
+      for (const nova of DEFAULT_NOVAS) {
+        expect(nova.name).toBeTruthy()
+        expect(['skill', 'hook']).toContain(nova.category)
+        expect(nova.version).toBeTruthy()
+        expect(nova.title).toBeTruthy()
+        expect(nova.description).toBeTruthy()
+        expect(nova.spec).toBeTruthy()
+        expect(nova.metadata).toBeTruthy()
+      }
+    })
+
+    it('all spec fields are valid JSON', () => {
+      for (const nova of DEFAULT_NOVAS) {
+        expect(() => JSON.parse(nova.spec)).not.toThrow()
+        expect(() => JSON.parse(nova.metadata)).not.toThrow()
+      }
+    })
+
+    describe('Skills', () => {
+      const skills = DEFAULT_NOVAS.filter(n => n.category === 'skill') as Array<NovaDefinitionSeed & { spec: { triggerPatterns: string[], systemPrompt: string } }>
+
+      it('skills have triggerPatterns and systemPrompt in spec', () => {
+        for (const skill of skills) {
+          const spec = JSON.parse(skill.spec)
+          expect(Array.isArray(spec.triggerPatterns)).toBe(true)
+          expect(spec.triggerPatterns.length).toBeGreaterThan(0)
+          expect(typeof spec.systemPrompt).toBe('string')
+          expect(spec.systemPrompt.length).toBeGreaterThan(50)
+        }
+      })
+
+      it('skill names match expected list', () => {
+        const names = skills.map(s => s.name).sort()
+        expect(names).toEqual([
+          'backup-recovery',
+          'cluster-health',
+          'dns-troubleshoot',
+          'docker-troubleshoot',
+          'k8s-debug',
+        ])
+      })
+    })
+
+    describe('Hooks', () => {
+      const hooks = DEFAULT_NOVAS.filter(n => n.category === 'hook')
+      function parseSpec(nova: { spec: string }) {
+        return JSON.parse(nova.spec) as Record<string, unknown>
+      }
+
+      it('hooks have valid trigger types and action types', () => {
+        for (const hook of hooks) {
+          const spec = parseSpec(hook)
+          expect(spec.triggerType).toBeTruthy()
+          expect(spec.triggerFilter).toBeDefined()
+          expect(spec.actionType).toBeTruthy()
+          expect(['run_shell_command', 'send_notification']).toContain(spec.actionType)
+          expect(spec.actionConfig).toBeDefined()
+        }
+      })
+
+      it('hook names match expected list', () => {
+        const names = hooks.map(h => h.name).sort()
+        expect(names).toEqual([
+          'argocd_sync_degraded',
+          'diagnose_pod_crashloop',
+          'disk_full_warning',
+          'notify_oom_kill',
+          'tool_usage_audit',
+        ])
+      })
+
+      it('hooks with send_notification have channel in actionConfig', () => {
+        const notificationHooks = hooks.filter(n => {
+          const spec = parseSpec(n)
+          return spec.actionType === 'send_notification'
+        })
+        for (const hook of notificationHooks) {
+          const spec = parseSpec(hook)
+          expect(spec.actionConfig.channel).toBeTruthy()
+          expect(spec.actionConfig.message).toBeTruthy()
+        }
+      })
+
+      it('hooks with run_shell_command have command in actionConfig', () => {
+        const shellHooks = hooks.filter(n => {
+          const spec = parseSpec(n)
+          return spec.actionType === 'run_shell_command'
+        })
+        for (const hook of shellHooks) {
+          const spec = parseSpec(hook)
+          expect(spec.actionConfig.command).toBeTruthy()
+        }
+      })
+    })
+  })
+
+  describe('Rulesets', () => {
+    it('exports exactly 4 rulesets', () => {
+      expect(DEFAULT_RULESETS).toHaveLength(4)
+    })
+
+    it('all rulesets have required fields', () => {
+      for (const ruleset of DEFAULT_RULESETS) {
+        expect(ruleset.name).toBeTruthy()
+        expect(ruleset.description).toBeTruthy()
+        expect(() => JSON.parse(ruleset.criteria)).not.toThrow()
+        expect(() => JSON.parse(ruleset.triggers)).not.toThrow()
+      }
+    })
+
+    it('criteria entries have required fields', () => {
+      for (const ruleset of DEFAULT_RULESETS) {
+        const criteria = JSON.parse(ruleset.criteria) as Array<Record<string, unknown>>
+        for (const entry of criteria) {
+          expect(entry.name).toBeTruthy()
+          expect(entry.type).toBeTruthy()
+          expect(entry.threshold).toBeDefined()
+          expect(entry.weight).toBeDefined()
+          expect(typeof entry.weight).toBe('number')
+        }
+      }
+    })
+
+    it('criteria weights sum close to 1.0 per ruleset', () => {
+      for (const ruleset of DEFAULT_RULESETS) {
+        const criteria = JSON.parse(ruleset.criteria) as Array<{ weight: number }>
+        const total = criteria.reduce((sum, e) => sum + e.weight, 0)
+        expect(total).toBeGreaterThan(0.9)
+        expect(total).toBeLessThanOrEqual(1.0)
+      }
+    })
+
+    it('ruleset names match expected list', () => {
+      const names = DEFAULT_RULESETS.map(r => r.name).sort()
+      expect(names).toEqual([
+        'conversation-quality',
+        'hook-failure',
+        'skill-low-precision',
+        'task-complete',
+      ])
+    })
+  })
+})

--- a/apps/web/src/lib/default-novas.ts
+++ b/apps/web/src/lib/default-novas.ts
@@ -1,0 +1,236 @@
+export interface NovaDefinitionSeed {
+  name: string
+  category: "skill" | "hook"
+  version: string
+  title: string
+  description: string
+  spec: string
+  metadata: string
+}
+
+export const DEFAULT_NOVAS: NovaDefinitionSeed[] = [
+  // --- 5 SKILLS ---
+
+  {
+    name: "k8s-debug",
+    category: "skill",
+    version: "1.0",
+    title: "Kubernetes Debugging",
+    description: "Structured methodology for debugging common Kubernetes pod issues including CrashLoopBackOff, OOMKill, ImagePullBackOff, and pending pods.",
+    spec: JSON.stringify({
+      triggerPatterns: [
+        "crashloop", "CrashLoopBackOff", "CrashLoop",
+        "pod is stuck", "pod not starting", "pod pending", "ImagePullBackOff", "ErrImagePull",
+        "pod crash", "container restarting", "OOMKill", "oom",
+        "kubernetes debug", "k8s debug", "troubleshoot pod",
+      ],
+      systemPrompt: `You are a Kubernetes debugging specialist. Use this methodology:
+1. Check pod status: \`kubectl get pods -n {namespace} -w\`
+2. Describe the pod: \`kubectl describe pod {pod_name} -n {namespace}\`
+3. Check events: \`kubectl get events --field-selector involvedObject.name={pod_name} -n {namespace}\`
+4. Check logs: \`kubectl logs {pod_name} -n {namespace}\`
+5. If CrashLoopBackOff, check previous logs: \`kubectl logs {pod_name} -n {namespace} --previous\`
+6. For OOM: check resource limits vs actual usage: \`kubectl top pods -n {namespace}\`
+7. For ImagePullBackOff: check image name, registry auth, and network: \`kubectl describe pod {pod_name} -n {namespace}\`
+
+Be methodical. Do not restart pods or make changes without explaining why.`,
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "debugging"] }),
+  },
+
+  {
+    name: "docker-troubleshoot",
+    category: "skill",
+    version: "1.0",
+    title: "Docker Troubleshooting",
+    description: "Debugging methodology for Docker containers — image issues, resource problems, container lifecycle.",
+    spec: JSON.stringify({
+      triggerPatterns: [
+        "docker", "container crash", "container not starting",
+        "container stuck", "docker log", "image not found",
+      ],
+      systemPrompt: `You are a Docker troubleshooting specialist. Use this methodology:
+1. Check container status: \`docker ps -a\`
+2. Inspect the container: \`docker inspect {container_name}\`
+3. Check logs: \`docker logs {container_name}\`
+4. Check resource usage: \`docker stats {container_name}\`
+5. For network issues: \`docker network ls\`, \`docker network inspect {network_name}\`
+6. For image issues: \`docker images\`, \`docker pull {image_name}\`
+
+Be methodical. Do not remove containers or images without explaining why.`,
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["docker", "debugging"] }),
+  },
+
+  {
+    name: "cluster-health",
+    category: "skill",
+    version: "1.0",
+    title: "Cluster Health",
+    description: "Comprehensive cluster health checking — nodes, pods, resources, storage, networking.",
+    spec: JSON.stringify({
+      triggerPatterns: [
+        "cluster health", "cluster status", "node health",
+        "cluster overview", "cluster check", "is the cluster healthy",
+        "health check", "cluster diagnostics",
+      ],
+      systemPrompt: `You are a cluster health specialist. Follow this diagnostic checklist:
+1. Node status: \`kubectl get nodes -o wide\`
+2. Pod health across all namespaces: \`kubectl get pods --all-namespaces --field-selector status.phase!=Running\`
+3. Resource usage: \`kubectl top nodes\`, \`kubectl top pods --all-namespaces\`
+4. Persistent volumes: \`kubectl get pv,pvc --all-namespaces\`
+5. Core system pods: \`kubectl get pods -n kube-system\`
+6. Ingress/DNS: \`kubectl get services -n kube-system\`, \`kubectl get ingress -A\`
+7. ArgoCD apps (if available): \`kubectl get applications -n argocd\`
+
+Report findings in priority order: Critical > Warning > Info.`,
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "health-check"] }),
+  },
+
+  {
+    name: "backup-recovery",
+    category: "skill",
+    version: "1.0",
+    title: "Backup & Recovery",
+    description: "Backup and recovery procedures for K8s clusters and Docker environments.",
+    spec: JSON.stringify({
+      triggerPatterns: [
+        "backup", "restore", "recover", "snapshot",
+        "velero", "velero backup", "backup restore",
+        "data loss", "recovery",
+      ],
+      systemPrompt: `You are a backup and recovery specialist. Follow these procedures:
+1. Check backup status: \`velero backup get\` (or equivalent)
+2. List recent backups: \`velero backup get --limit 5\`
+3. For restores: \`velero restore create --from-backup {backup_name}\`
+4. Verify restored resources: \`kubectl get all -n {namespace}\`
+5. For Docker: \`docker volume ls\`, \`docker ps -a\`
+
+Always verify before and after states. Document what was restored.`,
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["backup", "recovery"] }),
+  },
+
+  {
+    name: "dns-troubleshoot",
+    category: "skill",
+    version: "1.0",
+    title: "DNS Troubleshooting",
+    description: "DNS debugging for Kubernetes services and CoreDNS.",
+    spec: JSON.stringify({
+      triggerPatterns: [
+        "dns", "coredns", "service discovery", "cannot resolve",
+        "name resolution", "dns lookup", "dns failure",
+      ],
+      systemPrompt: `You are a DNS troubleshooting specialist. Follow this methodology:
+1. Check CoreDNS pods: \`kubectl get pods -n kube-system -l k8s-app=kube-dns\`
+2. Test DNS resolution: \`kubectl run dns-test --rm --image=busybox -- nslookup kubernetes.default.svc.cluster.local\`
+3. Check CoreDNS config: \`kubectl get configmap coredns -n kube-system -o yaml\`
+4. Check service endpoints: \`kubectl get endpoints -n {namespace}\`
+5. Check node DNS config: \`kubectl get nodes -o jsonpath='{.items[*].status.nodeConfig}'\`
+
+Test resolution step by step and report which layer fails.`,
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "dns"] }),
+  },
+
+  // --- 5 HOOKS ---
+
+  {
+    name: "diagnose_pod_crashloop",
+    category: "hook",
+    version: "1.0",
+    title: "Diagnose Pod CrashLoop",
+    description: "When a pod enters CrashLoopBackOff, automatically run diagnostic commands (kubectl describe + logs).",
+    spec: JSON.stringify({
+      triggerType: "on_pod_crashloop",
+      triggerFilter: {},
+      actionType: "run_shell_command",
+      actionConfig: {
+        command: "kubectl describe pod {pod_name} -n {namespace} && kubectl logs --previous {pod_name} -n {namespace} --tail=50",
+      },
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "auto-diagnose"] }),
+  },
+
+  {
+    name: "notify_oom_kill",
+    category: "hook",
+    version: "1.0",
+    title: "Notify OOM Kill",
+    description: "Send a notification when a container is OOM killed.",
+    spec: JSON.stringify({
+      triggerType: "on_pod_oom",
+      triggerFilter: {},
+      actionType: "send_notification",
+      actionConfig: {
+        channel: "cluster-alerts",
+        message: "Pod {pod_name} in namespace {namespace} was OOM killed. Memory usage exceeded limits.",
+      },
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "notification"] }),
+  },
+
+  {
+    name: "disk_full_warning",
+    category: "hook",
+    version: "1.0",
+    title: "Disk Full Warning",
+    description: "When a node disk usage exceeds 90%, report and list large files.",
+    spec: JSON.stringify({
+      triggerType: "on_node_disk_full",
+      triggerFilter: { threshold: 90 },
+      actionType: "run_shell_command",
+      actionConfig: {
+        command: "kubectl get nodes -o wide && df -h",
+      },
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["kubernetes", "disk"] }),
+  },
+
+  {
+    name: "argocd_sync_degraded",
+    category: "hook",
+    version: "1.0",
+    title: "ArgoCD Sync Degraded",
+    description: "When an ArgoCD application becomes degraded, report the health issues.",
+    spec: JSON.stringify({
+      triggerType: "on_sync_degraded",
+      triggerFilter: { health: "Degraded" },
+      actionType: "run_shell_command",
+      actionConfig: {
+        command: "kubectl get applications -n argocd -l health=Degraded -o wide",
+      },
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["argocd", "health"] }),
+  },
+
+  {
+    name: "tool_usage_audit",
+    category: "hook",
+    version: "1.0",
+    title: "Tool Usage Audit",
+    description: "Log when high-impact tools are used for auditing purposes.",
+    spec: JSON.stringify({
+      triggerType: "on_tool_execution",
+      triggerFilter: { toolNames: ["kubectl_delete_*", "docker_rm_*", "kubectl_delete_namespace_*"] },
+      actionType: "send_notification",
+      actionConfig: {
+        channel: "audit-log",
+        message: "High-impact tool executed: {tool_name} with args: {tool_args}",
+      },
+    }),
+    metadata: JSON.stringify({ author: "orion", tags: ["audit", "security"] }),
+  },
+]
+
+export async function seedNovaDefinitions(prisma: any): Promise<void> {
+  for (const nova of DEFAULT_NOVAS) {
+    await prisma.novaDefinition.upsert({
+      where: { name: nova.name },
+      update: { spec: nova.spec, description: nova.description, title: nova.title, version: nova.version, metadata: nova.metadata },
+      create: { ...nova },
+    })
+  }
+}

--- a/apps/web/src/lib/default-rulesets.ts
+++ b/apps/web/src/lib/default-rulesets.ts
@@ -41,7 +41,7 @@ export const DEFAULT_RULESETS: RulesetSeed[] = [
     name: "skill-low-precision",
     description: "Periodic check for skills that fire too broadly without helping.",
     criteria: JSON.stringify([
-      { name: "fire_rate", type: "completeness_check", threshold: 5, weight: 0.3 },
+      { name: "fire_rate", type: "tool_count", threshold: 5, weight: 0.3 },
       { name: "success_rate", type: "response_quality", threshold: 0.3, weight: 0.7 },
     ]),
     triggers: JSON.stringify(["periodic"]),

--- a/apps/web/src/lib/default-rulesets.ts
+++ b/apps/web/src/lib/default-rulesets.ts
@@ -1,0 +1,59 @@
+export interface RulesetSeed {
+  name: string
+  description: string
+  criteria: string  // JSON string
+  triggers: string  // JSON string
+}
+
+export const DEFAULT_RULESETS: RulesetSeed[] = [
+  {
+    name: "task-complete",
+    description: "Evaluate agent performance when a task completes.",
+    criteria: JSON.stringify([
+      { name: "tool_count", type: "tool_count", threshold: 20, weight: 0.15, inverted: true },
+      { name: "safety", type: "safety_check", threshold: 100, weight: 0.3 },
+      { name: "completeness", type: "completeness_check", threshold: 50, weight: 0.25 },
+      { name: "response_quality", type: "response_quality", threshold: 60, weight: 0.3 },
+    ]),
+    triggers: JSON.stringify(["on_task_complete"]),
+  },
+  {
+    name: "conversation-quality",
+    description: "Evaluate agent performance at the end of a conversation.",
+    criteria: JSON.stringify([
+      { name: "response_length", type: "response_quality", threshold: 50, weight: 0.2 },
+      { name: "tool_diversity", type: "tool_count", threshold: 5, weight: 0.15 },
+      { name: "safety", type: "safety_check", threshold: 100, weight: 0.3 },
+      { name: "user_satisfaction", type: "completeness_check", threshold: 60, weight: 0.35 },
+    ]),
+    triggers: JSON.stringify(["on_conversation_end"]),
+  },
+  {
+    name: "hook-failure",
+    description: "Evaluate when a hook action fails.",
+    criteria: JSON.stringify([
+      { name: "execution_time", type: "tool_count", threshold: 30000, weight: 0.4, inverted: true },
+      { name: "error_type", type: "error_check", threshold: 0, weight: 0.6 },
+    ]),
+    triggers: JSON.stringify(["on_hook_failure"]),
+  },
+  {
+    name: "skill-low-precision",
+    description: "Periodic check for skills that fire too broadly without helping.",
+    criteria: JSON.stringify([
+      { name: "fire_rate", type: "completeness_check", threshold: 5, weight: 0.3 },
+      { name: "success_rate", type: "response_quality", threshold: 0.3, weight: 0.7 },
+    ]),
+    triggers: JSON.stringify(["periodic"]),
+  },
+]
+
+export async function seedRulesets(prisma: any): Promise<void> {
+  for (const ruleset of DEFAULT_RULESETS) {
+    await prisma.ruleset.upsert({
+      where: { name: ruleset.name },
+      update: { description: ruleset.description, criteria: ruleset.criteria, triggers: ruleset.triggers },
+      create: { ...ruleset },
+    })
+  }
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

Add default NovaDefinitions and Rulesets seed data.

### 5 Skills
- `k8s-debug` — Kubernetes debugging methodology
- `docker-troubleshoot` — Docker container debugging
- `cluster-health` — Comprehensive cluster health checking
- `backup-recovery` — Backup and recovery procedures
- `dns-troubleshoot` — DNS/CoreDNS debugging

### 5 Hooks
- `diagnose_pod_crashloop` — Auto-diagnose CrashLoopBackOff pods
- `notify_oom_kill` — Send notification on OOM kills
- `disk_full_warning` — Report when disk exceeds 90%
- `argocd_sync_degraded` — Report ArgoCD health issues
- `tool_usage_audit` — Log high-impact tool usage

### 4 Rulesets
- `task-complete` — Evaluate agent on task completion
- `conversation-quality` — Evaluate at conversation end
- `hook-failure` — Evaluate on hook failures
- `skill-low-precision` — Periodic skill tuning check

---
Phase 2 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (Prisma schema).

Note: `prisma generate` must be run after merging #331.