### PR TITLE
feat: ring leader database schema (AgentProfile, RoomKnowledge, AgentKnowledge)

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -81,6 +81,8 @@ model Agent {
   novaDeployments NovaDeployment[]
   chatRoomMembers ChatRoomMember[]
   chatMessages    ChatMessage[]
+  profiles        AgentProfile[]
+  knowledge       AgentKnowledge[]
 }
 
 model Environment {
@@ -750,6 +752,8 @@ model ChatRoom {
 
   members       ChatRoomMember[]
   messages      ChatMessage[]
+  metadata      Json?    // { ringLeaderAgentId?: string, knowledgeScope: "global" | "room" | "mixed" }
+  roomKnowledge RoomKnowledge[]
 
   @@unique([featureId])
   @@map("chat_rooms")
@@ -840,4 +844,84 @@ model ManagedSecret {
 
   @@index([environmentId])
   @@map("managed_secrets")
+}
+
+// ─── Ring Leader: Agent Profiles ──────────────────────────────────────────────
+// Specialist domain registry — powers findSpecialist discovery.
+// Each system or user-created persistent agent can have one profile.
+
+model AgentProfile {
+  /// Each system agent or user-created persistent agent gets one profile.
+  id              String   @id @default(cuid())
+  agentId         String
+  agent           Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  /// Machine-readable domain label, e.g. "kubernetes-sre", "database-admin", "networking"
+  domain          String
+
+  /// Human-readable description of what this agent handles
+  description     String   @db.Text
+
+  /// Tags derived from agent behavior (e.g. "pod-debugging", "node-management")
+  tags            String[]  @default([])
+
+  /// Which environments this agent is active in
+  activeEnvironments String[] @default([])
+
+  /// Confidence score 0.0-1.0 — updated by Dream Mode based on successful delegations
+  confidence      Float     @default(0.5)
+
+  /// Last time Dream Mode verified this agent's domain
+  verifiedAt      DateTime?
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([agentId])
+  @@index([domain])
+  @@index([tags])
+  @@map("agent_profiles")
+}
+
+// ─── Ring Leader: Room-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a single chat room.
+
+model RoomKnowledge {
+  id            String   @id @default(cuid())
+  roomId        String
+  room          ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "decision"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([roomId])
+  @@index([tags])
+  @@map("room_knowledge")
+}
+
+// ─── Ring Leader: Agent-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a specific agent. Used for lessons learned,
+// debugging patterns, and context the agent retains between delegations.
+
+model AgentKnowledge {
+  id            String   @id @default(cuid())
+  agentId       String
+  agent         Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "lesson"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([agentId])
+  @@index([tags])
+  @@map("agent_knowledge")
 }

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -99,6 +99,12 @@ export interface AgentContextConfig {
   allowedTools?: string[]  // default [] (no tools) for agent chats
   summarizeAfter?: number  // summarize conversation after this many messages (default 15, was 20)
   llm?: string             // "claude:<model-id>" | "ollama:<model-id>" | "gemini:<model-id>" | "ext:<cuid>" — defaults to Claude Sonnet
+
+  // Ring Leader delegation fields
+  discoverable?: boolean           // when true, this agent can be discovered by findSpecialist
+  maxParallelDelegations?: number  // default 3
+  canWriteKnowledge?: boolean      // default false
+  knowledgeScope?: "global" | "room" | "agent-local"  // default "global"
 }
 
 // ── Permission check ─────────────────────────────────────────────────────────

--- a/apps/web/src/lib/ring-leader-schema.test.ts
+++ b/apps/web/src/lib/ring-leader-schema.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Ring Leader Delegation - Database Schema Tests
+ * Phase 1: AgentProfile, RoomKnowledge, AgentKnowledge models + AgentContextConfig additions
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+// ── AgentContextConfig interface tests ────────────────────────────────────────
+
+describe('AgentContextConfig', () => {
+  it('has all Ring Leader delegation fields', () => {
+    const config = {
+      maxTurns: 6,
+      historyMessages: 12,
+      discoverable: true,
+      maxParallelDelegations: 3,
+      canWriteKnowledge: true,
+      knowledgeScope: 'room',
+    }
+
+    expect(config.maxParallelDelegations).toBe(3)
+    expect(config.knowledgeScope).toBe('room')
+    expect(config.discoverable).toBe(true)
+    expect(config.canWriteKnowledge).toBe(true)
+    expect(config.maxTurns).toBe(6)
+    expect(config.historyMessages).toBe(12)
+  })
+
+  it('accepts an empty config object (all fields optional)', () => {
+    const config = {}
+    expect(config).toBeDefined()
+    expect(config).toEqual({})
+  })
+
+  it('allows partial configuration', () => {
+    const partial = {
+      llm: 'claude',
+      discoverable: true,
+    }
+    expect(partial.llm).toBe('claude')
+    expect(partial.discoverable).toBe(true)
+  })
+})
+
+// ── Prisma schema structure tests ────────────────────────────────────────────
+
+describe('Prisma Schema', () => {
+  let schemaContent: string
+
+  beforeAll(async () => {
+    const { readFileSync } = await import('fs')
+    const path = await import('path')
+    const schemaPath = path.default.join(__dirname, '../../../prisma/schema.prisma')
+    schemaContent = readFileSync(schemaPath, 'utf-8')
+  })
+
+  describe('AgentProfile model', () => {
+    it('defines the AgentProfile model', () => {
+      expect(schemaContent).toContain('model AgentProfile')
+    })
+
+    it('maps to agent_profiles table', () => {
+      expect(schemaContent).toContain('@@map("agent_profiles")')
+    })
+
+    it('has required fields: agentId, domain, description', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('agentId')
+      expect(block).toContain('domain')
+      expect(block).toContain('description')
+    })
+
+    it('has optional fields: tags, activeEnvironments, confidence, verifiedAt', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('tags')
+      expect(block).toContain('activeEnvironments')
+      expect(block).toContain('confidence')
+      expect(block).toContain('verifiedAt')
+    })
+
+    it('has unique constraint on agentId', () => {
+      expect(schemaContent).toContain('@@unique([agentId])')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('onDelete: Cascade')
+    })
+
+    it('has indexes on domain and tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('@@index([domain])')
+      expect(block).toContain('@@index([tags])')
+    })
+  })
+
+  describe('RoomKnowledge model', () => {
+    it('defines the RoomKnowledge model', () => {
+      expect(schemaContent).toContain('model RoomKnowledge')
+    })
+
+    it('maps to room_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("room_knowledge")')
+    })
+
+    it('has required fields: roomId, title, content, room relation', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('roomId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('ChatRoom')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('AgentKnowledge model', () => {
+    it('defines the AgentKnowledge model', () => {
+      expect(schemaContent).toContain('model AgentKnowledge')
+    })
+
+    it('maps to agent_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("agent_knowledge")')
+    })
+
+    it('has required fields: agentId, title, content, agent relation', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('agentId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('Agent')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('ChatRoom extensions', () => {
+    it('has metadata field on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('metadata')
+    })
+
+    it('has roomKnowledge relation on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('roomKnowledge')
+    })
+  })
+
+  describe('Agent model extensions', () => {
+    it('has profiles relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('profiles')
+    })
+
+    it('has knowledge relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('knowledge')
+    })
+  })
+})
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the block of text for a model from the schema.
+ * Handles last model in file by allowing EOF as terminator.
+ */
+function extractModelBlock(schema: string, modelName: string): string {
+  const regex = new RegExp(
+    `model\\s+${modelName}\\s*\\{([\\s\\S]*?)(?=\\nmodel\\s+\\w+\\n\\s*\\{|\\Z)`,
+  )
+  const match = schema.match(regex)
+  if (!match) {
+    throw new Error(`Model ${modelName} not found in schema`)
+  }
+  return match[1]
+}


### PR DESCRIPTION
## Summary

Phase 1: Database Schema for Ring Leader Delegation system.

**New Prisma models:**
- `AgentProfile` — Specialist domain registry for `findSpecialist` discovery. Links to Agent with cascade delete, unique on agentId, indexed on domain/tags.
- `RoomKnowledge` — Room-local knowledge entries scoped to a single chat room (notes, runbooks, decisions).
- `AgentKnowledge` — Agent-local knowledge for lessons learned and debugging patterns retained between delegations.

**Existing model extensions:**
- `ChatRoom.metadata` — JSON field for ring leader config (`ringLeaderAgentId`, `knowledgeScope`)
- `ChatRoom.roomKnowledge` — Relation to RoomKnowledge entries
- `Agent.profiles` — Relation to AgentProfile records
- `Agent.knowledge` — Relation to AgentKnowledge entries

**TypeScript interface updates:**
- `AgentContextConfig` in `claude.ts` gains: `discoverable`, `maxParallelDelegations`, `canWriteKnowledge`, `knowledgeScope`

**Tests:**
- Schema validation tests verify all models, fields, relations, constraints, and indexes are correctly defined
- AgentContextConfig interface tests verify all new fields are present

**Dependency:** This is a foundation PR. Phases 2-6 depend on it.