### PR TITLE
fix: resolve all remaining TypeScript build errors

### DIFF
--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -186,6 +186,11 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     createdEvals.push(evalRecord)
   }
 
+  // Aggregate score across all created evals for use in AgentScore update
+  const scoreTotalPct = createdEvals.length > 0
+    ? createdEvals.reduce((sum, e) => sum + e.scoreTotal, 0) / createdEvals.length
+    : 0
+
   // 3. Update or create AgentScore for the target
   const existingScore = await prisma.agentScore.findUnique({
     where: {
@@ -213,7 +218,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       }
     }
 
-    const totalKeys = new Set()
+    const totalKeys = new Set<string>()
     for (const evalRec of allEvalsForTarget) {
       try {
         const parsed = JSON.parse(evalRec.scores)
@@ -256,6 +261,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
         targetType,
         targetId,
         scoreTotal: scoreTotalPct,
+        accuracy: scoreTotalPct,
         safety: 0,
         completeness: 0,
         quality: 0,

--- a/apps/web/src/app/api/monitoring/security/alerts/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/route.ts
@@ -21,7 +21,8 @@ export async function GET(request: Request) {
   if (typeof acknowledged === 'boolean') where.acknowledged = acknowledged
 
   const cutoff = new Date(Date.now() - minutes * 60 * 1000)
-  ;(where as any).createdAt = { ...where.createdAt, gte: cutoff }
+  const existingCreatedAt = (where.createdAt ?? {}) as Record<string, unknown>
+  where.createdAt = { ...existingCreatedAt, gte: cutoff }
 
   const [events, total] = await Promise.all([
     prisma.securityEvent.findMany({

--- a/apps/web/src/components/security/FlowTable.tsx
+++ b/apps/web/src/components/security/FlowTable.tsx
@@ -59,7 +59,7 @@ export default function FlowTable() {
   const sorted = [...filtered].sort((a, b) => {
     const aVal = a[sortCol]
     const bVal = b[sortCol]
-    if (typeof aVal === 'number') {
+    if (typeof aVal === 'number' && typeof bVal === 'number') {
       return sortDir === 'asc' ? aVal - bVal : bVal - aVal
     }
     return sortDir === 'asc'

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -134,7 +134,7 @@ async function argocdConfigureApp(token: string, envName: string, repoUrl: strin
     spec: {
       project: slug,
       source: {
-        repoURL,
+        repoURL: repoUrl,
         targetRevision: 'main',
         path: 'deployments',
       },
@@ -738,9 +738,10 @@ async function ensureGitRepo(env: { name: string; gitOwner: string | null; gitRe
 
 /** Bootstrap a K8s/Talos cluster environment (original flow). */
 async function bootstrapK8sCluster(
-  env: Awaited<ReturnType<typeof prisma.environment.findUnique>>,
+  env: NonNullable<Awaited<ReturnType<typeof prisma.environment.findUnique>>>,
   emit: (event: BootstrapEvent) => void,
 ): Promise<void> {
+  if (!env.kubeconfig) throw new Error('No kubeconfig stored for this environment')
   const tmpDir = join(tmpdir(), `orion-bootstrap-${randomBytes(8).toString('hex')}`)
   await mkdir(tmpDir, { recursive: true })
 
@@ -936,7 +937,7 @@ async function bootstrapK8sCluster(
 
 /** Vault + ESO configuration (shared K8s logic). */
 async function bootstrapK8sVaultAndEso(
-  env: Awaited<ReturnType<typeof prisma.environment.findUnique>>,
+  env: NonNullable<Awaited<ReturnType<typeof prisma.environment.findUnique>>>,
   slug: string,
   kenv: Record<string, string>,
   tmpDir: string,
@@ -1047,7 +1048,7 @@ async function bootstrapK8sVaultAndEso(
 
 /** Bootstrap a single Docker host environment. */
 async function bootstrapDockerEnvironment(
-  env: Awaited<ReturnType<typeof prisma.environment.findUnique>>,
+  env: NonNullable<Awaited<ReturnType<typeof prisma.environment.findUnique>>>,
   emit: (event: BootstrapEvent) => void,
 ): Promise<void> {
   const tmpDir = join(tmpdir(), `orion-bootstrap-${randomBytes(8).toString('hex')}`)
@@ -1090,7 +1091,7 @@ async function bootstrapDockerEnvironment(
 
 /** Bootstrap a Docker Swarm environment. */
 async function bootstrapSwarmEnvironment(
-  env: Awaited<ReturnType<typeof prisma.environment.findUnique>>,
+  env: NonNullable<Awaited<ReturnType<typeof prisma.environment.findUnique>>>,
   emit: (event: BootstrapEvent) => void,
 ): Promise<void> {
   const tmpDir = join(tmpdir(), `orion-bootstrap-${randomBytes(8).toString('hex')}`)

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -2357,7 +2357,7 @@ registerTool({
   parallelSafe: true,
   availableIn: 'task',
   handler: async (args) => {
-    const { query, limit, minConfidence } = args as {
+    const { query, environment, limit, minConfidence } = args as {
       query?: string; environment?: string; limit?: number; minConfidence?: number
     }
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Fixes all remaining TypeScript errors blocking the web build. After running `prisma generate` to refresh the client types, only 8 real errors remained (vs 32 with stale client types). All fixed:

### Hard errors
- **`evals/run/route.ts`**: `scoreTotalPct` referenced outside loop scope — now computed as an aggregate after the loop. Also added missing `accuracy` field to `AgentScore.create`.
- **`monitoring/security/alerts/route.ts`**: Spread of `where.createdAt` (typed `unknown`) failed — now narrows via local typed variable.
- **`components/security/FlowTable.tsx`**: Arithmetic only narrowed one side — now narrows both `aVal` and `bVal`.
- **`cluster-bootstrap.ts`**: 4 function signatures used nullable `Awaited<ReturnType<...findUnique>>` — now `NonNullable<...>`. Added kubeconfig null guard. Fixed `repoURL` → `repoUrl` typo.
- **`tool-registry.ts`**: `find_specialist` referenced `environment` without destructuring it from `args`.

### Config
- **`tsconfig.json`**: Added `target: es2020` — required for regex `/s` (dotAll) flag used in `cluster-bootstrap.ts` and `room-agents.ts`.

## Verification

```
cd apps/web && npx tsc --noEmit -p .
Errors: 0
```

## Test plan
- [ ] CI web build (next build) passes
- [ ] Eval runs produce sensible aggregate scoreTotalPct values