### PR TITLE
feat: add nebula field to agent runner context

### DIFF
--- a/apps/web/src/lib/agent-runner/claude-runner.ts
+++ b/apps/web/src/lib/agent-runner/claude-runner.ts
@@ -36,6 +36,7 @@ export const claudeRunner: AgentRunner = {
           model:        modelName,
           agentId:      ctx.agentId,
           maxTurns:     20,
+          ...(ctx.nebula && { nebula: ctx.nebula }),
         }),
         signal: AbortSignal.timeout(300_000),
       })

--- a/apps/web/src/lib/agent-runner/types.ts
+++ b/apps/web/src/lib/agent-runner/types.ts
@@ -32,6 +32,7 @@ export interface TaskRunContext {
     definitions: ManagementToolDef[]
     execute: (name: string, argsRaw: string) => Promise<string>
   }
+  nebula?: { environmentId: string; traceId: string }  // Nebula observability context
 }
 
 export type AgentEvent =


### PR DESCRIPTION
## Summary

Add optional `nebula` field to TaskRunContext and forward to orion-claude sidecar.

- `TaskRunContext.nebula` — `{ environmentId, traceId }`
- `claude-runner.ts` forwards nebula in fetch body
- ollama/openai/dispatcher runners pass through automatically

---
Phase 11 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (Prisma schema).