### PR TITLE
fix: RoomChat viewport overflow and page scroll on load

### DIFF
--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -369,7 +369,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   )
 
   return (
-    <>
+    <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border-subtle flex-shrink-0">
         <button onClick={onMobileBack} className="md:hidden p-1 rounded hover:bg-bg-raised"><Hash size={16} className="text-text-muted" /></button>
@@ -670,6 +670,6 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           </div>
         </div>
       )}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- `RoomChat` was returning a bare fragment `<>...</>`, making its children direct flex items of the parent container without a height constraint
- The `flex-1 overflow-y-auto` messages div wasn't bounded, so it grew to fit all content beyond the viewport
- `scrollIntoView` then scrolled the whole page to the bottom instead of scrolling within the messages div

## Fix

Replaced the fragment with `<div className="flex-1 flex flex-col min-w-0 overflow-hidden">` — the same wrapper pattern `ChatWindow` already uses. This gives the messages div a proper height bound so internal scrolling works correctly.

## Test plan

- [ ] Open a chat room — messages area should be constrained to available height (no page overflow)
- [ ] On load, the view should scroll to the latest message *within* the messages panel, not scroll the whole page
- [ ] AI chat (`ChatWindow`) still works normally (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)