### PR TITLE
refactor: remove message count limit — compaction manages context

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -539,8 +539,9 @@ export async function triggerRoomAgentReplies(
     where: { roomId, senderType: 'compaction' },
     orderBy: { createdAt: 'desc' },
   })
-  const histLimitSetting = await prisma.systemSetting.findUnique({ where: { key: 'chat.historyLimit' } })
-  const histTake = Math.max(parseInt(String(histLimitSetting?.value ?? '50'), 10) || 50, 10)
+  // Safety cap for the DB query — compaction is the real context limit, not message count.
+  // At ~200-500 tokens/message and a 256K context window, compaction fires well before 1000 messages.
+  const histTake = 1000
 
   // Track token count across agents in this turn; start from room's stored value
   let currentTokenCount = room?.tokenCount ?? 0


### PR DESCRIPTION
## Summary

- `chat.historyLimit` setting removed — message count caps conflict with token-based compaction
- History fetch now uses a 1000-row DB safety cap (query guard only)
- Compaction at 90% token utilisation is the actual context boundary

A per-message count limit cuts off history arbitrarily and can discard the compaction summary message, undermining the system we just built. Token usage tracked via `usage.prompt_tokens` is the right signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)