### PR TITLE
feat: auto-install NovaDefinitions as NebulaInstances on env creation

### DIFF
--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { Prisma } from '@prisma/client'
 import { getDefaultTools } from '@/lib/default-tools'
+import { seedNovaDefinitions } from '@/lib/default-novas'
 import { getCurrentUser, requireAdmin } from '@/lib/auth'
 import { CreateEnvironmentSchema } from '@/lib/validate'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
@@ -72,6 +73,27 @@ export async function POST(req: NextRequest) {
       skipDuplicates: true,
     })
   }
+
+  // Phase 5: Auto-install default Nebula entries (NovaDefinitions where category is 'skill' or 'hook')
+  seedNovaDefinitions(prisma)
+    .then(async () => {
+      const definitions = await prisma.novaDefinition.findMany({
+        where: { category: { in: ['skill', 'hook'] } },
+      })
+      if (definitions.length > 0) {
+        await prisma.nebulaInstance.createMany({
+          data: definitions.map((def: any) => ({
+            environmentId: env.id,
+            name: def.name,
+            category: def.category,
+            spec: def.spec,
+            sourceNovaId: def.id,
+          })),
+          skipDuplicates: true,
+        })
+      }
+    })
+    .catch(() => {}) // Silently fail — non-blocking
 
   const envWithTools = await prisma.environment.findUnique({
     where: { id: env.id },


### PR DESCRIPTION
## Summary

When a new environment is created, automatically seed all default NovaDefinitions
(skills and hooks) as NebulaInstances for that environment.

Non-blocking — silently fails if seeding encounters errors.

---
Phase 5 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (schema), #332 (seed data).