### PR TITLE
fix: setup.completed check comparing against string not boolean

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic'
 export default async function LoginPage() {
   // If setup hasn't been completed, go to wizard first
   const completed = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
-  if (!completed || completed.value !== 'true') redirect('/setup')
+  if (!completed || (completed.value !== true && completed.value !== 'true')) redirect('/setup')
 
   // Only redirect if the session has a valid user id (not just a stale JWT)
   const session = await getServerSession(authOptions)

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic'
 export default async function LoginPage() {
   // If setup hasn't been completed, go to wizard first
   const completed = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
-  if (!completed || completed.value !== true) redirect('/setup')
+  if (!completed || completed.value !== 'true') redirect('/setup')
 
   // Only redirect if the session has a valid user id (not just a stale JWT)
   const session = await getServerSession(authOptions)

--- a/apps/web/src/app/(setup)/setup/page.tsx
+++ b/apps/web/src/app/(setup)/setup/page.tsx
@@ -4,6 +4,6 @@ import SetupWizard from './SetupWizard'
 
 export default async function SetupPage() {
   const setting = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
-  if (setting?.value === 'true') redirect('/login')
+  if (setting?.value === true || setting?.value === 'true') redirect('/login')
   return <SetupWizard />
 }

--- a/apps/web/src/app/(setup)/setup/page.tsx
+++ b/apps/web/src/app/(setup)/setup/page.tsx
@@ -4,6 +4,6 @@ import SetupWizard from './SetupWizard'
 
 export default async function SetupPage() {
   const setting = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
-  if (setting?.value === true) redirect('/login')
+  if (setting?.value === 'true') redirect('/login')
   return <SetupWizard />
 }


### PR DESCRIPTION
## Summary

`setup.completed` is stored in `SystemSetting` as the JSON string `"true"`, but both the login page and setup page were comparing against the boolean `true`:

- `completed.value !== true` → always `true` for a string → always redirects to `/setup`
- `setting?.value === true` → always `false` for a string → setup page never redirects away

This meant every visit to `/login` bounced to `/setup`, even after setup was long completed.

## Fix

Changed both comparisons to `=== 'true'` / `!== 'true'` to match the stored string value.

## Test plan

- [ ] Visiting `/login` after setup is complete goes to login form, not setup wizard
- [ ] Visiting `/setup` after setup is complete redirects to `/login`
- [ ] Fresh install (no `setup.completed` setting) still shows setup wizard correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)