### PR TITLE
fix: don't call tools in response to conversational messages

### DIFF
--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -464,7 +464,7 @@ export const TOOLS_SYSTEM_ADDENDUM = `
 
 ## Your ORION Tools
 
-You have access to ORION management tools. Use them — do not pretend to perform an action when you can call a tool instead.
+You have access to ORION management tools. Use them — do not pretend to perform an action when you can call a tool instead. Do NOT call tools in response to conversational messages, greetings, or check-ins — just reply directly.
 
 **IMPORTANT — Tool Discovery:**
 Never guess or invent tool names. Use the discovery tools first:


### PR DESCRIPTION
Agents were calling tools in response to simple check-ins like "Bueller?" instead of just replying. Added clarification to TOOLS_SYSTEM_ADDENDUM: do not call tools for conversational messages, greetings, or check-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)