### PR TITLE
feat: context compaction — token tracking and auto-summarisation for chat rooms

### DIFF
--- a/apps/web/prisma/migrations/8_chat_room_token_tracking/migration.sql
+++ b/apps/web/prisma/migrations/8_chat_room_token_tracking/migration.sql
@@ -1,0 +1,6 @@
+-- Migration: add token tracking columns to chat_rooms
+-- tokenCount: rolling prompt_tokens from the last LLM turn (used for context utilisation tracking)
+-- tokenLimit: optional override for the context window size; null = auto-discover from model /props
+
+ALTER TABLE "chat_rooms" ADD COLUMN IF NOT EXISTS "tokenCount" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "chat_rooms" ADD COLUMN IF NOT EXISTS "tokenLimit" INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -757,6 +757,8 @@ model ChatRoom {
   createdBy     String
   createdAt     DateTime           @default(now())
   updatedAt     DateTime           @updatedAt
+  tokenCount    Int                @default(0)   // rolling prompt_tokens from last LLM turn
+  tokenLimit    Int?                             // override context limit; null = auto-discover from model
 
   members       ChatRoomMember[]
   messages      ChatMessage[]

--- a/apps/web/src/app/api/chatrooms/[id]/compact/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/compact/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { compactRoom } from '@/lib/compaction'
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id: roomId } = await params
+
+  try {
+    await compactRoom(roomId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[compact] room ${roomId} failed:`, message)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -102,6 +102,40 @@ export function invalidateSnapshotCache(): void {
   invalidate('snapshot')
 }
 
+// ── Dynamic context limit discovery ──────────────────────────────────────────
+// Hits the llama.cpp /props endpoint to discover n_ctx for OpenAI-compat
+// endpoints. Cached per baseUrl with a 10-minute TTL so transient network
+// failures don't permanently lock a model to the 8192 fallback.
+
+const CONTEXT_LIMIT_TTL_MS = 10 * 60 * 1000  // 10 minutes
+const contextLimitCache = new Map<string, { value: number; expiresAt: number }>()
+
+/**
+ * Discover the context window size for an OpenAI-compatible model endpoint.
+ * Uses llama.cpp's GET /props (returns { n_ctx: number, ... }).
+ * Result is cached per baseUrl for 10 minutes; falls back to 8192.
+ */
+export async function getModelContextLimit(baseUrl: string): Promise<number> {
+  const cached = contextLimitCache.get(baseUrl)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}/props`, {
+      signal: AbortSignal.timeout(5_000),
+    })
+    if (res.ok) {
+      const data = await res.json() as Record<string, unknown>
+      const n_ctx = typeof data.n_ctx === 'number' ? data.n_ctx : 8192
+      contextLimitCache.set(baseUrl, { value: n_ctx, expiresAt: Date.now() + CONTEXT_LIMIT_TTL_MS })
+      return n_ctx
+    }
+  } catch { /* ignore — not llama.cpp or unreachable */ }
+
+  // Cache the fallback too, but with a shorter TTL so we retry sooner
+  contextLimitCache.set(baseUrl, { value: 8192, expiresAt: Date.now() + 60_000 })
+  return 8192
+}
+
 export async function buildAgentLocalContext(agentId: string): Promise<string> {
   try {
     const knowledge = await prisma.agentKnowledge.findMany({

--- a/apps/web/src/lib/compaction.ts
+++ b/apps/web/src/lib/compaction.ts
@@ -1,0 +1,249 @@
+/**
+ * Context compaction for chat rooms.
+ *
+ * When a room's context utilisation reaches 90% of the model's context limit
+ * the system auto-compacts; at 70% it emits a warning banner via SSE.
+ *
+ * Compaction works by:
+ * 1. Fetching all messages since the last compaction (or all messages if none).
+ * 2. Asking the default AI model to summarise them into a structured markdown block.
+ * 3. Saving the summary as a `senderType: 'compaction'` ChatMessage.
+ * 4. Resetting the room's tokenCount to 0.
+ * 5. Publishing the new compaction message via Redis SSE so it appears live.
+ *
+ * Future history queries use the compaction message as their start boundary,
+ * so the LLM always receives an accurate, space-efficient conversation context.
+ */
+
+import { prisma } from './db'
+import { publishChatMessage } from './chat-redis'
+
+// ── Concurrency guard ─────────────────────────────────────────────────────────
+// Prevents two simultaneous compactions for the same room (e.g. two agents both
+// hitting the 90% threshold in the same turn). A simple in-process Set is sufficient
+// since compaction is triggered from within a single Next.js server process.
+const compactingRooms = new Set<string>()
+
+const COMPACTION_PROMPT = `You are summarizing a conversation for context compaction. Your goal is to create a comprehensive but concise summary that preserves:
+
+- All key decisions made and their rationale
+- Current task status and what has been accomplished
+- Open questions, blockers, and next steps
+- Important facts, numbers, file paths, or technical details
+- The overall goal and where things currently stand
+
+Format the summary in markdown with clear sections. Be complete — this summary will replace the full conversation history for the AI agents involved.
+
+Conversation transcript to summarize:
+`
+
+type OpenAICompatMessage = { role: string; content: string }
+
+/**
+ * Call a model via OpenAI-compatible /v1/chat/completions for compaction.
+ * Returns the model's text reply or null on failure.
+ */
+async function callForSummary(
+  baseUrl: string,
+  modelId: string,
+  apiKey: string | null | undefined,
+  transcript: string,
+): Promise<string | null> {
+  const messages: OpenAICompatMessage[] = [
+    { role: 'user', content: COMPACTION_PROMPT + transcript },
+  ]
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, '')}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ model: modelId, stream: false, messages }),
+      signal: AbortSignal.timeout(120_000),
+    })
+    if (!res.ok) {
+      console.error(`[compaction] model ${modelId} at ${baseUrl} returned HTTP ${res.status}`)
+      return null
+    }
+    const data = await res.json() as { choices?: Array<{ message: { content: string } }> }
+    return data.choices?.[0]?.message?.content?.trim() ?? null
+  } catch (err) {
+    console.error(`[compaction] callForSummary failed: ${err instanceof Error ? err.message : String(err)}`)
+    return null
+  }
+}
+
+/**
+ * Compact the conversation history for a room into a single summary message.
+ * Throws if the summary cannot be generated.
+ */
+export async function compactRoom(roomId: string): Promise<void> {
+  // Guard: skip if this room is already being compacted
+  if (compactingRooms.has(roomId)) {
+    console.warn(`[compaction] room ${roomId}: compaction already in progress — skipping`)
+    return
+  }
+  compactingRooms.add(roomId)
+
+  try {
+    await _compactRoom(roomId)
+  } finally {
+    compactingRooms.delete(roomId)
+  }
+}
+
+async function _compactRoom(roomId: string): Promise<void> {
+  // Find the most recent compaction boundary — only compact messages since then
+  const lastCompaction = await prisma.chatMessage.findFirst({
+    where: { roomId, senderType: 'compaction' },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  const messages = await prisma.chatMessage.findMany({
+    where: {
+      roomId,
+      senderType: { notIn: ['system', 'compaction'] },
+      ...(lastCompaction ? { createdAt: { gt: lastCompaction.createdAt } } : {}),
+    },
+    orderBy: { createdAt: 'asc' },
+    include: {
+      agent: { select: { name: true } },
+      user:  { select: { username: true, name: true } },
+    },
+  })
+
+  if (messages.length === 0) {
+    console.warn(`[compaction] room ${roomId}: nothing to compact`)
+    return
+  }
+
+  // Build a transcript the LLM can summarise
+  const lines: string[] = []
+  if (lastCompaction) {
+    lines.push('## Prior Context (already summarised)')
+    lines.push(lastCompaction.content)
+    lines.push('')
+    lines.push('## Continuation')
+  }
+  for (const m of messages) {
+    if (m.senderType === 'tool_call') {
+      const att = m.attachments as { tool?: string; output?: string } | null
+      lines.push(`[tool: ${att?.tool ?? m.content}] → ${(att?.output ?? '').slice(0, 300)}`)
+    } else {
+      const name = m.agent?.name ?? m.user?.name ?? m.user?.username ?? 'User'
+      lines.push(`${name}: ${m.content}`)
+    }
+  }
+  const transcript = lines.join('\n')
+
+  // Resolve the default model setting
+  const defaultModelSetting = await prisma.systemSetting.findUnique({ where: { key: 'ai.default-model' } })
+  const rawDefault = defaultModelSetting?.value
+  const defaultModelId: string = typeof rawDefault === 'string'
+    ? rawDefault.replace(/^"|"$/g, '')
+    : (typeof rawDefault === 'object' && rawDefault !== null ? String(rawDefault) : '')
+
+  let summary: string | null = null
+
+  // Resolve which model to use
+  if (defaultModelId.startsWith('ext:')) {
+    const extId = defaultModelId.slice('ext:'.length)
+    const extModel = await prisma.externalModel.findUnique({ where: { id: extId } })
+    if (extModel) {
+      summary = await callForSummary(extModel.baseUrl, extModel.modelId, extModel.apiKey, transcript)
+    }
+  } else if (defaultModelId.startsWith('ollama:')) {
+    // Find first enabled Ollama model
+    const ollamaModel = await prisma.externalModel.findFirst({ where: { provider: 'ollama', enabled: true } })
+    if (ollamaModel) {
+      summary = await callForSummary(ollamaModel.baseUrl, ollamaModel.modelId, null, transcript)
+    }
+  }
+
+  // Fallback: use any enabled external model with OpenAI compat
+  if (!summary) {
+    const fallback = await prisma.externalModel.findFirst({
+      where: { enabled: true, provider: { not: 'ollama' } },
+    })
+    if (fallback) {
+      summary = await callForSummary(fallback.baseUrl, fallback.modelId, fallback.apiKey, transcript)
+    }
+  }
+
+  // Last resort: try any enabled model
+  if (!summary) {
+    const last = await prisma.externalModel.findFirst({ where: { enabled: true } })
+    if (last) {
+      summary = await callForSummary(last.baseUrl, last.modelId, last.apiKey, transcript)
+    }
+  }
+
+  if (!summary) {
+    throw new Error('[compaction] failed to generate summary — no usable model found')
+  }
+
+  // Persist as a compaction message and reset the room's token counter
+  const compactionMsg = await prisma.chatMessage.create({
+    data: {
+      roomId,
+      senderType: 'compaction',
+      content: summary,
+      attachments: { originalMessageCount: messages.length, compactedAt: new Date().toISOString() } as unknown as object,
+    },
+  })
+
+  await prisma.chatRoom.update({
+    where: { id: roomId },
+    data: { tokenCount: 0, updatedAt: new Date() },
+  })
+
+  // Publish via Redis so the UI shows the compaction message live
+  await publishChatMessage(roomId, {
+    id:          compactionMsg.id,
+    senderType:  'compaction',
+    content:     summary,
+    attachments: { originalMessageCount: messages.length, compactedAt: compactionMsg.createdAt instanceof Date ? compactionMsg.createdAt.toISOString() : compactionMsg.createdAt },
+    sender:      { type: 'system', id: null, name: 'System' },
+    createdAt:   compactionMsg.createdAt instanceof Date ? compactionMsg.createdAt.toISOString() : compactionMsg.createdAt,
+  })
+
+  console.log(`[compaction] room ${roomId}: compacted ${messages.length} messages into summary`)
+}
+
+/**
+ * Publish a compaction threshold warning as a system message in the room.
+ * Saves to DB so it persists after page refresh.
+ */
+export async function publishCompactionWarning(
+  roomId: string,
+  percentage: number,
+  tokenCount: number,
+  tokenLimit: number,
+): Promise<void> {
+  const pct = Math.round(percentage * 100)
+  const content = `Context is at ${pct}% capacity (${tokenCount.toLocaleString()} / ${tokenLimit.toLocaleString()} tokens). Consider compacting the conversation to free up context.`
+
+  const msg = await prisma.chatMessage.create({
+    data: {
+      roomId,
+      senderType: 'system',
+      content,
+      attachments: {
+        type:       'compaction-warning',
+        percentage: pct,
+        tokenCount,
+        tokenLimit,
+      } as unknown as object,
+    },
+  })
+
+  await publishChatMessage(roomId, {
+    id:          msg.id,
+    senderType:  'system',
+    content,
+    attachments: { type: 'compaction-warning', percentage: pct, tokenCount, tokenLimit },
+    sender:      { type: 'system', id: null, name: 'System' },
+    createdAt:   msg.createdAt instanceof Date ? msg.createdAt.toISOString() : msg.createdAt,
+  })
+}

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -20,7 +20,8 @@ import { buildToolDefinitions, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agen
 import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
-import { buildAgentContext, invalidateSnapshotCache } from './agent-context'
+import { buildAgentContext, invalidateSnapshotCache, getModelContextLimit } from './agent-context'
+import { compactRoom, publishCompactionWarning } from './compaction'
 import { getPrompt } from './system-prompts'
 import type { AgentGateway } from './agent-gateway'
 import type { GatewayTool } from './agent-runner/types'
@@ -192,6 +193,8 @@ async function callOllamaChat(
 type OpenAIMessage = { role: string; content: string | null; tool_calls?: ToolCall[]; tool_call_id?: string; name?: string }
 type ToolCall = { id: string; type: 'function'; function: { name: string; arguments: string } }
 
+type OpenAICallResult = { reply: string | null; tokensUsed: number; contextLimit: number }
+
 /** OpenAI-compatible /v1/chat/completions endpoint — supports tool calling */
 async function callOpenAIChat(
   agentName: string,
@@ -205,12 +208,15 @@ async function callOpenAIChat(
   toolContext?: { roomId: string; agentId: string; llm: string },
   gateway?: AgentGateway | null,
   gatewayTools?: GatewayTool[],
-): Promise<string | null> {
+): Promise<OpenAICallResult> {
   const hasTools = !!toolContext
   const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+  // Discover context window size for this endpoint (cached after first call)
+  const contextLimit = await getModelContextLimit(baseUrl)
 
   const messages: OpenAIMessage[] = [{ role: 'system', content: sys }, ...chatMsgs]
 
@@ -249,6 +255,11 @@ async function callOpenAIChat(
   // thinking mode via think:false fixes the inconsistency without removing reasoning ability.
   const isQwen3 = /qwen3/i.test(model)
 
+  type Choice = { finish_reason: string; message: { role: string; content: string | null; tool_calls?: ToolCall[] } }
+  type OpenAIResponse = { choices?: Choice[]; usage?: { prompt_tokens?: number } }
+
+  let tokensUsed = 0
+
   // Tool-call loop — keep going until the model produces a text reply
   const maxToolRoundsSetting = await prisma.systemSetting.findUnique({ where: { key: 'agent.chat.maxToolRounds' } })
   const MAX_TOOL_ROUNDS = parseInt(String(maxToolRoundsSetting?.value ?? '15'), 10) || 15
@@ -265,17 +276,17 @@ async function callOpenAIChat(
     })
     if (!res.ok) {
       console.error(`[room-agents] OpenAI-compat ${baseUrl} returned HTTP ${res.status}`)
-      return null
+      return { reply: null, tokensUsed, contextLimit }
     }
 
-    type Choice = { finish_reason: string; message: { role: string; content: string | null; tool_calls?: ToolCall[] } }
-    const data = await res.json() as { choices?: Choice[] }
+    const data = await res.json() as OpenAIResponse
+    tokensUsed = data.usage?.prompt_tokens ?? tokensUsed
     const choice = data.choices?.[0]
-    if (!choice) return null
+    if (!choice) return { reply: null, tokensUsed, contextLimit }
 
     // Plain text reply — done
     if (choice.finish_reason !== 'tool_calls' || !choice.message.tool_calls?.length) {
-      return choice.message.content?.trim() || null
+      return { reply: choice.message.content?.trim() || null, tokensUsed, contextLimit }
     }
 
     // Tool calls — execute each and feed results back
@@ -346,10 +357,10 @@ async function callOpenAIChat(
     body: JSON.stringify(finalBody),
     signal: AbortSignal.timeout(120_000),
   }).catch(() => null)
-  if (!finalRes?.ok) return null
-  type Choice = { finish_reason: string; message: { role: string; content: string | null } }
-  const finalData = await finalRes.json() as { choices?: Choice[] }
-  return finalData.choices?.[0]?.message?.content?.trim() || null
+  if (!finalRes?.ok) return { reply: null, tokensUsed, contextLimit }
+  const finalData = await finalRes.json() as OpenAIResponse
+  tokensUsed = finalData.usage?.prompt_tokens ?? tokensUsed
+  return { reply: finalData.choices?.[0]?.message?.content?.trim() || null, tokensUsed, contextLimit }
 }
 
 /** Resolve a fallback Ollama base URL from configured ExternalModels */
@@ -493,15 +504,36 @@ export async function triggerRoomAgentReplies(
     ringLeaderContext = `\n\nNo specialist agents are currently registered. Handle all questions yourself without delegation.`
   }
 
+  // ── Pre-loop context setup ────────────────────────────────────────────────────
+  // Find the last compaction boundary and read settings once — shared across all agents.
+  const lastCompaction = await prisma.chatMessage.findFirst({
+    where: { roomId, senderType: 'compaction' },
+    orderBy: { createdAt: 'desc' },
+  })
+  const histLimitSetting = await prisma.systemSetting.findUnique({ where: { key: 'chat.historyLimit' } })
+  const histTake = Math.max(parseInt(String(histLimitSetting?.value ?? '50'), 10) || 50, 10)
+
+  // Track token count across agents in this turn; start from room's stored value
+  let currentTokenCount = room?.tokenCount ?? 0
+  const roomTokenLimit: number | null = room?.tokenLimit ?? null
+  // Once compaction fires for this room in this turn, skip token writes for subsequent agents
+  // (their prompt_tokens reflect pre-compaction context and would re-trigger the threshold)
+  let compactedThisTurn = false
+
   let lastSavedReply: string | null = null
 
   for (const agent of triggeredAgents) {
     try {
-      // Re-fetch history each iteration so each agent sees the previous agent's reply
+      // Re-fetch history each iteration so each agent sees the previous agent's reply.
+      // Start from the most recent compaction boundary if one exists — this keeps the
+      // LLM context bounded and ensures the compaction summary is always included.
       const recentMessages = await prisma.chatMessage.findMany({
-        where: { roomId },
+        where: {
+          roomId,
+          ...(lastCompaction ? { createdAt: { gte: lastCompaction.createdAt } } : {}),
+        },
         orderBy: { createdAt: 'desc' },
-        take: 21,
+        take: histTake,
         include: {
           agent: { select: { id: true, name: true } },
           user:  { select: { username: true, name: true } },
@@ -516,9 +548,10 @@ export async function triggerRoomAgentReplies(
       const lastSender  = lastMsg?.agent?.name ?? lastMsg?.user?.name ?? lastMsg?.user?.username ?? 'User'
       const latestTurn  = lastMsg ? `${lastSender}: ${lastMsg.content}` : triggerContent
 
-      // Build structured history with isSelf flag so LLMs can use proper role assignments
+      // Build structured history with isSelf flag so LLMs can use proper role assignments.
+      // Compaction messages appear as [Summary] — they are the summarised prior context.
       const history: HistoryEntry[] = historyMsgs.map((m: any) => ({
-        name:   m.agent?.name ?? m.user?.name ?? m.user?.username ?? 'User',
+        name:   m.senderType === 'compaction' ? '[Summary]' : (m.agent?.name ?? m.user?.name ?? m.user?.username ?? 'User'),
         content: m.content,
         isSelf: m.agentId === agent.id,
       }))
@@ -567,6 +600,8 @@ export async function triggerRoomAgentReplies(
       console.log(`[room-agents] ${agent.name} (${llm}${toolsEnabled ? ', tools' : ''}${gateway ? ', gateway' : ''}) → replying to room ${roomId}`)
 
       let reply: string | null = null
+      let tokensUsed = 0
+      let discoveredContextLimit = 0
 
       setTyping(roomId, agent.name)
       try {
@@ -581,8 +616,11 @@ export async function triggerRoomAgentReplies(
           if (extModel.provider === 'ollama') {
             reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, !!toolContext)
           } else {
-            // openai / custom — OpenAI-compatible (supports tool calling)
-            reply = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext, gateway, gatewayTools)
+            // openai / custom — OpenAI-compatible (supports tool calling + token tracking)
+            const result = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext, gateway, gatewayTools)
+            reply = result.reply
+            tokensUsed = result.tokensUsed
+            discoveredContextLimit = result.contextLimit
           }
         } else if (llm.startsWith('ollama:')) {
           const model   = llm.slice('ollama:'.length)
@@ -658,6 +696,48 @@ export async function triggerRoomAgentReplies(
 
       console.log(`[room-agents] ${agent.name} replied (${reply.length} chars)`)
       lastSavedReply = reply
+
+      // ── Token tracking + compaction threshold checks ──────────────────────────
+      // Only update when we have actual token usage (OpenAI-compat ext: models).
+      // Skip if compaction already fired this turn — subsequent agents' prompt_tokens
+      // reflect pre-compaction context and would incorrectly re-trigger the threshold.
+      if (tokensUsed > 0 && !compactedThisTurn) {
+        currentTokenCount = tokensUsed  // prompt_tokens is cumulative context size for this turn
+        const effectiveLimit = roomTokenLimit ?? (discoveredContextLimit > 0 ? discoveredContextLimit : 0)
+        await prisma.chatRoom.update({
+          where: { id: roomId },
+          data: { tokenCount: currentTokenCount, updatedAt: new Date() },
+        })
+        if (effectiveLimit > 0) {
+          const pct = currentTokenCount / effectiveLimit
+          console.log(`[room-agents] room ${roomId}: ${currentTokenCount}/${effectiveLimit} tokens (${Math.round(pct * 100)}%)`)
+          if (pct >= 0.9) {
+            console.warn(`[room-agents] room ${roomId}: context at ${Math.round(pct * 100)}% — auto-compacting`)
+            try {
+              await compactRoom(roomId)
+              currentTokenCount = 0
+              compactedThisTurn = true
+              await prisma.chatRoom.update({
+                where: { id: roomId },
+                data: { tokenCount: 0, updatedAt: new Date() },
+              })
+            } catch (err) {
+              console.error(`[room-agents] auto-compact failed: ${err instanceof Error ? err.message : String(err)}`)
+              // tokenCount stays at the high value so the threshold re-triggers next turn
+            }
+          } else if (pct >= 0.7) {
+            // Only warn once per 70% crossing — check if last system message is already a warning
+            const lastSystemMsg = await prisma.chatMessage.findFirst({
+              where: { roomId, senderType: 'system' },
+              orderBy: { createdAt: 'desc' },
+            })
+            const lastAtt = lastSystemMsg?.attachments as Record<string, unknown> | null
+            if (typeof lastAtt?.type !== 'string' || lastAtt.type !== 'compaction-warning') {
+              await publishCompactionWarning(roomId, pct, currentTokenCount, effectiveLimit).catch(() => null)
+            }
+          }
+        }
+      }
     } catch (e) {
       console.error(`[room-agents] ${agent.name} failed: ${e instanceof Error ? e.message : String(e)}`)
     }


### PR DESCRIPTION
## Summary

- **Token tracking**: `callOpenAIChat` now captures `usage.prompt_tokens` from each LLM response and stores it as `tokenCount` on the room. Uses the llama.cpp `/props` endpoint to discover `n_ctx` dynamically (cached with 10-min TTL, falls back to 8192).
- **Compaction**: New `compaction.ts` module — `compactRoom()` fetches messages since the last compaction boundary, calls the `ai.default-model` to produce a structured markdown summary, saves it as `senderType: 'compaction'`, and resets `tokenCount` to 0. A module-level Set prevents concurrent compaction of the same room.
- **Thresholds**: At 70% context utilisation a `compaction-warning` system message is published (deduped against the last system message). At 90% the room is auto-compacted. The `compactedThisTurn` flag prevents stale pre-compaction token counts from re-triggering the threshold for subsequent agents in the same turn.
- **History boundary**: History queries now start from the most recent compaction message (`createdAt gte`) and respect the `chat.historyLimit` system setting instead of the former hardcoded `take: 21`.
- **Schema**: Migration #8 adds `tokenCount INT DEFAULT 0` and `tokenLimit INT?` to `chat_rooms`. `tokenLimit` can be set per-room to override the auto-discovered value.
- **Manual compact**: `POST /api/chatrooms/[id]/compact` (auth-guarded) lets users trigger compaction on demand from the UI.

## Opus review findings addressed

- `currentTokenCount = 0` only executes if `compactRoom()` succeeds
- `compactedThisTurn` flag skips token writes for agents after compaction fires in same turn
- Concurrency guard (`compactingRooms` Set) prevents duplicate compaction summaries
- `contextLimitCache` now has 10-min TTL (1-min TTL for fallback values)
- `/compact` route requires authenticated session
- Warning dedup checks `typeof lastAtt?.type === 'string'` for type safety

## Test plan

- [ ] Send messages in a room with a local llama.cpp model (ext: type) — verify `tokenCount` updates in DB after each turn
- [ ] Manually POST to `/api/chatrooms/{id}/compact` — verify compaction message appears in room and `tokenCount` resets to 0
- [ ] Set `tokenLimit` on a room to a low value and verify 70% warning and 90% auto-compact fire correctly
- [ ] Verify history respects compaction boundary — messages before compaction are not included (only the `[Summary]` compaction message)
- [ ] Verify concurrent compact calls for the same room are deduplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)