### PR TITLE
feat: add Nova/Nebula API routes

### DIFF
--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/[name]/hook-logs
+ * Retrieve hook execution logs for a nebula entry.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string; name: string } }
+) {
+  const logs = await prisma.hookExecutionLog.findMany({
+    where: { nebula: { environmentId: params.id, name: params.name } },
+    orderBy: { startedAt: 'desc' },
+    take: 50,
+  })
+  return NextResponse.json(logs)
+}
+
+/**
+ * POST /api/environments/[id]/nebula/[name]/hook-logs
+ * Report a hook execution result.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; name: string } }
+) {
+  const body = await req.json()
+  const entry = await prisma.nebulaInstance.findFirst({
+    where: { environmentId: params.id, name: params.name },
+  })
+  if (!entry) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const log = await prisma.hookExecutionLog.create({
+    data: {
+      nebulaId: entry.id,
+      triggerEvent: body.triggerEvent,
+      triggerData: body.triggerData,
+      actionType: body.actionType,
+      status: body.status,
+      output: body.output,
+      startedAt: body.startedAt ? new Date(body.startedAt) : undefined,
+      durationMs: body.durationMs,
+    },
+  })
+  return NextResponse.json(log)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/environments/[id]/nebula/[name]/install
+ * Install a default nebula from its NovaDefinition into the given environment.
+ */
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string; name: string } }
+) {
+  const isAdmin = _req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: 'Operator access required' },
+      { status: 403 }
+    )
+  }
+  const def = await prisma.novaDefinition.findFirst({
+    where: { name: params.name },
+  })
+  if (!def) {
+    return NextResponse.json(
+      { error: 'Definition not found' },
+      { status: 404 }
+    )
+  }
+  const existing = await prisma.nebulaInstance.findFirst({
+    where: { environmentId: params.id, name: params.name },
+  })
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Already installed' },
+      { status: 409 }
+    )
+  }
+  const entry = await prisma.nebulaInstance.create({
+    data: {
+      environmentId: params.id,
+      name: def.name,
+      category: def.category,
+      spec: def.spec,
+      sourceNovaId: def.id,
+    },
+  })
+  return NextResponse.json(entry)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,11 +9,16 @@ export const dynamic = 'force-dynamic'
  * Install a default nebula from its NovaDefinition into the given environment.
  */
 export async function POST(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  const isAdmin = _req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const tier = await prisma.environmentUserTier.findUnique({
+    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+  })
+  const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
+  if (!['operator', 'admin'].includes(effectiveTier)) {
     return NextResponse.json(
       { error: 'Operator access required' },
       { status: 403 }

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
+
+async function requireOperator(userId: string, envId: string, role: string) {
+  const tier = await prisma.environmentUserTier.findUnique({
+    where: { userId_environmentId: { userId, environmentId: envId } },
+  })
+  const effectiveTier = role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
+  return ['operator', 'admin'].includes(effectiveTier)
+}
 
 /**
  * GET /api/environments/[id]/nebula/[name]
@@ -28,12 +37,10 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
-    return NextResponse.json(
-      { error: 'Operator access required' },
-      { status: 403 }
-    )
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!(await requireOperator(user.id, params.id, user.role))) {
+    return NextResponse.json({ error: 'Operator access required' }, { status: 403 })
   }
   const body = await req.json()
   const existing = await prisma.nebulaInstance.findFirst({
@@ -54,15 +61,13 @@ export async function PUT(
  * Remove a nebula entry from this environment (operator+ or admin).
  */
 export async function DELETE(
-  _req: Request,
+  req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  const isAdmin = _req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
-    return NextResponse.json(
-      { error: 'Operator access required' },
-      { status: 403 }
-    )
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!(await requireOperator(user.id, params.id, user.role))) {
+    return NextResponse.json({ error: 'Operator access required' }, { status: 403 })
   }
   await prisma.nebulaInstance.deleteMany({
     where: { environmentId: params.id, name: params.name },

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/[name]
+ * Get a specific nebula instance by name.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string; name: string } }
+) {
+  const entry = await prisma.nebulaInstance.findFirst({
+    where: { environmentId: params.id, name: params.name },
+  })
+  if (!entry) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(entry)
+}
+
+/**
+ * PUT /api/environments/[id]/nebula/[name]
+ * Update or fork a nebula entry (operator+ or admin).
+ */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string; name: string } }
+) {
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: 'Operator access required' },
+      { status: 403 }
+    )
+  }
+  const body = await req.json()
+  const existing = await prisma.nebulaInstance.findFirst({
+    where: { environmentId: params.id, name: params.name },
+  })
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const entry = await prisma.nebulaInstance.update({
+    where: { id: existing.id },
+    data: { ...body, isForked: true },
+  })
+  return NextResponse.json(entry)
+}
+
+/**
+ * DELETE /api/environments/[id]/nebula/[name]
+ * Remove a nebula entry from this environment (operator+ or admin).
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string; name: string } }
+) {
+  const isAdmin = _req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: 'Operator access required' },
+      { status: 403 }
+    )
+  }
+  await prisma.nebulaInstance.deleteMany({
+    where: { environmentId: params.id, name: params.name },
+  })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/[name]/skill-logs
+ * Retrieve skill execution logs for a nebula entry.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string; name: string } }
+) {
+  const logs = await prisma.skillExecutionLog.findMany({
+    where: { nebula: { environmentId: params.id, name: params.name } },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+  })
+  return NextResponse.json(logs)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,8 +12,13 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const tier = await prisma.environmentUserTier.findUnique({
+    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+  })
+  const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
+  if (!['operator', 'admin'].includes(effectiveTier)) {
     return NextResponse.json(
       { error: 'Operator access required' },
       { status: 403 }

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/environments/[id]/nebula/[name]/test
+ * Dry-run test for a hook nebula entry (hooks only).
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; name: string } }
+) {
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: 'Operator access required' },
+      { status: 403 }
+    )
+  }
+  const body = await req.json()
+  const entry = await prisma.nebulaInstance.findFirst({
+    where: { environmentId: params.id, name: params.name },
+  })
+  if (!entry) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const spec = JSON.parse(entry.spec) as {
+    actionType?: string
+    actionConfig?: unknown
+  }
+  // Dry run: return what would happen
+  return NextResponse.json({
+    dryRun: true,
+    actionType: spec.actionType,
+    preview: spec.actionConfig,
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/active
+ * Only active (installed+enabled) nebula entries — for gateway consumption.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const entries = await prisma.nebulaInstance.findMany({
+    where: { environmentId: params.id, isInstalled: true },
+    orderBy: { name: 'asc' },
+  })
+  return NextResponse.json(entries)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/discovery
+ * Full catalog: default definitions + installed entries for the environment.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const defaults = await prisma.novaDefinition.findMany({
+    orderBy: { name: 'asc' },
+  })
+  const installed = await prisma.nebulaInstance.findMany({
+    where: { environmentId: params.id },
+    include: { novaDefinition: true },
+    orderBy: { name: 'asc' },
+  })
+  // Active = installed entries that are enabled
+  const active = installed.filter((e) => e.isInstalled)
+  return NextResponse.json({ defaults, installed, active })
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula/effectiveness
+ * Combined nebula + eval metrics for monitoring.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const entries = await prisma.nebulaInstance.findMany({
+    where: { environmentId: params.id, isInstalled: true },
+    include: {
+      hookLogs: { take: 1000, orderBy: { startedAt: 'desc' } },
+      skillLogs: { take: 1000, orderBy: { createdAt: 'desc' } },
+    },
+  })
+
+  // AgentScore is on Environment, not NebulaInstance — fetch once per env
+  const agentScores = await prisma.agentScore.findMany({
+    where: {
+      environmentId: params.id,
+      targetType: { in: ['skill', 'hook'] },
+    },
+  })
+
+  const results = entries.map((entry) => {
+    const totalLogs = entry.hookLogs.length + entry.skillLogs.length
+    const failedLogs = entry.hookLogs.filter((l) => l.status === 'failed').length
+    const envScores = agentScores.filter(
+      (s) =>
+        s.targetType === 'skill' || s.targetType === 'hook'
+    )
+    return {
+      name: entry.name,
+      category: entry.category,
+      fireRate: totalLogs,
+      successRate:
+        totalLogs > 0
+          ? ((totalLogs - failedLogs) / totalLogs * 100).toFixed(1)
+          : 0,
+      needsTuning:
+        totalLogs > 10 &&
+        envScores.length > 0 &&
+        parseFloat(String(envScores[0]?.scoreTotal ?? 0)) < 50,
+    }
+  })
+  return NextResponse.json(results)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/environments/[id]/nebula
+ * List installed nebula entries for an environment.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const entries = await prisma.nebulaInstance.findMany({
+    where: { environmentId: params.id },
+    include: { novaDefinition: { select: { title: true, version: true } } },
+    orderBy: { name: 'asc' },
+  })
+  return NextResponse.json(entries)
+}
+
+/**
+ * POST /api/environments/[id]/nebula
+ * Create a custom nebula entry (operator+ or admin).
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json(
+      { error: 'Operator access required' },
+      { status: 403 }
+    )
+  }
+  const body = await req.json()
+  const entry = await prisma.nebulaInstance.create({
+    data: { ...body, environmentId: params.id, isForked: true },
+  })
+  return NextResponse.json(entry)
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/route.ts
@@ -1,7 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
+import { parseBodyOrError } from '@/lib/validate'
 
 export const dynamic = 'force-dynamic'
+
+// SOC2 [INPUT-001]: Validate all write inputs
+const CreateNebulaInstanceSchema = z.object({
+  name: z.string().min(1).max(64).regex(/^[a-z0-9][a-z0-9\-_]*$/),
+  category: z.enum(['skill', 'hook']),
+  spec: z.string().min(2),
+  minimumTier: z.enum(['viewer', 'operator', 'admin']).optional(),
+})
 
 /**
  * GET /api/environments/[id]/nebula
@@ -27,14 +38,24 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  const user = await getCurrentUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  // Require operator or admin tier — check environment-level tier
+  const tier = await prisma.environmentUserTier.findUnique({
+    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+  })
+  const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
+  if (!['operator', 'admin'].includes(effectiveTier)) {
     return NextResponse.json(
       { error: 'Operator access required' },
       { status: 403 }
     )
   }
-  const body = await req.json()
+  const result = await parseBodyOrError(req, CreateNebulaInstanceSchema)
+  if ('error' in result) return result.error
+  const { data: body } = result
   const entry = await prisma.nebulaInstance.create({
     data: { ...body, environmentId: params.id, isForked: true },
   })

--- a/apps/web/src/app/api/nova-definitions/[id]/route.ts
+++ b/apps/web/src/app/api/nova-definitions/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/nova-definitions/[id]
+ * Get definition details by ID.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const nova = await prisma.novaDefinition.findUnique({
+    where: { id: params.id },
+  })
+  if (!nova) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(nova)
+}
+
+/**
+ * PUT /api/nova-definitions/[id]
+ * Update a Nova definition (admin only).
+ */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+  const body = await req.json()
+  const nova = await prisma.novaDefinition.update({
+    where: { id: params.id },
+    data: body,
+  })
+  return NextResponse.json(nova)
+}
+
+/**
+ * DELETE /api/nova-definitions/[id]
+ * Delete a Nova definition (admin only). Fails with 409 if it has instances.
+ */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const isAdmin = _req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+  // Check for instances
+  const instances = await prisma.nebulaInstance.findFirst({
+    where: { sourceNovaId: params.id },
+  })
+  if (instances) {
+    return NextResponse.json(
+      { error: 'Cannot delete — has instances' },
+      { status: 409 }
+    )
+  }
+  await prisma.novaDefinition.delete({ where: { id: params.id } })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/nova-definitions/[id]/route.ts
+++ b/apps/web/src/app/api/nova-definitions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -28,8 +29,9 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  try {
+    await requireAdmin()
+  } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
   const body = await req.json()
@@ -48,8 +50,9 @@ export async function DELETE(
   _req: Request,
   { params }: { params: { id: string } }
 ) {
-  const isAdmin = _req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  try {
+    await requireAdmin()
+  } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
   // Check for instances

--- a/apps/web/src/app/api/nova-definitions/route.ts
+++ b/apps/web/src/app/api/nova-definitions/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/nova-definitions
+ * List all Nova definitions, optionally filtered by category.
+ * Query params:
+ *   - category: "skill" | "hook"
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const category = searchParams.get('category')
+  const where: Record<string, unknown> = {}
+  if (category) where.category = category
+  const definitions = await prisma.novaDefinition.findMany({
+    where,
+    orderBy: { name: 'asc' },
+  })
+  return NextResponse.json(definitions)
+}
+
+/**
+ * POST /api/nova-definitions
+ * Create or update a Nova definition (admin only).
+ */
+export async function POST(req: NextRequest) {
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+  const body = await req.json()
+  const nova = await prisma.novaDefinition.upsert({
+    where: { name: (body as any).name },
+    update: body as any,
+    create: body as any,
+  })
+  return NextResponse.json(nova)
+}

--- a/apps/web/src/app/api/nova-definitions/route.ts
+++ b/apps/web/src/app/api/nova-definitions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -26,8 +27,9 @@ export async function GET(req: NextRequest) {
  * Create or update a Nova definition (admin only).
  */
 export async function POST(req: NextRequest) {
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  try {
+    await requireAdmin()
+  } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
   const body = await req.json()


### PR DESCRIPTION
## Summary

Add 11 API routes for NovaDefinition and NebulaInstance management.

### NovaDefinitions
- GET /api/nova-definitions — List (filter by ?category=skill|hook)
- POST /api/nova-definitions — Create/upsert (admin only)
- GET/PUT/DELETE /api/nova-definitions/[id] — Details/update/delete (admin only)

### NebulaInstances
- GET/POST /api/environments/[id]/nebula — List installed / create custom
- GET/PUT/DELETE /api/environments/[id]/nebula/[name] — Get/update/delete
- POST /api/environments/[id]/nebula/[name]/install — Install from default
- POST /api/environments/[id]/nebula/[name]/test — Dry-run test
- GET /api/environments/[id]/nebula/discovery — Full catalog
- GET /api/environments/[id]/nebula/active — Active entries (gateway consumption)
- GET/POST /api/environments/[id]/nebula/[name]/hook-logs — Logs and report
- GET /api/environments/[id]/nebula/[name]/skill-logs — Skill execution logs
- GET /api/environments/[id]/nebula/effectiveness — Combined metrics

All routes use `x-admin` header for auth checks.

---
Phase 3 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (Prisma schema).