### PR TITLE
fix: cast afterCreate record to any before accessing .id

### DIFF
--- a/apps/web/src/app/api/notes/route.ts
+++ b/apps/web/src/app/api/notes/route.ts
@@ -9,7 +9,8 @@ export const { GET, POST } = makeCrudRoutes({
   orderBy:      [{ pinned: 'desc' }, { updatedAt: 'desc' }],
   afterCreate:  async (record) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ok = await embedNote(record as any).catch(err => { console.error('[embed] failed for new note:', err); return false })
-    if (ok) computeSemanticEdges(record.id).catch(() => {})
+    const r = record as any
+    const ok = await embedNote(r).catch(err => { console.error('[embed] failed for new note:', err); return false })
+    if (ok) computeSemanticEdges(r.id).catch(() => {})
   },
 })


### PR DESCRIPTION
## Summary

- Fixes TypeScript build error introduced in #361
- `afterCreate` callback types `record` as `unknown` — accessing `record.id` directly causes a type error
- Cast to `any` first via a named variable `r` so both `embedNote(r)` and `computeSemanticEdges(r.id)` compile cleanly

## Test plan
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)