### PR TITLE
fix: deduplicate gitops PRs — block agents from creating duplicate PRs

### DIFF
--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -645,6 +645,21 @@ async function handleProposeGitops(args: unknown, ctx: ToolExecutionContext): Pr
       return 'Error: environment has no git repo — run bootstrap first'
     }
 
+    // Deduplication guard — if there's already an open PR for this environment with a similar
+    // title, return it instead of creating another one. This prevents agents from spamming PRs
+    // when they retry the same deployment step multiple times.
+    const existingPR = await ctx.prisma.gitOpsPR.findFirst({
+      where: {
+        environmentId: env.id,
+        status: 'open',
+        title: { contains: title!.slice(0, 30), mode: 'insensitive' },
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+    if (existingPR) {
+      return `PR #${existingPR.prNumber} already exists for this deployment: "${existingPR.title}". URL: ${existingPR.prUrl}\n\nDo not create another PR — wait for this one to be reviewed and merged, or check ArgoCD sync status.`
+    }
+
     const policy = (env.policyConfig ?? {}) as { overrides?: Record<string, string>; reviewAll?: boolean }
 
     // Live ArgoCD path discovery — query the cluster for the Application watching this repo.


### PR DESCRIPTION
## Summary
- Before proposing a new GitOps PR, `gitops_propose` now checks if an open PR already exists for the same environment with a similar title (first 30 chars match)
- If one exists, returns the existing PR URL and tells the agent to wait for it to be reviewed/merged — no new PR is created
- Prevents the "agent creates 10 PRs for the same deployment" pattern

## Why this happens
Alpha has no persistent memory of what PRs it's already opened within a session. When it retries a deployment step (due to a tool error, a second user message, etc.), it calls `gitops_propose` again, which creates another branch and PR without checking the existing ones.

## Test plan
- [ ] Call `gitops_propose` for an environment with an existing open PR → should return the existing PR URL
- [ ] Call with a different title → should create a new PR normally
- [ ] Closed/merged PRs → should not block new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)