### PR TITLE
fix: require agents to query ArgoCD app sources before GitOps work

### DIFF
--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -474,4 +474,9 @@ Never guess or invent tool names. Use the discovery tools first:
 
 Example workflow: "I need to create a task" → call list_tools(category: "tasks") → see orion_create_task → call describe_tool(name: "orion_create_task") → call orion_create_task with correct params.
 
+**MANDATORY — Before any GitOps or infrastructure work:**
+1. Call **orion_get_environment** to get the target environment's git repo and conventions.
+2. Run **kubectl_get** on ArgoCD Applications to find out what path is being watched: \`kubectl get applications -A -o yaml\`. This tells you exactly where to put manifests so ArgoCD picks them up automatically.
+3. Call **gitops_ls** to check the existing repo structure before proposing any files.
+
 When you use a tool, report the result back clearly (e.g. "Done — PR #42 opened: 'feat: deploy Tailscale Operator'").`


### PR DESCRIPTION
## Problem
Agents were guessing where to put manifests instead of querying ArgoCD to find out what path it's watching. Alpha has `kubectl_get` available but nothing told it to use it this way.

## Change
Added step 2 to the mandatory pre-GitOps workflow in `TOOLS_SYSTEM_ADDENDUM`:

> Run `kubectl_get` on ArgoCD Applications to find out what path is being watched. This tells you exactly where to put manifests so ArgoCD picks them up automatically.

Alpha can now discover `path: deployments` directly from the ArgoCD `Application` resource rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)