### PR TITLE
fix: resolve TypeScript build errors from merged PRs

### DIFF
--- a/apps/gateway/src/builtin-tools/discovery.test.ts
+++ b/apps/gateway/src/builtin-tools/discovery.test.ts
@@ -3,7 +3,7 @@
  * Tests the find_specialist scoring algorithm.
  */
 
-import { describe, it, expect } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 function scoreProfile(
   query: string,

--- a/apps/gateway/src/builtin-tools/security.test.ts
+++ b/apps/gateway/src/builtin-tools/security.test.ts
@@ -57,7 +57,7 @@ describe('Security Tools', () => {
     it('crowdsec_blocks has limit parameter', () => {
       const tool = securityTools[0]
       expect(tool.inputSchema.properties.limit).toBeDefined()
-      expect(tool.inputSchema.properties.limit.type).toBe('number')
+      expect(tool.inputSchema.properties.limit?.type).toBe('number')
     })
 
     it('prometheus_query requires query parameter', () => {

--- a/apps/gateway/src/builtin-tools/security.ts
+++ b/apps/gateway/src/builtin-tools/security.ts
@@ -238,7 +238,7 @@ export const securityTools = [
       const user = process.env.WAZUH_USERNAME ?? ''
       const pass = process.env.WAZUH_PASSWORD ?? ''
       const limit = args.limit ?? 50
-      const filter = args.filter ?? ''
+      const filter = String(args.filter ?? '')
       const params = new URLSearchParams({
         select: '*',
         pretty: 'true',

--- a/apps/gateway/src/hooks-engine.test.ts
+++ b/apps/gateway/src/hooks-engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { HooksEngine, type HookEvent } from './hooks-engine'
+import { OrionClient } from './orion-client'
 
 function createMockOrionClient() {
   return {
@@ -16,7 +17,7 @@ describe('HooksEngine', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     mockClient = createMockOrionClient()
-    engine = new HooksEngine(mockClient)
+    engine = new HooksEngine(mockClient as unknown as OrionClient)
   })
 
   afterAll(() => {
@@ -46,7 +47,7 @@ describe('HooksEngine', () => {
 
   describe('matchesFilter', () => {
     function makeEngine() {
-      return new HooksEngine(createMockOrionClient())
+      return new HooksEngine(createMockOrionClient() as unknown as OrionClient)
     }
 
     it('returns true when event payload matches all filter keys', () => {

--- a/apps/gateway/src/hooks-engine.ts
+++ b/apps/gateway/src/hooks-engine.ts
@@ -82,7 +82,7 @@ function sanitizeEventData(data: Record<string, unknown>): Record<string, string
 export class HooksEngine {
   private orion: OrionClient
   private hooks: Array<{ id: string; name: string; spec: any }> = []
-  private interval: NodeJS.Timer | null = null
+  private interval: ReturnType<typeof setInterval> | null = null
 
   constructor(orion: OrionClient) {
     this.orion = orion
@@ -144,7 +144,7 @@ export class HooksEngine {
       } else if (spec.actionType === 'send_notification') {
         output = spec.actionConfig.message.replace(
           /{(\w+)}/g,
-          (_, key) => String((event.payload as any)[key] ?? ''),
+          (_: string, key: string) => String((event.payload as any)[key] ?? ''),
         )
       }
     } catch (err) {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -362,7 +362,7 @@ function timingSafeCompare(a: string, b: string): boolean {
   const bufB = Buffer.from(b)
   // timingSafeEqual throws on mismatch, so we catch it
   try {
-    return crypto.timingSafeEqual(bufA, bufB)
+    return timingSafeEqual(bufA, bufB)
   } catch {
     return false
   }

--- a/apps/gateway/src/orion-client.test.ts
+++ b/apps/gateway/src/orion-client.test.ts
@@ -126,12 +126,12 @@ describe('OrionClient', () => {
     it('POSTs ingresses to correct endpoint', async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
       const client = new OrionClient(cfg)
-      await client.reportIngresses([{ host: 'example.com', path: '/api' }])
+      await client.reportIngresses([{ host: 'example.com', paths: ['/api'], tls: false, namespace: 'default', ingressName: 'test' }])
       expect(global.fetch).toHaveBeenCalledWith(
         'http://orion.local/api/environments/env-1/ingress/sync',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ ingresses: [{ host: 'example.com', path: '/api' }] }),
+          body: JSON.stringify({ ingresses: [{ host: 'example.com', paths: ['/api'], tls: false, namespace: 'default', ingressName: 'test' }] }),
         }),
       )
     })
@@ -147,12 +147,12 @@ describe('OrionClient', () => {
     it('POSTs sync status to correct endpoint', async () => {
       global.fetch = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('') })
       const client = new OrionClient(cfg)
-      await client.reportSyncStatus([{ name: 'my-app', status: 'Healthy' }])
+      await client.reportSyncStatus([{ name: 'my-app', namespace: 'default', project: 'default', syncStatus: 'Synced', healthStatus: 'Healthy', revision: 'abc', message: '', reconciledAt: null }])
       expect(global.fetch).toHaveBeenCalledWith(
         'http://orion.local/api/environments/env-1/sync-status',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ applications: [{ name: 'my-app', status: 'Healthy' }] }),
+          body: JSON.stringify({ applications: [{ name: 'my-app', namespace: 'default', project: 'default', syncStatus: 'Synced', healthStatus: 'Healthy', revision: 'abc', message: '', reconciledAt: null }] }),
         }),
       )
     })

--- a/apps/gateway/src/skill-loader.test.ts
+++ b/apps/gateway/src/skill-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SkillLoader, type SkillMatch } from './skill-loader'
 
 // Mock OrionClient

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes 9 TypeScript compilation errors introduced by the batch PR merges:

- `discovery.test.ts`: `@jest/globals` → `vitest`
- `security.test.ts`: optional chaining on `properties.limit?.type`
- `security.ts`: cast `unknown` → `string` before `URLSearchParams.set()`
- `hooks-engine.test.ts`: cast mock as `unknown as OrionClient`
- `hooks-engine.ts`: typed replace callback params; fix `ReturnType<typeof setInterval>` timer type
- `index.ts`: use imported `timingSafeEqual` from `crypto` not `crypto.timingSafeEqual`
- `orion-client.test.ts`: fix `path` → `paths`, fix `ArgoCDApp` fixture fields
- `skill-loader.test.ts`: add `beforeEach` to vitest import
- `tsconfig.json`: exclude `*.test.ts` from tsc build

## Test plan
- [ ] `cd apps/gateway && npm run build` exits 0
- [ ] CI passes