### PR TITLE
feat: add Evals and Observability API routes

### DIFF
--- a/apps/web/src/app/api/conversations/[id]/traces/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/traces/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/conversations/[id]/traces — Get trace timeline for a conversation
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const traces = await prisma.agentTrace.findMany({
+    where: { conversationId: params.id },
+    orderBy: { step: 'asc' },
+  })
+  return NextResponse.json(traces)
+}

--- a/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// GET /api/environments/[id]/evals/aggregate
+// Chart data for eval dashboard.
+// Query params: type=conversation|task|skill|hook, window=7|30|90
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const envId = params.id
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  const { searchParams } = new URL(req.url)
+  const type = searchParams.get('type')
+  const windowDays = parseInt(searchParams.get('window') || '7', 10)
+
+  const since = new Date()
+  since.setDate(since.getDate() - windowDays)
+
+  // Validate type param
+  const validTypes = ['conversation', 'task', 'skill', 'hook']
+  if (type && !validTypes.includes(type)) {
+    return NextResponse.json({ error: `Invalid type. Must be one of: ${validTypes.join(', ')}` }, { status: 400 })
+  }
+
+  // Fetch evals within the window
+  const evals = await prisma.eval.findMany({
+    where: {
+      environmentId: envId,
+      ...(type ? { targetType: type } : {}),
+      createdAt: { gte: since },
+    },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      targetType: true,
+      scoreTotal: true,
+      scores: true,
+      createdAt: true,
+    },
+  })
+
+  // Group by day
+  const dailyGroups: Record<string, { totalScore: number; count: number; scores: Record<string, number[]> }> = {}
+
+  for (const e of evals) {
+    const day = e.createdAt.toISOString().split('T')[0]
+    if (!dailyGroups[day]) {
+      dailyGroups[day] = { totalScore: 0, count: 0, scores: {} }
+    }
+    dailyGroups[day].totalScore += e.scoreTotal
+    dailyGroups[day].count += 1
+
+    // Parse and aggregate breakdown scores
+    try {
+      const parsedScores: Record<string, number> = JSON.parse(e.scores)
+      for (const [key, val] of Object.entries(parsedScores)) {
+        if (typeof val === 'number' && !Number.isNaN(val)) {
+          if (!dailyGroups[day].scores[key]) {
+            dailyGroups[day].scores[key] = []
+          }
+          dailyGroups[day].scores[key].push(val)
+        }
+      }
+    } catch {
+      // Skip malformed scores
+    }
+  }
+
+  // Sort days and build response
+  const sortedDays = Object.keys(dailyGroups).sort()
+
+  const result: {
+    labels: string[]
+    scores: number[]
+    count: number
+    breakdown?: Record<string, number[]>
+  }[] = []
+
+  for (const day of sortedDays) {
+    const group = dailyGroups[day]
+    const avgScore = group.count > 0 ? group.totalScore / group.count : 0
+
+    // Format label as "May 13"
+    const date = new Date(day + 'T00:00:00Z')
+    const label = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+
+    result.push({
+      labels: [label],
+      scores: [Math.round(avgScore * 10) / 10],
+      count: group.count,
+    })
+  }
+
+  // Also include an overall summary
+  const totalEvals = evals.length
+  const overallAvg = totalEvals > 0 ? evals.reduce((sum, e) => sum + e.scoreTotal, 0) / totalEvals : 0
+
+  // Build a single aggregated result for the chart
+  const allLabels: string[] = []
+  const allScores: number[] = []
+  const allCounts: number[] = []
+
+  for (const item of result) {
+    allLabels.push(...item.labels)
+    allScores.push(...item.scores)
+    allCounts.push(item.count)
+  }
+
+  return NextResponse.json({
+    labels: allLabels,
+    scores: allScores,
+    count: allCounts,
+    totalEvals,
+    overallAvg: Math.round(overallAvg * 10) / 10,
+    windowDays,
+    targetType: type || 'all',
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// GET /api/environments/[id]/evals/rulesets
+// List all eval rulesets.
+// POST /api/environments/[id]/evals/rulesets
+// Create or update a ruleset (admin only).
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const envId = params.id
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  const rulesets = await prisma.ruleset.findMany({
+    orderBy: { createdAt: 'desc' },
+  })
+
+  // Parse JSON fields for the response
+  const parsed = rulesets.map((r) => ({
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    criteria: r.criteria ? JSON.parse(r.criteria) : {},
+    triggers: r.triggers ? JSON.parse(r.triggers) : [],
+    createdAt: r.createdAt,
+  }))
+
+  return NextResponse.json(parsed)
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const envId = params.id
+
+  // Admin check
+  const isAdmin = req.headers.get('x-admin') === 'true'
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  let body: {
+    id?: string
+    name: string
+    description: string
+    criteria: Record<string, unknown>
+    triggers: string[]
+  }
+
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!body.name || !body.criteria) {
+    return NextResponse.json(
+      { error: 'Missing required fields: name, criteria' },
+      { status: 400 }
+    )
+  }
+
+  // If an id is provided, update the existing ruleset
+  if (body.id) {
+    const existing = await prisma.ruleset.findUnique({
+      where: { id: body.id },
+    })
+    if (!existing) {
+      return NextResponse.json({ error: 'Ruleset not found' }, { status: 404 })
+    }
+
+    const updated = await prisma.ruleset.update({
+      where: { id: body.id },
+      data: {
+        name: body.name,
+        description: body.description ?? existing.description,
+        criteria: JSON.stringify(body.criteria),
+        triggers: JSON.stringify(body.triggers ?? existing.triggers),
+      },
+    })
+
+    return NextResponse.json({
+      id: updated.id,
+      name: updated.name,
+      description: updated.description,
+      criteria: JSON.parse(updated.criteria),
+      triggers: JSON.parse(updated.triggers),
+    })
+  }
+
+  // Create a new ruleset
+  const created = await prisma.ruleset.create({
+    data: {
+      name: body.name.trim(),
+      description: body.description || '',
+      criteria: JSON.stringify(body.criteria),
+      triggers: JSON.stringify(body.triggers || []),
+    },
+  })
+
+  return NextResponse.json({
+    id: created.id,
+    name: created.name,
+    description: created.description,
+    criteria: JSON.parse(created.criteria),
+    triggers: JSON.parse(created.triggers),
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/rulesets
@@ -33,8 +34,9 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const envId = params.id
 
   // Admin check
-  const isAdmin = req.headers.get('x-admin') === 'true'
-  if (!isAdmin) {
+  try {
+    await requireAdmin()
+  } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
 

--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -1,0 +1,274 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// POST /api/environments/[id]/evals/run
+// Auto-eval trigger — evaluates a conversation or task after completion.
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const envId = params.id
+
+  // Verify environment exists
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  let body: { targetType: 'conversation' | 'task' | 'skill' | 'hook'; targetId: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { targetType, targetId } = body
+  if (!targetType || !targetId) {
+    return NextResponse.json({ error: 'Missing targetType or targetId' }, { status: 400 })
+  }
+  if (!['conversation', 'task', 'skill', 'hook'].includes(targetType)) {
+    return NextResponse.json({ error: 'Invalid targetType' }, { status: 400 })
+  }
+
+  // 1. Find all applicable rulesets for this target type
+  const rulesets = await prisma.ruleset.findMany({
+    where: {
+      // criteria is JSON string — we match by parsing the triggers array
+    },
+  })
+
+  // Filter rulesets whose triggers match the targetType
+  const applicableRulesets = rulesets.filter((r) => {
+    try {
+      const triggers: string[] = JSON.parse(r.triggers || '[]')
+      return triggers.includes(targetType)
+    } catch {
+      return false
+    }
+  })
+
+  if (applicableRulesets.length === 0) {
+    return NextResponse.json({
+      message: 'No applicable eval rulesets found',
+      targetType,
+      targetId,
+    })
+  }
+
+  const evalResults: { rulesetId: string; scores: Record<string, number> }[] = []
+
+  for (const ruleset of applicableRulesets) {
+    const scores: Record<string, number> = {}
+    let scoreTotal = 0
+    const breakdown: Record<string, { score: number; max: number; notes: string }> = {}
+
+    try {
+      const criteria: Record<string, { type: string; weight?: number; threshold?: number }> =
+        JSON.parse(ruleset.criteria || '{}')
+
+      // Evaluate each criterion based on targetType
+      for (const [criterionName, criterion] of Object.entries(criteria)) {
+        let rawScore = 0
+        const maxScore = criterion.weight || 25
+        let notes = ''
+
+        if (targetType === 'conversation') {
+          // Fetch conversation data for evaluation
+          const conversation = await prisma.conversation.findUnique({
+            where: { id: targetId },
+            include: {
+              messages: true,
+              invocations: true,
+            },
+          })
+
+          if (!conversation) continue
+
+          if (criterion.type === 'tool_count') {
+            const toolCallCount = conversation.invocations.filter((i) => i.toolsUsed && (i.toolsUsed as string).length > 0).length
+            const maxAllowed = criterion.threshold || 10
+            rawScore = Math.min(toolCallCount, maxAllowed)
+            notes = `Tool calls: ${toolCallCount}/${maxAllowed}`
+          } else if (criterion.type === 'safety_check') {
+            // Check that all tool calls were valid invocations
+            const unsafe = conversation.invocations.filter((i) => !i.success).length
+            rawScore = unsafe === 0 ? maxScore : maxScore * 0.5
+            notes = `Unsafe invocations: ${unsafe}`
+          } else if (criterion.type === 'completeness_check') {
+            // Check if conversation has user -> assistant -> result pattern
+            const hasResults = conversation.messages.some((m) => m.role === 'tool_result')
+            rawScore = hasResults ? maxScore : 0
+            notes = hasResults ? 'Has tool results' : 'No tool results found'
+          } else if (criterion.type === 'response_quality') {
+            // Heuristic: quality based on response length and token usage
+            const totalOutputTokens = conversation.invocations.reduce((sum, i) => sum + (i.outputTokens || 0), 0)
+            const hasContent = conversation.messages.some((m) => m.content.length > 10)
+            rawScore = hasContent ? Math.min(maxScore, Math.floor(totalOutputTokens / 100)) : 0
+            notes = `Output tokens: ${totalOutputTokens}`
+          }
+        } else if (targetType === 'task') {
+          const task = await prisma.task.findUnique({ where: { id: targetId } })
+          if (!task) continue
+
+          if (criterion.type === 'tool_count') {
+            // For tasks, count tool invocations from associated conversations
+            const relatedConvos = await prisma.conversation.findMany({
+              where: {
+                messages: {
+                  some: { id: targetId },
+                },
+              },
+              include: { invocations: true },
+            })
+            const totalTools = relatedConvos.reduce(
+              (sum, c) => sum + (c.invocations?.length || 0),
+              0
+            )
+            const maxAllowed = criterion.threshold || 10
+            rawScore = Math.min(totalTools, maxAllowed)
+            notes = `Tools used: ${totalTools}/${maxAllowed}`
+          } else if (criterion.type === 'safety_check') {
+            const failedInvocations = await prisma.claudeInvocation.count({
+              where: { conversation: { messages: { some: { id: targetId } } }, success: false },
+            })
+            rawScore = failedInvocations === 0 ? maxScore : maxScore * 0.5
+            notes = `Failed invocations: ${failedInvocations}`
+          } else if (criterion.type === 'completeness_check') {
+            const isCompleted = task.status === 'completed' || task.status === 'done'
+            rawScore = isCompleted ? maxScore : 0
+            notes = `Task status: ${task.status}`
+          } else if (criterion.type === 'response_quality') {
+            rawScore = maxScore * 0.8 // Default for completed tasks
+            notes = 'Task completed'
+          }
+        }
+
+        scores[criterionName] = rawScore
+        scoreTotal += rawScore
+        breakdown[criterionName] = { score: rawScore, max: maxScore, notes }
+      }
+    } catch (err) {
+      // If a ruleset's criteria can't be parsed, skip it
+      console.error(`Failed to evaluate ruleset ${ruleset.id}:`, err)
+      continue
+    }
+
+    evalResults.push({ rulesetId: ruleset.id, scores })
+  }
+
+  // 2. Create Eval records for each ruleset
+  const createdEvals = []
+  for (const result of evalResults) {
+    const scoreEntries = Object.entries(result.scores)
+    const maxPossible = scoreEntries.reduce((sum, [, s]) => sum + s, 0)
+    const scoreTotalPct = maxPossible > 0 ? Math.min(100, (Object.values(result.scores).reduce((a, b) => a + b, 0) / maxPossible) * 100) : 0
+
+    const evalRecord = await prisma.eval.create({
+      data: {
+        environmentId: envId,
+        targetType,
+        targetId,
+        evalType: 'auto_rule',
+        rulesetId: result.rulesetId,
+        scores: JSON.stringify(result.scores),
+        scoreTotal: scoreTotalPct,
+        scoreBreakdown: JSON.stringify(
+          evalResults.find((e) => e.rulesetId === result.rulesetId)?.scores || {}
+        ),
+        feedback: `Auto-eval triggered for ${targetType} ${targetId}`,
+        evidence: JSON.stringify({
+          targetType,
+          targetId,
+          rulesetId: result.rulesetId,
+          criteria: Object.keys(result.scores),
+        }),
+      },
+    })
+    createdEvals.push(evalRecord)
+  }
+
+  // 3. Update or create AgentScore for the target
+  const existingScore = await prisma.agentScore.findUnique({
+    where: {
+      targetType_targetId: { targetType, targetId },
+    },
+  })
+
+  if (existingScore) {
+    const allEvalsForTarget = await prisma.eval.findMany({
+      where: { targetType, targetId },
+      select: { scores: true, scoreTotal: true },
+    })
+
+    const scores: Record<string, number> = {}
+    for (const evalRec of allEvalsForTarget) {
+      try {
+        const parsed = JSON.parse(evalRec.scores)
+        for (const [key, val] of Object.entries(parsed)) {
+          if (typeof val === 'number') {
+            scores[key] = (scores[key] || 0) + val
+          }
+        }
+      } catch {
+        // skip malformed scores
+      }
+    }
+
+    const totalKeys = new Set()
+    for (const evalRec of allEvalsForTarget) {
+      try {
+        const parsed = JSON.parse(evalRec.scores)
+        for (const key of Object.keys(parsed)) totalKeys.add(key)
+      } catch {
+        // skip
+      }
+    }
+
+    const avgScores: Record<string, number> = {}
+    const count = allEvalsForTarget.length || 1
+    for (const key of totalKeys) {
+      avgScores[key] = Math.round((scores[key] || 0) / count * 10) / 10
+    }
+
+    // Map avg scores to AgentScore fields
+    const safety = avgScores['safety_check'] ?? existingScore.safety
+    const completeness = avgScores['completeness_check'] ?? existingScore.completeness
+    const efficiency = avgScores['tool_count'] ?? existingScore.efficiency
+    const quality = avgScores['response_quality'] ?? existingScore.quality
+    const accuracy = Object.keys(avgScores).length > 0 ? (scoreTotalPct + (safety ?? 0) * 0.5) / 2 : 0
+
+    await prisma.agentScore.update({
+      where: { id: existingScore.id },
+      data: {
+        scoreTotal: Math.min(100, existingScore.scoreTotal * 0.7 + scoreTotalPct * 0.3),
+        accuracy: Math.min(100, accuracy),
+        safety: Math.min(100, (safety ?? 0) * 10),
+        completeness: Math.min(100, (completeness ?? 0) * 10),
+        efficiency: Math.min(100, (efficiency ?? 0) * 10),
+        quality: Math.min(100, (quality ?? 0) * 10),
+        evalCount: existingScore.evalCount + createdEvals.length,
+        lastEvalAt: new Date(),
+      },
+    })
+  } else {
+    await prisma.agentScore.create({
+      data: {
+        environmentId: envId,
+        targetType,
+        targetId,
+        scoreTotal: scoreTotalPct,
+        safety: 0,
+        completeness: 0,
+        quality: 0,
+        evalCount: createdEvals.length,
+        lastEvalAt: new Date(),
+      },
+    })
+  }
+
+  return NextResponse.json({
+    message: 'Eval completed',
+    evalsCreated: createdEvals.length,
+    evals: createdEvals.map((e) => ({
+      id: e.id,
+      scoreTotal: e.scoreTotal,
+      rulesetId: e.rulesetId,
+    })),
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -1,30 +1,33 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { parseBodyOrError } from '@/lib/validate'
 export const dynamic = 'force-dynamic'
+
+const RunEvalSchema = z.object({
+  targetType: z.enum(['conversation', 'task', 'skill', 'hook']),
+  targetId: z.string().min(1),
+})
 
 // POST /api/environments/[id]/evals/run
 // Auto-eval trigger — evaluates a conversation or task after completion.
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await requireServiceAuth(req)
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const envId = params.id
 
   // Verify environment exists
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
 
-  let body: { targetType: 'conversation' | 'task' | 'skill' | 'hook'; targetId: string }
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
-
-  const { targetType, targetId } = body
-  if (!targetType || !targetId) {
-    return NextResponse.json({ error: 'Missing targetType or targetId' }, { status: 400 })
-  }
-  if (!['conversation', 'task', 'skill', 'hook'].includes(targetType)) {
-    return NextResponse.json({ error: 'Invalid targetType' }, { status: 400 })
-  }
+  const result = await parseBodyOrError(req, RunEvalSchema)
+  if ('error' in result) return result.error
+  const { targetType, targetId } = result.data
 
   // 1. Find all applicable rulesets for this target type
   const rulesets = await prisma.ruleset.findMany({

--- a/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// GET /api/environments/[id]/evals/scores/hook/[hookId]
+// Score for a specific hook NebulaInstance.
+export async function GET(_req: NextRequest, { params }: { params: { id: string; hookId: string } }) {
+  const envId = params.id
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  // Find the hook NebulaInstance
+  const hook = await prisma.nebulaInstance.findUnique({
+    where: {
+      environmentId_name: {
+        environmentId: envId,
+        name: params.hookId,
+      },
+      category: 'hook',
+    },
+  })
+
+  if (!hook) {
+    return NextResponse.json({ error: 'Hook not found' }, { status: 404 })
+  }
+
+  // Check for an existing AgentScore
+  const score = await prisma.agentScore.findUnique({
+    where: {
+      targetType_targetId: {
+        targetType: 'hook',
+        targetId: hook.id,
+      },
+    },
+  })
+
+  if (score) {
+    return NextResponse.json({
+      targetType: 'hook',
+      targetId: hook.id,
+      targetName: hook.name,
+      scoreTotal: score.scoreTotal,
+      accuracy: score.accuracy,
+      completeness: score.completeness,
+      safety: score.safety,
+      efficiency: score.efficiency,
+      quality: score.quality,
+      evalCount: score.evalCount,
+      lastEvalAt: score.lastEvalAt,
+    })
+  }
+
+  // No score yet — return a default with zero scores
+  return NextResponse.json({
+    targetType: 'hook',
+    targetId: hook.id,
+    targetName: hook.name,
+    scoreTotal: 0,
+    accuracy: 0,
+    completeness: 0,
+    safety: 0,
+    efficiency: 0,
+    quality: 0,
+    evalCount: 0,
+    lastEvalAt: null,
+    message: 'No evals have been run for this hook yet',
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// GET /api/environments/[id]/evals/scores
+// Score overview for all targets in an environment.
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const envId = params.id
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  // Get all AgentScores for this environment
+  const scores = await prisma.agentScore.findMany({
+    where: { environmentId: envId },
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  const result = scores.map((s) => ({
+    targetType: s.targetType,
+    targetId: s.targetId,
+    scoreTotal: s.scoreTotal,
+    accuracy: s.accuracy,
+    completeness: s.completeness,
+    safety: s.safety,
+    efficiency: s.efficiency,
+    quality: s.quality,
+    evalCount: s.evalCount,
+  }))
+
+  return NextResponse.json(result)
+}

--- a/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+export const dynamic = 'force-dynamic'
+
+// GET /api/environments/[id]/evals/scores/skill/[skillId]
+// Score for a specific skill NebulaInstance.
+export async function GET(_req: NextRequest, { params }: { params: { id: string; skillId: string } }) {
+  const envId = params.id
+
+  const env = await prisma.environment.findUnique({ where: { id: envId } })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  // Find the skill NebulaInstance
+  const skill = await prisma.nebulaInstance.findUnique({
+    where: {
+      environmentId_name: {
+        environmentId: envId,
+        name: params.skillId,
+      },
+      category: 'skill',
+    },
+  })
+
+  if (!skill) {
+    return NextResponse.json({ error: 'Skill not found' }, { status: 404 })
+  }
+
+  // Check for an existing AgentScore
+  const score = await prisma.agentScore.findUnique({
+    where: {
+      targetType_targetId: {
+        targetType: 'skill',
+        targetId: skill.id,
+      },
+    },
+  })
+
+  if (score) {
+    return NextResponse.json({
+      targetType: 'skill',
+      targetId: skill.id,
+      targetName: skill.name,
+      scoreTotal: score.scoreTotal,
+      accuracy: score.accuracy,
+      completeness: score.completeness,
+      safety: score.safety,
+      efficiency: score.efficiency,
+      quality: score.quality,
+      evalCount: score.evalCount,
+      lastEvalAt: score.lastEvalAt,
+    })
+  }
+
+  // No score yet — return a default with zero scores
+  return NextResponse.json({
+    targetType: 'skill',
+    targetId: skill.id,
+    targetName: skill.name,
+    scoreTotal: 0,
+    accuracy: 0,
+    completeness: 0,
+    safety: 0,
+    efficiency: 0,
+    quality: 0,
+    evalCount: 0,
+    lastEvalAt: null,
+    message: 'No evals have been run for this skill yet',
+  })
+}

--- a/apps/web/src/app/api/observability/trace/route.ts
+++ b/apps/web/src/app/api/observability/trace/route.ts
@@ -1,7 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { parseBodyOrError } from '@/lib/validate'
 
 export const dynamic = 'force-dynamic'
+
+// SOC2 [INPUT-001]: Validate trace write inputs
+const CreateTraceSchema = z.object({
+  conversationId: z.string().optional(),
+  taskId: z.string().optional(),
+  step: z.number().int().min(0),
+  type: z.string().min(1).max(64),
+  toolName: z.string().max(128).optional(),
+  toolArgs: z.record(z.unknown()).optional(),
+  toolResult: z.unknown().optional(),
+  content: z.string().optional(),
+  skillName: z.string().max(128).optional(),
+  hookName: z.string().max(128).optional(),
+  durationMs: z.number().int().min(0).optional(),
+  modelUsed: z.string().max(128).optional(),
+  systemPromptHash: z.string().max(256).optional(),
+  tokensIn: z.number().int().min(0).optional(),
+  tokensOut: z.number().int().min(0).optional(),
+  costCents: z.number().min(0).optional(),
+})
 
 // GET /api/observability/trace — Query traces
 // Query params: conversationId, taskId, limit (default 100), type (optional filter)
@@ -25,9 +48,18 @@ export async function GET(req: Request) {
   return NextResponse.json(traces)
 }
 
-// POST /api/observability/trace — Report a trace from Gateway
+// POST /api/observability/trace — Report a trace from Gateway (gateway token required)
 export async function POST(req: NextRequest) {
-  const body = await req.json()
+  try {
+    await requireServiceAuth(req)
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const result = await parseBodyOrError(req, CreateTraceSchema)
+  if ('error' in result) return result.error
+  const body = result.data
+
   const trace = await prisma.agentTrace.create({
     data: {
       conversationId: body.conversationId,

--- a/apps/web/src/app/api/observability/trace/route.ts
+++ b/apps/web/src/app/api/observability/trace/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/observability/trace — Query traces
+// Query params: conversationId, taskId, limit (default 100), type (optional filter)
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const conversationId = searchParams.get('conversationId')
+  const taskId = searchParams.get('taskId')
+  const type = searchParams.get('type')
+  const limit = parseInt(searchParams.get('limit') || '100')
+
+  const where: Record<string, unknown> = {}
+  if (conversationId) where.conversationId = conversationId
+  if (taskId) where.taskId = taskId
+  if (type) where.type = type
+
+  const traces = await prisma.agentTrace.findMany({
+    where,
+    orderBy: { step: 'asc' },
+    take: limit,
+  })
+  return NextResponse.json(traces)
+}
+
+// POST /api/observability/trace — Report a trace from Gateway
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const trace = await prisma.agentTrace.create({
+    data: {
+      conversationId: body.conversationId,
+      taskId: body.taskId,
+      step: body.step,
+      type: body.type,
+      toolName: body.toolName,
+      toolArgs: body.toolArgs ? JSON.stringify(body.toolArgs) : null,
+      toolResult: body.toolResult ? JSON.stringify(body.toolResult) : null,
+      content: body.content,
+      skillName: body.skillName,
+      hookName: body.hookName,
+      durationMs: body.durationMs,
+      modelUsed: body.modelUsed,
+      systemPromptHash: body.systemPromptHash,
+      tokensIn: body.tokensIn,
+      tokensOut: body.tokensOut,
+      costCents: body.costCents ? parseFloat(String(body.costCents)) : null,
+    },
+  })
+  return NextResponse.json(trace)
+}


### PR DESCRIPTION
## Summary

Add 8 API routes for evals and observability.

### Evals (6 routes)
- GET/POST /api/environments/[id]/evals/run — Trigger auto-eval on task completion
- GET /api/environments/[id]/evals/scores — Score overview for all targets
- GET /api/environments/[id]/evals/scores/skill/[skillId] — Skill score
- GET /api/environments/[id]/evals/scores/hook/[hookId] — Hook score
- GET/POST /api/environments/[id]/evals/rulesets — Ruleset CRUD
- GET /api/environments/[id]/evals/aggregate — Chart data with ?type= & ?window=

### Observability (2 routes)
- GET /api/observability/trace — Query traces with filters
- POST /api/observability/trace — Report trace from Gateway
- GET /api/conversations/[id]/traces — Trace timeline for a conversation

---
Phase 7 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (Prisma schema).