### PR TITLE
fix: use tokensUsed instead of nonexistent outputTokens on ClaudeInvocation

### DIFF
--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -100,10 +100,10 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
             notes = hasResults ? 'Has tool results' : 'No tool results found'
           } else if (criterion.type === 'response_quality') {
             // Heuristic: quality based on response length and token usage
-            const totalOutputTokens = conversation.invocations.reduce((sum, i) => sum + (i.outputTokens || 0), 0)
+            const totalTokens = conversation.invocations.reduce((sum, i) => sum + (i.tokensUsed || 0), 0)
             const hasContent = conversation.messages.some((m) => m.content.length > 10)
-            rawScore = hasContent ? Math.min(maxScore, Math.floor(totalOutputTokens / 100)) : 0
-            notes = `Output tokens: ${totalOutputTokens}`
+            rawScore = hasContent ? Math.min(maxScore, Math.floor(totalTokens / 100)) : 0
+            notes = `Tokens used: ${totalTokens}`
           }
         } else if (targetType === 'task') {
           const task = await prisma.task.findUnique({ where: { id: targetId } })


### PR DESCRIPTION
## Summary

The `response_quality` ruleset criterion in `/api/environments/[id]/evals/run` was referencing `i.outputTokens` on `ClaudeInvocation` records, but that field does not exist on the model. The Prisma model only tracks `tokensUsed` (total tokens, input + output combined).

This was the final TypeScript error blocking the web build.

## Change

- `apps/web/src/app/api/environments/[id]/evals/run/route.ts:103` — replaced `i.outputTokens` with `i.tokensUsed` and updated the notes text accordingly

## Test plan
- [ ] `cd apps/web && npm run build` exits 0
- [ ] CI web build passes
- [ ] Eval run for `response_quality` criterion still produces a reasonable score