### PR TITLE
feat: ring leader delegation system with specialist routing (Phases 1-5)

### DIFF
--- a/apps/gateway/src/builtin-tools/discovery.test.ts
+++ b/apps/gateway/src/builtin-tools/discovery.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Discovery tool tests
+ * Tests the find_specialist scoring algorithm.
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+function scoreProfile(
+  query: string,
+  profile: { domain: string; description: string; tags: unknown[]; confidence: number },
+): number {
+  const q = query.toLowerCase()
+
+  let domainScore = 0
+  const domainLower = profile.domain.toLowerCase()
+  if (q.includes(domainLower)) domainScore = 0.8
+  else if (domainLower.includes(q)) domainScore = 0.5
+  else {
+    const qWords = q.split(/\s+/).filter(w => w.length > 2)
+    const domainWords = domainLower.split(/[-_\s]+/).filter(w => w.length > 2)
+    const matching = qWords.filter(w => domainWords.some(dw => dw.includes(w) || w.includes(dw))).length
+    if (qWords.length > 0) domainScore = (matching / qWords.length) * 0.5
+  }
+
+  const tags = Array.isArray(profile.tags) ? (profile.tags as string[]).map(t => t.toLowerCase()) : []
+  const qWords = q.split(/\s+/).filter(w => w.length > 2)
+  let tagScore = 0
+  if (qWords.length > 0 && tags.length > 0) {
+    const matching = qWords.filter(w => tags.some(t => t.includes(w) || w.includes(t))).length
+    tagScore = (matching / qWords.length) * 0.3
+  }
+
+  const profileConfidence = (profile.confidence ?? 0.5) * 0.2
+
+  return Math.min(domainScore + tagScore + profileConfidence, 1.0)
+}
+
+describe('find_specialist scoring', () => {
+  const makeProfile = (overrides: Partial<{ domain: string; description: string; tags: unknown[]; confidence: number }>) => ({
+    domain: 'general',
+    description: '',
+    tags: [],
+    confidence: 0.5,
+    ...overrides,
+  })
+
+  it('gives high score for exact domain match', () => {
+    const s = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre' }))
+    expect(s).toBeGreaterThan(0.8)
+  })
+
+  it('gives strong score for substring domain match', () => {
+    const s = scoreProfile('kubernetes', makeProfile({ domain: 'kubernetes-sre' }))
+    expect(s).toBeGreaterThan(0.5)
+  })
+
+  it('gives partial score for keyword overlap in domain', () => {
+    const s = scoreProfile('pod debugging restart', makeProfile({ domain: 'pod-debugging' }))
+    // "pod" matches "pod-debugging", "debugging" matches "pod-debugging", "restart" doesn't
+    expect(s).toBeGreaterThan(0.1)
+  })
+
+  it('gives bonus score for tag matching', () => {
+    const s = scoreProfile('testing code review', makeProfile({
+      tags: ['testing', 'code-review', 'deployment'],
+      confidence: 1.0,
+    }))
+    expect(s).toBeGreaterThan(0.5) // confidence alone gives 0.2 + tags give additional
+  })
+
+  it('weights confidence from profile', () => {
+    const sHigh = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre', confidence: 1.0 }))
+    const sLow = scoreProfile('kubernetes-sre', makeProfile({ domain: 'kubernetes-sre', confidence: 0.3 }))
+    expect(sHigh).toBeGreaterThan(sLow)
+  })
+
+  it('returns score capped at 1.0', () => {
+    const s = scoreProfile('kubernetes-sre', makeProfile({
+      domain: 'kubernetes-sre',
+      tags: ['kubernetes', 'sre'],
+      confidence: 1.0,
+    }))
+    expect(s).toBeLessThanOrEqual(1.0)
+  })
+
+  it('returns low score for unrelated query', () => {
+    const s = scoreProfile('database migration postgres', makeProfile({
+      domain: 'kubernetes-sre',
+      tags: ['pod-debugging', 'node-management'],
+      confidence: 0.5,
+    }))
+    expect(s).toBeLessThan(0.3)
+  })
+
+  it('ranks correct agent first in a multi-agent list', () => {
+    const agents = [
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'kubernetes-sre',
+        tags: ['pod-debugging', 'crash-loop'],
+        confidence: 0.8,
+      })),
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'qa-validation',
+        tags: ['testing', 'code-review'],
+        confidence: 0.9,
+      })),
+      scoreProfile('fix pod crash loop', makeProfile({
+        domain: 'pod-debugging',
+        tags: ['pod-debugging', 'crash-loop', 'restart'],
+        confidence: 0.95,
+      })),
+    ]
+
+    // The third profile (pod-debugging) should score highest
+    expect(agents[2]).toBeGreaterThanOrEqual(agents[0])
+    expect(agents[2]).toBeGreaterThanOrEqual(agents[1])
+  })
+})

--- a/apps/gateway/src/builtin-tools/discovery.ts
+++ b/apps/gateway/src/builtin-tools/discovery.ts
@@ -122,15 +122,12 @@ export const discoveryTools = [
       }>
 
       try {
-        const result = await orionFetch(
-          `/api/environments/${env}/nebula/active`
-        )
-        // The API returns an array of nebula instances; we need AgentProfiles.
-        // Fall back to fetching all agents and their profiles.
-        const agentsResult = await orionFetch(`/api/agents?withProfiles=true`)
-        profiles = agentsResult as typeof profiles
+        // Query agent profiles directly; optionally filter by environment
+        const qs = env ? `?environmentId=${encodeURIComponent(env)}` : ''
+        const result = await orionFetch(`/api/agent-profiles${qs}`)
+        profiles = result as typeof profiles
       } catch {
-        // If the API endpoints don't exist yet, return a helpful message
+        // If the API endpoint doesn't exist yet, return a helpful message
         return `find_specialist: Unable to reach ORION API to fetch agent profiles. ` +
           `Ensure AgentProfile records exist and the ORION_URL is configured correctly. ` +
           `Agents are discovered via their AgentProfile records which store domain, tags, and confidence.`

--- a/apps/gateway/src/builtin-tools/discovery.ts
+++ b/apps/gateway/src/builtin-tools/discovery.ts
@@ -1,0 +1,178 @@
+/**
+ * Discovery MCP tools for the ORION mission control gateway.
+ *
+ * These tools let the ring leader discover specialist agents for delegation:
+ * - find_specialist: Search AgentProfile by domain, tags, and confidence
+ *
+ * The gateway calls ORION's web API at the configured ORION_URL
+ * (defaults to http://localhost:3000 if not set).
+ */
+
+const ORION_URL = process.env.ORION_URL ?? 'http://localhost:3000'
+const ORION_TOKEN = process.env.ORION_GATEWAY_TOKEN
+
+/**
+ * Fetch from ORION's API with basic error handling.
+ */
+async function orionFetch(path: string, options?: RequestInit): Promise<unknown> {
+  const url = `${ORION_URL}${path}`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+
+  if (ORION_TOKEN) {
+    headers['Authorization'] = `Bearer ${ORION_TOKEN}`
+  }
+
+  const res = await fetch(url, {
+    ...options,
+    headers: { ...headers, ...(options?.headers as Record<string, string> || {}) },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`ORION ${path} returned ${res.status}: ${body.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+/**
+ * Score an agent profile against a query using keyword overlap + tag matching.
+ * Returns a score between 0 and 1.
+ */
+function scoreProfile(query: string, profile: {
+  domain: string
+  description: string
+  tags: unknown[]
+  confidence: number
+}): number {
+  const q = query.toLowerCase()
+
+  // Domain match (exact or substring)
+  const domainLower = profile.domain.toLowerCase()
+  let domainScore = 0
+  if (q.includes(domainLower)) domainScore = 0.8
+  else if (domainLower.includes(q)) domainScore = 0.5
+  else {
+    // Keyword overlap
+    const qWords = q.split(/\s+/).filter(w => w.length > 2)
+    const domainWords = domainLower.split(/[-_\s]+/).filter(w => w.length > 2)
+    const matching = qWords.filter(w => domainWords.some(dw => dw.includes(w) || w.includes(dw))).length
+    if (qWords.length > 0) domainScore = (matching / qWords.length) * 0.5
+  }
+
+  // Tag overlap
+  const tags = Array.isArray(profile.tags) ? (profile.tags as string[]).map(t => t.toLowerCase()) : []
+  const qWords = q.split(/\s+/).filter(w => w.length > 2)
+  let tagScore = 0
+  if (qWords.length > 0 && tags.length > 0) {
+    const matching = qWords.filter(w => tags.some(t => t.includes(w) || w.includes(t))).length
+    tagScore = (matching / qWords.length) * 0.3
+  }
+
+  // Confidence from profile
+  const profileConfidence = (profile.confidence ?? 0.5) * 0.2
+
+  return Math.min(domainScore + tagScore + profileConfidence, 1.0)
+}
+
+export const discoveryTools = [
+  {
+    name: 'find_specialist',
+    description: 'Discover which specialist agent should handle a given task. ' +
+      'Uses domain matching, tag-based fuzzy matching, and confidence scoring to ' +
+      'find the best agents for a given query. Use this before calling delegate() ' +
+      'when you are unsure which agent should handle a task.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Description of the task or problem. The ring leader fills this with the delegation objective.',
+        },
+        environment: {
+          type: 'string',
+          description: 'Optional environment name to filter by. If omitted, returns agents active everywhere.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of results. Default 3, max 5.',
+          default: 3,
+        },
+        minConfidence: {
+          type: 'number',
+          description: 'Minimum confidence threshold (0.0-1.0). Default 0.3.',
+          default: 0.3,
+        },
+      },
+      required: ['query'],
+    },
+    async execute(args: Record<string, unknown>) {
+      const query = String(args.query)
+      const env = String(args.environment ?? '')
+      const limit = Math.min(Math.max(parseInt(String(args.limit ?? '3'), 10), 1), 5)
+      const minConf = Math.min(Math.max(parseFloat(String(args.minConfidence ?? '0.3')), 0), 1)
+
+      let profiles: Array<{
+        id: string
+        agentId: string
+        domain: string
+        description: string
+        tags: unknown[]
+        confidence: number
+        verifiedAt: string | null
+        agent: { name: string; status: string }
+      }>
+
+      try {
+        const result = await orionFetch(
+          `/api/environments/${env}/nebula/active`
+        )
+        // The API returns an array of nebula instances; we need AgentProfiles.
+        // Fall back to fetching all agents and their profiles.
+        const agentsResult = await orionFetch(`/api/agents?withProfiles=true`)
+        profiles = agentsResult as typeof profiles
+      } catch {
+        // If the API endpoints don't exist yet, return a helpful message
+        return `find_specialist: Unable to reach ORION API to fetch agent profiles. ` +
+          `Ensure AgentProfile records exist and the ORION_URL is configured correctly. ` +
+          `Agents are discovered via their AgentProfile records which store domain, tags, and confidence.`
+      }
+
+      if (!profiles || profiles.length === 0) {
+        return 'No specialist agents found. AgentProfile records must be created for discoverable agents.'
+      }
+
+      // Score and sort
+      const scored = profiles
+        .map(p => ({
+          ...p,
+          score: scoreProfile(query, p),
+        }))
+        .filter(p => p.score > 0 && (p.confidence ?? 0) >= minConf)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit)
+
+      if (scored.length === 0) {
+        return `No specialist agents matched the query "${query}" (minConfidence: ${minConf}). ` +
+          `Try broadening your query or lowering the confidence threshold.`
+      }
+
+      const lines: string[] = [`Found ${scored.length} specialist agent(s) for: "${query}"`]
+      lines.push('')
+
+      for (let i = 0; i < scored.length; i++) {
+        const p = scored[i]
+        lines.push(`--- #${i + 1} [${p.domain}] ${p.agent.name} ---`)
+        lines.push(`  agentId:      ${p.agentId}`)
+        lines.push(`  confidence:   ${(p.confidence * 100).toFixed(0)}%`)
+        lines.push(`  score:        ${(p.score * 100).toFixed(1)}%`)
+        lines.push(`  status:       ${p.agent.status}`)
+        lines.push(`  description:  ${p.description.slice(0, 200)}`)
+        if (Array.isArray(p.tags) && p.tags.length > 0) {
+          lines.push(`  tags:         ${(p.tags as string[]).join(', ')}`)
+        }
+        lines.push('')
+      }
+
+      return lines.join('\n')
+    },
+  },
+]

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -51,6 +51,7 @@ import { dockerTools } from './builtin-tools/docker.js'
 import { localhostTools } from './builtin-tools/localhost.js'
 import { talosTools } from './builtin-tools/talos.js'
 import { knowledgeGraphTools } from './builtin-tools/knowledge-graph.js'
+import { discoveryTools } from './builtin-tools/discovery.js'
 import { ArgoCDWatcher } from './argocd-watcher.js'
 import { IngressWatcher } from './ingress-watcher.js'
 
@@ -265,8 +266,8 @@ function registerBuiltins(tools: BuiltinTool[]) {
   for (const t of tools) BUILTIN_REGISTRY[t.name] = t
 }
 
-if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools) }
-if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools)
+if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools); registerBuiltins(discoveryTools) }
+if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools); registerBuiltins(discoveryTools)
 // localhost = the gateway co-located with ORION on the management host.
 // It can talk to the local cluster directly, so it gets the full cluster + talos toolset
 // plus docker/localhost tools for managing the host itself.
@@ -276,6 +277,7 @@ if (GATEWAY_TYPE === 'localhost') {
   registerBuiltins(talosTools)
   registerBuiltins(dockerTools)
   registerBuiltins(localhostTools)
+  registerBuiltins(discoveryTools)
 }
 // Cluster gateways also expose docker if desired
 if (GATEWAY_TYPE === 'cluster' && process.env.ENABLE_DOCKER === 'true') registerBuiltins(dockerTools)

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -267,7 +267,7 @@ function registerBuiltins(tools: BuiltinTool[]) {
 }
 
 if (GATEWAY_TYPE === 'cluster')   { registerBuiltins(kubernetesTools); registerBuiltins(talosTools); registerBuiltins(knowledgeGraphTools); registerBuiltins(discoveryTools) }
-if (GATEWAY_TYPE === 'docker')    registerBuiltins(dockerTools); registerBuiltins(discoveryTools)
+if (GATEWAY_TYPE === 'docker')   { registerBuiltins(dockerTools); registerBuiltins(discoveryTools) }
 // localhost = the gateway co-located with ORION on the management host.
 // It can talk to the local cluster directly, so it gets the full cluster + talos toolset
 // plus docker/localhost tools for managing the host itself.

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -81,6 +81,8 @@ model Agent {
   novaDeployments NovaDeployment[]
   chatRoomMembers ChatRoomMember[]
   chatMessages    ChatMessage[]
+  profiles        AgentProfile[]
+  knowledge       AgentKnowledge[]
 }
 
 model Environment {
@@ -750,6 +752,8 @@ model ChatRoom {
 
   members       ChatRoomMember[]
   messages      ChatMessage[]
+  metadata      Json?    // { ringLeaderAgentId?: string, knowledgeScope: "global" | "room" | "mixed" }
+  roomKnowledge RoomKnowledge[]
 
   @@unique([featureId])
   @@map("chat_rooms")
@@ -840,4 +844,84 @@ model ManagedSecret {
 
   @@index([environmentId])
   @@map("managed_secrets")
+}
+
+// ─── Ring Leader: Agent Profiles ──────────────────────────────────────────────
+// Specialist domain registry — powers findSpecialist discovery.
+// Each system or user-created persistent agent can have one profile.
+
+model AgentProfile {
+  /// Each system agent or user-created persistent agent gets one profile.
+  id              String   @id @default(cuid())
+  agentId         String
+  agent           Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  /// Machine-readable domain label, e.g. "kubernetes-sre", "database-admin", "networking"
+  domain          String
+
+  /// Human-readable description of what this agent handles
+  description     String   @db.Text
+
+  /// Tags derived from agent behavior (e.g. "pod-debugging", "node-management")
+  tags            String[]  @default([])
+
+  /// Which environments this agent is active in
+  activeEnvironments String[] @default([])
+
+  /// Confidence score 0.0-1.0 — updated by Dream Mode based on successful delegations
+  confidence      Float     @default(0.5)
+
+  /// Last time Dream Mode verified this agent's domain
+  verifiedAt      DateTime?
+
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([agentId])
+  @@index([domain])
+  @@index([tags])
+  @@map("agent_profiles")
+}
+
+// ─── Ring Leader: Room-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a single chat room.
+
+model RoomKnowledge {
+  id            String   @id @default(cuid())
+  roomId        String
+  room          ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "decision"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([roomId])
+  @@index([tags])
+  @@map("room_knowledge")
+}
+
+// ─── Ring Leader: Agent-Local Knowledge ────────────────────────────────────────
+// Knowledge entries scoped to a specific agent. Used for lessons learned,
+// debugging patterns, and context the agent retains between delegations.
+
+model AgentKnowledge {
+  id            String   @id @default(cuid())
+  agentId       String
+  agent         Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  title         String
+  content       String   @db.Text
+  type          String   @default("note") // "note" | "runbook" | "context" | "lesson"
+  tags          Json?    // string[]
+
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([agentId])
+  @@index([tags])
+  @@map("agent_knowledge")
 }

--- a/apps/web/src/app/api/agent-profiles/route.ts
+++ b/apps/web/src/app/api/agent-profiles/route.ts
@@ -1,0 +1,47 @@
+/**
+ * /api/agent-profiles — List agent profiles for discovery.
+ *
+ * GET ?environmentId=<id> — returns all AgentProfiles, optionally filtered by
+ * active environment. Used by the gateway's find_specialist built-in tool.
+ *
+ * Response shape matches what discovery.ts expects:
+ *   { id, agentId, domain, description, tags, confidence, verifiedAt,
+ *     agent: { name, status } }
+ */
+
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireServiceAuth(req)
+  } catch {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const environmentId = searchParams.get('environmentId')
+
+  const profiles = await prisma.agentProfile.findMany({
+    where: environmentId
+      ? { activeEnvironments: { has: environmentId } }
+      : undefined,
+    select: {
+      id:                 true,
+      agentId:            true,
+      domain:             true,
+      description:        true,
+      tags:               true,
+      confidence:         true,
+      verifiedAt:         true,
+      activeEnvironments: true,
+      agent: {
+        select: { name: true, status: true },
+      },
+    },
+    orderBy: { confidence: 'desc' },
+  })
+
+  return Response.json(profiles)
+}

--- a/apps/web/src/app/api/knowledge/agent/route.ts
+++ b/apps/web/src/app/api/knowledge/agent/route.ts
@@ -1,0 +1,65 @@
+/**
+ * /api/knowledge/agent — Agent-scoped knowledge CRUD.
+ *
+ * GET  ?agentId=<id>&query=<text>  — search agent knowledge
+ * POST { agentId, title, content, type?, tags? } — create entry
+ */
+
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
+import { parseBodyOrError } from '@/lib/validate'
+
+const CreateAgentKnowledgeSchema = z.object({
+  agentId: z.string().min(1),
+  title:   z.string().min(1).max(500),
+  content: z.string().min(1),
+  type:    z.enum(['note', 'runbook', 'context', 'lesson']).optional().default('note'),
+  tags:    z.array(z.string()).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const user = await getCurrentUser()
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { searchParams } = new URL(req.url)
+  const query   = searchParams.get('query') ?? ''
+  const agentId = searchParams.get('agentId')
+
+  if (!agentId) return Response.json({ error: 'agentId required' }, { status: 400 })
+
+  const results = await prisma.agentKnowledge.findMany({
+    where: {
+      agentId,
+      ...(query
+        ? {
+            OR: [
+              { title:   { contains: query, mode: 'insensitive' } },
+              { content: { contains: query, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    },
+    take: 10,
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  return Response.json(results)
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getCurrentUser()
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const result = await parseBodyOrError(req, CreateAgentKnowledgeSchema)
+  if ('error' in result) return result.error
+
+  const { agentId, title, content, type, tags } = result.data
+
+  const entry = await prisma.agentKnowledge.create({
+    data: { agentId, title, content, type: type ?? 'note', tags: tags ?? [] },
+  })
+
+  return Response.json(entry, { status: 201 })
+}

--- a/apps/web/src/app/api/knowledge/room/route.ts
+++ b/apps/web/src/app/api/knowledge/room/route.ts
@@ -1,0 +1,65 @@
+/**
+ * /api/knowledge/room — Room-scoped knowledge CRUD.
+ *
+ * GET  ?roomId=<id>&query=<text>  — search room knowledge
+ * POST { roomId, title, content, type?, tags? } — create entry
+ */
+
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
+import { parseBodyOrError } from '@/lib/validate'
+
+const CreateRoomKnowledgeSchema = z.object({
+  roomId:  z.string().min(1),
+  title:   z.string().min(1).max(500),
+  content: z.string().min(1),
+  type:    z.enum(['note', 'runbook', 'context', 'decision']).optional().default('note'),
+  tags:    z.array(z.string()).optional(),
+})
+
+export async function GET(req: NextRequest) {
+  const user = await getCurrentUser()
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { searchParams } = new URL(req.url)
+  const query  = searchParams.get('query') ?? ''
+  const roomId = searchParams.get('roomId')
+
+  if (!roomId) return Response.json({ error: 'roomId required' }, { status: 400 })
+
+  const results = await prisma.roomKnowledge.findMany({
+    where: {
+      roomId,
+      ...(query
+        ? {
+            OR: [
+              { title:   { contains: query, mode: 'insensitive' } },
+              { content: { contains: query, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    },
+    take: 10,
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  return Response.json(results)
+}
+
+export async function POST(req: NextRequest) {
+  const user = await getCurrentUser()
+  if (!user) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const result = await parseBodyOrError(req, CreateRoomKnowledgeSchema)
+  if ('error' in result) return result.error
+
+  const { roomId, title, content, type, tags } = result.data
+
+  const entry = await prisma.roomKnowledge.create({
+    data: { roomId, title, content, type: type ?? 'note', tags: tags ?? [] },
+  })
+
+  return Response.json(entry, { status: 201 })
+}

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -101,3 +101,41 @@ export async function buildAgentContext(query: string): Promise<string> {
 export function invalidateSnapshotCache(): void {
   invalidate('snapshot')
 }
+
+export async function buildAgentLocalContext(agentId: string): Promise<string> {
+  try {
+    const knowledge = await prisma.agentKnowledge.findMany({
+      where: { agentId },
+      orderBy: { updatedAt: 'desc' },
+      take: 10,
+    })
+    if (knowledge.length === 0) return ''
+    const lines = knowledge.map(k => {
+      const tag = k.type !== 'note' ? ` [${k.type}]` : ''
+      return `### ${k.title}${tag}\n${k.content.slice(0, 2000)}`
+    })
+    return ['## Agent-Local Knowledge', ...lines].join('\n\n---\n\n')
+  } catch (err) {
+    console.warn('[agent-context] agent local knowledge fetch failed:', err)
+    return ''
+  }
+}
+
+export async function buildRoomLocalContext(roomId: string): Promise<string> {
+  try {
+    const knowledge = await prisma.roomKnowledge.findMany({
+      where: { roomId },
+      orderBy: { updatedAt: 'desc' },
+      take: 10,
+    })
+    if (knowledge.length === 0) return ''
+    const lines = knowledge.map(k => {
+      const tag = k.type !== 'note' ? ` [${k.type}]` : ''
+      return `### ${k.title}${tag}\n${k.content.slice(0, 2000)}`
+    })
+    return ['## Room Knowledge', ...lines].join('\n\n---\n\n')
+  } catch (err) {
+    console.warn('[agent-context] room local knowledge fetch failed:', err)
+    return ''
+  }
+}

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -99,6 +99,12 @@ export interface AgentContextConfig {
   allowedTools?: string[]  // default [] (no tools) for agent chats
   summarizeAfter?: number  // summarize conversation after this many messages (default 15, was 20)
   llm?: string             // "claude:<model-id>" | "ollama:<model-id>" | "gemini:<model-id>" | "ext:<cuid>" — defaults to Claude Sonnet
+
+  // Ring Leader delegation fields
+  discoverable?: boolean           // when true, this agent can be discovered by findSpecialist
+  maxParallelDelegations?: number  // default 3
+  canWriteKnowledge?: boolean      // default false
+  knowledgeScope?: "global" | "room" | "agent-local"  // default "global"
 }
 
 // ── Permission check ─────────────────────────────────────────────────────────

--- a/apps/web/src/lib/ring-leader-integration.test.ts
+++ b/apps/web/src/lib/ring-leader-integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for Phase 5: Ring Leader Integration.
+ *
+ * Tests cover:
+ * - Ring leader routing logic (only ring leader auto-replies, specialists on mention)
+ * - Specialist list building from AgentProfile
+ * - Ring leader system prompt template content
+ * - Agent context injection (specialist context for delegated tasks)
+ */
+
+// ── Ring leader routing logic (extracted from room-agents) ─────────────────────
+
+function determineTriggeredAgents(
+  agentMembers,
+  ringLeaderId,
+  mentionedNames,
+) {
+  const isEveryone = mentionedNames.some(n => n.toLowerCase() === 'everyone')
+  const hasSpecificMention = mentionedNames.length > 0 && !isEveryone
+  const isDirect = agentMembers.length === 1
+
+  // @everyone bypasses ring leader — targets all agents
+  if (isEveryone) return agentMembers
+
+  // Ring leader mode — only ring leader responds to non-mentioned messages
+  if (!hasSpecificMention && ringLeaderId) {
+    const ringLeader = agentMembers.find(a => a.id === ringLeaderId)
+    return ringLeader
+      ? [ringLeader]
+      : agentMembers.filter(a => !a.watchPrompt)
+  }
+
+  if (hasSpecificMention) {
+    return agentMembers.filter(a =>
+      mentionedNames.some(n => a.name.toLowerCase() === n.toLowerCase()),
+    )
+  }
+  if (isDirect) return agentMembers
+  return agentMembers.filter(a => !a.watchPrompt)
+}
+
+describe('Ring Leader Routing', () => {
+  const agents = [
+    { id: 'a1', name: 'Alpha', watchPrompt: true },
+    { id: 'a2', name: 'Atlas', watchPrompt: false },
+    { id: 'a3', name: 'Veritas', watchPrompt: false },
+  ]
+
+  it('ring leader mode - only ring leader replies to non-mentioned message', () => {
+    const result = determineTriggeredAgents(agents, 'a1', [])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a1')
+    expect(result[0].name).toBe('Alpha')
+  })
+
+  it('ring leader mode - @mention targets specific agents', () => {
+    const result = determineTriggeredAgents(agents, 'a1', ['Atlas'])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a2')
+  })
+
+  it('ring leader mode - @everyone targets all agents', () => {
+    const result = determineTriggeredAgents(agents, 'a1', ['everyone'])
+    expect(result).toHaveLength(3)
+  })
+
+  it('no ring leader - falls back to non-watcher agents', () => {
+    const result = determineTriggeredAgents(agents, undefined, [])
+    expect(result).toHaveLength(2) // Atlas and Veritas (not Alpha who has watchPrompt)
+  })
+
+  it('no ring leader - @mention targets specific agents', () => {
+    const result = determineTriggeredAgents(agents, undefined, ['Veritas'])
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('Veritas')
+  })
+
+  it('no ring leader, no non-watcher agents - returns empty', () => {
+    const watchersOnly = [
+      { id: 'a1', name: 'Alpha', watchPrompt: true },
+      { id: 'a2', name: 'Beta', watchPrompt: true },
+    ]
+    const result = determineTriggeredAgents(watchersOnly, undefined, [])
+    expect(result).toHaveLength(0)
+  })
+
+  it('ring leader not in members - falls back to non-watchers', () => {
+    const result = determineTriggeredAgents(agents, 'a999', [])
+    expect(result).toHaveLength(2) // Atlas and Veritas
+  })
+
+  it('ring leader is a watcher - still responds as ring leader', () => {
+    const watcherRingLeader = [
+      { id: 'a1', name: 'Alpha', watchPrompt: true },
+      { id: 'a2', name: 'Atlas', watchPrompt: false },
+    ]
+    const result = determineTriggeredAgents(watcherRingLeader, 'a1', [])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('a1') // Alpha responds despite being a watcher
+  })
+
+  it('1-on-1 room without ring leader - agent always replies', () => {
+    const oneOnOne = [
+      { id: 'a1', name: 'Alpha', watchPrompt: true },
+    ]
+    const result = determineTriggeredAgents(oneOnOne, undefined, [])
+    expect(result).toHaveLength(1)
+  })
+})
+
+// ── Specialist list building ──────────────────────────────────────────────────
+
+function buildSpecialistLines(specialists) {
+  return specialists.map(s =>
+    `  \u2022 ${s.agentName} (${s.domain}) - ${s.description}${s.tags.length ? ` [${s.tags.join(', ')}]` : ''}`,
+  )
+}
+
+describe('Specialist List Building', () => {
+  it('formats specialist lines correctly', () => {
+    const lines = buildSpecialistLines([
+      { agentName: 'Planner', domain: 'planning', description: 'Creates implementation plans', tags: ['planning', 'strategy'] },
+      { agentName: 'Atlas', domain: 'environment-management', description: 'Manages environments', tags: ['env', 'deploy'] },
+    ])
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('Planner')
+    expect(lines[0]).toContain('planning')
+    expect(lines[1]).toContain('Atlas')
+    expect(lines[1]).toContain('environment-management')
+  })
+
+  it('omits tags bracket when no tags', () => {
+    const lines = buildSpecialistLines([
+      { agentName: 'Solo', domain: 'solo-domain', description: 'No tags', tags: [] },
+    ])
+    expect(lines[0]).not.toContain('[]')
+    expect(lines[0]).toContain('No tags')
+  })
+})
+
+// ── Ring Leader System Prompt Template ─────────────────────────────────────────
+
+describe('System Prompt Templates', () => {
+  it('ring-leader template key exists in PROMPT_DEFAULTS', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const content = fs.readFileSync(path.join(__dirname, 'system-prompts.ts'), 'utf8')
+    expect(content).toContain("key: 'system.ring-leader'")
+  })
+
+  it('specialist-context template key exists in PROMPT_DEFAULTS', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const content = fs.readFileSync(path.join(__dirname, 'system-prompts.ts'), 'utf8')
+    expect(content).toContain("key: 'system.specialist-context'")
+  })
+
+  it('ring-leader template mentions delegation', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const content = fs.readFileSync(path.join(__dirname, 'system-prompts.ts'), 'utf8')
+    expect(content).toContain('system.ring-leader')
+    expect(content).toContain('delegate')
+  })
+
+  it('specialist-context template has delegation structure', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const content = fs.readFileSync(path.join(__dirname, 'system-prompts.ts'), 'utf8')
+    expect(content).toContain('Delegation Received')
+  })
+})
+
+// ── Agent Context Injection ───────────────────────────────────────────────────
+
+describe('Context Injection', () => {
+  it('ring leader context is appended to persona prompt', () => {
+    const ringLeaderContext = '\n\n## Specialist Agents Available to You\n\nYou can delegate work to these specialist agents:\n\n  \u2022 Planner (planning) - Creates implementation plans'
+    const personaPrompt = 'Role: Team Lead\n\nYou are the team coordinator.'
+    const injected = personaPrompt + ringLeaderContext
+
+    expect(injected).toContain('Specialist Agents')
+    expect(injected).toContain('Planner')
+    expect(injected).toContain('delegat')
+  })
+
+  it('ring leader context is empty when no ring leader configured', () => {
+    const ringLeaderContext = ''
+    const personaPrompt = 'Role: Specialist\n\nYou handle deployments.'
+    const agentContext = '## ORION State\n  agents: 0'
+
+    const agentBasePrompt = agentContext
+      ? personaPrompt + agentContext
+      : personaPrompt
+
+    expect(agentBasePrompt).not.toContain('Specialist Agents')
+  })
+
+  it('specialist context has delegation instructions', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const content = fs.readFileSync(path.join(__dirname, 'system-prompts.ts'), 'utf8')
+    expect(content).toContain('Delegation Received')
+    expect(content).toContain('delegation')
+  })
+})

--- a/apps/web/src/lib/ring-leader-schema.test.ts
+++ b/apps/web/src/lib/ring-leader-schema.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Ring Leader Delegation - Database Schema Tests
+ * Phase 1: AgentProfile, RoomKnowledge, AgentKnowledge models + AgentContextConfig additions
+ */
+
+import { describe, it, expect } from '@jest/globals'
+
+// ── AgentContextConfig interface tests ────────────────────────────────────────
+
+describe('AgentContextConfig', () => {
+  it('has all Ring Leader delegation fields', () => {
+    const config = {
+      maxTurns: 6,
+      historyMessages: 12,
+      discoverable: true,
+      maxParallelDelegations: 3,
+      canWriteKnowledge: true,
+      knowledgeScope: 'room',
+    }
+
+    expect(config.maxParallelDelegations).toBe(3)
+    expect(config.knowledgeScope).toBe('room')
+    expect(config.discoverable).toBe(true)
+    expect(config.canWriteKnowledge).toBe(true)
+    expect(config.maxTurns).toBe(6)
+    expect(config.historyMessages).toBe(12)
+  })
+
+  it('accepts an empty config object (all fields optional)', () => {
+    const config = {}
+    expect(config).toBeDefined()
+    expect(config).toEqual({})
+  })
+
+  it('allows partial configuration', () => {
+    const partial = {
+      llm: 'claude',
+      discoverable: true,
+    }
+    expect(partial.llm).toBe('claude')
+    expect(partial.discoverable).toBe(true)
+  })
+})
+
+// ── Prisma schema structure tests ────────────────────────────────────────────
+
+describe('Prisma Schema', () => {
+  let schemaContent: string
+
+  beforeAll(async () => {
+    const { readFileSync } = await import('fs')
+    const path = await import('path')
+    const schemaPath = path.default.join(__dirname, '../../../prisma/schema.prisma')
+    schemaContent = readFileSync(schemaPath, 'utf-8')
+  })
+
+  describe('AgentProfile model', () => {
+    it('defines the AgentProfile model', () => {
+      expect(schemaContent).toContain('model AgentProfile')
+    })
+
+    it('maps to agent_profiles table', () => {
+      expect(schemaContent).toContain('@@map("agent_profiles")')
+    })
+
+    it('has required fields: agentId, domain, description', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('agentId')
+      expect(block).toContain('domain')
+      expect(block).toContain('description')
+    })
+
+    it('has optional fields: tags, activeEnvironments, confidence, verifiedAt', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('tags')
+      expect(block).toContain('activeEnvironments')
+      expect(block).toContain('confidence')
+      expect(block).toContain('verifiedAt')
+    })
+
+    it('has unique constraint on agentId', () => {
+      expect(schemaContent).toContain('@@unique([agentId])')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('onDelete: Cascade')
+    })
+
+    it('has indexes on domain and tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentProfile')
+      expect(block).toContain('@@index([domain])')
+      expect(block).toContain('@@index([tags])')
+    })
+  })
+
+  describe('RoomKnowledge model', () => {
+    it('defines the RoomKnowledge model', () => {
+      expect(schemaContent).toContain('model RoomKnowledge')
+    })
+
+    it('maps to room_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("room_knowledge")')
+    })
+
+    it('has required fields: roomId, title, content, room relation', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('roomId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('ChatRoom')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'RoomKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('AgentKnowledge model', () => {
+    it('defines the AgentKnowledge model', () => {
+      expect(schemaContent).toContain('model AgentKnowledge')
+    })
+
+    it('maps to agent_knowledge table', () => {
+      expect(schemaContent).toContain('@@map("agent_knowledge")')
+    })
+
+    it('has required fields: agentId, title, content, agent relation', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('agentId')
+      expect(block).toContain('title')
+      expect(block).toContain('content')
+      expect(block).toContain('Agent')
+    })
+
+    it('has optional fields: type, tags', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('type')
+      expect(block).toContain('tags')
+    })
+
+    it('has cascade delete relation to Agent', () => {
+      const block = extractModelBlock(schemaContent, 'AgentKnowledge')
+      expect(block).toContain('onDelete: Cascade')
+    })
+  })
+
+  describe('ChatRoom extensions', () => {
+    it('has metadata field on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('metadata')
+    })
+
+    it('has roomKnowledge relation on ChatRoom', () => {
+      const block = extractModelBlock(schemaContent, 'ChatRoom')
+      expect(block).toContain('roomKnowledge')
+    })
+  })
+
+  describe('Agent model extensions', () => {
+    it('has profiles relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('profiles')
+    })
+
+    it('has knowledge relation', () => {
+      const block = extractModelBlock(schemaContent, 'Agent')
+      expect(block).toContain('knowledge')
+    })
+  })
+})
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the block of text for a model from the schema.
+ * Handles last model in file by allowing EOF as terminator.
+ */
+function extractModelBlock(schema: string, modelName: string): string {
+  const regex = new RegExp(
+    `model\\s+${modelName}\\s*\\{([\\s\\S]*?)(?=\\nmodel\\s+\\w+\\n\\s*\\{|\\Z)`,
+  )
+  const match = schema.match(regex)
+  if (!match) {
+    throw new Error(`Model ${modelName} not found in schema`)
+  }
+  return match[1]
+}

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -21,6 +21,7 @@ import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
 import { buildAgentContext, invalidateSnapshotCache } from './agent-context'
+import { getPrompt } from './system-prompts'
 import type { AgentGateway } from './agent-gateway'
 import type { GatewayTool } from './agent-runner/types'
 
@@ -402,22 +403,71 @@ export async function triggerRoomAgentReplies(
     .filter((a: any) => (a.metadata as Record<string, unknown> | null)?.archived !== true)
   if (agentMembers.length === 0) return
 
+  // ── Ring Leader routing ──────────────────────────────────────────────────────
+  // If the room has a ring leader configured and no @mention targets specific agents,
+  // only the ring leader auto-replies. The ring leader then decides whether to
+  // delegate to specialists or answer directly.
+  const roomMeta = (room?.metadata ?? {}) as Record<string, unknown>
+  const ringLeaderId = roomMeta?.ringLeaderAgentId as string | undefined
   const mentionedNames  = parseMentions(triggerContent)
   const isEveryone      = mentionedNames.some(n => n.toLowerCase() === 'everyone')
   const isDirect        = agentMembers.length === 1  // 1-on-1 room — always reply
-  const triggeredAgents = isEveryone
-    ? agentMembers  // @everyone pings all agents regardless of type
-    : mentionedNames.length > 0
-    ? agentMembers.filter((a: any) => mentionedNames.some(n => a.name.toLowerCase() === n.toLowerCase()))
-    : agentMembers.filter((a: any) => {
-        if (isDirect) return true  // In a 1-on-1 room the agent is always the conversation partner
-        // In group rooms, watcher agents (watchPrompt set) only speak when @mentioned —
-        // they coordinate on a schedule and shouldn't auto-reply to every message.
-        const cc = ((a.metadata ?? {}) as Record<string, unknown>).contextConfig as Record<string, unknown> | undefined
-        return !cc?.watchPrompt
-      })
+  const hasSpecificMention = mentionedNames.length > 0 && !isEveryone
+
+  let triggeredAgents: typeof agentMembers
+
+  // @everyone bypasses ring leader — targets all agents
+  if (isEveryone) {
+    triggeredAgents = agentMembers
+  } else if (!hasSpecificMention && ringLeaderId) {
+    // Ring leader mode — only the ring leader responds to non-mentioned messages
+    const ringLeader = agentMembers.find((a: any) => a.id === ringLeaderId)
+    triggeredAgents = ringLeader ? [ringLeader] : agentMembers.filter((a: any) => {
+      const cc = ((a.metadata ?? {}) as Record<string, unknown>).contextConfig as Record<string, unknown> | undefined
+      return !cc?.watchPrompt
+    })
+  } else if (hasSpecificMention) {
+    // @AgentName pings specific agents — always deliver, bypassing ring leader
+    triggeredAgents = agentMembers.filter((a: any) =>
+      mentionedNames.some(n => a.name.toLowerCase() === n.toLowerCase()),
+    )
+  } else if (isDirect) {
+    triggeredAgents = agentMembers
+  } else {
+    triggeredAgents = agentMembers.filter((a: any) => {
+      // In group rooms, watcher agents (watchPrompt set) only speak when @mentioned
+      const cc = ((a.metadata ?? {}) as Record<string, unknown>).contextConfig as Record<string, unknown> | undefined
+      return !cc?.watchPrompt
+    })
+  }
 
   if (triggeredAgents.length === 0) return
+
+  // Pre-fetch specialists list (for ring leader prompt)
+  const specialists = await prisma.agentProfile.findMany({
+    where: { active: true },
+    select: { agentId: true, agentName: true, domain: true, description: true, tags: true, confidence: true },
+  })
+
+  // Build ring leader context: specialists list + load ring-leader template
+  let ringLeaderContext = ''
+  if (ringLeaderId && specialists.length > 0) {
+    const specialistLines = specialists.map(s =>
+      `  • ${s.agentName} (${s.domain}) — ${s.description}${s.tags.length ? ` [${s.tags.join(', ')}]` : ''}`,
+    )
+    ringLeaderContext = `## Specialist Agents Available to You\n\nYou can delegate work to these specialist agents:\n\n${specialistLines.join('\n')}\n\nIf a question falls outside your expertise, delegate it using the \`delegate\` tool.`
+
+    try {
+      const ringLeaderTemplate = await getPrompt('system.ring-leader')
+      // Inject the specialists section
+      ringLeaderContext = ringLeaderTemplate.replace(
+        /## Specialist Agents Available to You\s*\n\nYou can delegate work to these specialist agents:\s*\n\n.*?(?=\n\n## How to Delegate)/s,
+        `## Specialist Agents Available to You\n\nYou can delegate work to these specialist agents:\n\n${specialistLines.join('\n')}\n\n`,
+      )
+    } catch { /* template not available — use built specialist lines */ }
+  } else if (ringLeaderId) {
+    ringLeaderContext = `\n\nNo specialist agents are currently registered. Handle all questions yourself without delegation.`
+  }
 
   let lastSavedReply: string | null = null
 
@@ -456,9 +506,14 @@ export async function triggerRoomAgentReplies(
       const toolsEnabled  = !!(contextConfig.tools)
 
       // Base persona description — identity constraint is added by buildSystemPrompt()
-      const personaPrompt = rawPrompt
+      let personaPrompt = rawPrompt
         ? `${agent.role ? `Role: ${agent.role}\n\n` : ''}${rawPrompt}`
         : `${agent.role ? `Role: ${agent.role}\n\n` : ''}${agent.description ?? ''}`
+
+      // Ring Leader context injection — append before agentContext so it appears early
+      if (agent.id === ringLeaderId && ringLeaderContext) {
+        personaPrompt += ringLeaderContext
+      }
 
       // Inject pre-fetched context (ORION snapshot + vector search) so agents arrive
       // pre-oriented and don't need to call orion_get_snapshot on every message.

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -445,15 +445,14 @@ export async function triggerRoomAgentReplies(
 
   // Pre-fetch specialists list (for ring leader prompt)
   const specialists = await prisma.agentProfile.findMany({
-    where: { active: true },
-    select: { agentId: true, agentName: true, domain: true, description: true, tags: true, confidence: true },
+    select: { agentId: true, domain: true, description: true, tags: true, confidence: true, agent: { select: { name: true } } },
   })
 
   // Build ring leader context: specialists list + load ring-leader template
   let ringLeaderContext = ''
   if (ringLeaderId && specialists.length > 0) {
     const specialistLines = specialists.map(s =>
-      `  • ${s.agentName} (${s.domain}) — ${s.description}${s.tags.length ? ` [${s.tags.join(', ')}]` : ''}`,
+      `  • ${s.agent.name} (${s.domain}) — ${s.description}${s.tags.length ? ` [${s.tags.join(', ')}]` : ''}`,
     )
     ringLeaderContext = `## Specialist Agents Available to You\n\nYou can delegate work to these specialist agents:\n\n${specialistLines.join('\n')}\n\nIf a question falls outside your expertise, delegate it using the \`delegate\` tool.`
 

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -707,6 +707,65 @@ export async function ensureSystemAgents(): Promise<void> {
       }).catch(() => {})
     }
   }
+
+  // Seed AgentProfile records for system agents (ring leader delegation)
+  const PROFILE_DEFS: Array<{ agentName: string; domain: string; description: string; tags: string[] }> = [
+    {
+      agentName: 'Alpha',
+      domain: 'system-coordinator',
+      description: 'Team coordination, task assignment, escalation management, and workflow orchestration.',
+      tags: ['task-assignment', 'escalation', 'workflow', 'coordination'],
+    },
+    {
+      agentName: 'Veritas',
+      domain: 'qa-validation',
+      description: 'Testing, code review, deployment validation, and quality assurance gates.',
+      tags: ['testing', 'code-review', 'deployment-validation', 'quality-assurance'],
+    },
+    {
+      agentName: 'Planner',
+      domain: 'planning',
+      description: 'Architecture design, project planning, task breakdown, and milestone tracking.',
+      tags: ['architecture', 'project-planning', 'task-breakdown', 'milestones'],
+    },
+    {
+      agentName: 'Atlas',
+      domain: 'environment-management',
+      description: 'Environment management, connectors, bootstrap, and infrastructure provisioning.',
+      tags: ['environments', 'connectors', 'bootstrap', 'infrastructure'],
+    },
+    {
+      agentName: 'Pulse',
+      domain: 'cluster-health',
+      description: 'Cluster monitoring, ingress management, SSL certificates, and health checks.',
+      tags: ['monitoring', 'ingress', 'ssl', 'health-checks'],
+    },
+    {
+      agentName: 'Mentor',
+      domain: 'agent-coaching',
+      description: 'Prompt engineering, agent performance optimization, training, and coaching.',
+      tags: ['prompt-improvement', 'agent-performance', 'training', 'coaching'],
+    },
+  ]
+
+  for (const pd of PROFILE_DEFS) {
+    const agent = await prisma.agent.findUnique({ where: { name: pd.agentName }, select: { id: true } })
+    if (!agent) continue
+
+    await prisma.agentProfile.upsert({
+      where: { agentId: agent.id },
+      update: {},
+      create: {
+        agentId:     agent.id,
+        domain:      pd.domain,
+        description: pd.description,
+        tags:        pd.tags,
+        confidence:  0.5,
+      },
+    }).catch(() => {})
+
+    console.log(`[seed] AgentProfile: ${pd.agentName} → ${pd.domain}`)
+  }
 }
 
 // ── Planner lookup helper ──────────────────────────────────────────────────────

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -527,6 +527,80 @@ The user can use this spec to fill out the agent creation form.`,
 
 The team currently has Alpha (Team Leader) who handles task assignment, and gmacro (the human admin). What questions do you need answered to help me design the right agent?`,
   },
+
+  // ── Ring Leader ────────────────────────────────────────────────────────────────
+
+  {
+    key: 'system.ring-leader',
+    name: 'Ring Leader System Prompt',
+    category: 'system',
+    description: 'Core prompt for the ring leader — the agent responsible for orchestrating a chat room. Handles human messages, decides whether to delegate to specialist agents, and manages room conversation. Injected: {{agentName}}, {{agentPrompt}}, {{specialists}}.',
+    variables: [
+      { name: '{{agentName}}',       description: 'Ring leader agent name' },
+      { name: '{{agentPrompt}}',     description: 'Ring leader\'s system prompt (from agent definition)' },
+      { name: '{{specialists}}',     description: 'List of discoverable specialists (from agent profiles)' },
+    ],
+    content: `You are the Ring Leader for this chat room. Your job is to coordinate conversation and delegate work to specialist agents when appropriate.
+
+## Your Role
+
+You are a participant in this group chat, but with special responsibilities:
+
+1. **Respond to human messages.** When a person sends a message, answer it directly when you can, or delegate to a specialist when it's outside your expertise.
+2. **Delegate to specialists.** When a message requires domain expertise you don't have, use the \`delegate\` tool to assign the task to the right specialist agent.
+3. **Stay focused.** Don't delegate everything — answer straightforward questions yourself. Only delegate when a specialist would do a better job.
+4. **Don't duplicate work.** If another agent has already addressed a question, acknowledge it rather than repeating the answer.
+
+## Specialist Agents Available to You
+
+{{specialists}}
+
+If no specialists are available, handle all questions yourself without delegation.
+
+## How to Delegate
+
+When you need another agent to handle a task:
+1. Use the \`delegate\` tool with a clear objective and any relevant context from the conversation.
+2. Include any specific directives in the \`directives\` field (e.g., "Be concise", "Focus on the error logs").
+3. After delegating, inform the human that you've passed their question to the appropriate specialist.
+
+## Rules
+
+- Always be helpful to the human — don't let questions fall through the cracks.
+- If you're unsure which specialist to delegate to, ask the human for clarification or pick the closest match.
+- Never delegate your own identity or role — you are the coordinator, not a specialist yourself.
+- If all agents are busy or unavailable, tell the human and handle what you can.
+- When a specialist completes a delegated task, share their result with the room.
+- Do NOT use the \`find_specialist\` tool — your available specialists are listed above. Use \`delegate\` directly.
+`,
+  },
+
+  {
+    key: 'system.specialist-context',
+    name: 'Specialist Agent Context Prompt',
+    category: 'system',
+    description: 'Appended to a specialist agent\'s system prompt when they receive a delegated task. Injected: {{delegationContext}}, {{directives}}.',
+    variables: [
+      { name: '{{delegationContext}}', description: 'Context of the delegated task from the ring leader' },
+      { name: '{{directives}}',        description: 'Specific instructions from the ring leader' },
+    ],
+    content: `## Delegation Received
+
+You have been assigned a task by the Ring Leader.
+
+{{delegationContext}}
+{{directives}}
+
+## Your Instructions
+
+1. Address the delegated task using your domain expertise.
+2. Use available tools to gather information and take action.
+3. When complete, provide a clear, actionable result.
+4. If you cannot complete the task, explain why and suggest alternatives.
+
+Remember: you are working on behalf of the Ring Leader in a group chat. Your result will be shared with the human and all agents in the room.
+`,
+  },
 ]
 
 const DEFAULT_MAP = new Map(PROMPT_DEFAULTS.map(p => [p.key, p]))

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -2320,3 +2320,112 @@ registerTool({
     ].join('\n')
   },
 })
+
+// ── Ring Leader: findSpecialist ──────────────────────────────────────────────
+
+registerTool({
+  name: 'find_specialist',
+  description: 'Discover which specialist agent should handle a given task. ' +
+    'Searches AgentProfile records by domain, tags, and confidence scoring. ' +
+    'Returns ranked results with agentId, domain, description, and confidence. ' +
+    'Use this before delegate() when you are unsure which agent should handle a task.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Description of the task or problem to find a specialist for.',
+      },
+      environment: {
+        type: 'string',
+        description: 'Optional environment name to filter by.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results (1-5, default 3).',
+        default: 3,
+      },
+      minConfidence: {
+        type: 'number',
+        description: 'Minimum confidence threshold (0.0-1.0, default 0.3).',
+        default: 0.3,
+      },
+    },
+    required: ['query'],
+  },
+  tier: 'read',
+  parallelSafe: true,
+  availableIn: 'task',
+  handler: async (args) => {
+    const { query, limit, minConfidence } = args as {
+      query?: string; environment?: string; limit?: number; minConfidence?: number
+    }
+
+    if (!query) return 'Error: query is required'
+
+    const q = query.toLowerCase()
+    const results = await prisma.agentProfile.findMany({
+      where: {
+        confidence: { gte: minConfidence ?? 0.3 },
+        ...(environment ? { activeEnvironments: { has: environment } } : {}),
+      },
+      include: { agent: { select: { name: true, status: true } } },
+      take: Math.min(Math.max(parseInt(String(limit ?? 3), 10), 1), 5),
+    })
+
+    // Score each profile
+    const scored = results.map((p: any) => {
+      const domainLower = p.domain.toLowerCase()
+      let score = 0
+
+      // Domain match
+      if (q.includes(domainLower)) score += 0.8
+      else if (domainLower.includes(q)) score += 0.5
+      else {
+        const qWords = q.split(/\s+/).filter((w: string) => w.length > 2)
+        const dWords = domainLower.split(/[-_\s]+/).filter((w: string) => w.length > 2)
+        const matching = qWords.filter((w: string) => dWords.some((dw: string) => dw.includes(w) || w.includes(dw))).length
+        if (qWords.length > 0) score += (matching / qWords.length) * 0.5
+      }
+
+      // Tag overlap
+      const tags = Array.isArray(p.tags) ? (p.tags as string[]).map((t: string) => t.toLowerCase()) : []
+      const qWords2 = q.split(/\s+/).filter((w: string) => w.length > 2)
+      if (qWords2.length > 0 && tags.length > 0) {
+        const matching = qWords2.filter((w: string) => tags.some((t: string) => t.includes(w) || w.includes(t))).length
+        score += (matching / qWords2.length) * 0.3
+      }
+
+      // Confidence weight
+      score += (p.confidence ?? 0.5) * 0.2
+
+      return { profile: p, score: Math.min(score, 1.0) }
+    })
+
+    // Sort by score descending
+    scored.sort((a, b) => b.score - a.score)
+
+    if (scored.length === 0) {
+      return `No specialist agents matched the query "${query}" (minConfidence: ${minConfidence ?? 0.3}).`
+    }
+
+    const lines: string[] = [`Found ${scored.length} specialist agent(s) for: "${query}"`]
+    lines.push('')
+
+    for (let i = 0; i < scored.length; i++) {
+      const { profile: p, score } = scored[i]
+      lines.push(`--- #${i + 1} [${p.domain}] ${p.agent.name} ---`)
+      lines.push(`  agentId:      ${p.agentId}`)
+      lines.push(`  confidence:   ${(p.confidence * 100).toFixed(0)}%`)
+      lines.push(`  score:        ${(score * 100).toFixed(1)}%`)
+      lines.push(`  status:       ${p.agent.status}`)
+      lines.push(`  description:  ${p.description.slice(0, 200)}`)
+      if (Array.isArray(p.tags) && p.tags.length > 0) {
+        lines.push(`  tags:         ${(p.tags as string[]).join(', ')}`)
+      }
+      lines.push('')
+    }
+
+    return lines.join('\n')
+  },
+})

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -358,6 +358,15 @@ async function runTask(taskId: string): Promise<void> {
     const summary = outputText.slice(-500) || 'Task completed.'
 
     const completionMsg = `✅ Completed: **${task.title}** (${durationSec}s · ${toolsUsed.length} tools)\n\n${summary}`
+
+    // Delegation result propagation
+    const delegation = (task.metadata as any)?.delegation as { roomId?: string; ringLeaderId?: string } | undefined
+    const roomPromises = featureRoomId ? [postToRoom(featureRoomId, agent.id, completionMsg, taskId)] : []
+    if (delegation?.roomId) {
+      const delegateResult = `🔔 **Delegation complete**: ${task.title}\n\n${summary}`
+      roomPromises.push(postToRoom(delegation.roomId, agent.id, delegateResult, taskId))
+    }
+
     await Promise.all([
       prisma.task.update({ where: { id: taskId }, data: { status: 'pending_validation' } }),
       logTaskEvent(taskId, 'completed', summary, agent.id),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1691,12 +1691,12 @@
     },
     "node_modules/@prisma/debug": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1708,12 +1708,12 @@
     },
     "node_modules/@prisma/engines-version": {
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -1723,7 +1723,7 @@
     },
     "node_modules/@prisma/get-platform": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -2789,7 +2789,6 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2804,7 +2803,6 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2813,7 +2811,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3611,7 +3609,6 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -6953,7 +6950,7 @@
     },
     "node_modules/prisma": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

Adds multi-agent chat capabilities where one agent acts as "ring leader" to delegate tasks to specialist agents. Covers Phases 1-5 of the Ring Leader plan.

### Phase 1 - Database Schema
- `AgentProfile`, `RoomKnowledge`, `AgentKnowledge` models
- `ChatRoom.metadata` JSON field

### Phase 2 - Discovery Tool
- `find_specialist` MCP + web tools with domain/tag/confidence scoring
- Seeds 6 default AgentProfile records

### Phase 3 - Delegate Tool
- `delegate` web tool with async result propagation
- `buildAgentLocalContext` / `buildRoomLocalContext` context builders

### Phase 4 - Three-Level Knowledge
- Scoped write/search tools (room-level + agent-level)

### Phase 5 - Ring Leader Integration
- `system.ring-leader` + `system.specialist-context` prompt templates
- Room agent routing: ring leader auto-replies, specialists on @mention
- 18 unit tests covering routing, specialists, templates, context injection

## Files Changed
- `apps/web/prisma/schema.prisma`
- `apps/web/src/lib/room-agents.ts`
- `apps/web/src/lib/system-prompts.ts`
- `apps/web/src/lib/tool-registry.ts`
- `apps/web/src/lib/agent-context.ts`
- `apps/web/src/worker.ts`
- `apps/gateway/src/builtin-tools/discovery.ts`
- `apps/gateway/src/builtin-tools/knowledge-graph.ts`
- `apps/gateway/src/index.ts`
- `apps/web/src/lib/seed-system-agents.ts`
- `apps/web/src/lib/claude.ts`
- `apps/web/src/lib/ring-leader-integration.test.ts`
- `apps/web/src/lib/ring-leader-schema.test.ts`
