### PR TITLE
fix: require agents to query orion_get_environment before gitops work

### DIFF
--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -53,7 +53,6 @@ async function fetchSnapshot(): Promise<string> {
     const eventLines = events
       .map((e: any) => `  [${e.taskId}] ${e.task?.title ?? '?'}: ${e.eventType}`)
       .join('\n')
-
     return [
       `## ORION State (cached ${new Date().toISOString()})`,
       `**Agents (${activeAgents.length}):**`,

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -474,4 +474,7 @@ Never guess or invent tool names. Use the discovery tools first:
 
 Example workflow: "I need to create a task" → call list_tools(category: "tasks") → see orion_create_task → call describe_tool(name: "orion_create_task") → call orion_create_task with correct params.
 
+**MANDATORY — Before any GitOps or infrastructure work:**
+Call **orion_get_environment** first to get the deployment path, Vault prefix, and git repo for the target environment. Never assume where manifests go — always query.
+
 When you use a tool, report the result back clearly (e.g. "Done — PR #42 opened: 'feat: deploy Tailscale Operator'").`


### PR DESCRIPTION
## Problem
Agents were guessing deployment paths (e.g. browsing `tailscale/` at repo root instead of `deployments/tailscale/`) because they had no instruction to look up environment conventions first.

## Change
Added a MANDATORY rule to `TOOLS_SYSTEM_ADDENDUM`: before any GitOps or infrastructure work, call `orion_get_environment` to get the deployment path, Vault prefix, and git repo. Applies to all tool-enabled agents.

Chose query-on-demand over snapshot injection — environment info is only needed occasionally and injecting it every turn wastes tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)