### PR TITLE
fix: bound main element height to prevent viewport overflow

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -21,7 +21,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <Header />
       <div className="flex flex-1 min-h-0 overflow-hidden">
         <Sidebar />
-        <main className="flex-1 min-h-0 overflow-auto relative">
+        <main className="flex-1 min-h-0 h-full overflow-auto relative">
           {children}
         </main>
       </div>


### PR DESCRIPTION
## Summary

- `main` in `(app)/layout.tsx` had `overflow-auto` and `align-self: stretch` (flex row default)
- Some browsers compute a flex item's height from its content when `overflow` is not `visible`, rather than using the flex-allocated container height — causing `main` to grow taller than the viewport
- Adding `h-full` explicitly resolves `height: 100%` against the parent div's definite flex-allocated height, bounding `main` correctly

## Test plan

- [ ] All pages render without `main` exceeding viewport height
- [ ] Pages with in-flow content (Infrastructure, Agents, Tasks) still scroll normally via `main`'s `overflow-auto`
- [ ] Pages with `absolute inset-0` (Messages, Logs) fill `main` without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)