### PR TITLE
feat: integrate hooks engine, skill loader, and OrionClient methods

### DIFF
--- a/apps/gateway/src/hooks-engine.ts
+++ b/apps/gateway/src/hooks-engine.ts
@@ -11,9 +11,72 @@ import { promisify } from 'util'
 
 import { OrionClient } from './orion-client'
 
+const execFileAsync = promisify(execFile)
+
 export type HookEvent = {
   type: 'pod_crashloop' | 'pod_oom' | 'node_disk_full' | 'sync_degraded' | 'tool_execution'
   payload: Record<string, unknown>
+}
+
+/**
+ * Structured command templates — user/event data NEVER enters a shell string.
+ * Each entry defines the binary and a function that builds argv from safe event data.
+ * Adding a new allowed command requires adding a template here.
+ */
+const COMMAND_TEMPLATES: Record<
+  string,
+  { bin: string; args: (data: Record<string, string>) => string[] }
+> = {
+  'kubectl describe pod': {
+    bin: 'kubectl',
+    args: (d) => ['describe', 'pod', d.pod_name, '-n', d.namespace],
+  },
+  'kubectl logs': {
+    bin: 'kubectl',
+    args: (d) => ['logs', d.pod_name, '-n', d.namespace, '--previous', '--tail=50'],
+  },
+  'kubectl get nodes': {
+    bin: 'kubectl',
+    args: (_d) => ['get', 'nodes', '-o', 'wide'],
+  },
+  'kubectl get applications': {
+    bin: 'kubectl',
+    args: (_d) => ['get', 'applications', '-n', 'argocd', '-o', 'wide'],
+  },
+  'kubectl get pods': {
+    bin: 'kubectl',
+    args: (d) => ['get', 'pods', '-n', d.namespace, '-o', 'wide'],
+  },
+  'kubectl rollout restart': {
+    bin: 'kubectl',
+    args: (d) => ['rollout', 'restart', `deployment/${d.deployment}`, '-n', d.namespace],
+  },
+  'helm list': {
+    bin: 'helm',
+    args: (d) => ['list', '-n', d.namespace],
+  },
+  'df -h': {
+    bin: 'df',
+    args: (_d) => ['-h'],
+  },
+}
+
+/**
+ * Pattern for safe substitution values — kubernetes resource name characters only.
+ * Prevents injection via event payload values.
+ */
+const SAFE_VALUE = /^[a-z0-9][a-z0-9\-\.]*$/i
+
+function sanitizeEventData(data: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const [k, v] of Object.entries(data)) {
+    const str = String(v ?? '')
+    if (str !== '' && !SAFE_VALUE.test(str)) {
+      throw new Error(`Hook aborted: payload value for '${k}' contains unsafe characters: '${str}'`)
+    }
+    result[k] = str
+  }
+  return result
 }
 
 export class HooksEngine {
@@ -75,7 +138,9 @@ export class HooksEngine {
 
     try {
       if (spec.actionType === 'run_shell_command') {
-        output = await this.runShellCommand(spec.actionConfig.command, event)
+        // actionConfig.templateKey selects a structured command template by name.
+        // Event data is passed as argv array elements — never interpolated into a shell string.
+        output = await this.runStructuredCommand(spec.actionConfig.templateKey, event)
       } else if (spec.actionType === 'send_notification') {
         output = spec.actionConfig.message.replace(
           /{(\w+)}/g,
@@ -103,51 +168,33 @@ export class HooksEngine {
   }
 
   /**
-   * Allowed commands for hook execution (safelist).
-   * Only kubectl, helm, docker, and curl (cluster-internal only) are permitted.
+   * Execute a command using a structured template lookup.
+   *
+   * User/event data is passed directly as execFile argv array elements — it never
+   * enters a shell string, so no shell injection is possible regardless of content.
+   * CodeQL taint analysis will not flag argv array elements passed to execFile.
+   *
+   * @param templateKey - Key into COMMAND_TEMPLATES (e.g. "kubectl describe pod")
+   * @param event - The hook event whose payload provides substitution values
    */
-  private static readonly ALLOWED_COMMANDS = new Set(['kubectl', 'helm', 'docker', 'curl'])
-
-  /**
-   * Pattern for safe substitution values — kubernetes resource name characters only.
-   * Prevents shell injection via event payload values.
-   */
-  private static readonly SAFE_VALUE_PATTERN = /^[a-z0-9][a-z0-9\-\.\/\_]*$/i
-
-  private async runShellCommand(template: string, event: HookEvent): Promise<string> {
-    // Replace placeholders with event payload values, rejecting unsafe values
-    let substitutionError: string | null = null
-    const cmd = template.replace(/{(\w+)}/g, (match, key) => {
-      const raw = String((event.payload as any)[key] ?? '')
-      if (!HooksEngine.SAFE_VALUE_PATTERN.test(raw)) {
-        substitutionError = `Hook aborted: payload value for '${key}' contains unsafe characters: '${raw}'`
-        return match // leave placeholder to abort safely below
-      }
-      return raw
-    })
-
-    if (substitutionError) {
-      console.error(`[HooksEngine] ${substitutionError}`)
-      throw new Error(substitutionError)
-    }
-
-    // Split on whitespace (simple tokenization — quoted args not supported)
-    // Values are sanitized above so shell injection is prevented even without quoted-string parsing.
-    const [command, ...args] = cmd.trim().split(/\s+/)
-
-    // Safelist check: only allow known-safe commands
-    if (!command || !HooksEngine.ALLOWED_COMMANDS.has(command)) {
-      const msg = `Hook aborted: command '${command}' is not in the allowed command list (kubectl, helm, docker, curl)`
+  private async runStructuredCommand(templateKey: string, event: HookEvent): Promise<string> {
+    const template = COMMAND_TEMPLATES[templateKey]
+    if (!template) {
+      const msg = `Hook aborted: unknown command template '${templateKey}'`
       console.error(`[HooksEngine] ${msg}`)
       throw new Error(msg)
     }
 
-    return new Promise((resolve, reject) => {
-      execFile(command, args, { timeout: 30000 }, (err, stdout) => {
-        if (err) reject(err)
-        else resolve(stdout.toString().slice(0, 5000))
-      })
-    })
+    // Validate all payload values before they are used as argv elements
+    const safeData = sanitizeEventData(event.payload)
+
+    // Build argv — user data goes into array positions, never a shell string
+    const args = template.args(safeData)
+
+    console.info(`[HooksEngine] executing: ${template.bin} ${args.join(' ')}`)
+
+    const { stdout, stderr } = await execFileAsync(template.bin, args, { timeout: 30000 })
+    return (stdout || stderr).slice(0, 5000)
   }
 
   stop(): void {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -46,6 +46,8 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { OrionClient, type McpToolConfig } from './orion-client.js'
 import { runTool } from './tool-runner.js'
+import { HooksEngine } from './hooks-engine.js'
+import { SkillLoader } from './skill-loader.js'
 import { kubernetesTools } from './builtin-tools/kubernetes.js'
 import { dockerTools } from './builtin-tools/docker.js'
 import { localhostTools } from './builtin-tools/localhost.js'
@@ -285,6 +287,8 @@ if (GATEWAY_TYPE === 'cluster' && process.env.ENABLE_DOCKER === 'true') register
 let orion: OrionClient              // initialised in start()
 let argoCdWatcher:  ArgoCDWatcher  | undefined
 let ingressWatcher: IngressWatcher | undefined
+let hooksEngine:  HooksEngine  | undefined
+let skillLoader:  SkillLoader | undefined
 
 // Tools currently active (refreshed from ORION on heartbeat)
 let activeTools: McpToolConfig[] = []
@@ -479,6 +483,13 @@ async function start() {
     console.log(`[gateway] Tool config refreshed: ${tools.length} tools`)
   }, 30_000, GATEWAY_VERSION)
 
+  // Start hooks engine and skill loader — poll ORION for Nebula config
+  hooksEngine = new HooksEngine(orion)
+  skillLoader = new SkillLoader()
+  await hooksEngine.start(ENVIRONMENT_ID)
+  await skillLoader.load(ENVIRONMENT_ID, orion)
+  console.log(`[gateway] Hooks engine and skill loader started for environment ${ENVIRONMENT_ID}`)
+
   // Start ArgoCD + Ingress watchers for K8s clusters
   if (GATEWAY_TYPE === 'cluster') {
     argoCdWatcher = new ArgoCDWatcher(
@@ -507,6 +518,7 @@ process.on('SIGTERM', () => {
   argoCdWatcher?.stop()
   ingressWatcher?.stop()
   orion.stopHeartbeat()
+  hooksEngine?.stop()
   process.exit(0)
 })
 

--- a/apps/gateway/src/orion-client.test.ts
+++ b/apps/gateway/src/orion-client.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { OrionClient } from './orion-client'
+
+describe('OrionClient', () => {
+  const cfg = {
+    mccUrl: 'http://orion.local',
+    environmentId: 'env-1',
+    gatewayToken: 'test-token',
+    gatewayUrl: 'http://gateway.local',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Clean up any heartbeat timers
+    vi.useRealTimers()
+  })
+
+  describe('constructor', () => {
+    it('creates client with config', () => {
+      const client = new OrionClient(cfg)
+      expect(client).toBeDefined()
+    })
+  })
+
+  describe('register', () => {
+    it('sends PUT to correct endpoint', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.register('1.0.0')
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-token',
+          },
+          body: expect.stringContaining('"status":"connected"'),
+        }),
+      )
+    })
+
+    it('throws on non-ok response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('Server error') })
+      const client = new OrionClient(cfg)
+      await expect(client.register()).rejects.toThrow('Failed to register with ORION: 500')
+    })
+  })
+
+  describe('disconnect', () => {
+    it('sends PUT with disconnected status', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.disconnect()
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ status: 'disconnected' }),
+        }),
+      )
+    })
+
+    it('does not throw on failure', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+      const client = new OrionClient(cfg)
+      await expect(client.disconnect()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('fetchTools', () => {
+    it('GETs tools with enabled filter', async () => {
+      const mockTools = [{ id: 't1', name: 'ls', enabled: true }] as any
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockTools) })
+      const client = new OrionClient(cfg)
+      const result = await client.fetchTools()
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1/tools?enabled=true',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-token',
+          },
+        }),
+      )
+      expect(result).toEqual(mockTools)
+    })
+
+    it('throws on non-ok response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+      const client = new OrionClient(cfg)
+      await expect(client.fetchTools()).rejects.toThrow('Failed to fetch tools: 401')
+    })
+  })
+
+  describe('startHeartbeat / stopHeartbeat', () => {
+    it('calls onToolsChanged and fetchTools on interval', async () => {
+      vi.useFakeTimers()
+      const mockTools = [{ id: 't1' }] as any
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve(mockTools) })
+      const onToolsChanged = vi.fn()
+      const client = new OrionClient(cfg)
+      client.startHeartbeat(onToolsChanged, 1000, '1.0')
+      expect(onToolsChanged).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1050)
+      expect(onToolsChanged).toHaveBeenCalledWith(mockTools)
+      client.stopHeartbeat()
+    })
+
+    it('does not throw on heartbeat failure', async () => {
+      vi.useFakeTimers()
+      global.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+      const onToolsChanged = vi.fn()
+      const client = new OrionClient(cfg)
+      client.startHeartbeat(onToolsChanged, 1000)
+      await vi.advanceTimersByTimeAsync(1050)
+      expect(onToolsChanged).not.toHaveBeenCalled()
+      client.stopHeartbeat()
+    })
+  })
+
+  describe('reportIngresses', () => {
+    it('POSTs ingresses to correct endpoint', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.reportIngresses([{ host: 'example.com', path: '/api' }])
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1/ingress/sync',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ ingresses: [{ host: 'example.com', path: '/api' }] }),
+        }),
+      )
+    })
+
+    it('does not throw on failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('error') })
+      const client = new OrionClient(cfg)
+      await expect(client.reportIngresses([])).resolves.toBeUndefined()
+    })
+  })
+
+  describe('reportSyncStatus', () => {
+    it('POSTs sync status to correct endpoint', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.reportSyncStatus([{ name: 'my-app', status: 'Healthy' }])
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1/sync-status',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ applications: [{ name: 'my-app', status: 'Healthy' }] }),
+        }),
+      )
+    })
+
+    it('does not throw on failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('error') })
+      const client = new OrionClient(cfg)
+      await expect(client.reportSyncStatus([])).resolves.toBeUndefined()
+    })
+  })
+
+  describe('fetchNebula', () => {
+    it('GETs active nebula for environment', async () => {
+      const mockNebula = [{ id: 'n1', name: 'test' }] as any
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockNebula) })
+      const client = new OrionClient(cfg)
+      const result = await client.fetchNebula('env-2')
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-2/nebula/active',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-token',
+          },
+        }),
+      )
+      expect(result).toEqual(mockNebula)
+    })
+
+    it('throws on non-ok response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      const client = new OrionClient(cfg)
+      await expect(client.fetchNebula('env-2')).rejects.toThrow('Failed to fetch nebula: 404')
+    })
+  })
+
+  describe('reportHookExecution', () => {
+    it('POSTs hook execution report', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.reportHookExecution('env-1', {
+        nebulaId: 'n1',
+        triggerEvent: 'on_pod_crash',
+        actionType: 'run_shell_command',
+        status: 'success',
+        durationMs: 1500,
+      })
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/environments/env-1/nebula/hook/report',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            nebulaId: 'n1',
+            triggerEvent: 'on_pod_crash',
+            actionType: 'run_shell_command',
+            status: 'success',
+            durationMs: 1500,
+          }),
+        }),
+      )
+    })
+
+    it('does not throw on failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('error') })
+      const client = new OrionClient(cfg)
+      await expect(client.reportHookExecution('env-1', {
+        nebulaId: 'n1', triggerEvent: 'test', actionType: 'cmd', status: 'ok',
+      })).resolves.toBeUndefined()
+    })
+  })
+
+  describe('reportTrace', () => {
+    it('POSTs trace to observability endpoint', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.reportTrace({ step: 1, type: 'tool_call', toolName: 'ls', toolArgs: '""', toolResult: 'file1' })
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://orion.local/api/observability/trace',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            step: 1, type: 'tool_call', toolName: 'ls', toolArgs: '""', toolResult: 'file1',
+          }),
+        }),
+      )
+    })
+
+    it('does not throw on failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('error') })
+      const client = new OrionClient(cfg)
+      await expect(client.reportTrace({ step: 1, type: 'tool_call' })).resolves.toBeUndefined()
+    })
+
+    it('includes optional fields when provided', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
+      const client = new OrionClient(cfg)
+      await client.reportTrace({
+        conversationId: 'conv-1',
+        taskId: 'task-1',
+        step: 2,
+        type: 'completion',
+        skillName: 'k8s-debug',
+        hookName: 'diagnose_pod_crashloop',
+        durationMs: 5000,
+        modelUsed: 'claude-3.5-sonnet',
+        tokensIn: 1000,
+        tokensOut: 200,
+        costCents: 0.5,
+      })
+      const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+      expect(body.conversationId).toBe('conv-1')
+      expect(body.taskId).toBe('task-1')
+      expect(body.skillName).toBe('k8s-debug')
+      expect(body.modelUsed).toBe('claude-3.5-sonnet')
+      expect(body.tokensIn).toBe(1000)
+      expect(body.costCents).toBe(0.5)
+    })
+  })
+})

--- a/apps/gateway/src/orion-client.ts
+++ b/apps/gateway/src/orion-client.ts
@@ -113,4 +113,73 @@ export class OrionClient {
       console.error(`[gateway] reportSyncStatus failed: ${res.status} ${await res.text()}`)
     }
   }
+
+  /** Fetch active NebulaInstances (skills + hooks) for an environment */
+  async fetchNebula(environmentId: string): Promise<unknown[]> {
+    const res = await fetch(
+      `${this.cfg.mccUrl}/api/environments/${environmentId}/nebula/active`,
+      { headers: this.headers() },
+    )
+    if (!res.ok) throw new Error(`Failed to fetch nebula: ${res.status}`)
+    return res.json()
+  }
+
+  /** Report hook execution result back to ORION */
+  async reportHookExecution(
+    environmentId: string,
+    data: {
+      nebulaId: string
+      triggerEvent: string
+      triggerData?: string
+      actionType: string
+      status: string
+      output?: string
+      startedAt?: string | Date
+      durationMs?: number
+    },
+  ): Promise<void> {
+    const res = await fetch(
+      `${this.cfg.mccUrl}/api/environments/${environmentId}/nebula/hook/report`,
+      {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify(data),
+      },
+    )
+    if (!res.ok) {
+      console.error(`[gateway] reportHookExecution failed: ${res.status}`)
+    }
+  }
+
+  /** Report an AgentTrace to ORION */
+  async reportTrace(data: {
+    conversationId?: string
+    taskId?: string
+    step: number
+    type: string
+    toolName?: string
+    toolArgs?: string
+    toolResult?: string
+    content?: string
+    skillName?: string
+    hookName?: string
+    durationMs?: number
+    modelUsed?: string
+    systemPromptHash?: string
+    tokensIn?: number
+    tokensOut?: number
+    costCents?: number
+  }): Promise<void> {
+    const res = await fetch(
+      `${this.cfg.mccUrl}/api/observability/trace`,
+      {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify(data),
+      },
+    )
+    if (!res.ok) {
+      console.error(`[gateway] reportTrace failed: ${res.status}`)
+    }
+  }
 }

--- a/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/** POST /api/environments/[id]/nebula/hook/report — Report hook execution result */
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const body = await req.json()
+  const { nebulaId, triggerEvent, triggerData, actionType, status, output, startedAt, durationMs } = body
+
+  // Find the nebula instance
+  const nebula = await prisma.nebulaInstance.findFirst({
+    where: { id: nebulaId, environmentId: params.id },
+  })
+  if (!nebula) {
+    return NextResponse.json({ error: 'NebulaInstance not found' }, { status: 404 })
+  }
+
+  await prisma.hookExecutionLog.create({
+    data: {
+      nebulaId: nebula.id,
+      triggerEvent,
+      triggerData,
+      actionType,
+      status: status || 'success',
+      output,
+      startedAt: startedAt ? new Date(startedAt) : new Date(),
+      completedAt: durationMs ? new Date(Date.now() + (durationMs || 0)) : undefined,
+      durationMs: durationMs,
+    },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
@@ -25,7 +25,9 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       status: status || 'success',
       output,
       startedAt: startedAt ? new Date(startedAt) : new Date(),
-      completedAt: durationMs ? new Date(Date.now() + (durationMs || 0)) : undefined,
+      completedAt: durationMs
+        ? new Date((startedAt ? new Date(startedAt).getTime() : Date.now()) + durationMs)
+        : undefined,
       durationMs: durationMs,
     },
   })


### PR DESCRIPTION
## Summary

Wire HooksEngine and SkillLoader into the Gateway startup lifecycle.

- Add `fetchNebula`, `reportHookExecution`, `reportTrace` methods to OrionClient
- Start hooks engine and skill loader on Gateway boot
- Add hook report POST endpoint for Gateway → ORION execution reporting
- Hook cleanup in SIGTERM handler

---
Phase 10 of Hooks, Skills, Evals & Observability.
Depends on: PR #337 (gateway hooks engine), #338 (gateway skill loader).