### PR TITLE
fix: guard gatewayTools possibly undefined — build fix

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -346,7 +346,7 @@ async function callOpenAIChat(
         const available = [
           ...Array.from(registryToolNames),
           ...Array.from(legacyToolNames),
-          ...(gateway ? gatewayTools.map((t: any) => t.name) : []),
+          ...(gateway && gatewayTools ? gatewayTools.map((t: any) => t.name) : []),
         ].sort()
         result = `Error: tool "${tc.function.name}" does not exist. Available tools: ${available.join(', ')}`
       }


### PR DESCRIPTION
Null guard missed when #374 was merged. `gatewayTools` is `GatewayTool[] | undefined` — need `gateway && gatewayTools` not just `gateway` before calling `.map()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)