### PR TITLE
feat: add Nebula, Effectiveness, Trace, and Eval dashboard UI pages

### DIFF
--- a/apps/web/src/app/(app)/conversations/[id]/traces/page.tsx
+++ b/apps/web/src/app/(app)/conversations/[id]/traces/page.tsx
@@ -1,0 +1,344 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import {
+  MessageSquare, Tool, Bot, Play, RotateCcw, ChevronDown, ChevronUp,
+  Clock, Terminal, Sparkles,
+} from 'lucide-react'
+
+interface TraceEntry {
+  id: string
+  conversationId: string | null
+  taskId: string | null
+  step: number
+  type: string // "tool_call" | "tool_result" | "skill_injected" | "hook_triggered" | "text_generation" | "error"
+  toolName: string | null
+  toolArgs: string | null
+  toolResult: string | null
+  content: string | null
+  skillName: string | null
+  hookName: string | null
+  durationMs: number | null
+  modelUsed: string | null
+  systemPromptHash: string | null
+  tokensIn: number | null
+  tokensOut: number | null
+  costCents: number | null
+  createdAt: string
+}
+
+const TYPE_CONFIG: Record<string, {
+  icon: React.ReactNode
+  color: string
+  bg: string
+  label: string
+}> = {
+  tool_call: {
+    icon: <Tool size={14} />,
+    color: 'text-blue-400',
+    bg: 'bg-blue-500/10 border-blue-500/30',
+    label: 'Tool Call',
+  },
+  tool_result: {
+    icon: <Play size={14} />,
+    color: 'text-green-400',
+    bg: 'bg-green-500/10 border-green-500/30',
+    label: 'Tool Result',
+  },
+  skill_injected: {
+    icon: <Sparkles size={14} />,
+    color: 'text-purple-400',
+    bg: 'bg-purple-500/10 border-purple-500/30',
+    label: 'Skill Injected',
+  },
+  hook_triggered: {
+    icon: <RotateCcw size={14} />,
+    color: 'text-orange-400',
+    bg: 'bg-orange-500/10 border-orange-500/30',
+    label: 'Hook Triggered',
+  },
+  text_generation: {
+    icon: <MessageSquare size={14} />,
+    color: 'text-gray-400',
+    bg: 'bg-gray-500/10 border-gray-500/30',
+    label: 'Text Generation',
+  },
+  error: {
+    icon: <Terminal size={14} />,
+    color: 'text-red-400',
+    bg: 'bg-red-500/10 border-red-500/30',
+    label: 'Error',
+  },
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || ms === 0) return '—'
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function truncate(str: string | null, len: number = 200): string | null {
+  if (!str) return null
+  if (str.length <= len) return str
+  return str.slice(0, len) + '...'
+}
+
+export default function TracesPage() {
+  const { id } = useParams() as { id: string }
+  const [traces, setTraces] = useState<TraceEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set())
+  const [filter, setFilter] = useState<string>('')
+  const [totalCost, setTotalCost] = useState(0)
+  const [totalTokens, setTotalTokens] = useState({ in: 0, out: 0 })
+
+  const load = async () => {
+    try {
+      const res = await fetch(`/api/conversations/${id}/traces`)
+      const data = await res.json()
+      const traceList = Array.isArray(data) ? data : []
+      setTraces(traceList)
+
+      // Calculate totals
+      let cost = 0
+      let tokensIn = 0
+      let tokensOut = 0
+      for (const t of traceList) {
+        if (t.costCents !== null) cost += Number(t.costCents)
+        if (t.tokensIn !== null) tokensIn += t.tokensIn
+        if (t.tokensOut !== null) tokensOut += t.tokensOut
+      }
+      setTotalCost(cost)
+      setTotalTokens({ in: tokensIn, out: tokensOut })
+    } catch { /* ignore */ }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    load()
+  }, [id])
+
+  const toggleStep = (traceId: string) => {
+    setExpandedSteps(prev => {
+      const next = new Set(prev)
+      if (next.has(traceId)) next.delete(traceId)
+      else next.add(traceId)
+      return next
+    })
+  }
+
+  const filtered = traces.filter(t => {
+    if (!filter) return true
+    return t.type.includes(filter) || (t.toolName && t.toolName.includes(filter))
+  })
+
+  const typeCounts: Record<string, number> = {}
+  for (const t of traces) {
+    typeCounts[t.type] = (typeCounts[t.type] || 0) + 1
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <Bot size={18} className="text-accent" />
+          <h1 className="text-sm font-semibold text-text-primary">Trace Timeline</h1>
+          <p className="text-xs text-text-muted ml-2">
+            {traces.length} steps
+          </p>
+        </div>
+        <button
+          onClick={load}
+          className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
+          title="Refresh"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M23 4v6h-6M1 20v-6h6" />
+            <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Summary Bar */}
+      {traces.length > 0 && (
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-border-subtle flex-shrink-0 text-[10px]">
+          <span className="flex items-center gap-1 text-blue-400">
+            <Tool size={10} />
+            {typeCounts.tool_call || 0} tool_calls
+          </span>
+          <span className="flex items-center gap-1 text-green-400">
+            <Play size={10} />
+            {typeCounts.tool_result || 0} results
+          </span>
+          <span className="flex items-center gap-1 text-purple-400">
+            <Sparkles size={10} />
+            {typeCounts.skill_injected || 0} skills
+          </span>
+          <span className="flex items-center gap-1 text-orange-400">
+            <RotateCcw size={10} />
+            {typeCounts.hook_triggered || 0} hooks
+          </span>
+          <span className="flex items-center gap-1 text-gray-400 ml-auto">
+            <Clock size={10} />
+            {traces.reduce((sum, t) => sum + (t.durationMs || 0), 0) / 1000 | 0}s total
+          </span>
+          {totalCost > 0 && (
+            <span className="text-text-muted">
+              ${totalCost.toFixed(4)} cost
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Filter */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle flex-shrink-0">
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="">All Types</option>
+          <option value="tool_call">Tool Calls</option>
+          <option value="tool_result">Tool Results</option>
+          <option value="skill_injected">Skill Injected</option>
+          <option value="hook_triggered">Hook Triggered</option>
+          <option value="text_generation">Text Generation</option>
+          <option value="error">Errors</option>
+        </select>
+
+        {Object.keys(typeCounts).length > 1 && (
+          <button
+            onClick={() => setFilter('')}
+            className="px-2 py-1 text-[10px] rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
+          >
+            Clear Filter
+          </button>
+        )}
+      </div>
+
+      {/* Timeline */}
+      <div className="flex-1 overflow-auto px-4 py-3">
+        {loading ? (
+          <div className="text-center py-8 text-text-muted text-sm">Loading traces...</div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-8 text-text-muted text-sm">No trace data available for this conversation.</div>
+        ) : (
+          <div className="space-y-0">
+            {filtered.map((trace, idx) => {
+              const config = TYPE_CONFIG[trace.type] || TYPE_CONFIG.text_generation
+              const isExpanded = expandedSteps.has(trace.id)
+
+              return (
+                <div key={trace.id} className="relative">
+                  {/* Vertical line connector */}
+                  {idx < filtered.length - 1 && (
+                    <div className="absolute left-[17px] top-8 bottom-[-1px] w-px bg-border-subtle" />
+                  )}
+
+                  <div
+                    className={`relative flex gap-3 px-3 py-2.5 rounded-lg border transition-colors cursor-pointer hover:bg-bg-raised ${
+                      isExpanded ? 'border-accent/30' : 'border-transparent'
+                    }`}
+                    onClick={() => toggleStep(trace.id)}
+                  >
+                    {/* Step number and icon */}
+                    <div className="flex flex-col items-center flex-shrink-0">
+                      <div className={`w-8 h-8 rounded-full flex items-center justify-center border ${config.bg} ${config.color}`}>
+                        {config.icon}
+                      </div>
+                    </div>
+
+                    {/* Content */}
+                    <div className="flex-1 min-w-0">
+                      {/* Header row */}
+                      <div className="flex items-center gap-2">
+                        <span className="text-[10px] font-medium text-text-muted w-6">
+                          #{trace.step}
+                        </span>
+                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${config.bg} ${config.color}`}>
+                          {config.label}
+                        </span>
+                        {trace.toolName && (
+                          <span className="text-xs text-text-primary font-mono truncate">
+                            {trace.toolName}
+                          </span>
+                        )}
+                        {trace.skillName && (
+                          <span className="text-xs text-purple-400 font-mono">
+                            skill:{trace.skillName}
+                          </span>
+                        )}
+                        {trace.hookName && (
+                          <span className="text-xs text-orange-400 font-mono">
+                            hook:{trace.hookName}
+                          </span>
+                        )}
+                        {trace.modelUsed && (
+                          <span className="text-[10px] text-text-muted ml-auto">
+                            {trace.modelUsed}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Metadata */}
+                      <div className="flex items-center gap-3 mt-1 text-[10px] text-text-muted">
+                        {trace.durationMs !== null && (
+                          <span className="flex items-center gap-1">
+                            <Clock size={9} />
+                            {formatDuration(trace.durationMs)}
+                          </span>
+                        )}
+                        {trace.tokensIn !== null && trace.tokensIn > 0 && (
+                          <span>{trace.tokensIn.toLocaleString()} in</span>
+                        )}
+                        {trace.tokensOut !== null && trace.tokensOut > 0 && (
+                          <span>{trace.tokensOut.toLocaleString()} out</span>
+                        )}
+                        {trace.costCents !== null && trace.costCents > 0 && (
+                          <span>${Number(trace.costCents).toFixed(4)}</span>
+                        )}
+                      </div>
+
+                      {/* Collapsible Detail */}
+                      {isExpanded && (
+                        <div className="mt-2 space-y-2">
+                          {trace.content && (
+                            <div className="text-xs text-text-secondary bg-bg-raised rounded p-2 border border-border-subtle max-h-40 overflow-auto">
+                              {truncate(trace.content, 500)}
+                            </div>
+                          )}
+                          {trace.toolArgs && (
+                            <div>
+                              <span className="text-[10px] font-medium text-text-muted">Args:</span>
+                              <pre className="text-[10px] text-text-secondary bg-bg-raised rounded p-2 border border-border-subtle mt-0.5 overflow-auto whitespace-pre-wrap max-h-40 font-mono">
+                                {truncate(trace.toolArgs, 800)}
+                              </pre>
+                            </div>
+                          )}
+                          {trace.toolResult && (
+                            <div>
+                              <span className="text-[10px] font-medium text-text-muted">Result:</span>
+                              <pre className="text-[10px] text-text-secondary bg-bg-raised rounded p-2 border border-border-subtle mt-0.5 overflow-auto whitespace-pre-wrap max-h-40 font-mono">
+                                {truncate(trace.toolResult, 800)}
+                              </pre>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Expand indicator */}
+                    <div className="flex-shrink-0 mt-1 text-text-muted">
+                      {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/environments/[id]/evals/page.tsx
+++ b/apps/web/src/app/(app)/environments/[id]/evals/page.tsx
@@ -1,0 +1,363 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import {
+  BarChart3, Play, RefreshCw, TrendingUp, Star, Shield, Target,
+  Zap, CheckCircle, AlertCircle,
+} from 'lucide-react'
+
+interface ScoreEntry {
+  targetType: string
+  targetId: string
+  scoreTotal: number
+  accuracy: number
+  completeness: number
+  safety: number
+  efficiency: number
+  quality: number
+  evalCount: number
+}
+
+interface AggregateData {
+  labels: string[]
+  scores: number[]
+  count: number[]
+  totalEvals: number
+  overallAvg: number
+  windowDays: number
+  targetType: string
+}
+
+type Window = 7 | 30 | 90
+type EvalType = 'conversation' | 'task' | 'skill' | 'hook'
+
+export default function EvalsPage() {
+  const { id } = useParams() as { id: string }
+  const [scores, setScores] = useState<ScoreEntry[]>([])
+  const [aggregate, setAggregate] = useState<AggregateData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [window, setWindow] = useState<Window>(30)
+  const [evalType, setEvalType] = useState<EvalType>('conversation')
+  const [runMessage, setRunMessage] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const loadScores = async () => {
+    try {
+      const res = await fetch(`/api/environments/${id}/evals/scores`)
+      const data = await res.json()
+      setScores(Array.isArray(data) ? data : [])
+    } catch { /* ignore */ }
+  }
+
+  const loadAggregate = async () => {
+    try {
+      const res = await fetch(
+        `/api/environments/${id}/evals/aggregate?type=${evalType}&window=${window}`
+      )
+      const data = await res.json()
+      setAggregate(data)
+    } catch { /* ignore */ }
+  }
+
+  const loadAll = async () => {
+    setError(null)
+    setLoading(true)
+    await Promise.all([loadScores(), loadAggregate()])
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadAll()
+  }, [id])
+
+  // Reload aggregate when filters change
+  useEffect(() => {
+    loadAggregate()
+  }, [id, window, evalType])
+
+  const handleRunEval = async (targetType: 'conversation' | 'task' | 'skill' | 'hook', targetId: string) => {
+    setRunning(true)
+    setRunMessage('')
+    setError(null)
+    try {
+      const res = await fetch(`/api/environments/${id}/evals/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetType, targetId }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Eval failed')
+      setRunMessage(`Eval completed: ${data.evalsCreated} eval(s) created`)
+      loadAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  // Compute summary stats
+  const avgScore = scores.length > 0
+    ? scores.reduce((sum, s) => sum + s.scoreTotal, 0) / scores.length
+    : 0
+  const avgAccuracy = scores.length > 0
+    ? scores.reduce((sum, s) => sum + s.accuracy, 0) / scores.length
+    : 0
+  const avgSafety = scores.length > 0
+    ? scores.reduce((sum, s) => sum + s.safety, 0) / scores.length
+    : 0
+  const totalEvals = scores.reduce((sum, s) => sum + s.evalCount, 0)
+
+  const getScoreColor = (score: number) => {
+    if (score >= 80) return 'text-green-400'
+    if (score >= 50) return 'text-yellow-400'
+    return 'text-red-400'
+  }
+
+  const getScoreBg = (score: number) => {
+    if (score >= 80) return 'bg-green-500/10 border-green-500/30'
+    if (score >= 50) return 'bg-yellow-500/10 border-yellow-500/30'
+    return 'bg-red-500/10 border-red-500/30'
+  }
+
+  // Build simple CSS bar chart data
+  const maxScore = aggregate ? Math.max(...aggregate.scores, 1) : 1
+
+  return (
+    <div className="flex flex-col h-full overflow-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <BarChart3 size={18} className="text-accent" />
+          <h1 className="text-sm font-semibold text-text-primary">Eval Dashboard</h1>
+          <p className="text-xs text-text-muted ml-2">
+            {scores.length} targets &middot; {totalEvals} evals
+          </p>
+        </div>
+        <button
+          onClick={loadAll}
+          className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4 space-y-4">
+        {/* Summary Cards */}
+        {loading ? (
+          <div className="text-center py-8 text-text-muted text-sm">Loading eval data...</div>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div className={`rounded-lg border ${getScoreBg(avgScore)} p-3`}>
+                <div className={`text-2xl font-bold ${getScoreColor(avgScore)}`}>
+                  {avgScore.toFixed(1)}%
+                </div>
+                <div className="text-[10px] text-text-muted mt-1">Avg Score</div>
+              </div>
+              <div className="rounded-lg border border-border-subtle bg-bg-surface p-3">
+                <div className={`text-2xl font-bold ${getScoreColor(avgAccuracy)}`}>
+                  {avgAccuracy.toFixed(1)}%
+                </div>
+                <div className="text-[10px] text-text-muted mt-1 flex items-center gap-1">
+                  <Target size={10} /> Accuracy
+                </div>
+              </div>
+              <div className="rounded-lg border border-border-subtle bg-bg-surface p-3">
+                <div className={`text-2xl font-bold ${getScoreColor(avgSafety)}`}>
+                  {avgSafety.toFixed(1)}%
+                </div>
+                <div className="text-[10px] text-text-muted mt-1 flex items-center gap-1">
+                  <Shield size={10} /> Safety
+                </div>
+              </div>
+              <div className="rounded-lg border border-border-subtle bg-bg-surface p-3">
+                <div className="text-2xl font-bold text-text-primary">
+                  {totalEvals}
+                </div>
+                <div className="text-[10px] text-text-muted mt-1 flex items-center gap-1">
+                  <CheckCircle size={10} /> Total Evals
+                </div>
+              </div>
+            </div>
+
+            {/* Score Breakdown Row */}
+            {scores.length > 0 && (
+              <div className="rounded-lg border border-border-subtle bg-bg-surface p-4">
+                <h3 className="text-xs font-medium text-text-primary mb-3 flex items-center gap-1.5">
+                  <TrendingUp size={13} className="text-accent" />
+                  Score Breakdown
+                </h3>
+                <div className="space-y-2">
+                  {scores.slice(0, 5).map(s => (
+                    <div key={s.targetId} className="flex items-center gap-3">
+                      <div className="w-32 text-[10px] font-mono text-text-primary truncate" title={s.targetId}>
+                        {s.targetType}:{s.targetId.slice(0, 8)}
+                      </div>
+                      {/* Score bars */}
+                      <div className="flex-1 flex items-center gap-2">
+                        <div className="flex-1 bg-bg-raised rounded-full h-2 overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${
+                              s.accuracy >= 80 ? 'bg-green-500' : s.accuracy >= 50 ? 'bg-yellow-500' : 'bg-red-500'
+                            }`}
+                            style={{ width: `${s.accuracy}%` }}
+                          />
+                        </div>
+                        <span className={`text-[10px] text-text-muted w-10 text-right`}>
+                          {s.accuracy}%
+                        </span>
+                      </div>
+                      <span className={`text-[10px] w-12 text-right ${getScoreColor(s.scoreTotal)}`}>
+                        {s.scoreTotal.toFixed(0)}%
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Aggregate Chart (CSS Bar Chart) */}
+            {aggregate && aggregate.labels.length > 0 && (
+              <div className="rounded-lg border border-border-subtle bg-bg-surface p-4">
+                <h3 className="text-xs font-medium text-text-primary mb-1 flex items-center gap-1.5">
+                  <BarChart3 size={13} className="text-accent" />
+                  Avg Score Over Time
+                </h3>
+                <p className="text-[10px] text-text-muted mb-3">
+                  Type: {aggregate.targetType} &middot; Window: {aggregate.windowDays} days &middot; Overall Avg: {aggregate.overallAvg.toFixed(1)}% &middot; {aggregate.totalEvals} evals
+                </p>
+                <div className="flex items-end gap-1 h-32">
+                  {aggregate.labels.map((label, i) => {
+                    const height = aggregate.scores[i] ? (aggregate.scores[i] / maxScore) * 100 : 0
+                    const isHigh = (aggregate.scores[i] || 0) >= 80
+                    const isMid = (aggregate.scores[i] || 0) >= 50 && (aggregate.scores[i] || 0) < 80
+
+                    return (
+                      <div key={i} className="flex-1 flex flex-col items-center gap-0.5">
+                        <span className="text-[9px] text-text-muted">
+                          {aggregate.scores[i] !== null ? aggregate.scores[i].toFixed(0) : '--'}
+                        </span>
+                        <div
+                          className={`w-full rounded-t-sm transition-all ${
+                            isHigh ? 'bg-green-500/60' : isMid ? 'bg-yellow-500/60' : 'bg-red-500/60'
+                          }`}
+                          style={{ height: `${Math.max(height, 2)}%` }}
+                          title={`${label}: ${aggregate.scores[i]?.toFixed(1)}% (${aggregate.count[i]} evals)`}
+                        />
+                        <span className="text-[8px] text-text-muted whitespace-nowrap rotate-0">
+                          {label}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+
+                {/* Legend */}
+                <div className="flex items-center gap-3 mt-2 text-[10px] text-text-muted">
+                  <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-full bg-green-500/60" />
+                    &ge;80% Healthy
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-full bg-yellow-500/60" />
+                    50-80% Warning
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <span className="w-2 h-2 rounded-full bg-red-500/60" />
+                    &lt;50% Critical
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* Run Eval Section */}
+            <div className="rounded-lg border border-border-subtle bg-bg-surface p-4">
+              <h3 className="text-xs font-medium text-text-primary mb-3 flex items-center gap-1.5">
+                <Play size={13} className="text-accent" />
+                Run Manual Eval
+              </h3>
+
+              {/* Run All Quick Button */}
+              <div className="mb-3">
+                <button
+                  onClick={() => handleRunEval(evalType, '')}
+                  disabled={running}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs bg-accent/15 text-accent hover:bg-accent/25 transition-colors disabled:opacity-50"
+                >
+                  <Zap size={12} />
+                  {running ? 'Running...' : 'Run Eval'}
+                </button>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {scores.slice(0, 10).map(s => (
+                  <div key={s.targetId} className="flex items-center justify-between px-3 py-2 border border-border-subtle rounded-lg">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-mono text-text-primary truncate max-w-[120px]" title={`${s.targetType}:${s.targetId}`}>
+                        {s.targetType}:{s.targetId.slice(0, 8)}
+                      </span>
+                      <span className={`text-[10px] ${getScoreColor(s.scoreTotal)}`}>
+                        {s.scoreTotal.toFixed(0)}%
+                      </span>
+                    </div>
+                    <button
+                      onClick={() => handleRunEval(s.targetType as 'conversation' | 'task' | 'skill' | 'hook', s.targetId)}
+                      disabled={running}
+                      className="px-2 py-1 rounded text-[10px] bg-accent/10 text-accent hover:bg-accent/20 transition-colors disabled:opacity-50"
+                    >
+                      Re-eval
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Filter Controls */}
+            <div className="flex items-center gap-3 flex-wrap">
+              <div>
+                <label className="text-[10px] text-text-muted mr-2">Type:</label>
+                <select
+                  value={evalType}
+                  onChange={e => setEvalType(e.target.value as EvalType)}
+                  className="px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+                >
+                  <option value="conversation">Conversations</option>
+                  <option value="task">Tasks</option>
+                  <option value="skill">Skills</option>
+                  <option value="hook">Hooks</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-[10px] text-text-muted mr-2">Window:</label>
+                <select
+                  value={window}
+                  onChange={e => setWindow(parseInt(e.target.value, 10) as Window)}
+                  className="px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+                >
+                  <option value={7}>7 Days</option>
+                  <option value={30}>30 Days</option>
+                  <option value={90}>90 Days</option>
+                </select>
+              </div>
+              {runMessage && (
+                <span className="text-xs text-green-400 flex items-center gap-1">
+                  <CheckCircle size={12} />
+                  {runMessage}
+                </span>
+              )}
+              {error && (
+                <span className="text-xs text-red-400 flex items-center gap-1">
+                  <AlertCircle size={12} />
+                  {error}
+                </span>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/environments/[id]/nebula/effectiveness/page.tsx
+++ b/apps/web/src/app/(app)/environments/[id]/nebula/effectiveness/page.tsx
@@ -1,0 +1,215 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import { Cpu, Filter, ChevronDown, ChevronUp, Zap, CheckCircle, AlertTriangle } from 'lucide-react'
+
+interface EffectivenessEntry {
+  name: string
+  category: string // "skill" | "hook"
+  fireRate: number
+  successRate: string | number
+  needsTuning: boolean
+}
+
+export default function EffectivenessPage() {
+  const { id } = useParams() as { id: string }
+  const [entries, setEntries] = useState<EffectivenessEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [filter, setFilter] = useState<string>('')
+  const [sortField, setSortField] = useState<'name' | 'fireRate' | 'successRate' | 'needsTuning'>('needsTuning')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+
+  const load = async () => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/effectiveness`)
+      const data = await res.json()
+      setEntries(Array.isArray(data) ? data : [])
+    } catch { /* ignore */ }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    load()
+    const interval = setInterval(load, 30000) // Auto-refresh every 30s
+    return () => clearInterval(interval)
+  }, [id])
+
+  const toggleSort = (field: typeof sortField) => {
+    if (sortField === field) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDir('asc')
+    }
+  }
+
+  const sorted = [...entries].sort((a, b) => {
+    let cmp = 0
+    if (sortField === 'name') cmp = a.name.localeCompare(b.name)
+    else if (sortField === 'fireRate') cmp = Number(a.fireRate) - Number(b.fireRate)
+    else if (sortField === 'successRate') cmp = Number(a.successRate) - Number(b.successRate)
+    else if (sortField === 'needsTuning') cmp = (b.needsTuning ? 1 : 0) - (a.needsTuning ? 1 : 0)
+    return sortDir === 'asc' ? cmp : -cmp
+  })
+
+  const filtered = sorted.filter(e => {
+    if (filter && e.category !== filter) return false
+    return true
+  })
+
+  const needsTuning = entries.filter(e => e.needsTuning).length
+  const total = entries.length
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <Zap size={18} className="text-accent" />
+          <h1 className="text-sm font-semibold text-text-primary">Effectiveness</h1>
+          <p className="text-xs text-text-muted ml-2">Monitor skill and hook performance</p>
+        </div>
+        <div className="flex items-center gap-3 text-xs">
+          <span className="text-text-muted">
+            {needsTuning}/{total} need tuning
+          </span>
+          <button
+            onClick={load}
+            className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
+            title="Refresh"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle flex-shrink-0">
+        <Filter size={12} className="text-text-muted" />
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="px-2 py-1 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="">All Types</option>
+          <option value="skill">Skills</option>
+          <option value="hook">Hooks</option>
+        </select>
+
+        <div className="flex-1" />
+
+        <div className="flex items-center gap-1 text-[10px] text-text-muted">
+          Auto-refresh: 30s
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      {entries.length > 0 && (
+        <div className="grid grid-cols-3 gap-3 px-4 pt-3 flex-shrink-0">
+          <div className="rounded-lg border border-border-subtle bg-bg-surface p-3 text-center">
+            <div className="text-lg font-semibold text-text-primary">{total}</div>
+            <div className="text-[10px] text-text-muted">Total Instances</div>
+          </div>
+          <div className="rounded-lg border border-green-500/20 bg-bg-surface p-3 text-center">
+            <div className="text-lg font-semibold text-green-400">{total - needsTuning}</div>
+            <div className="text-[10px] text-text-muted">Healthy</div>
+          </div>
+          <div className="rounded-lg border border-red-500/20 bg-bg-surface p-3 text-center">
+            <div className="text-lg font-semibold text-red-400">{needsTuning}</div>
+            <div className="text-[10px] text-text-muted">Needs Tuning</div>
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto px-4 py-3">
+        {loading ? (
+          <div className="text-center py-8 text-text-muted text-sm">Loading effectiveness data...</div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-8 text-text-muted text-sm">No data available yet.</div>
+        ) : (
+          <div className="border border-border-subtle rounded-lg overflow-auto">
+            <table className="w-full text-xs">
+              <thead className="bg-bg-raised border-b border-border-subtle">
+                <tr>
+                  <th className="px-3 py-2 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                    <button onClick={() => toggleSort('name')} className="flex items-center gap-1 hover:text-text-primary">
+                      Name {sortField === 'name' && (sortDir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />)}
+                    </button>
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                    Type
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                    <button onClick={() => toggleSort('fireRate')} className="flex items-center gap-1 hover:text-text-primary">
+                      Fire Rate {sortField === 'fireRate' && (sortDir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />)}
+                    </button>
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                    <button onClick={() => toggleSort('successRate')} className="flex items-center gap-1 hover:text-text-primary">
+                      Success Rate {sortField === 'successRate' && (sortDir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />)}
+                    </button>
+                  </th>
+                  <th className="px-3 py-2 text-left text-[10px] font-medium text-text-muted uppercase tracking-wider">
+                    <button onClick={() => toggleSort('needsTuning')} className="flex items-center gap-1 hover:text-text-primary">
+                      Status {sortField === 'needsTuning' && (sortDir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />)}
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {filtered.map(entry => (
+                  <tr
+                    key={entry.name}
+                    className={`transition-colors ${
+                      entry.needsTuning ? 'bg-red-500/5' : ''
+                    } hover:bg-bg-raised`}
+                  >
+                    <td className="px-3 py-2.5">
+                      <span className="font-mono text-xs text-text-primary">{entry.name}</span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+                        entry.category === 'skill'
+                          ? 'bg-green-500/20 text-green-400'
+                          : 'bg-orange-500/20 text-orange-400'
+                      }`}>
+                        {entry.category}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5 text-text-secondary">
+                      {entry.fireRate}
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <span className={
+                        entry.needsTuning ? 'text-red-400' : 'text-green-400'
+                      }>
+                        {entry.successRate}%
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      {entry.needsTuning ? (
+                        <span className="flex items-center gap-1 text-red-400 text-[10px] font-medium">
+                          <AlertTriangle size={11} />
+                          Needs Tuning
+                        </span>
+                      ) : (
+                        <span className="flex items-center gap-1 text-green-400 text-[10px] font-medium">
+                          <CheckCircle size={11} />
+                          Healthy
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/environments/[id]/nebula/page.tsx
+++ b/apps/web/src/app/(app)/environments/[id]/nebula/page.tsx
@@ -1,0 +1,431 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import { Cpu, Package, Settings, Download, X, CheckCircle, Clock } from 'lucide-react'
+
+interface NebulaInstance {
+  id: string
+  name: string
+  category: string // "skill" | "hook"
+  isInstalled: boolean
+  isEnabled: boolean
+  isForked: boolean
+  spec: string
+  sourceNovaId: string | null
+  novaDefinition?: {
+    id: string
+    name: string
+    title: string
+    description: string
+    category: string
+    version: string
+  }
+  hookLogs: Array<{ id: string; status: string }>
+  skillLogs: Array<{ id: string }>
+}
+
+interface NovaDefinition {
+  id: string
+  name: string
+  title: string
+  description: string
+  category: string
+  version: string
+  instances?: NebulaInstance
+}
+
+type Tab = 'installed' | 'catalog' | 'settings'
+
+const CATEGORY_COLORS: Record<string, string> = {
+  skill: 'bg-green-500/20 text-green-400 border border-green-500/30',
+  hook: 'bg-orange-500/20 text-orange-400 border border-orange-500/30',
+}
+
+export default function NebulaPage() {
+  const { id } = useParams() as { id: string }
+  const [activeTab, setActiveTab] = useState<Tab>('installed')
+  const [instances, setInstances] = useState<NebulaInstance[]>([])
+  const [loading, setLoading] = useState(true)
+  const [novaDefs, setNovaDefs] = useState<NovaDefinition[]>([])
+
+  const loadInstances = async () => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/instances`)
+      const data = await res.json()
+      setInstances(data.instances || [])
+    } catch { /* ignore */ }
+  }
+
+  const loadNovaDefs = async () => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/catalog`)
+      const data = await res.json()
+      setNovaDefs(data.definitions || [])
+    } catch { /* ignore */ }
+  }
+
+  useEffect(() => {
+    loadInstances()
+    loadNovaDefs()
+  }, [id])
+
+  const handleInstall = async (novaId: string, targetName?: string) => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/install`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ novaId, name: targetName }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      loadInstances()
+    } catch (err) {
+      console.error('Install failed:', err)
+    }
+  }
+
+  const handleUninstall = async (instanceId: string) => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/${instanceId}/uninstall`, {
+        method: 'POST',
+      })
+      if (!res.ok) throw new Error(await res.text())
+      loadInstances()
+    } catch (err) {
+      console.error('Uninstall failed:', err)
+    }
+  }
+
+  const handleToggle = async (instanceId: string, enabled: boolean) => {
+    try {
+      const res = await fetch(`/api/environments/${id}/nebula/${instanceId}/toggle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setInstances(prev =>
+        prev.map(i => i.id === instanceId ? { ...i, isEnabled: !i.isEnabled } : i)
+      )
+    } catch (err) {
+      console.error('Toggle failed:', err)
+    }
+  }
+
+  const installedInstances = instances.filter(i => i.isInstalled)
+  const availableDefs = novaDefs.filter(d => !installedInstances.some(i => i.sourceNovaId === d.id))
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <Cpu size={18} className="text-accent" />
+          <h1 className="text-sm font-semibold text-text-primary">Nebula</h1>
+          <p className="text-xs text-text-muted ml-2">Manage skills and hooks</p>
+        </div>
+        <button
+          onClick={() => { loadInstances(); loadNovaDefs() }}
+          className="p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-bg-raised transition-colors"
+          title="Refresh"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M23 4v6h-6M1 20v-6h6" />
+            <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex items-center gap-1 px-4 border-b border-border-subtle flex-shrink-0">
+        {[
+          { key: 'installed' as Tab, label: 'Installed', icon: Package, count: installedInstances.length },
+          { key: 'catalog' as Tab, label: 'Catalog', icon: Download, count: availableDefs.length },
+          { key: 'settings' as Tab, label: 'Settings', icon: Settings, count: instances.length },
+        ].map(({ key, label, icon: Icon, count }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`flex items-center gap-1.5 px-3 py-2 text-xs font-medium border-b-2 transition-colors ${
+              activeTab === key
+                ? 'border-accent text-accent'
+                : 'border-transparent text-text-muted hover:text-text-primary'
+            }`}
+          >
+            <Icon size={13} />
+            {label}
+            <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+              activeTab === key ? 'bg-accent/15 text-accent' : 'bg-bg-raised text-text-muted'
+            }`}>
+              {count}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="flex-1 overflow-auto p-4">
+        {activeTab === 'installed' && (
+          <InstalledTab
+            instances={installedInstances}
+            onInstall={(novaId, name) => handleInstall(novaId, name)}
+            onUninstall={handleUninstall}
+          />
+        )}
+        {activeTab === 'catalog' && (
+          <CatalogTab
+            definitions={availableDefs}
+            onInstall={handleInstall}
+          />
+        )}
+        {activeTab === 'settings' && (
+          <SettingsTab
+            instances={instances}
+            onToggle={handleToggle}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Installed Tab ────────────────────────────────────────────────────────────────
+
+function InstalledTab({
+  instances,
+  onInstall,
+  onUninstall,
+}: {
+  instances: NebulaInstance[]
+  onInstall: (novaId: string, name: string) => void
+  onUninstall: (id: string) => void
+}) {
+  if (instances.length === 0) {
+    return (
+      <div className="text-center py-12 text-text-muted text-sm">
+        No Nebula instances installed yet. Visit the Catalog to browse skills and hooks.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {instances.map(inst => (
+        <div
+          key={inst.id}
+          className="border border-border-subtle rounded-lg p-4 bg-bg-surface hover:border-accent/40 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            <div className={`p-2 rounded ${inst.category === 'skill' ? 'bg-green-500/20' : 'bg-orange-500/20'}`}>
+              {inst.category === 'skill' ? (
+                <Package size={16} className="text-green-400" />
+              ) : (
+                <Settings size={16} className="text-orange-400" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs font-medium text-text-primary truncate">{inst.name}</span>
+                {inst.isForked && (
+                  <span className="text-[9px] px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium">Fork</span>
+                )}
+              </div>
+              <span className={`text-[10px] px-1.5 py-0.5 rounded ${CATEGORY_COLORS[inst.category] || ''}`}>
+                {inst.category}
+              </span>
+            </div>
+          </div>
+
+          {inst.novaDefinition?.description && (
+            <p className="text-[10px] text-text-muted mt-2 line-clamp-2">{inst.novaDefinition.description}</p>
+          )}
+
+          {/* Stats */}
+          <div className="flex items-center gap-3 mt-3 text-[10px] text-text-muted">
+            <span className="flex items-center gap-1">
+              <CheckCircle size={10} className="text-green-400" />
+              {inst.hookLogs.length + inst.skillLogs.length} executions
+            </span>
+            {inst.isForked && (
+              <span className="flex items-center gap-1">
+                <Clock size={10} />
+                Forked
+              </span>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="mt-3 pt-3 border-t border-border-subtle">
+            <div className="flex gap-1.5">
+              <button
+                onClick={() => onUninstall(inst.id)}
+                className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-[11px] bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors"
+              >
+                <X size={11} />
+                Uninstall
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Catalog Tab ──────────────────────────────────────────────────────────────────
+
+function CatalogTab({
+  definitions,
+  onInstall,
+}: {
+  definitions: NovaDefinition[]
+  onInstall: (novaId: string, name: string) => void
+}) {
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<string>('')
+
+  const filtered = definitions.filter(d => {
+    if (filter && d.category !== filter) return false
+    if (search) {
+      const q = search.toLowerCase()
+      return d.name.toLowerCase().includes(q) || d.title.toLowerCase().includes(q)
+    }
+    return true
+  })
+
+  const categories = Array.from(new Set(definitions.map(d => d.category)))
+
+  return (
+    <div className="space-y-3">
+      {/* Filters */}
+      <div className="flex gap-2 flex-wrap items-center">
+        <div className="flex-1 min-w-[200px] relative">
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search catalog..."
+            className="w-full px-3 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+          />
+        </div>
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className="px-2 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="">All Categories</option>
+          {categories.map(cat => (
+            <option key={cat} value={cat}>{cat}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filtered.map(def => (
+          <div
+            key={def.id}
+            className="border border-border-subtle rounded-lg p-4 bg-bg-surface hover:border-accent/40 transition-colors"
+          >
+            <div className="flex items-start gap-2.5">
+              <div className={`p-2 rounded ${def.category === 'skill' ? 'bg-green-500/20' : 'bg-orange-500/20'}`}>
+                {def.category === 'skill' ? (
+                  <Package size={16} className="text-green-400" />
+                ) : (
+                  <Settings size={16} className="text-orange-400" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-xs font-medium text-text-primary truncate">{def.title}</span>
+                  <span className={`text-[10px] px-1.5 py-0.5 rounded ${CATEGORY_COLORS[def.category] || ''}`}>
+                    {def.category}
+                  </span>
+                </div>
+                {def.description && (
+                  <p className="text-[10px] text-text-muted mt-1 line-clamp-2">{def.description}</p>
+                )}
+              </div>
+            </div>
+
+            <button
+              onClick={() => onInstall(def.id, def.name)}
+              className="mt-3 w-full flex items-center justify-center gap-1.5 px-3 py-1.5 rounded text-xs bg-accent/15 text-accent hover:bg-accent/25 transition-colors"
+            >
+              <Download size={12} />
+              Install
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-text-muted text-sm">
+          No catalog items match your filters.
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Settings Tab ─────────────────────────────────────────────────────────────────
+
+function SettingsTab({
+  instances,
+  onToggle,
+}: {
+  instances: NebulaInstance[]
+  onToggle: (id: string, enabled: boolean) => void
+}) {
+  if (instances.length === 0) {
+    return (
+      <div className="text-center py-12 text-text-muted text-sm">
+        No Nebula instances to configure.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {instances.map(inst => (
+        <div
+          key={inst.id}
+          className="flex items-center justify-between px-4 py-3 border border-border-subtle rounded-lg bg-bg-surface"
+        >
+          <div className="flex items-center gap-3">
+            <div className={`p-2 rounded ${inst.category === 'skill' ? 'bg-green-500/20' : 'bg-orange-500/20'}`}>
+              {inst.category === 'skill' ? (
+                <Package size={14} className="text-green-400" />
+              ) : (
+                <Settings size={14} className="text-orange-400" />
+              )}
+            </div>
+            <div>
+              <div className="text-xs font-medium text-text-primary">{inst.name}</div>
+              <span className={`text-[10px] px-1.5 py-0.5 rounded ${CATEGORY_COLORS[inst.category] || ''}`}>
+                {inst.category}
+              </span>
+              {inst.isForked && (
+                <span className="text-[10px] text-purple-400 ml-2">Forked</span>
+              )}
+            </div>
+          </div>
+
+          {/* Toggle */}
+          <button
+            onClick={() => onToggle(inst.id, !inst.isEnabled)}
+            className={`relative w-10 h-5 rounded-full transition-colors ${
+              inst.isEnabled ? 'bg-green-500/30' : 'bg-bg-raised border border-border-visible'
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 w-4 h-4 rounded-full transition-transform ${
+                inst.isEnabled
+                  ? 'translate-x-5 bg-green-400'
+                  : 'translate-x-0.5 bg-text-muted'
+              }`}
+            />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/environments/[id]/nebula/page.tsx
+++ b/apps/web/src/app/(app)/environments/[id]/nebula/page.tsx
@@ -50,17 +50,19 @@ export default function NebulaPage() {
 
   const loadInstances = async () => {
     try {
-      const res = await fetch(`/api/environments/${id}/nebula/instances`)
+      const res = await fetch(`/api/environments/${id}/nebula`)
       const data = await res.json()
-      setInstances(data.instances || [])
+      // GET /api/environments/[id]/nebula returns an array directly
+      setInstances(Array.isArray(data) ? data : (data.instances || []))
     } catch { /* ignore */ }
   }
 
   const loadNovaDefs = async () => {
     try {
-      const res = await fetch(`/api/environments/${id}/nebula/catalog`)
+      const res = await fetch(`/api/environments/${id}/nebula/discovery`)
       const data = await res.json()
-      setNovaDefs(data.definitions || [])
+      // GET /api/environments/[id]/nebula/discovery returns { defaults, installed, active }
+      setNovaDefs(data.defaults || data.definitions || [])
     } catch { /* ignore */ }
   }
 


### PR DESCRIPTION
## Summary

Add 4 new UI pages:

### Nebula Page (`/environments/[id]/nebula`)
- **Installed** tab: Grid of Nebula instances with status, execution stats, install/uninstall
- **Catalog** tab: Browse NovaDefinitions with search and install
- **Settings** tab: Toggle enable/disable per Nebula instance

### Effectiveness Dashboard (`/environments/[id]/nebula/effectiveness`)
- Table: name, category, fireRate, successRate, needsTuning flag
- Color coding: green (healthy) / red (needs tuning)
- Summary cards (total, healthy, needsTuning)
- 30s auto-refresh

### Trace Timeline (`/conversations/[id]/traces`)
- Vertical timeline with step numbers, type icons, tool/skill/hook names
- Color-coded types: tool_call (blue), tool_result (green), skill_injected (purple), hook_triggered (orange), text_generation (gray), error (red)
- Collapsible detail panels, summary bar, filter by type

### Eval Dashboard (`/environments/[id]/evals`)
- Score overview cards: avg score, accuracy, safety, total evals
- CSS bar chart (no external dependencies) with score breakdown
- Filter by eval type and time window (7/30/90 days)
- Manual "Run Eval" button

---
Phase 12 of Hooks, Skills, Evals & Observability.
Depends on: PR #331 (Prisma schema), #334 (tracing+skill injection), #336 (evals API).