### PR TITLE
fix: resolve category via BUILTIN_REGISTRY instead of invalid McpToolConfig cast

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -379,7 +379,7 @@ app.get('/tools', requireAuth, (_req: Request, res: Response) => {
   res.json(activeTools.map(t => ({
     name:        t.name,
     description: t.description,
-    category:    (t as BuiltinTool).category ?? 'general',
+    category:    BUILTIN_REGISTRY[t.name]?.category ?? 'general',
     inputSchema: t.inputSchema,
   })))
 })


### PR DESCRIPTION
## Problem

Gateway build failing with:

```
src/index.ts(382,19): error TS2352: Conversion of type 'McpToolConfig' to type 'BuiltinTool' may be a mistake because neither type sufficiently overlaps with the other.
  Type 'McpToolConfig' is missing the following properties from type 'BuiltinTool': category, execute
```

PR #364 added `category` to `BuiltinTool` and used `(t as BuiltinTool).category` in the `/tools` endpoint. But `activeTools` is typed as `McpToolConfig[]`, and TypeScript rejects the cast because `McpToolConfig` has no overlap with `BuiltinTool` (which requires `category` and `execute`).

## Fix

Look up the category from `BUILTIN_REGISTRY[t.name]?.category` instead of casting. The registry already holds all built-in tools with their categories — same result, no problematic cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)