### PR TITLE
feat: gateway tool categories + lean system prompt injection

### DIFF
--- a/apps/gateway/src/builtin-tools/discovery.ts
+++ b/apps/gateway/src/builtin-tools/discovery.ts
@@ -73,7 +73,7 @@ function scoreProfile(query: string, profile: {
   return Math.min(domainScore + tagScore + profileConfidence, 1.0)
 }
 
-export const discoveryTools = [
+export const discoveryTools = ([
   {
     name: 'find_specialist',
     description: 'Discover which specialist agent should handle a given task. ' +
@@ -172,4 +172,4 @@ export const discoveryTools = [
       return lines.join('\n')
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'discovery' as const }))

--- a/apps/gateway/src/builtin-tools/docker.ts
+++ b/apps/gateway/src/builtin-tools/docker.ts
@@ -8,7 +8,7 @@ async function docker(args: string[]): Promise<string> {
   return stdout || stderr
 }
 
-export const dockerTools = [
+export const dockerTools = ([
   {
     name: 'docker_ps',
     description: 'List running containers on this node',
@@ -121,4 +121,4 @@ export const dockerTools = [
       return docker(cmdArgs)
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'docker' as const }))

--- a/apps/gateway/src/builtin-tools/knowledge-graph.ts
+++ b/apps/gateway/src/builtin-tools/knowledge-graph.ts
@@ -39,7 +39,7 @@ async function orionFetch(path: string, options?: RequestInit): Promise<unknown>
   return res.json()
 }
 
-export const knowledgeGraphTools = [
+export const knowledgeGraphTools = ([
   {
     name: 'knowledge_search',
     description: 'Semantically search the ORION knowledge base (notes, wikis, runbooks). ' +
@@ -331,4 +331,4 @@ export const knowledgeGraphTools = [
       )
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'knowledge' as const }))

--- a/apps/gateway/src/builtin-tools/kubernetes.ts
+++ b/apps/gateway/src/builtin-tools/kubernetes.ts
@@ -14,7 +14,7 @@ async function helm(args: string[]): Promise<string> {
   return stdout || stderr
 }
 
-export const kubernetesTools = [
+export const kubernetesTools = ([
   {
     name: 'kubectl_get_pods',
     description: 'List pods in a namespace (or all namespaces)',
@@ -409,4 +409,4 @@ export const kubernetesTools = [
       return helm(cmdArgs)
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'cluster-ops' as const }))

--- a/apps/gateway/src/builtin-tools/localhost.ts
+++ b/apps/gateway/src/builtin-tools/localhost.ts
@@ -54,7 +54,7 @@ async function sh(cmd: string, args: string[], timeoutMs = 30_000): Promise<stri
   return stdout || stderr
 }
 
-export const localhostTools = [
+export const localhostTools = ([
   {
     name: 'shell_exec',
     description: 'Run a shell command on the ORION management host',
@@ -151,4 +151,4 @@ export const localhostTools = [
       return lines.join('\n')
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'localhost' as const }))

--- a/apps/gateway/src/builtin-tools/security.ts
+++ b/apps/gateway/src/builtin-tools/security.ts
@@ -40,7 +40,7 @@ async function crowdsecGet(endpoint: string, params: Record<string, string> = {}
   return jsonStr(JSON.parse(await res.text()))
 }
 
-export const securityTools = [
+export const securityTools = ([
   {
     name: 'crowdsec_blocks',
     description: 'Get blocked IPs / requests from CrowdSec LAPI',
@@ -356,4 +356,4 @@ export const securityTools = [
       return jsonStr(data)
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'security' as const }))

--- a/apps/gateway/src/builtin-tools/talos.ts
+++ b/apps/gateway/src/builtin-tools/talos.ts
@@ -30,7 +30,7 @@ function withConfig(talosConfigB64: string, args: string[]): string[] {
   return ['--talosconfig', tmpFile, ...args]
 }
 
-export const talosTools = [
+export const talosTools = ([
   {
     name: 'talos_get_version',
     description: 'Get Talos version info for a node',
@@ -180,4 +180,4 @@ export const talosTools = [
       }
     },
   },
-]
+] as const).map(t => ({ ...t, category: 'talos' as const }))

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -259,6 +259,7 @@ async function persistCredentials(): Promise<void> {
 type BuiltinTool = {
   name: string
   description: string
+  category: string
   inputSchema: Record<string, unknown>
   execute: (args: Record<string, unknown>) => Promise<string>
 }
@@ -378,6 +379,7 @@ app.get('/tools', requireAuth, (_req: Request, res: Response) => {
   res.json(activeTools.map(t => ({
     name:        t.name,
     description: t.description,
+    category:    (t as BuiltinTool).category ?? 'general',
     inputSchema: t.inputSchema,
   })))
 })

--- a/apps/web/src/lib/agent-runner/types.ts
+++ b/apps/web/src/lib/agent-runner/types.ts
@@ -49,6 +49,7 @@ export interface AgentRunner {
 export interface GatewayTool {
   name: string
   description: string
+  category?: string
   inputSchema: {
     type: string
     properties?: Record<string, SchemaProperty>

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -49,14 +49,35 @@ type ChatMsg = { role: 'system' | 'user' | 'assistant'; content: string }
  */
 const LOCAL_MODEL_PLAN_FIRST = `
 
-## Plan Before You Act
+## Tool Use Discipline
 
-Before calling any tool:
-1. State what you already know
-2. State what you still need
-3. List the exact sequence of tool calls you will make
+Before calling any tool, check: do you already have this information from an earlier result in this conversation? If yes, use it — do not re-fetch.
 
-Then execute that plan — one tool at a time, in order. Do not call the same tool twice. Do not improvise mid-plan. If a step fails, report it and stop — do not retry or chain to a different tool hoping for a better result.`
+When you do call tools:
+1. State what you know and what you still need
+2. Call one tool, read the result, then decide the next step
+3. After gathering what you need, ACT — write the manifest, apply the change, or give your answer
+
+When stuck: write what you know, what's blocking you, and ask the user — do not call more tools hoping for a better result.
+Call list_tools(category) to discover what tools are available in a category.`
+
+/**
+ * Build a compact gateway tool category summary for injection into system prompts.
+ * Shows category names and counts only — agents call list_tools(category) to drill in.
+ */
+function buildGatewayCategorySummary(gatewayTools: GatewayTool[]): string {
+  if (gatewayTools.length === 0) return ''
+  const byCategory = new Map<string, number>()
+  for (const t of gatewayTools) {
+    const cat = t.category ?? 'general'
+    byCategory.set(cat, (byCategory.get(cat) ?? 0) + 1)
+  }
+  const lines = ['\n\n## Gateway Tool Categories', 'Use list_tools(category) to see tool names in any category.']
+  for (const [cat, count] of byCategory) {
+    lines.push(`- **${cat}** (${count} tools)`)
+  }
+  return lines.join('\n')
+}
 
 function buildSystemPrompt(
   agentName: string,
@@ -65,6 +86,8 @@ function buildSystemPrompt(
   hasTools: boolean | 'legacy' | 'mcp' = false,
   /** True for non-Claude (Ollama/OpenAI-compat) models — injects plan-first constraint */
   localModel = false,
+  /** Compact category summary built from gateway tools — injected when tools are enabled */
+  gatewayCategorySummary = '',
 ): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
@@ -91,7 +114,7 @@ Rules you must follow without exception:
 7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT
 
 ---
-${agentBasePrompt}${toolAddendum}${planFirst}`
+${agentBasePrompt}${toolAddendum}${gatewayCategorySummary}${planFirst}`
 }
 
 /**
@@ -168,8 +191,9 @@ async function callOllamaChat(
   model: string,
   baseUrl: string,
   hasTools = false,
+  gatewayCategorySummary = '',
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true, gatewayCategorySummary)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const res = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
@@ -207,7 +231,8 @@ async function callOpenAIChat(
   gatewayTools?: GatewayTool[],
 ): Promise<string | null> {
   const hasTools = !!toolContext
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true)
+  const gatewayCategorySummary = gatewayTools ? buildGatewayCategorySummary(gatewayTools) : ''
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true, gatewayCategorySummary)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
@@ -292,6 +317,10 @@ async function callOpenAIChat(
         result = await executeRegisteredTool(tc.function.name, args, {
           agentId: toolContext!.agentId,
           prisma,
+          gateway: gateway ? {
+            executeTool: (n, a) => gateway.client.executeTool(n, a),
+            listTools: () => gateway.client.listTools(),
+          } : undefined,
         })
       } else if (legacyToolNames.has(tc.function.name)) {
         // Legacy agent-tools (create_task, orion_manage_task, etc.)
@@ -590,7 +619,7 @@ export async function triggerRoomAgentReplies(
           if (toolsEnabled) {
             console.warn(`[room-agents] ${agent.name} has tools enabled but ${llm} route does not support function calling — scope awareness injected but tool invocation unavailable`)
           }
-          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext)
+          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext, buildGatewayCategorySummary(gatewayTools))
         } else {
           // claude / claude:<model> — routed through orion-claude sidecar.
           // When tools are enabled, the sidecar writes a per-request .mcp.json so Claude

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -59,6 +59,7 @@ export interface ToolExecutionContext {
   prisma: typeof prisma
   gateway?: {
     executeTool: (name: string, args: Record<string, unknown>) => Promise<string>
+    listTools?: () => Promise<Array<{ name: string; description: string; category?: string; inputSchema: Record<string, unknown> }>>
   }
   // Legacy: conversationId used in chat path for propose_tool
   conversationId?: string
@@ -2546,13 +2547,13 @@ registerTool({
 
 registerTool({
   name: 'list_tools',
-  description: 'List available tools by category. Call this to discover what you can actually do before attempting an operation. Pass a category to narrow the results. If unsure which category applies, omit it to see all categories and their tool names.',
+  description: 'List available tools by category. Call this to discover what you can actually do before attempting an operation. Pass a category to narrow the results. ORION categories: tasks, agents, rooms, features, gitops, knowledge, environment, secrets, tools. Gateway categories (when linked): cluster-ops, docker, talos, localhost, security, discovery. Omit category to list everything.',
   inputSchema: {
     type: 'object',
     properties: {
       category: {
         type: 'string',
-        description: 'Optional category filter: tasks, agents, rooms, features, gitops, knowledge, environment, secrets, tools. Omit to list all categories with their tool names.',
+        description: 'Optional category filter. ORION: tasks, agents, rooms, features, gitops, knowledge, environment, secrets, tools. Gateway: cluster-ops, docker, talos, localhost, security, discovery. Omit to list all.',
       },
     },
   },
@@ -2560,30 +2561,50 @@ registerTool({
   parallelSafe: true,
   availableIn: 'both',
   category: 'tools',
-  handler: async (args) => {
+  handler: async (args, ctx) => {
     const { category } = (args as Record<string, unknown>) ?? {}
 
-    if (category && typeof category === 'string') {
-      const tools = getToolsByCategory(category as ToolCategory)
-      if (tools.length === 0) {
-        const all = getAllCategories()
-        return `No tools found for category "${category}". Available categories: ${all.join(', ')}`
-      }
-      return `Tools in category "${category}":\n` +
-        tools.map(t => `  - ${t.name}`).join('\n') +
-        `\n\nCall describe_tool(name) to get full details on any tool.`
+    // Fetch gateway tools if available
+    const gatewayTools = ctx.gateway?.listTools ? await ctx.gateway.listTools().catch(() => []) : []
+    const gatewayByCategory = new Map<string, string[]>()
+    for (const t of gatewayTools) {
+      const cat = t.category ?? 'general'
+      if (!gatewayByCategory.has(cat)) gatewayByCategory.set(cat, [])
+      gatewayByCategory.get(cat)!.push(t.name)
     }
 
-    // No category — list all categories with their tool names
-    const categories = getAllCategories()
-    const lines: string[] = ['Available tool categories:\n']
-    for (const cat of categories) {
-      const tools = getToolsByCategory(cat)
-      lines.push(`${cat}:`)
-      lines.push(tools.map(t => `  - ${t.name}`).join('\n'))
-      lines.push('')
+    if (category && typeof category === 'string') {
+      // Check ORION registry first
+      const orionTools = getToolsByCategory(category as ToolCategory)
+      // Then gateway
+      const gwTools = gatewayByCategory.get(category) ?? []
+
+      if (orionTools.length === 0 && gwTools.length === 0) {
+        const allOrion = getAllCategories()
+        const allGw = [...gatewayByCategory.keys()]
+        return `No tools found for category "${category}". ORION categories: ${allOrion.join(', ')}${allGw.length ? `. Gateway categories: ${allGw.join(', ')}` : ''}`
+      }
+
+      const lines: string[] = [`Tools in category "${category}":`]
+      if (orionTools.length > 0) lines.push(...orionTools.map(t => `  - ${t.name}`))
+      if (gwTools.length > 0) lines.push(...gwTools.map(n => `  - ${n}`))
+      lines.push('\nCall describe_tool(name) to get full details on any tool.')
+      return lines.join('\n')
     }
-    lines.push('Call list_tools(category) to filter, or describe_tool(name) for full details.')
+
+    // No category — list all
+    const lines: string[] = ['Available tool categories:\n', '## ORION tools']
+    for (const cat of getAllCategories()) {
+      const tools = getToolsByCategory(cat)
+      lines.push(`${cat} (${tools.length}): ${tools.map(t => t.name).join(', ')}`)
+    }
+    if (gatewayByCategory.size > 0) {
+      lines.push('\n## Gateway tools')
+      for (const [cat, names] of gatewayByCategory) {
+        lines.push(`${cat} (${names.length}): ${names.join(', ')}`)
+      }
+    }
+    lines.push('\nCall list_tools(category) to filter, or describe_tool(name) for full details.')
     return lines.join('\n')
   },
 })


### PR DESCRIPTION
## Summary

- Gateway builtin tools now carry a `category` field — each file maps to a category (`cluster-ops`, `docker`, `talos`, `localhost`, `knowledge`, `security`, `discovery`)
- The `/tools` REST endpoint includes `category` in each tool entry
- System prompts now inject a **compact category summary** (name + count only) instead of dumping every tool name — agents call `list_tools(category)` to drill in when they need specifics
- `list_tools` tool extended to include gateway tool categories alongside ORION registry categories
- `LOCAL_MODEL_PLAN_FIRST` rewritten to be generic — no hardcoded tool names, just discipline rules and a pointer to `list_tools(category)`

## What changed and why

Previously, the tool list injected into every system prompt named specific tools (e.g. `kubectl_get`, `orion_list_secrets`) regardless of what the agent actually had available. This caused two problems: context bloat on every turn, and hardcoded names that break if tools are renamed or the agent has a different toolset.

Now:
- **System prompt** gets `cluster-ops (12 tools)`, `docker (6 tools)`, etc. — compact, always accurate
- **Agents call `list_tools("cluster-ops")`** when they need to know what's actually in a category
- **`list_tools` without args** shows all categories across both ORION and gateway, with tool counts and names

## Test plan

- [ ] Agent with gateway linked: system prompt includes gateway category summary
- [ ] Agent without gateway: system prompt has no gateway section
- [ ] `list_tools()` in chat returns both ORION and gateway categories
- [ ] `list_tools("cluster-ops")` returns kubectl/helm tool names
- [ ] `list_tools("docker")` returns docker tool names
- [ ] `/tools` endpoint on gateway returns `category` field per tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)