### PR TITLE
fix: wire agent/room knowledge into room chat context and fix knowledge_remember

### DIFF
--- a/apps/web/prisma/migrations/9_agent_room_knowledge_unique/migration.sql
+++ b/apps/web/prisma/migrations/9_agent_room_knowledge_unique/migration.sql
@@ -1,0 +1,8 @@
+-- Add unique constraints to AgentKnowledge and RoomKnowledge so knowledge_remember
+-- can upsert by (agentId, title) and (roomId, title) without creating duplicates.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_knowledge_agentId_title_key"
+  ON "agent_knowledge"("agentId", "title");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "room_knowledge_roomId_title_key"
+  ON "room_knowledge"("roomId", "title");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -948,6 +948,7 @@ model RoomKnowledge {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
+  @@unique([roomId, title])
   @@index([roomId])
   @@index([tags])
   @@map("room_knowledge")
@@ -970,6 +971,7 @@ model AgentKnowledge {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
+  @@unique([agentId, title])
   @@index([agentId])
   @@index([tags])
   @@map("agent_knowledge")

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   Users, Bot, User as UserIcon,
-  Hash, Send, X, Loader2, Plus, LogOut, AtSign, BookmarkCheck, Terminal,
+  Hash, Send, X, Loader2, Plus, LogOut, AtSign, BookmarkCheck, Terminal, Layers,
 } from 'lucide-react'
 
 /** Render message content with @mention highlighting */
@@ -442,6 +442,15 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               >
                 {msg.senderType === 'system' ? (
                   <div className="text-[10px] text-text-muted py-1">{msg.content}</div>
+                ) : msg.senderType === 'compaction' ? (
+                  <div className="w-full rounded-lg border border-status-warning/30 bg-status-warning/5 text-xs overflow-hidden">
+                    <div className="flex items-center gap-2 px-3 py-1.5 border-b border-status-warning/20 bg-status-warning/10">
+                      <Layers size={12} className="text-status-warning" />
+                      <span className="font-mono text-status-warning">context compacted</span>
+                      <span className="ml-auto text-[9px] text-status-warning/60 font-sans">{new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                    </div>
+                    <div className="px-3 py-2 font-mono text-text-muted whitespace-pre-wrap max-h-48 overflow-y-auto">{msg.content}</div>
+                  </div>
                 ) : msg.senderType === 'tool_call' ? (
                   (() => {
                     const tc = msg.attachments as ToolCallAttachment

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -125,7 +125,12 @@ export async function getModelContextLimit(baseUrl: string): Promise<number> {
     })
     if (res.ok) {
       const data = await res.json() as Record<string, unknown>
-      const n_ctx = typeof data.n_ctx === 'number' ? data.n_ctx : 8192
+      // llama.cpp /props: n_ctx is at data.default_generation_settings.n_ctx
+      // Fall back to top-level data.n_ctx for other implementations, then 8192
+      const dgs = data.default_generation_settings as Record<string, unknown> | undefined
+      const n_ctx = typeof dgs?.n_ctx === 'number' ? dgs.n_ctx
+                  : typeof data.n_ctx === 'number'  ? data.n_ctx
+                  : 8192
       contextLimitCache.set(baseUrl, { value: n_ctx, expiresAt: Date.now() + CONTEXT_LIMIT_TTL_MS })
       return n_ctx
     }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -539,8 +539,9 @@ export async function triggerRoomAgentReplies(
     where: { roomId, senderType: 'compaction' },
     orderBy: { createdAt: 'desc' },
   })
-  const histLimitSetting = await prisma.systemSetting.findUnique({ where: { key: 'chat.historyLimit' } })
-  const histTake = Math.max(parseInt(String(histLimitSetting?.value ?? '50'), 10) || 50, 10)
+  // Safety cap for the DB query — compaction is the real context limit, not message count.
+  // At ~200-500 tokens/message and a 256K context window, compaction fires well before 1000 messages.
+  const histTake = 1000
 
   // Track token count across agents in this turn; start from room's stored value
   let currentTokenCount = room?.tokenCount ?? 0

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -20,7 +20,7 @@ import { buildToolDefinitions, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agen
 import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
-import { buildAgentContext, invalidateSnapshotCache, getModelContextLimit } from './agent-context'
+import { buildAgentContext, buildAgentLocalContext, buildRoomLocalContext, invalidateSnapshotCache, getModelContextLimit } from './agent-context'
 import { compactRoom, publishCompactionWarning } from './compaction'
 import { getPrompt } from './system-prompts'
 import type { AgentGateway } from './agent-gateway'
@@ -604,8 +604,16 @@ export async function triggerRoomAgentReplies(
 
       // Inject pre-fetched context (ORION snapshot + vector search) so agents arrive
       // pre-oriented and don't need to call orion_get_snapshot on every message.
-      const agentContext = await buildAgentContext(latestTurn)
-      const agentBasePrompt = agentContext ? personaPrompt + agentContext : personaPrompt
+      const [agentContext, agentLocalContext, roomLocalContext] = await Promise.all([
+        buildAgentContext(latestTurn),
+        buildAgentLocalContext(agent.id),
+        buildRoomLocalContext(roomId),
+      ])
+      const contextParts = [personaPrompt]
+      if (agentContext)      contextParts.push(agentContext)
+      if (agentLocalContext) contextParts.push(agentLocalContext)
+      if (roomLocalContext)  contextParts.push(roomLocalContext)
+      const agentBasePrompt = contextParts.join('\n\n')
 
       // Names of other agents/users in the room so the model can @mention them
       const otherParticipants = agentMembers

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -1691,11 +1691,11 @@ registerTool({
 
 registerTool({
   name: 'knowledge_remember',
-  description: 'Save an important fact, insight, or learned pattern to persistent memory for future tasks to reference',
+  description: 'Save an important fact, decision, or learned pattern to your persistent agent memory. It will be injected into your context on every future turn so you can recall it without tool calls. Use for: namespace locations, cluster quirks, decisions made, operator configurations, etc.',
   inputSchema: {
     type: 'object' as const,
     properties: {
-      key:     { type: 'string', description: 'Short category label (e.g. "deployment-pattern", "cluster-quirk")' },
+      key:     { type: 'string', description: 'Short descriptive title (e.g. "tailscale-operator-namespace", "cluster-quirk-no-gpu")' },
       value:   { type: 'string', description: 'The fact or insight to remember' },
       context: { type: 'string', description: 'Why this is important (optional)' },
     },
@@ -1710,34 +1710,29 @@ registerTool({
     if (!key?.trim())   return 'Error: key is required'
     if (!value?.trim()) return 'Error: value is required'
 
-    // Find the conversation linked to this task
-    let conversationId: string | null = null
-    if (ctx.taskId) {
-      const conv = await ctx.prisma.conversation.findFirst({
-        where: { metadata: { path: ['taskId'], equals: ctx.taskId } },
-        select: { id: true },
-        orderBy: { createdAt: 'desc' },
+    // Prefer agent-scoped knowledge (surfaced on every turn via buildAgentLocalContext)
+    if (ctx.agentId) {
+      const content = ctx2 ? `${value.trim()}\n\nContext: ${ctx2}` : value.trim()
+      await ctx.prisma.agentKnowledge.upsert({
+        where:  { agentId_title: { agentId: ctx.agentId, title: key.trim() } },
+        update: { content, updatedAt: new Date() },
+        create: { agentId: ctx.agentId, title: key.trim(), content, type: 'note' },
       })
-      conversationId = conv?.id ?? null
+      return `Remembered: [${key.trim()}] ${value.trim()}`
     }
 
-    if (!conversationId) {
-      // No linked conversation — fall back to a shared "agent-memory" conversation
-      const fallback = await ctx.prisma.conversation.upsert({
-        where:  { id: 'agent-memory-global' },
-        update: {},
-        create: { id: 'agent-memory-global', title: 'Agent Memory (global)', metadata: { system: true } as any },
+    // Fallback: room-scoped knowledge when no agentId (shouldn't happen in normal room chat)
+    if (ctx.roomId) {
+      const content = ctx2 ? `${value.trim()}\n\nContext: ${ctx2}` : value.trim()
+      await ctx.prisma.roomKnowledge.upsert({
+        where:  { roomId_title: { roomId: ctx.roomId, title: key.trim() } },
+        update: { content, updatedAt: new Date() },
+        create: { roomId: ctx.roomId, title: key.trim(), content, type: 'note' },
       })
-      conversationId = fallback.id
+      return `Remembered (room-scoped): [${key.trim()}] ${value.trim()}`
     }
 
-    await ctx.prisma.memory.upsert({
-      where:  { conversationId_key: { conversationId, key: key.trim() } },
-      update: { value: value.trim(), context: ctx2 ?? null },
-      create: { conversationId, key: key.trim(), value: value.trim(), context: ctx2 ?? null },
-    })
-
-    return `Remembered: [${key.trim()}] ${value.trim()}`
+    return 'Error: no agentId or roomId in context — cannot persist memory.'
   },
 })
 


### PR DESCRIPTION
## Problem

Three bugs that together meant `knowledge_remember` was completely broken for room agents:

1. **Dead write path**: `knowledge_remember` wrote to the `Memory` table scoped to a `Conversation` ID. Room chats don't have linked conversations, so it fell back to a global `agent-memory-global` record that was never read anywhere.

2. **No write path for the right tables**: `AgentKnowledge` and `RoomKnowledge` exist in the schema with read functions (`buildAgentLocalContext`, `buildRoomLocalContext`) but had no tool to write to them.

3. **Read path never called**: `buildAgentLocalContext` and `buildRoomLocalContext` were never called from `room-agents.ts`, so even if data existed it would never surface in the agent's context.

Result: Alpha calls `knowledge_remember` → data disappears → next turn Alpha has no memory of what it learned.

## Fix

- `knowledge_remember` now upserts into `AgentKnowledge` (keyed by `agentId + title`) when `ctx.agentId` is present, falling back to `RoomKnowledge` when only `ctx.roomId` exists
- `room-agents.ts` now calls `buildAgentLocalContext(agent.id)` and `buildRoomLocalContext(roomId)` in parallel alongside `buildAgentContext`, injecting results into the system prompt
- Added `@@unique([agentId, title])` and `@@unique([roomId, title])` to schema + migration so upserts work correctly

## Test plan
- [ ] Alpha calls `knowledge_remember` with a fact (e.g. namespace location)
- [ ] On the next turn the fact appears in Alpha's system prompt under `## Agent-Local Knowledge`
- [ ] Calling `knowledge_remember` again with the same key updates rather than duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)