### PR TITLE
fix: remove duplicate ARGOCD_SERVER/AUTH_TOKEN keys in docker-compose.yml

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -59,8 +59,6 @@ services:
       # ArgoCD — bootstrap uses this to register clusters and create apps
       ARGOCD_SERVER: http://host.docker.internal:8083
       ARGOCD_AUTH_TOKEN: ${ARGOCD_ADMIN_PASSWORD:-}
-      ARGOCD_SERVER: http://host.docker.internal:8083
-      ARGOCD_AUTH_TOKEN: ${ARGOCD_ADMIN_PASSWORD:-}
       # Claude Code sidecar URL (for OAuth bootstrap and credential status)
       ORION_CLAUDE_URL: ${ORION_CLAUDE_URL:-http://orion-claude:3100}
       # MCP service token — shared with orion-claude so Claude can call ORION tools via MCP


### PR DESCRIPTION
## Summary
- `ARGOCD_SERVER` and `ARGOCD_AUTH_TOKEN` were defined twice in `deploy/docker-compose.yml` (lines 60–63)
- Docker Compose v2 treats duplicate YAML mapping keys as a parse error — CI deploy job was failing with exit code 1

## Root cause
The two keys were likely added by two separate commits that both introduced the ArgoCD env vars without checking for existing ones.

## Test plan
- [ ] CI deploy job succeeds (`docker compose pull` + `docker compose up -d`) with no YAML parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)