### PR TITLE
Fix GitOps policy classification priority

### DIFF
--- a/apps/web/src/lib/gitops-policy.ts
+++ b/apps/web/src/lib/gitops-policy.ts
@@ -197,18 +197,23 @@ export function classifyManifest(manifest: string): OperationType {
 export function classifyOperation(description: string): OperationType {
   const d = description.toLowerCase()
 
-  if (d.includes('scale') || d.includes('replicas')) return 'scale'
-  if (d.includes('restart') || d.includes('rollout')) return 'rolling-restart'
-  if (d.includes('configmap') && !d.includes('secret')) return 'configmap-update'
-  if (d.includes('resource') && (d.includes('limit') || d.includes('request'))) return 'resource-limits'
+  // Check TIER 2 (review-required) structural changes FIRST
+  // These take precedence over operational changes to avoid false positives
+  if (d.includes('delete') || d.includes('destroy') || d.includes('remove all')) return 'destructive'
+  if (d.includes('new deployment') || d.includes('deploy ') || d.includes('create deployment')) return 'new-deployment'
+  if (d.includes('new service') || d.includes('create service')) return 'new-service'
   if (d.includes('ingress')) return 'ingress-change'
   if (d.includes('rbac') || d.includes('clusterrole') || d.includes('rolebinding')) return 'rbac-change'
   if (d.includes('networkpolicy') || d.includes('network policy')) return 'network-policy'
   if (d.includes('namespace')) return 'new-namespace'
   if (d.includes('secret') || d.includes('externalsecret') || d.includes('vault')) return 'secret-change'
-  if (d.includes('delete') || d.includes('destroy') || d.includes('remove all')) return 'destructive'
-  if (d.includes('new deployment') || d.includes('deploy ') || d.includes('create deployment')) return 'new-deployment'
-  if (d.includes('new service') || d.includes('create service')) return 'new-service'
+
+  // Check TIER 1 (auto-merge safe) operational changes
+  // Only checked if no structural change keywords were found
+  if (d.includes('scale') || d.includes('replicas')) return 'scale'
+  if (d.includes('restart') || d.includes('rollout')) return 'rolling-restart'
+  if (d.includes('configmap') && !d.includes('secret')) return 'configmap-update'
+  if (d.includes('resource') && (d.includes('limit') || d.includes('request'))) return 'resource-limits'
   if (d.includes('image') || d.includes('tag') || d.includes('upgrade')) {
     if (d.includes('major')) return 'image-update-major'
     if (d.includes('minor')) return 'image-update-minor'


### PR DESCRIPTION
## Summary

Fixes incorrect classification of structural changes (Tier 2, review-required) as operational changes (Tier 1, auto-merge) when both keywords appear in the operation description.

## Problem

The `classifyOperation()` function evaluated checks in the wrong order. Keywords like 'scale' were checked before 'deploy', causing descriptions like "Deploy Tailscale and scale to 1 replica" to return 'scale' instead of 'new-deployment'.

This caused new deployments to be incorrectly marked for auto-merge, which Gitea's API rejected with 405 errors, blocking tasks.

## Solution

Reorganized checks to prioritize Tier 2 (structural, review-required) changes over Tier 1 (operational, auto-safe) changes:
- Destructive, new-deployment, new-service, ingress, RBAC, network-policy, namespace, and secret changes are now checked first
- Operational changes (scale, restart, configmap, resource-limits, image updates) are checked only if no structural keywords are found

## Example

**Before:** "Deploy Tailscale and scale to 1 replica" → 'scale' (auto-merge) ❌
**After:** "Deploy Tailscale and scale to 1 replica" → 'new-deployment' (review-required) ✅

## Testing

This fix prevents false positives in the classification logic. Existing tests should pass, and new multi-keyword descriptions will be classified correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)