### PR TITLE
fix: pass undefined gateway in list_tools fallback — TS type error

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -348,10 +348,7 @@ async function callOpenAIChat(
         const toolList = await executeRegisteredTool('list_tools', {}, {
           agentId: toolContext!.agentId,
           prisma,
-          gateway: gateway ? {
-            executeTool: (n, a) => gateway.client.executeTool(n, a),
-            listTools:   () => gateway.client.listTools(),
-          } : undefined,
+          gateway: undefined,
         }).catch(() => '')
         result = `Error: tool "${tc.function.name}" does not exist. Call list_tools to find the correct name.\n\n${toolList}`
       }


### PR DESCRIPTION
In the `else` branch `gateway` is already narrowed to null/falsy by the preceding `} else if (gateway) {`, so the ternary `gateway ? gateway.client...` is unreachable and TypeScript errors with `Property 'client' does not exist on type 'never'`. Pass `undefined` directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)