### PR TITLE
feat: ring leader discovery tool (findSpecialist) + default agent profiles

### DIFF
--- a/apps/gateway/src/builtin-tools/discovery.test.ts
+++ b/apps/gateway/src/builtin-tools/discovery.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Discovery tool tests
+ * Tests the find_specialist scoring algorithm.
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+function scoreProfile(
+  query: string,
+  profile: { domain: string; description: string; tags: unknown[]; confidence: number },
+): number {
+  const q = query.toLowerCase()
+
+  let domainScore = 0
+  const domainLower = profile.domain.toLowerCase()
+  if (q.includes(domainLower)) domainScore = 0.8
+  else if (domainLower.includes(q)) domainScore = 0.5
+  else {
+    const qWords = q.split(/\s+/).filter(w => w.length > 2)
+    const domainWords = domainLower.split(/[-_\s]+/).filter(w => w.length > 2)
+    const matching = qWords.filter(w => domainWords.some(dw => dw.includes(w) || w.includes(dw))).length
+    if (qWords.length > 0) domainScore = (matching / qWords.length) * 0.5
+  }
+
+  const tags = Array.isArray(profile.tags) ? (profile.tags as string[]).map(t => t.toLowerCase()) : []
+  const qWords = q.split(/\s+/).filter(w => w.length > 2)
+  let tagScore = 0
+  if (qWords.length > 0 && tags.length > 0) {
+    const matching = qWords.filter(w => tags.some(t => t.includes(w) || w.includes(t))).length
+    tagScore = (matching / qWords.length) * 0.3
+  }
+
+  const profileConfidence = (profile.confidence ?? 0.5) * 0.2
+
+  return Math.min(domainScore + tagScore + profileConfidence, 1.0)
+}
+
+describe('find_specialist scoring', () => {
+  const makeProfile = (overrides: Partial<{ domain: string; description: string; tags: unknown[]; confidence: number }>) => ({
+    domain: 'general',
+    description: '',
+    tags: [],
+    confidence: 0.5,
+    ...overrides,
+  })
+
+  it('gives high score for exact domain match', () => {
+    const s = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre' }))
+    expect(s).toBeGreaterThan(0.8)
+  })
+
+  it('gives strong score for substring domain match', () => {
+    const s = scoreProfile('kubernetes', makeProfile({ domain: 'kubernetes-sre' }))
+    expect(s).toBeGreaterThan(0.5)
+  })
+
+  it('gives partial score for keyword overlap in domain', () => {
+    const s = scoreProfile('pod debugging restart', makeProfile({ domain: 'pod-debugging' }))
+    // "pod" matches "pod-debugging", "debugging" matches "pod-debugging", "restart" doesn't
+    expect(s).toBeGreaterThan(0.1)
+  })
+
+  it('gives bonus score for tag matching', () => {
+    const s = scoreProfile('testing code review', makeProfile({
+      tags: ['testing', 'code-review', 'deployment'],
+      confidence: 1.0,
+    }))
+    expect(s).toBeGreaterThan(0.5) // confidence alone gives 0.2 + tags give additional
+  })
+
+  it('weights confidence from profile', () => {
+    const sHigh = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre', confidence: 1.0 }))
+    const sLow = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre', confidence: 0.3 }))
+    expect(sHigh).toBeGreaterThan(sLow)
+  })
+
+  it('returns score capped at 1.0', () => {
+    const s = scoreProfile('kubernetes-sre', makeProfile({
+      domain: 'kubernetes-sre',
+      tags: ['kubernetes', 'sre'],
+      confidence: 1.0,
+    }))
+    expect(s).toBeLessThanOrEqual(1.0)
+  })
+
+  it('returns low score for unrelated query', () => {
+    const s = scoreProfile('database migration postgres', makeProfile({
+      domain: 'kubernetes-sre',
+      tags: ['pod-debugging', 'node-management'],
+      confidence: 0.5,
+    }))
+    expect(s).toBeLessThan(0.3)
+  })
+
+  it('ranks correct agent first in a multi-agent list', () => {
+    const agents = [
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'kubernetes-sre',
+        tags: ['pod-debugging', 'crash-loop'],
+        confidence: 0.8,
+      })),
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'qa-validation',
+        tags: ['testing', 'code-review'],
+        confidence: 0.9,
+      })),
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'pod-debugging',
+        tags: ['pod-debugging', 'crash-loop', 'restart'],
+        confidence: 0.95,
+      })),
+    ]
+
+    // The third profile (pod-debugging) should score highest
+    expect(agents[2]).toBeGreaterThanOrEqual(agents[0])
+    expect(agents[2]).toBeGreaterThanOrEqual(agents[1])
+  })
+})

--- a/apps/gateway/src/builtin-tools/discovery.ts
+++ b/apps/gateway/src/builtin-tools/discovery.ts
@@ -1,0 +1,178 @@
+/**
+ * Discovery MCP tools for the ORION mission control gateway.
+ *
+ * These tools let the ring leader discover specialist agents for delegation:
+ * - find_specialist: Search AgentProfile by domain, tags, and confidence
+ *
+ * The gateway calls ORION's web API at the configured ORION_URL
+ * (defaults to http://localhost:3000 if not set).
+ */
+
+const ORION_URL = process.env.ORION_URL ?? 'http://localhost:3000'
+const ORION_TOKEN = process.env.ORION_GATEWAY_TOKEN
+
+/**
+ * Fetch from ORION's API with basic error handling.
+ */
+async function orionFetch(path: string, options?: RequestInit): Promise<unknown> {
+  const url = `${ORION_URL}${path}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+
+  if (ORION_TOKEN) {
+    headers['Authorization'] = `Bearer ${ORION_TOKEN}`
+  }
+
+  const res = await fetch(url, {
+    ...options,
+    headers: { ...headers, ...(options?.headers as Record<string, string> || {}) },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`ORION ${path} returned ${res.status}: ${body.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+/**
+ * Score an agent profile against a query using keyword overlap + tag matching.
+ * Returns a score between 0 and 1.
+ */
+function scoreProfile(query: string, profile: {
+  domain: string
+  description: string
+  tags: unknown[]
+  confidence: number
+}): number {
+  const q = query.toLowerCase()
+
+  // Domain match (exact or substring)
+  const domainLower = profile.domain.toLowerCase()
+  let domainScore = 0
+  if (q.includes(domainLower)) domainScore = 0.8
+  else if (domainLower.includes(q)) domainScore = 0.5
+  else {
+    // Keyword overlap
+    const qWords = q.split(/\s+/).filter(w => w.length > 2)
+    const domainWords = domainLower.split(/[-_\s]+/).filter(w => w.length > 2)
+    const matching = qWords.filter(w => domainWords.some(dw => dw.includes(w) || w.includes(dw))).length
+    if (qWords.length > 0) domainScore = (matching / qWords.length) * 0.5
+  }
+
+  // Tag overlap
+  const tags = Array.isArray(profile.tags) ? (profile.tags as string[]).map(t => t.toLowerCase()) : []
+  const qWords = q.split(/\s+/).filter(w => w.length > 2)
+  let tagScore = 0
+  if (qWords.length > 0 && tags.length > 0) {
+    const matching = qWords.filter(w => tags.some(t => t.includes(w) || w.includes(t))).length
+    tagScore = (matching / qWords.length) * 0.3
+  }
+
+  // Confidence from profile
+  const profileConfidence = (profile.confidence ?? 0.5) * 0.2
+
+  return Math.min(domainScore + tagScore + profileConfidence, 1.0)
+}
+
+export const discoveryTools = [
+  {
+    name: 'find_specialist',
+    description: 'Discover which specialist agent should handle a given task. ' +
+      'Uses domain matching, tag-based fuzzy matching, and confidence scoring to ' +
+      'find the best agents for a given query. Use this before calling delegate() ' +
+      'when you are unsure which agent should handle a task.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Description of the task or problem. The ring leader fills this with the delegation objective.',
+        },
+        environment: {
+          type: 'string',
+          description: 'Optional environment name to filter by. If omitted, returns agents active everywhere.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of results. Default 3, max 5.',
+          default: 3,
+        },
+        minConfidence: {
+          type: 'number',
+          description: 'Minimum confidence threshold (0.0-1.0). Default 0.3.',
+          default: 0.3,
+        },
+      },
+      required: ['query'],
+    },
+    async execute(args: Record<string, unknown>) {
+      const query = String(args.query)
+      const env = String(args.environment ?? '')
+      const limit = Math.min(Math.max(parseInt(String(args.limit ?? '3'), 10), 1), 5)
+      const minConf = Math.min(Math.max(parseFloat(String(args.minConfidence ?? '0.3')), 0), 1)
+
+      let profiles: Array<{
+        id: string
+        agentId: string
+        domain: string
+        description: string
+        tags: unknown[]
+        confidence: number
+        verifiedAt: string | null
+        agent: { name: string; status: string }
+      }>
+
+      try {
+        const result = await orionFetch(
+          `/api/environments/${env}/nebula/active`
+        )
+        // The API returns an array of nebula instances; we need AgentProfiles.
+        // Fall back to fetching all agents and their profiles.
+        const agentsResult = await orionFetch(`/api/agents?withProfiles=true`)
+        profiles = agentsResult as typeof profiles
+      } catch {
+        // If the API endpoints don't exist yet, return a helpful message
+        return `find_specialist: Unable to reach ORION API to fetch agent profiles. ` +
+          `Ensure AgentProfile records exist and the ORION_URL is configured correctly. ` +
+          `Agents are discovered via their AgentProfile records which store domain, tags, and confidence.`
+      }
+
+      if (!profiles || profiles.length === 0) {
+        return 'No specialist agents found. AgentProfile records must be created for discoverable agents.'
+      }
+
+      // Score and sort
+      const scored = profiles
+        .map(p => ({
+          ...p,
+          score: scoreProfile(query, p),
+        }))
+        .filter(p => p.score > 0 && (p.confidence ?? 0) >= minConf)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit)
+
+      if (scored.length === 0) {
+        return `No specialist agents matched the query "${query}" (minConfidence: ${minConf}). ` +
+          `Try broadening your query or lowering the confidence threshold.`
+      }
+
+      const lines: string[] = [`Found ${scored.length} specialist agent(s) for: "${query}"`]
+      lines.push('')
+
+      for (let i = 0; i < scored.length; i++) {
+        const p = scored[i]
+        lines.push(`--- #${i + 1} [${p.domain}] ${p.agent.name} ---`)
+        lines.push(`  agentId:      ${p.agentId}`)
+        lines.push(`  confidence:   ${(p.confidence * 100).toFixed(0)}%`)
+        lines.push(`  score:        ${(p.score * 100).toFixed(1)}%`)
+        lines.push(`  status:       ${p.agent.status}`)
+        lines.push(`  description:  ${p.description.slice(0, 200)}`)
+        if (Array.isArray(p.tags) && p.tags.length > 0) {
+          lines.push(`  tags:         ${(p.tags as string[]).join(', ')}`)
+        }
+        lines.push('')
+      }
+
+      return lines.join('\n')
+    },
+  },
+]

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -51,6 +51,7 @@ import { dockerTools } from './builtin-tools/docker.js'
 import { localhostTools } from './builtin-tools/localhost.js'
 import { talosTools } from './builtin-tools/talos.js'
 import { knowledgeGraphTools } from './builtin-tools/knowledge-graph.js'
+import { discoveryTools } from './builtin-tools/discovery.js'
 import { ArgoCDWatcher } from './argocd-watcher.js'
 import { IngressWatcher } from './ingress-watcher.js'
 
@@ -265,8 +266,8 @@ function registerBuiltins(tools: BuiltinTool[]) {
   for (const t of tools) BUILTIN_REGISTRY[t.name] = t
 }
 
-if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools) }
-if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools)
+if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools); registerBuiltins(discoveryTools) }
+if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools); registerBuiltins(discoveryTools)
 // localhost = the gateway co-located with ORION on the management host.
 // It can talk to the local cluster directly, so it gets the full cluster + talos toolset
 // plus docker/localhost tools for managing the host itself.
@@ -276,6 +277,7 @@ if (GATEWAY_TYPE === 'localhost') {
   registerBuiltins(talosTools)
   registerBuiltins(dockerTools)
   registerBuiltins(localhostTools)
+  registerBuiltins(discoveryTools)
 }
 // Cluster gateways also expose docker if desired
 if (GATEWAY_TYPE === 'cluster' && process.env.ENABLE_DOCKER === 'true') registerBuiltins(dockerTools)

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -81,6 +81,8 @@ model Agent {
   novaDeployments NovaDeployment[]
   chatRoomMembers ChatRoomMember[]
   chatMessages    ChatMessage[]
+  profiles        AgentProfile[]
+  knowledge       AgentKnowledge[]
 }
 
 model Environment {
@@ -750,6 +752,8 @@ model ChatRoom {
 
   members       ChatRoomMember[]
   messages      ChatMessage[]
+  metadata      Json?    // { ringLeaderAgentId?: string, knowledgeScope: "global" | "room" | "mixed" }
+  roomKnowledge RoomKnowledge[]
 
   @@unique([featureId])
   @@map("chat_rooms")
@@ -840,4 +844,84 @@ model ManagedSecret {
 
   @@index([environmentId])
   @@map("managed_secrets")
+}
+
+// ─── Ring Leader: Agent Profiles ──────────────────────────────────────────────
+// Specialist domain registry — powers findSpecialist discovery.
+// Each system or user-created persistent agent can have one profile.
+
+model AgentProfile {
+  /// Each system agent or user-created persistent agent gets one profile.
+  id              String   @id @default(cuid())
+  agentId         String
+  agent           Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  /// Machine-readable domain label, e.g. "kubernetes-sre", "database-admin", "networking"
+  domain          String
+
+  /// Human-readable description of what this agent handles
+  description     String   @db.Text
+
+  /// Tags derived from agent behavior (e.g. "pod-debugging", "node-management")
+  tags            String[]  @default([])
+
+  /// Which environments this agent is active in
+  activeEnvironments String[] @default([])
+
+  /// Confidence score 0.0-1.0 — updated by Dream Mode based on successful delegations
+  confidence      Float     @default(0.5)
+
+  /// Last time Dream Mode verified this agent's domain
+  verifiedAt      DateTime?
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([agentId])
+  @@index([domain])
+  @@index([tags])
+  @@map("agent_profiles")
+}
+
+// ─── Ring Leader: Room-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a single chat room.
+
+model RoomKnowledge {
+  id            String   @id @default(cuid())
+  roomId        String
+  room          ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "decision"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([roomId])
+  @@index([tags])
+  @@map("room_knowledge")
+}
+
+// ─── Ring Leader: Agent-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a specific agent. Used for lessons learned,
+// debugging patterns, and context the agent retains between delegations.
+
+model AgentKnowledge {
+  id            String   @id @default(cuid())
+  agentId       String
+  agent         Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "lesson"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([agentId])
+  @@index([tags])
+  @@map("agent_knowledge")
 }

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -99,6 +99,12 @@ export interface AgentContextConfig {
   allowedTools?: string[]  // default [] (no tools) for agent chats
   summarizeAfter?: number  // summarize conversation after this many messages (default 15, was 20)
   llm?: string             // "claude:<model-id>" | "ollama:<model-id>" | "gemini:<model-id>" | "ext:<cuid>" — defaults to Claude Sonnet
+
+  // Ring Leader delegation fields
+  discoverable?: boolean           // when true, this agent can be discovered by findSpecialist
+  maxParallelDelegations?: number  // default 3
+  canWriteKnowledge?: boolean      // default false
+  knowledgeScope?: "global" | "room" | "agent-local"  // default "global"
 }
 
 // ── Permission check ─────────────────────────────────────────────────────────

--- a/apps/web/src/lib/ring-leader-schema.test.ts
+++ b/apps/web/src/lib/ring-leader-schema.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Ring Leader Delegation - Database Schema Tests
+ * Phase 1: AgentProfile, RoomKnowledge, AgentKnowledge models + AgentContextConfig additions
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+// ── AgentContextConfig interface tests ────────────────────────────────────────
+
+describe('AgentContextConfig', () => {
+  it('has all Ring Leader delegation fields', () => {
+    const config = {
+      maxTurns: 6,
+      historyMessages: 12,
+      discoverable: true,
+      maxParallelDelegations: 3,
+      canWriteKnowledge: true,
+      knowledgeScope: 'room',
+    }
+
+    expect(config.maxParallelDelegations).toBe(3)
+    expect(config.knowledgeScope).toBe('room')
+    expect(config.discoverable).toBe(true)
+    expect(config.canWriteKnowledge).toBe(true)
+    expect(config.maxTurns).toBe(6)
+    expect(config.historyMessages).toBe(12)
+  })
+
+  it('accepts an empty config object (all fields optional)', () => {
+    const config = {}
+    expect(config).toBeDefined()
+    expect(config).toEqual({})
+  })
+
+  it('allows partial configuration', () => {
+    const partial = {
+      llm: 'claude',
+      discoverable: true,
+    }
+    expect(partial.llm).toBe('claude')
+    expect(partial.discoverable).toBe(true)
+  })
+})
+
+// ── Prisma schema structure tests ────────────────────────────────────────────
+
+describe('Prisma Schema', () => {
+  let schemaContent: string
+
+  beforeAll(async () => {
+    const { readFileSync } = await import('fs')
+    const path = await import('path')
+    const schemaPath = path.default.join(__dirname, '../../../prisma/schema.prisma')
+    schemaContent = readFileSync(schemaPath, 'utf-8')
+  })
+
+  describe('AgentProfile model', () => {
+    it('defines the AgentProfile model', () => {
+      expect(schemaContent).toContain('model AgentProfile')
+    })
+
+    it('maps to agent_profiles table', () => {
+      expect(schemaContent).toContain('@@map("agent_profiles")')
+    })
+
+    it('has required fields: agentId, domain, description', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('agentId')
+      expect(block).toContain('domain')
+      expect(block).toContain('description')
+    })
+
+    it('has optional fields: tags, activeEnvironments, confidence, verifiedAt', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('tags')
+      expect(block).toContain('activeEnvironments')
+      expect(block).toContain('confidence')
+      expect(block).toContain('verifiedAt')
+    })
+
+    it('has unique constraint on agentId', () => {
+      expect(schemaContent).toContain('@@unique([agentId])')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('onDelete: Cascade')
+    })
+
+    it('has indexes on domain and tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('@@index([domain])')
+      expect(block).toContain('@@index([tags])')
+    })
+  })
+
+  describe('RoomKnowledge model', () => {
+    it('defines the RoomKnowledge model', () => {
+      expect(schemaContent).toContain('model RoomKnowledge')
+    })
+
+    it('maps to room_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("room_knowledge")')
+    })
+
+    it('has required fields: roomId, title, content, room relation', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('roomId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('ChatRoom')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('AgentKnowledge model', () => {
+    it('defines the AgentKnowledge model', () => {
+      expect(schemaContent).toContain('model AgentKnowledge')
+    })
+
+    it('maps to agent_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("agent_knowledge")')
+    })
+
+    it('has required fields: agentId, title, content, agent relation', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('agentId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('Agent')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('ChatRoom extensions', () => {
+    it('has metadata field on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('metadata')
+    })
+
+    it('has roomKnowledge relation on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('roomKnowledge')
+    })
+  })
+
+  describe('Agent model extensions', () => {
+    it('has profiles relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('profiles')
+    })
+
+    it('has knowledge relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('knowledge')
+    })
+  })
+})
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the block of text for a model from the schema.
+ * Handles last model in file by allowing EOF as terminator.
+ */
+function extractModelBlock(schema: string, modelName: string): string {
+  const regex = new RegExp(
+    `model\\s+${modelName}\\s*\\{([\\s\\S]*?)(?=\\nmodel\\s+\\w+\\n\\s*\\{|\\Z)`,
+  )
+  const match = schema.match(regex)
+  if (!match) {
+    throw new Error(`Model ${modelName} not found in schema`)
+  }
+  return match[1]
+}

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -707,6 +707,65 @@ export async function ensureSystemAgents(): Promise<void> {
       }).catch(() => {})
     }
   }
+
+  // Seed AgentProfile records for system agents (ring leader delegation)
+  const PROFILE_DEFS: Array<{ agentName: string; domain: string; description: string; tags: string[] }> = [
+    {
+      agentName: 'Alpha',
+      domain: 'system-coordinator',
+      description: 'Team coordination, task assignment, escalation management, and workflow orchestration.',
+      tags: ['task-assignment', 'escalation', 'workflow', 'coordination'],
+    },
+    {
+      agentName: 'Veritas',
+      domain: 'qa-validation',
+      description: 'Testing, code review, deployment validation, and quality assurance gates.',
+      tags: ['testing', 'code-review', 'deployment-validation', 'quality-assurance'],
+    },
+    {
+      agentName: 'Planner',
+      domain: 'planning',
+      description: 'Architecture design, project planning, task breakdown, and milestone tracking.',
+      tags: ['architecture', 'project-planning', 'task-breakdown', 'milestones'],
+    },
+    {
+      agentName: 'Atlas',
+      domain: 'environment-management',
+      description: 'Environment management, connectors, bootstrap, and infrastructure provisioning.',
+      tags: ['environments', 'connectors', 'bootstrap', 'infrastructure'],
+    },
+    {
+      agentName: 'Pulse',
+      domain: 'cluster-health',
+      description: 'Cluster monitoring, ingress management, SSL certificates, and health checks.',
+      tags: ['monitoring', 'ingress', 'ssl', 'health-checks'],
+    },
+    {
+      agentName: 'Mentor',
+      domain: 'agent-coaching',
+      description: 'Prompt engineering, agent performance optimization, training, and coaching.',
+      tags: ['prompt-improvement', 'agent-performance', 'training', 'coaching'],
+    },
+  ]
+
+  for (const pd of PROFILE_DEFS) {
+    const agent = await prisma.agent.findUnique({ where: { name: pd.agentName }, select: { id: true } })
+    if (!agent) continue
+
+    await prisma.agentProfile.upsert({
+      where: { agentId: agent.id },
+      update: {},
+      create: {
+        agentId:     agent.id,
+        domain:      pd.domain,
+        description: pd.description,
+        tags:        pd.tags,
+        confidence:  0.5,
+      },
+    }).catch(() => {})
+
+    console.log(`[seed] AgentProfile: ${pd.agentName} → ${pd.domain}`)
+  }
 }
 
 // ── Planner lookup helper ──────────────────────────────────────────────────────

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -2320,3 +2320,112 @@ registerTool({
     ].join('\n')
   },
 })
+
+// ── Ring Leader: findSpecialist ──────────────────────────────────────────────
+
+registerTool({
+  name: 'find_specialist',
+  description: 'Discover which specialist agent should handle a given task. ' +
+    'Searches AgentProfile records by domain, tags, and confidence scoring. ' +
+    'Returns ranked results with agentId, domain, description, and confidence. ' +
+    'Use this before delegate() when you are unsure which agent should handle a task.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Description of the task or problem to find a specialist for.',
+      },
+      environment: {
+        type: 'string',
+        description: 'Optional environment name to filter by.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results (1-5, default 3).',
+        default: 3,
+      },
+      minConfidence: {
+        type: 'number',
+        description: 'Minimum confidence threshold (0.0-1.0, default 0.3).',
+        default: 0.3,
+      },
+    },
+    required: ['query'],
+  },
+  tier: 'read',
+  parallelSafe: true,
+  availableIn: 'task',
+  handler: async (args) => {
+    const { query, limit, minConfidence } = args as {
+      query?: string; environment?: string; limit?: number; minConfidence?: number
+    }
+
+    if (!query) return 'Error: query is required'
+
+    const q = query.toLowerCase()
+    const results = await prisma.agentProfile.findMany({
+      where: {
+        confidence: { gte: minConfidence ?? 0.3 },
+        ...(environment ? { activeEnvironments: { has: environment } } : {}),
+      },
+      include: { agent: { select: { name: true, status: true } } },
+      take: Math.min(Math.max(parseInt(String(limit ?? 3), 10), 1), 5),
+    })
+
+    // Score each profile
+    const scored = results.map((p: any) => {
+      const domainLower = p.domain.toLowerCase()
+      let score = 0
+
+      // Domain match
+      if (q.includes(domainLower)) score += 0.8
+      else if (domainLower.includes(q)) score += 0.5
+      else {
+        const qWords = q.split(/\s+/).filter((w: string) => w.length > 2)
+        const dWords = domainLower.split(/[-_\s]+/).filter((w: string) => w.length > 2)
+        const matching = qWords.filter((w: string) => dWords.some((dw: string) => dw.includes(w) || w.includes(dw))).length
+        if (qWords.length > 0) score += (matching / qWords.length) * 0.5
+      }
+
+      // Tag overlap
+      const tags = Array.isArray(p.tags) ? (p.tags as string[]).map((t: string) => t.toLowerCase()) : []
+      const qWords2 = q.split(/\s+/).filter((w: string) => w.length > 2)
+      if (qWords2.length > 0 && tags.length > 0) {
+        const matching = qWords2.filter((w: string) => tags.some((t: string) => t.includes(w) || w.includes(t))).length
+        score += (matching / qWords2.length) * 0.3
+      }
+
+      // Confidence weight
+      score += (p.confidence ?? 0.5) * 0.2
+
+      return { profile: p, score: Math.min(score, 1.0) }
+    })
+
+    // Sort by score descending
+    scored.sort((a, b) => b.score - a.score)
+
+    if (scored.length === 0) {
+      return `No specialist agents matched the query "${query}" (minConfidence: ${minConfidence ?? 0.3}).`
+    }
+
+    const lines: string[] = [`Found ${scored.length} specialist agent(s) for: "${query}"`]
+    lines.push('')
+
+    for (let i = 0; i < scored.length; i++) {
+      const { profile: p, score } = scored[i]
+      lines.push(`--- #${i + 1} [${p.domain}] ${p.agent.name} ---`)
+      lines.push(`  agentId:      ${p.agentId}`)
+      lines.push(`  confidence:   ${(p.confidence * 100).toFixed(0)}%`)
+      lines.push(`  score:        ${(score * 100).toFixed(1)}%`)
+      lines.push(`  status:       ${p.agent.status}`)
+      lines.push(`  description:  ${p.description.slice(0, 200)}`)
+      if (Array.isArray(p.tags) && p.tags.length > 0) {
+        lines.push(`  tags:         ${(p.tags as string[]).join(', ')}`)
+      }
+      lines.push('')
+    }
+
+    return lines.join('\n')
+  },
+})


### PR DESCRIPTION
## Summary

Phase 2: Discovery Tool for multi-agent delegation system.

**New files:**
- `discovery.ts` — find_specialist MCP tool for gateway with keyword overlap + tag matching scoring algorithm
- `discovery.test.ts` — unit tests for scoring algorithm

**Modified files:**
- `apps/gateway/src/index.ts` — register discovery tools for all gateway types
- `apps/web/src/lib/tool-registry.ts` — findSpecialist web tool with Prisma query
- `apps/web/src/lib/seed-system-agents.ts` — seed default AgentProfile records for all 6 system agents
- `apps/web/prisma/schema.prisma` + `claude.ts` — Phase 1 schema (cherry-picked)

**Agent profile defaults:**
- Alpha → system-coordinator
- Veritas → qa-validation
- Planner → planning
- Atlas → environment-management
- Pulse → cluster-health
- Mentor → agent-coaching

**Dependency:** Depends on PR #342 (Phase 1 schema).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
}