### PR TITLE
fix: add tool hallucination guards and per-session TTL cache for local models

### DIFF
--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -515,11 +515,20 @@ Workflow:
 3. Tool doesn't exist? → call **orion_request_tool** to request it
 
 **MANDATORY — Before any GitOps or infrastructure work:**
-Call **orion_get_environment** first to get the deployment path, Vault prefix, and git repo for the target environment. Never assume where manifests go — always query.
+1. Call **orion_get_environment** to get the target environment's git repo, deployment path, and Vault prefix. Never assume where manifests go — always query.
+2. Call **gitops_ls** to check what already exists in the repo. Never write a manifest for a resource that is already there — duplicate manifests break ArgoCD sync.
+3. Then call **gitops_propose** with only the files that are missing or need changing.
 
-**MANDATORY — Before any GitOps or infrastructure work:**
-1. Call **orion_get_environment** to get the target environment's git repo and conventions.
-2. Run **kubectl_get** on ArgoCD Applications to find out what path is being watched: \`kubectl get applications -A -o yaml\`. This tells you exactly where to put manifests so ArgoCD picks them up automatically.
-3. Call **gitops_ls** to check the existing repo structure before proposing any files.
+**MANDATORY — After every merged PR:**
+Do not declare success after opening or merging a PR. You must verify the deployment actually worked:
+1. Wait 2-3 minutes for ArgoCD to sync, then call **kubectl_get** (resource: "pods", namespace: target) to check pod status.
+2. If the pod is not Running, call **kubectl_logs** to read the error and diagnose before doing anything else.
+3. Only declare success when the pod is Running and logs show no fatal errors.
+4. Do NOT open another PR to fix a problem until you have read the logs and understand the root cause.
+
+**MANDATORY — Secrets:**
+1. Call **orion_list_secrets** before calling **write_secret** — if a secret with that name already exists in any state, do not call write_secret again.
+2. After write_secret, tell the user exactly which secret to fill in and wait for confirmation before proceeding with the deployment.
+3. Never assume a secret is filled in — check its status with **orion_list_secrets** before mounting it.
 
 When you use a tool, report the result back clearly (e.g. "Done — PR #42 opened: 'feat: deploy Tailscale Operator'").`

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -99,7 +99,13 @@ When you do call tools:
 3. After gathering what you need, ACT — write the manifest, apply the change, or give your answer
 
 When stuck: write what you know, what's blocking you, and ask the user — do not call more tools hoping for a better result.
-Call list_tools(category) to discover what tools are available in a category.`
+Call list_tools(category) to discover what tools are available in a category.
+
+## Critical Tool Call Rules
+
+- **NEVER write a tool name or XML function tag in your text reply.** You MUST use the JSON tool_calls mechanism. Any tool name written as prose (e.g. "kubectl_get_pods") or XML (e.g. \`<function=kubectl_get>\`) will be ignored and treated as a hallucination.
+- **Do NOT call tools in response to conversational messages**, greetings, or acknowledgements ("hello", "yes", "thanks", "it worked"). Only call tools when you need real data to complete a concrete task. If the message is conversational, reply in text only.
+- **Do NOT repeat a tool call** you already made with the same arguments in this session. Cached results will be returned automatically — do not re-fetch unless explicitly asked.`
 
 /**
  * Build a compact gateway tool category summary for injection into system prompts.
@@ -258,6 +264,60 @@ type ToolCall = { id: string; type: 'function'; function: { name: string; argume
 
 type OpenAICallResult = { reply: string | null; tokensUsed: number; contextLimit: number }
 
+// ── Tool result cache ─────────────────────────────────────────────────────────
+
+/**
+ * Per-call tool result cache with TTL.
+ * Prevents the model from re-fetching identical data within a single response session.
+ *
+ * TTL by category:
+ *   kubectl_* (get, logs, pods)  — 30s  cluster state changes fast during deploys
+ *   gitops_ls / gitops_read      — 60s  changes only on PR merge
+ *   orion_get_environment        — 120s static config, rarely changes mid-session
+ *   get_deployment_template      — ∞    templates are static, cache for full session
+ *   write ops (propose, write)   — no cache, always execute
+ */
+const TOOL_CACHE_TTLS: Record<string, number> = {
+  kubectl_get:          30_000,
+  kubectl_get_pods:     30_000,
+  kubectl_logs:         30_000,
+  gitops_ls:            60_000,
+  gitops_read:          60_000,
+  orion_get_environment: 120_000,
+  get_deployment_template: Infinity,
+  list_tools:           Infinity,
+}
+
+/** Tools that are write operations — never cache, always execute */
+const NO_CACHE_TOOLS = new Set([
+  'gitops_propose', 'knowledge_write', 'propose_tool',
+  'orion_create_agent', 'orion_update_agent', 'orion_archive_agent',
+])
+
+interface CacheEntry { result: string; expiresAt: number }
+
+function makeToolCacheKey(name: string, args: Record<string, unknown>): string {
+  return `${name}::${JSON.stringify(args, Object.keys(args).sort())}`
+}
+
+/**
+ * Patterns that indicate the model wrote a tool call as prose instead of using
+ * the JSON tool_calls mechanism. These replies must be discarded and the model
+ * prompted to produce a real text response.
+ */
+const FAKE_TOOL_CALL_PATTERNS = [
+  /^[a-z][a-z0-9]*(?:_[a-z0-9]+){1,4}$/,           // bare snake_case tool name only
+  /<function\s*=\s*\w+/i,                             // <function=kubectl_get> XML style
+  /<tool_call>/i,                                     // <tool_call> XML block
+  /^\s*\{?\s*"?function"?\s*:/i,                      // JSON function object as text
+]
+
+function isFakeToolCall(text: string): boolean {
+  const t = text.trim()
+  if (t.length > 200) return false  // real replies are longer
+  return FAKE_TOOL_CALL_PATTERNS.some(p => p.test(t))
+}
+
 /** OpenAI-compatible /v1/chat/completions endpoint — supports tool calling */
 async function callOpenAIChat(
   agentName: string,
@@ -330,6 +390,9 @@ async function callOpenAIChat(
 
   let tokensUsed = 0
 
+  // Per-session tool result cache — keyed by (toolName, args), evicted by TTL
+  const toolCache = new Map<string, CacheEntry>()
+
   // Tool-call loop — keep going until the model produces a text reply
   const maxToolRoundsSetting = await prisma.systemSetting.findUnique({ where: { key: 'agent.chat.maxToolRounds' } })
   const MAX_TOOL_ROUNDS = parseInt(String(maxToolRoundsSetting?.value ?? '15'), 10) || 15
@@ -354,9 +417,22 @@ async function callOpenAIChat(
     const choice = data.choices?.[0]
     if (!choice) return { reply: null, tokensUsed, contextLimit }
 
-    // Plain text reply — done
+    // Plain text reply — check for fake tool calls before accepting
     if (choice.finish_reason !== 'tool_calls' || !choice.message.tool_calls?.length) {
-      return { reply: choice.message.content?.trim() || null, tokensUsed, contextLimit }
+      const replyText = choice.message.content?.trim() || null
+      // Fix #1: detect when the model wrote a tool call as prose instead of using tool_calls
+      if (replyText && isFakeToolCall(replyText)) {
+        console.warn(`[room-agents] ${agentName}: detected fake tool call in text reply: "${replyText}" — injecting correction`)
+        messages.push({ role: 'assistant', content: replyText })
+        messages.push({
+          role: 'user',
+          content: `Your last reply looked like a tool call written as plain text ("${replyText}"). ` +
+            `Do NOT write tool names in your reply text. ` +
+            `Use the JSON tool_calls mechanism to call tools, or write a real text reply if you have an answer.`,
+        })
+        continue  // burn a round to get a real response
+      }
+      return { reply: replyText, tokensUsed, contextLimit }
     }
 
     // Tool calls — execute each and feed results back
@@ -365,65 +441,86 @@ async function callOpenAIChat(
     for (const tc of choice.message.tool_calls) {
       let args: Record<string, unknown> = {}
       try { args = JSON.parse(tc.function.arguments) } catch { /* ignore */ }
-      console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
+      // Fix #2: check tool cache before executing (skip write ops)
       let result: string
-      if (registryToolNames.has(tc.function.name)) {
-        // Registry tool — single source of truth, consistent across all contexts
-        result = await executeRegisteredTool(tc.function.name, args, {
-          agentId: toolContext!.agentId,
-          prisma,
-          gateway: gateway ? {
-            executeTool: (n, a) => gateway.client.executeTool(n, a),
-            listTools: () => gateway.client.listTools(),
-          } : undefined,
-        })
-      } else if (legacyToolNames.has(tc.function.name)) {
-        // Legacy agent-tools (create_task, orion_manage_task, etc.)
-        result = await executeTool(tc.function.name, args, {
-          roomId:        toolContext!.roomId,
-          callerAgentId: toolContext!.agentId,
-          callerLlm:     toolContext!.llm,
-        })
-      } else if (gateway && gatewayToolNames.has(tc.function.name)) {
-        // Known gateway tool
-        result = await gateway.client.executeTool(tc.function.name, args)
+      const cacheKey = makeToolCacheKey(tc.function.name, args)
+      const ttl = TOOL_CACHE_TTLS[tc.function.name]
+      const cached = !NO_CACHE_TOOLS.has(tc.function.name) && ttl !== undefined
+        ? toolCache.get(cacheKey)
+        : undefined
+
+      if (cached && Date.now() < cached.expiresAt) {
+        console.log(`[room-agents] ${agentName} tool cache hit: ${tc.function.name} (expires in ${Math.round((cached.expiresAt - Date.now()) / 1000)}s)`)
+        result = `[Cached result — fetched earlier this session]\n${cached.result}`
       } else {
-        // Hallucinated or unknown tool name — attempt fuzzy resolution before giving up.
-        const resolved = resolveToolName(tc.function.name, allKnownToolNames)
-        if (resolved?.confidence === 'high') {
-          // Auto-correct: call the real tool without burning a round trip
-          console.warn(`[room-agents] ${agentName}: auto-correcting hallucinated tool "${tc.function.name}" → "${resolved.name}"`)
-          if (registryToolNames.has(resolved.name)) {
-            result = await executeRegisteredTool(resolved.name, args, {
-              agentId: toolContext!.agentId,
-              prisma,
-              gateway: gateway ? {
-                executeTool: (n, a) => gateway.client.executeTool(n, a),
-                listTools:   () => gateway.client.listTools(),
-              } : undefined,
-            })
-          } else if (legacyToolNames.has(resolved.name)) {
-            result = await executeTool(resolved.name, args, {
-              roomId:        toolContext!.roomId,
-              callerAgentId: toolContext!.agentId,
-              callerLlm:     toolContext!.llm,
-            })
-          } else if (gateway) {
-            result = await gateway.client.executeTool(resolved.name, args)
-          } else {
-            result = `[Auto-corrected "${tc.function.name}" → "${resolved.name}" but still could not execute]`
-          }
-          result = `[Note: corrected "${tc.function.name}" → "${resolved.name}"]\n${result}`
-        } else {
-          // Can't resolve — return the full tool list so the model can self-correct
-          const toolList = await executeRegisteredTool('list_tools', {}, {
+        console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
+
+        if (registryToolNames.has(tc.function.name)) {
+          // Registry tool — single source of truth, consistent across all contexts
+          result = await executeRegisteredTool(tc.function.name, args, {
             agentId: toolContext!.agentId,
             prisma,
-            gateway: undefined,
-          }).catch(() => '')
-          const suggestion = resolved ? ` Did you mean "${resolved.name}"?` : ''
-          result = `Error: tool "${tc.function.name}" does not exist.${suggestion} Use the exact name from the list below — never guess.\n\n${toolList}`
+            gateway: gateway ? {
+              executeTool: (n, a) => gateway.client.executeTool(n, a),
+              listTools: () => gateway.client.listTools(),
+            } : undefined,
+          })
+        } else if (legacyToolNames.has(tc.function.name)) {
+          // Legacy agent-tools (create_task, orion_manage_task, etc.)
+          result = await executeTool(tc.function.name, args, {
+            roomId:        toolContext!.roomId,
+            callerAgentId: toolContext!.agentId,
+            callerLlm:     toolContext!.llm,
+          })
+        } else if (gateway && gatewayToolNames.has(tc.function.name)) {
+          // Known gateway tool
+          result = await gateway.client.executeTool(tc.function.name, args)
+        } else {
+          // Hallucinated or unknown tool name — attempt fuzzy resolution before giving up.
+          const resolved = resolveToolName(tc.function.name, allKnownToolNames)
+          if (resolved?.confidence === 'high') {
+            // Auto-correct: call the real tool without burning a round trip
+            console.warn(`[room-agents] ${agentName}: auto-correcting hallucinated tool "${tc.function.name}" → "${resolved.name}"`)
+            if (registryToolNames.has(resolved.name)) {
+              result = await executeRegisteredTool(resolved.name, args, {
+                agentId: toolContext!.agentId,
+                prisma,
+                gateway: gateway ? {
+                  executeTool: (n, a) => gateway.client.executeTool(n, a),
+                  listTools:   () => gateway.client.listTools(),
+                } : undefined,
+              })
+            } else if (legacyToolNames.has(resolved.name)) {
+              result = await executeTool(resolved.name, args, {
+                roomId:        toolContext!.roomId,
+                callerAgentId: toolContext!.agentId,
+                callerLlm:     toolContext!.llm,
+              })
+            } else if (gateway) {
+              result = await gateway.client.executeTool(resolved.name, args)
+            } else {
+              result = `[Auto-corrected "${tc.function.name}" → "${resolved.name}" but still could not execute]`
+            }
+            result = `[Note: corrected "${tc.function.name}" → "${resolved.name}"]\n${result}`
+          } else {
+            // Can't resolve — return the full tool list so the model can self-correct
+            const toolList = await executeRegisteredTool('list_tools', {}, {
+              agentId: toolContext!.agentId,
+              prisma,
+              gateway: undefined,
+            }).catch(() => '')
+            const suggestion = resolved ? ` Did you mean "${resolved.name}"?` : ''
+            result = `Error: tool "${tc.function.name}" does not exist.${suggestion} Use the exact name from the list below — never guess.\n\n${toolList}`
+          }
+        }
+
+        // Store in cache if this tool has a TTL
+        if (ttl !== undefined && !NO_CACHE_TOOLS.has(tc.function.name)) {
+          toolCache.set(cacheKey, {
+            result,
+            expiresAt: isFinite(ttl) ? Date.now() + ttl : Infinity,
+          })
         }
       }
 


### PR DESCRIPTION
## Summary

- **Fake tool call detection**: Before saving an agent reply, checks if it looks like a tool call written as prose (bare snake_case name, `<function=>` XML, `<tool_call>` block). If detected, injects a correction turn instead of saving the hallucination as a real message.
- **Per-session tool result cache with TTL**: Prevents the model re-fetching identical data within a single response session (kubectl: 30s, gitops: 60s, orion_get_environment: 120s, templates/list_tools: session). Write ops are never cached.
- **Anti-hallucination system prompt rules**: Three new rules injected for all local/Qwen models — never write tool names as prose, don't call tools for conversational messages, don't repeat a call already made this session.

## Test plan

- [ ] Send Alpha a greeting ("hello") — should reply in text only, no tool calls
- [ ] Ask Alpha to deploy an app — verify `gitops_ls` is not called twice back-to-back
- [ ] Verify tool_call messages in chat don't show bare tool names as agent replies
- [ ] Confirm write ops (gitops_propose, knowledge_write) still execute every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)