### PR TITLE
fix: wire up ring leader so agents respond in untagged group chats

### DIFF
--- a/apps/web/prisma/migrations/5_ring_leader_hooks_evals/migration.sql
+++ b/apps/web/prisma/migrations/5_ring_leader_hooks_evals/migration.sql
@@ -1,0 +1,335 @@
+-- AlterTable
+ALTER TABLE "managed_secrets" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "SecurityEvent" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT,
+    "type" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "severity" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "rawEvent" JSONB NOT NULL,
+    "dedupKey" TEXT NOT NULL,
+    "acknowledged" BOOLEAN NOT NULL DEFAULT false,
+    "acknowledgedAt" TIMESTAMP(3),
+    "acknowledgedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SecurityEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SecurityConfig" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SecurityConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "agent_profiles" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "domain" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "activeEnvironments" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+    "verifiedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agent_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "room_knowledge" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'note',
+    "tags" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "room_knowledge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "agent_knowledge" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'note',
+    "tags" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agent_knowledge_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NovaDefinition" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "version" TEXT NOT NULL DEFAULT '1.0',
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "spec" TEXT NOT NULL,
+    "metadata" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NovaDefinition_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NebulaInstance" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+    "sourceNovaId" TEXT,
+    "name" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "spec" TEXT NOT NULL,
+    "isForked" BOOLEAN NOT NULL DEFAULT false,
+    "isInstalled" BOOLEAN NOT NULL DEFAULT true,
+    "minimumTier" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NebulaInstance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "HookExecutionLog" (
+    "id" TEXT NOT NULL,
+    "nebulaId" TEXT NOT NULL,
+    "triggerEvent" TEXT NOT NULL,
+    "triggerData" TEXT,
+    "actionType" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "output" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "durationMs" INTEGER,
+
+    CONSTRAINT "HookExecutionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SkillExecutionLog" (
+    "id" TEXT NOT NULL,
+    "nebulaId" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "contextId" TEXT,
+    "matchedPattern" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SkillExecutionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AgentTrace" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT,
+    "taskId" TEXT,
+    "step" INTEGER NOT NULL,
+    "type" TEXT NOT NULL,
+    "toolName" TEXT,
+    "toolArgs" TEXT,
+    "toolResult" TEXT,
+    "content" TEXT,
+    "skillName" TEXT,
+    "hookName" TEXT,
+    "durationMs" INTEGER,
+    "modelUsed" TEXT,
+    "systemPromptHash" TEXT,
+    "tokensIn" INTEGER,
+    "tokensOut" INTEGER,
+    "costCents" DECIMAL(10,6),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentTrace_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Eval" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "evalType" TEXT NOT NULL,
+    "evaluator" TEXT,
+    "rulesetId" TEXT,
+    "scores" TEXT NOT NULL,
+    "scoreTotal" DOUBLE PRECISION NOT NULL,
+    "scoreBreakdown" TEXT,
+    "feedback" TEXT,
+    "evidence" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Eval_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ruleset" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "criteria" TEXT NOT NULL,
+    "triggers" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Ruleset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AgentScore" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "scoreTotal" DOUBLE PRECISION NOT NULL,
+    "accuracy" DOUBLE PRECISION NOT NULL,
+    "completeness" DOUBLE PRECISION,
+    "safety" DOUBLE PRECISION NOT NULL,
+    "efficiency" DOUBLE PRECISION,
+    "quality" DOUBLE PRECISION,
+    "evalCount" INTEGER NOT NULL DEFAULT 0,
+    "lastEvalAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentScore_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SecurityEvent_environmentId_createdAt_idx" ON "SecurityEvent"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityEvent_environmentId_type_acknowledged_idx" ON "SecurityEvent"("environmentId", "type", "acknowledged");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SecurityConfig_environmentId_key_key" ON "SecurityConfig"("environmentId", "key");
+
+-- CreateIndex
+CREATE INDEX "agent_profiles_domain_idx" ON "agent_profiles"("domain");
+
+-- CreateIndex
+CREATE INDEX "agent_profiles_tags_idx" ON "agent_profiles"("tags");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_profiles_agentId_key" ON "agent_profiles"("agentId");
+
+-- CreateIndex
+CREATE INDEX "room_knowledge_roomId_idx" ON "room_knowledge"("roomId");
+
+-- CreateIndex
+CREATE INDEX "room_knowledge_tags_idx" ON "room_knowledge"("tags");
+
+-- CreateIndex
+CREATE INDEX "agent_knowledge_agentId_idx" ON "agent_knowledge"("agentId");
+
+-- CreateIndex
+CREATE INDEX "agent_knowledge_tags_idx" ON "agent_knowledge"("tags");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NovaDefinition_name_key" ON "NovaDefinition"("name");
+
+-- CreateIndex
+CREATE INDEX "NovaDefinition_category_idx" ON "NovaDefinition"("category");
+
+-- CreateIndex
+CREATE INDEX "NebulaInstance_environmentId_category_isInstalled_idx" ON "NebulaInstance"("environmentId", "category", "isInstalled");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NebulaInstance_environmentId_name_key" ON "NebulaInstance"("environmentId", "name");
+
+-- CreateIndex
+CREATE INDEX "HookExecutionLog_nebulaId_startedAt_idx" ON "HookExecutionLog"("nebulaId", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "HookExecutionLog_status_startedAt_idx" ON "HookExecutionLog"("status", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "SkillExecutionLog_nebulaId_createdAt_idx" ON "SkillExecutionLog"("nebulaId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentTrace_conversationId_step_idx" ON "AgentTrace"("conversationId", "step");
+
+-- CreateIndex
+CREATE INDEX "AgentTrace_taskId_step_idx" ON "AgentTrace"("taskId", "step");
+
+-- CreateIndex
+CREATE INDEX "AgentTrace_type_createdAt_idx" ON "AgentTrace"("type", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentTrace_createdAt_idx" ON "AgentTrace"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Eval_environmentId_targetType_targetId_idx" ON "Eval"("environmentId", "targetType", "targetId");
+
+-- CreateIndex
+CREATE INDEX "Eval_evalType_createdAt_idx" ON "Eval"("evalType", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ruleset_name_key" ON "Ruleset"("name");
+
+-- CreateIndex
+CREATE INDEX "Ruleset_name_idx" ON "Ruleset"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentScore_targetType_targetId_key" ON "AgentScore"("targetType", "targetId");
+
+-- RenameForeignKey
+ALTER TABLE "managed_secrets" RENAME CONSTRAINT "managed_secrets_createdby_fkey" TO "managed_secrets_createdBy_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "managed_secrets" RENAME CONSTRAINT "managed_secrets_environmentid_fkey" TO "managed_secrets_environmentId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "SecurityEvent" ADD CONSTRAINT "SecurityEvent_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SecurityConfig" ADD CONSTRAINT "SecurityConfig_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "agent_profiles" ADD CONSTRAINT "agent_profiles_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "room_knowledge" ADD CONSTRAINT "room_knowledge_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "chat_rooms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "agent_knowledge" ADD CONSTRAINT "agent_knowledge_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NebulaInstance" ADD CONSTRAINT "NebulaInstance_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NebulaInstance" ADD CONSTRAINT "NebulaInstance_sourceNovaId_fkey" FOREIGN KEY ("sourceNovaId") REFERENCES "NovaDefinition"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HookExecutionLog" ADD CONSTRAINT "HookExecutionLog_nebulaId_fkey" FOREIGN KEY ("nebulaId") REFERENCES "NebulaInstance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SkillExecutionLog" ADD CONSTRAINT "SkillExecutionLog_nebulaId_fkey" FOREIGN KEY ("nebulaId") REFERENCES "NebulaInstance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Eval" ADD CONSTRAINT "Eval_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentScore" ADD CONSTRAINT "AgentScore_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "managed_secrets_environmentid_idx" RENAME TO "managed_secrets_environmentId_idx";
+

--- a/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/invite/route.ts
@@ -48,11 +48,28 @@ export async function POST(
     return NextResponse.json({ error: 'You must be a member of this room to invite others' }, { status: 403 })
   }
 
-  const roleValue = typeof body.role === 'string' ? body.role : 'member'
+  // If an explicit role is provided, use it. Otherwise, make the first agent
+  // added to a room the ring leader ('lead') — subsequent agents are 'member'.
+  const hasLeadAgent = agentId
+    ? room.members.some((m: any) => m.agentId && m.role === 'lead')
+    : false
+  const isNewRingLeader = agentId && !hasLeadAgent && typeof body.role !== 'string'
+  const roleValue = typeof body.role === 'string'
+    ? body.role
+    : isNewRingLeader ? 'lead' : 'member'
 
   await prisma.chatRoomMember.create({
     data: { roomId: id, userId, agentId, role: roleValue },
   })
+
+  // Write ringLeaderAgentId into room.metadata so the routing logic can find it
+  if (isNewRingLeader && agentId) {
+    const existingMeta = (room.metadata ?? {}) as Record<string, unknown>
+    await prisma.chatRoom.update({
+      where: { id },
+      data: { metadata: { ...existingMeta, ringLeaderAgentId: agentId } },
+    })
+  }
 
   const name = agentId
     ? (await prisma.agent.findUnique({ where: { id: agentId! }, select: { name: true } }))?.name || `Agent ${agentId}`

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -397,10 +397,9 @@ export async function triggerRoomAgentReplies(
     },
   })
 
-  const agentMembers = (room?.members ?? [])
-    .map((m: any) => m.agent!)
-    .filter(Boolean)
-    .filter((a: any) => (a.metadata as Record<string, unknown> | null)?.archived !== true)
+  const memberRecords = (room?.members ?? [])
+    .filter((m: any) => m.agent && (m.agent.metadata as Record<string, unknown> | null)?.archived !== true)
+  const agentMembers = memberRecords.map((m: any) => m.agent!)
   if (agentMembers.length === 0) return
 
   // ── Ring Leader routing ──────────────────────────────────────────────────────
@@ -434,8 +433,13 @@ export async function triggerRoomAgentReplies(
   } else if (isDirect) {
     triggeredAgents = agentMembers
   } else {
-    triggeredAgents = agentMembers.filter((a: any) => {
-      // In group rooms, watcher agents (watchPrompt set) only speak when @mentioned
+    // No explicit ring leader set — fall back to role='lead' (first agent added to room).
+    // This handles rooms created before ringLeaderAgentId was wired up.
+    const leadAgents = agentMembers.filter((a: any) => {
+      const member = memberRecords.find((m: any) => m.agentId === a.id)
+      return member?.role === 'lead'
+    })
+    triggeredAgents = leadAgents.length > 0 ? leadAgents : agentMembers.filter((a: any) => {
       const cc = ((a.metadata ?? {}) as Record<string, unknown>).contextConfig as Record<string, unknown> | undefined
       return !cc?.watchPrompt
     })

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -59,8 +59,6 @@ services:
       # ArgoCD — bootstrap uses this to register clusters and create apps
       ARGOCD_SERVER: http://host.docker.internal:8083
       ARGOCD_AUTH_TOKEN: ${ARGOCD_ADMIN_PASSWORD:-}
-      ARGOCD_SERVER: http://host.docker.internal:8083
-      ARGOCD_AUTH_TOKEN: ${ARGOCD_ADMIN_PASSWORD:-}
       # Claude Code sidecar URL (for OAuth bootstrap and credential status)
       ORION_CLAUDE_URL: ${ORION_CLAUDE_URL:-http://orion-claude:3100}
       # MCP service token — shared with orion-claude so Claude can call ORION tools via MCP


### PR DESCRIPTION
## Summary
- `room-agents.ts` read `room.metadata.ringLeaderAgentId` but nothing ever wrote it — so ring leader mode never activated and untagged group messages fell through to the `watchPrompt` filter, silencing all system agents
- `invite/route.ts` always assigned `role='member'` to manually added agents (no role sent by the UI), so the `role='lead'` fallback never had anything to match against either
- Added migration `5_ring_leader_hooks_evals` with all schema additions from the ring leader and hooks/evals plans that were missing from the DB (13 new tables, indexes, FK constraints)

## What changed
- **`invite/route.ts`**: first agent added to a room becomes `role='lead'` and has `ringLeaderAgentId` written into `room.metadata`; subsequent agents get `role='member'`
- **`room-agents.ts`**: conflict resolved — kept the `ringLeaderAgentId`-based routing from main, added `role='lead'` as an explicit fallback for rooms that predate this fix

## Routing precedence (no @mention)
1. `room.metadata.ringLeaderAgentId` set → that agent responds
2. Not set → first agent with `role='lead'` responds  
3. No lead → `!watchPrompt` filter (legacy fallback)

## Test plan
- [ ] Create a group room, add 2+ agents, send a message without tagging anyone — only the first-added agent responds
- [ ] Verify `@AgentName` still routes to the specific agent
- [ ] Verify `@everyone` triggers all agents
- [ ] Verify existing 1-on-1 rooms are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)