### PR TITLE
feat: wire knowledge graph connections and add dream synthesis phase

### DIFF
--- a/apps/web/prisma/migrations/7_note_embeddings_hnsw_index/migration.sql
+++ b/apps/web/prisma/migrations/7_note_embeddings_hnsw_index/migration.sql
@@ -1,0 +1,23 @@
+-- Migration: convert note_embeddings.embedding from text to native vector(768) type
+-- and add HNSW index for sub-millisecond cosine similarity search.
+--
+-- The text column stores JSON arrays like [0.1, -0.3, ...] which pgvector
+-- accepts directly via the USING cast. Existing rows are preserved.
+--
+-- Idempotent: skips ALTER if column is already vector type; uses IF NOT EXISTS for index.
+-- If switching to OpenAI text-embedding-3-small (1536-dim), re-run embedAllNotes() and
+-- alter to vector(1536) before creating the index.
+
+DO $$
+BEGIN
+  IF (SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'note_embeddings' AND column_name = 'embedding') = 'text' THEN
+    ALTER TABLE note_embeddings
+      ALTER COLUMN embedding TYPE vector(768)
+      USING embedding::vector(768);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS note_embeddings_embedding_hnsw_idx
+  ON note_embeddings
+  USING hnsw (embedding vector_cosine_ops);

--- a/apps/web/src/app/api/notes/[id]/route.ts
+++ b/apps/web/src/app/api/notes/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { embedNote } from '@/lib/embeddings'
+import { embedNote, computeSemanticEdges } from '@/lib/embeddings'
 import { requireServiceAuth } from '@/lib/auth'
 import { parseBodyOrError, UpdateNoteSchema } from '@/lib/validate'
 
@@ -36,7 +36,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     // Re-fetch with fresh data (the update may have returned a truncated row)
     const updated = await prisma.note.findUnique({ where: { id: params.id } })
     if (updated) {
-      embedNote(updated).catch(err => console.error('[embed] failed for updated note:', err))
+      const ok = await embedNote(updated).catch(err => { console.error('[embed] failed for updated note:', err); return false })
+      if (ok) computeSemanticEdges(updated.id).catch(() => {})
     }
   }
 

--- a/apps/web/src/app/api/notes/route.ts
+++ b/apps/web/src/app/api/notes/route.ts
@@ -1,6 +1,6 @@
 import { makeCrudRoutes } from '@/lib/crud-route-factory'
 import { CreateNoteSchema } from '@/lib/validate'
-import { embedNote } from '@/lib/embeddings'
+import { embedNote, computeSemanticEdges } from '@/lib/embeddings'
 
 export const { GET, POST } = makeCrudRoutes({
   model:        'note',
@@ -9,6 +9,7 @@ export const { GET, POST } = makeCrudRoutes({
   orderBy:      [{ pinned: 'desc' }, { updatedAt: 'desc' }],
   afterCreate:  async (record) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    embedNote(record as any).catch(err => console.error('[embed] failed for new note:', err))
+    const ok = await embedNote(record as any).catch(err => { console.error('[embed] failed for new note:', err); return false })
+    if (ok) computeSemanticEdges(record.id).catch(() => {})
   },
 })

--- a/apps/web/src/lib/dream.ts
+++ b/apps/web/src/lib/dream.ts
@@ -1,29 +1,38 @@
 /**
  * Dream — memory consolidation for ORION.
  *
- * Two phases, run on separate schedules:
+ * Three phases, run on separate schedules:
  *
  * 1. EXTRACTION (every 2 hours)
  *    Scans recent chat messages and task events since the last run.
- *    Sends batches to an LLM to extract durable facts, lessons, and patterns.
- *    Writes each extracted item as a Note + immediately embeds it.
+ *    Passes existing note titles so the LLM can [[wikilink]] to related notes.
+ *    Writes each extracted item as a Note + immediately embeds it + computes edges.
  *
- * 2. PRUNING (every 24 hours)
+ * 2. SYNTHESIS (every 12 hours)
+ *    Groups all notes by folder/tag cluster.
+ *    Asks an LLM to identify missing mid-level "hub" notes that should connect
+ *    related specifics (e.g. "ESO Secret Sync Patterns" tying together multiple
+ *    Tailscale/Vault/cert-manager notes). Writes hub notes with [[wikilinks]] to
+ *    their members so the graph has structure beyond leaf-level facts.
+ *
+ * 3. PRUNING (every 24 hours)
  *    Reads all notes in the knowledge base.
  *    Sends each note to an LLM with recent system context.
  *    Deletes notes the LLM marks as stale or superseded.
  *
  * Last-run timestamps are stored in SystemSetting:
  *   dream.extractionLastRun  — unix ms
+ *   dream.synthesisLastRun   — unix ms
  *   dream.pruningLastRun     — unix ms
  */
 
 import { prisma } from './db'
-import { embedNote } from './embeddings'
+import { embedNote, computeSemanticEdges } from './embeddings'
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const EXTRACTION_INTERVAL_MS = 2  * 60 * 60 * 1000  // 2 hours
+const SYNTHESIS_INTERVAL_MS  = 12 * 60 * 60 * 1000  // 12 hours
 const PRUNING_INTERVAL_MS    = 24 * 60 * 60 * 1000  // 24 hours
 const EXTRACTION_BATCH       = 80   // messages per LLM call
 const PRUNING_BATCH          = 20   // notes per pruning LLM call
@@ -176,6 +185,15 @@ export async function runExtraction(): Promise<void> {
     return
   }
 
+  // Fetch existing note titles so the LLM can wikilink to related notes
+  const existingNotes = await prisma.note.findMany({
+    select: { title: true, folder: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+  const existingTitles = existingNotes
+    .map(n => `  - ${n.title} (${n.folder})`)
+    .join('\n')
+
   // Build text corpus for the LLM
   const messageLines = messages.map(m => {
     const who    = m.agent?.name ?? m.senderType
@@ -195,6 +213,9 @@ export async function runExtraction(): Promise<void> {
 
 Review the following recent agent messages and task events, then extract durable facts, lessons, and patterns worth remembering for future tasks.
 
+EXISTING KNOWLEDGE BASE NOTES:
+${existingTitles || '  (none yet)'}
+
 CONTENT:
 ${corpus}
 
@@ -203,12 +224,13 @@ Instructions:
 - Skip transient state: "pod is running now", "task assigned", routine status updates.
 - Skip anything too vague to be actionable.
 - Each memory must be self-contained and searchable.
+- In the content field, use [[Note Title]] wikilink syntax to reference related existing notes by their exact title. This builds the knowledge graph — link to any note above that is genuinely related.
 
 Respond with a JSON array (and nothing else). Each item:
 {
   "title": "short searchable title including domain/service name",
-  "content": "## Context\\n...\\n## Lesson\\n...\\n## Rules for Next Time\\n- ...",
-  "folder": "Success Patterns" | "Failure Patterns" | "Cluster Quirks" | "Tool Usage" | "Agent Lessons",
+  "content": "## Context\\n...\\n## Lesson\\n...\\n## Rules for Next Time\\n- ...\\n## Related\\n- [[Exact Title of Related Note]]",
+  "folder": "Success Patterns" | "Failure Patterns" | "Cluster Quirks" | "Tool Usage" | "Agent Lessons" | "Infrastructure",
   "tags": ["tag1", "tag2"]
 }
 
@@ -251,7 +273,8 @@ If nothing is worth remembering, return an empty array: []`
         })
       }
 
-      await embedNote(note).catch(() => {})
+      const embedded = await embedNote(note).catch(() => false)
+      if (embedded) await computeSemanticEdges(note.id).catch(() => {})
       written++
     } catch (e) {
       console.error('[dream] Failed to write memory:', item.title, e)
@@ -260,6 +283,110 @@ If nothing is worth remembering, return an empty array: []`
 
   await setSetting('dream.extractionLastRun', String(now.getTime()))
   console.log(`[dream] Extraction complete — wrote ${written}/${extracted.length} memories`)
+}
+
+// ── Synthesis ─────────────────────────────────────────────────────────────────
+
+/**
+ * Identify missing hub notes that should connect clusters of related specifics.
+ * Creates mid-level "Infrastructure", "Agent Patterns", and topic-level notes
+ * that [[wikilink]] to their members — giving the knowledge graph real structure.
+ * Called every SYNTHESIS_INTERVAL_MS.
+ */
+export async function runSynthesis(): Promise<void> {
+  const lastRunStr = await getSetting('dream.synthesisLastRun')
+  const lastRun    = lastRunStr ? new Date(parseInt(lastRunStr, 10)) : new Date(0)
+  const now        = new Date()
+
+  console.log(`[dream] Synthesis — last run ${lastRun.toISOString()}`)
+
+  const notes = await prisma.note.findMany({
+    select: { id: true, title: true, folder: true, tags: true, content: true },
+    orderBy: { updatedAt: 'desc' },
+  })
+
+  if (notes.length < 5) {
+    console.log('[dream] Synthesis — not enough notes yet, skipping')
+    await setSetting('dream.synthesisLastRun', String(now.getTime()))
+    return
+  }
+
+  const noteIndex = notes
+    .map(n => `  [${n.folder}] ${n.title}`)
+    .join('\n')
+
+  const synthesisPrompt = `You are a knowledge architect for an AI agent team managing a Kubernetes homelab cluster.
+
+Below is the current knowledge base — a flat list of specific notes extracted from agent activity. Your job is to identify missing "hub" notes that should exist to connect related specifics into a coherent knowledge graph.
+
+CURRENT NOTES:
+${noteIndex}
+
+Instructions:
+- Identify clusters of related notes (e.g. multiple notes about ESO, Vault, Tailscale, agent coordination, GitOps).
+- For each cluster that lacks a hub note, propose one hub note that:
+  - Has a broad topic title (e.g. "ESO & Vault Secret Management", "Agent Coordination Patterns", "Tailscale Operator Setup")
+  - Has content summarising what's known about that topic
+  - Uses [[Note Title]] wikilinks to connect to every specific note in the cluster (use exact titles from the list above)
+- Only create hubs where 2+ specific notes exist on the same topic.
+- Do NOT recreate notes that already exist as hubs (check the list above).
+- Do NOT create hubs for unrelated one-off notes.
+
+Respond with a JSON array (and nothing else). Each hub note:
+{
+  "title": "Topic-Level Hub Title",
+  "content": "## Overview\\n...summary of what is known...\\n\\n## Notes in this cluster\\n- [[Exact Note Title]]\\n- [[Exact Note Title]]",
+  "folder": "Infrastructure" | "Agent Patterns" | "GitOps" | "Security" | "Networking" | "Observability",
+  "tags": ["hub", "tag2"]
+}
+
+If no hubs are missing, return an empty array: []`
+
+  let hubs: Array<{ title: string; content: string; folder: string; tags: string[] }> = []
+  try {
+    const raw = await callLLM(synthesisPrompt)
+    const jsonMatch = raw.match(/\[[\s\S]*\]/)
+    if (jsonMatch) hubs = JSON.parse(jsonMatch[0])
+  } catch (e) {
+    console.error('[dream] Synthesis LLM/parse error:', e)
+  }
+
+  console.log(`[dream] Synthesis — writing ${hubs.length} hub notes`)
+
+  let written = 0
+  for (const hub of hubs) {
+    if (!hub.title?.trim() || !hub.content?.trim()) continue
+    try {
+      const existing = await prisma.note.findFirst({ where: { title: hub.title.trim() } })
+      if (existing) {
+        // Hub already exists — update content to reflect current cluster membership
+        const note = await prisma.note.update({
+          where: { id: existing.id },
+          data: { content: hub.content.trim(), updatedAt: new Date() },
+        })
+        const embedded = await embedNote(note).catch(() => false)
+        if (embedded) await computeSemanticEdges(note.id).catch(() => {})
+      } else {
+        const note = await prisma.note.create({
+          data: {
+            title:   hub.title.trim(),
+            content: hub.content.trim(),
+            folder:  hub.folder ?? 'Infrastructure',
+            type:    'note',
+            tags:    (hub.tags ?? []) as any,
+          },
+        })
+        const embedded = await embedNote(note).catch(() => false)
+        if (embedded) await computeSemanticEdges(note.id).catch(() => {})
+      }
+      written++
+    } catch (e) {
+      console.error('[dream] Failed to write hub note:', hub.title, e)
+    }
+  }
+
+  await setSetting('dream.synthesisLastRun', String(now.getTime()))
+  console.log(`[dream] Synthesis complete — wrote ${written}/${hubs.length} hub notes`)
 }
 
 // ── Pruning ───────────────────────────────────────────────────────────────────
@@ -376,6 +503,7 @@ Rules:
 // ── Scheduler ─────────────────────────────────────────────────────────────────
 
 let extractionTimer: ReturnType<typeof setTimeout> | null = null
+let synthesisTimer:  ReturnType<typeof setTimeout> | null = null
 let pruningTimer:    ReturnType<typeof setTimeout> | null = null
 
 export function startDream(): void {
@@ -394,6 +522,19 @@ export function startDream(): void {
     }, delay)
   }
 
+  async function scheduleSynthesis() {
+    const lastRunStr = await getSetting('dream.synthesisLastRun').catch(() => null)
+    const lastRun    = lastRunStr ? parseInt(lastRunStr, 10) : 0
+    const nextRun    = lastRun + SYNTHESIS_INTERVAL_MS
+    const delay      = Math.max(0, nextRun - Date.now())
+
+    console.log(`[dream] Next synthesis in ${Math.round(delay / 60000)} min`)
+    synthesisTimer = setTimeout(async () => {
+      await runSynthesis().catch(e => console.error('[dream] Synthesis failed:', e))
+      scheduleSynthesis()
+    }, delay)
+  }
+
   async function schedulePruning() {
     const lastRunStr = await getSetting('dream.pruningLastRun').catch(() => null)
     const lastRun    = lastRunStr ? parseInt(lastRunStr, 10) : 0
@@ -408,10 +549,12 @@ export function startDream(): void {
   }
 
   scheduleExtraction()
+  scheduleSynthesis()
   schedulePruning()
 }
 
 export function stopDream(): void {
   if (extractionTimer) clearTimeout(extractionTimer)
+  if (synthesisTimer)  clearTimeout(synthesisTimer)
   if (pruningTimer)    clearTimeout(pruningTimer)
 }

--- a/apps/web/src/lib/embeddings.ts
+++ b/apps/web/src/lib/embeddings.ts
@@ -206,7 +206,7 @@ export async function vectorSearch(
       n."type",
       n.folder,
       n.pinned,
-      (1 - (ne.embedding::vector <-> ${vecStr}::vector))::float AS score
+      (1 - (ne.embedding <-> ${vecStr}::vector))::float AS score
     FROM "note_embeddings" ne
     JOIN "Note" n ON n.id = ne."noteId"
     WHERE ne.embedding IS NOT NULL
@@ -238,7 +238,6 @@ export async function computeSemanticEdges(
   const target = await prisma.noteEmbedding.findUnique({ where: { noteId } })
   if (!target) return
 
-  // target.embedding is already stored as a JSON array string like [-0.1, 0.5, ...]
   const vecStr = target.embedding
 
   const similar = await prisma.$queryRaw<
@@ -246,7 +245,7 @@ export async function computeSemanticEdges(
   >`
     SELECT
       other."noteId" AS "targetNoteId",
-      (1 - (other.embedding::vector <-> ${vecStr}::vector))::float AS score
+      (1 - (other.embedding <-> ${vecStr}::vector))::float AS score
     FROM "note_embeddings" other
     WHERE other."noteId" != ${noteId}
       AND other.embedding IS NOT NULL
@@ -283,7 +282,7 @@ export async function computeSemanticEdges(
 export async function retrieveKnowledgeContext(
   query: string,
   topK = 3,
-  minScore = 0.4,
+  minScore = 0.2,
 ): Promise<string> {
   try {
     const result = await generateEmbedding(query.slice(0, 2000))


### PR DESCRIPTION
## Summary

- **HNSW index** on `note_embeddings.embedding` — converts text column to native `vector(768)` type and adds HNSW cosine index for sub-millisecond similarity search. Migration is idempotent so fresh bootstraps apply it cleanly.
- **Fix: `computeSemanticEdges` never firing** — notes were being embedded but graph edges were never written. Now called after every note create, update, and dream extraction write.
- **Dream extraction wikilinks** — extraction prompt now passes all existing note titles to the LLM and explicitly asks for `[[wikilink]]` references, so new notes connect into the graph rather than sitting as isolated leaves.
- **Dream synthesis phase (new, every 12h)** — scans all notes, identifies missing hub notes that should connect clusters of related specifics (e.g. "ESO & Vault Secret Management" tying together multiple Tailscale/Vault/cert-manager notes), writes them with wikilinks to their members.
- **RAG threshold lowered** from `0.4` to `0.2` — all existing notes scored 0.06–0.27; none were reaching agents. 0.2 captures real signal from a small, diverse knowledge base.

## Test plan

- [ ] Trigger dream extraction manually — verify new notes contain `[[wikilink]]` references to existing notes
- [ ] After extraction, verify `SemanticConnection` rows are written (were previously only written via manual rebuild endpoint)
- [ ] After synthesis runs, verify hub notes appear in the Notes UI connecting related clusters
- [ ] Verify a task that relates to an existing note now gets that note injected in agent context
- [ ] On fresh deploy, verify migration applies cleanly (`embedding` column becomes `vector(768)`, HNSW index created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)