### PR TITLE
fix: tell agents when missing env link causes gateway tools to be invisible

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -537,6 +537,12 @@ export async function triggerRoomAgentReplies(
       const gateway = toolsEnabled ? await resolveAgentGateway(agent.id) : null
       const gatewayTools = gateway ? await gateway.client.listTools().catch(() => []) : []
 
+      // Warn the agent if tools are enabled but no environment is linked — gateway tools (kubectl, shell, etc.)
+      // will be invisible and the agent would otherwise burn turns requesting them via orion_request_tool.
+      if (toolsEnabled && !gateway) {
+        personaPrompt += `\n\n⚠️ WARNING: You have tools enabled but are not linked to any environment. Built-in gateway tools (kubectl_logs, kubectl_get, shell_exec, docker_ps, etc.) are unavailable until an admin links this agent to an environment. Do not request these tools — instead, inform the user that you need to be linked to an environment first.`
+      }
+
       console.log(`[room-agents] ${agent.name} (${llm}${toolsEnabled ? ', tools' : ''}${gateway ? ', gateway' : ''}) → replying to room ${roomId}`)
 
       let reply: string | null = null

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -845,6 +845,39 @@ async function handleRequestTool(args: unknown, ctx: ToolExecutionContext): Prom
   if (!tool_description) return 'Error: tool_description is required'
 
   const name = tool_name || tool_description.slice(0, 50)
+
+  // Check if this is actually a built-in gateway tool the agent can't see
+  // because it has no environment linked — surface the real problem immediately.
+  const { KUBERNETES_DEFAULT_TOOLS, TALOS_DEFAULT_TOOLS, DOCKER_DEFAULT_TOOLS, LOCALHOST_DEFAULT_TOOLS } = await import('./default-tools')
+  const allGatewayTools = [
+    ...KUBERNETES_DEFAULT_TOOLS,
+    ...TALOS_DEFAULT_TOOLS,
+    ...DOCKER_DEFAULT_TOOLS,
+    ...LOCALHOST_DEFAULT_TOOLS,
+  ]
+  const gatewayMatch = allGatewayTools.find(t =>
+    t.name === name ||
+    tool_description.toLowerCase().includes(t.name.toLowerCase())
+  )
+
+  if (gatewayMatch) {
+    // Check whether this agent has an environment linked
+    const envLink = ctx.agentId
+      ? await ctx.prisma.agentEnvironment.findFirst({ where: { agentId: ctx.agentId } })
+      : null
+
+    if (!envLink) {
+      const msg = `⚠️ Agent requested built-in gateway tool **${gatewayMatch.name}** but has no environment linked — tool is invisible to agent`
+      await auditLog(ctx.agentId ?? ctx.userId, msg)
+      return [
+        `"${gatewayMatch.name}" is a built-in gateway tool — it already exists but is not visible to you because this agent is not linked to an environment.`,
+        ``,
+        `An admin needs to link this agent to an environment (e.g. "Talos Cluster") via the ORION UI or orion_patch_environment.`,
+        `Once linked, "${gatewayMatch.name}" and all other gateway tools will be available automatically — no tool request needed.`,
+      ].join('\n')
+    }
+  }
+
   const msg = `🔧 Tool request **${name}** — ${tool_description.slice(0, 300)}`
   await auditLog(ctx.agentId ?? ctx.userId, msg)
 


### PR DESCRIPTION
## Summary

- When an agent calls `orion_request_tool` for a tool that already exists as a built-in gateway tool, return an actionable message explaining the real problem (no environment linked) instead of creating a tool request that will never resolve
- Inject a system prompt warning when an agent has tools enabled but no environment linked, so it knows upfront not to request built-in tools

## Why

Alpha called `orion_request_tool` to request `kubectl` access and got back "request submitted — Alpha will review". Alpha then told the user it was stuck waiting for approval. The tool already existed; Alpha just wasn't linked to an environment. Nothing in the system surfaced this to the agent or the user.

## Behaviour after this fix

**Before:** Agent requests `kubectl_logs` → generic "request submitted" → waits indefinitely

**After:**
- At prompt build time: agent is warned "you have no environment linked — kubectl_logs, shell_exec, etc. are unavailable — tell the user"
- If agent still calls `orion_request_tool` for a gateway tool: immediate response explaining the env-link requirement, audit log entry visible in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)