### PR TITLE
feat: add file deletion support to gitops_propose

### DIFF
--- a/apps/web/src/lib/git-provider/gitea-provider.ts
+++ b/apps/web/src/lib/git-provider/gitea-provider.ts
@@ -154,6 +154,25 @@ export class GiteaGitProvider implements GitProvider {
         body: JSON.stringify(body),
       })
     }
+
+    // Delete files
+    for (const path of opts.deletions ?? []) {
+      const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+      let sha: string | undefined
+      try {
+        const existing = await this.fetch<{ sha: string }>(
+          `/repos/${opts.owner}/${opts.repo}/contents/${encodedPath}?ref=${encodeURIComponent(opts.branch)}`,
+        )
+        sha = existing.sha
+      } catch (err: unknown) {
+        if (isNotFound(err)) continue // already gone — skip
+        throw err
+      }
+      await this.fetch(`/repos/${opts.owner}/${opts.repo}/contents/${encodedPath}`, {
+        method: 'DELETE',
+        body: JSON.stringify({ message: opts.message, sha, branch: opts.branch }),
+      })
+    }
   }
 
   // ── PRs ────────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/git-provider/github-provider.ts
+++ b/apps/web/src/lib/git-provider/github-provider.ts
@@ -109,8 +109,8 @@ export class GitHubGitProvider implements GitProvider {
     )
     const baseTreeSha = commitData.tree.sha
 
-    // Create blobs
-    const treeItems = await Promise.all(
+    // Create blobs for upserts
+    const upsertItems = await Promise.all(
       opts.files.map(async (f) => {
         const blob = await this.fetch<{ sha: string }>(
           `/repos/${opts.owner}/${opts.repo}/git/blobs`,
@@ -126,11 +126,19 @@ export class GitHubGitProvider implements GitProvider {
       }),
     )
 
+    // Deletion tree items — sha: null removes the file
+    const deletionItems = (opts.deletions ?? []).map(path => ({
+      path,
+      mode: '100644' as const,
+      type: 'blob' as const,
+      sha: null,
+    }))
+
     const tree = await this.fetch<{ sha: string }>(
       `/repos/${opts.owner}/${opts.repo}/git/trees`,
       {
         method: 'POST',
-        body: JSON.stringify({ base_tree: baseTreeSha, tree: treeItems }),
+        body: JSON.stringify({ base_tree: baseTreeSha, tree: [...upsertItems, ...deletionItems] }),
       },
     )
 

--- a/apps/web/src/lib/git-provider/gitlab-provider.ts
+++ b/apps/web/src/lib/git-provider/gitlab-provider.ts
@@ -118,9 +118,8 @@ export class GitLabGitProvider implements GitProvider {
 
   async commitFiles(opts: CommitFilesOptions): Promise<void> {
     // GitLab's commits API supports multiple file actions in one request
-    const actions = await Promise.all(
+    const upsertActions = await Promise.all(
       opts.files.map(async (f) => {
-        // Determine if file exists to decide create vs update
         const exists = await this.fileExists(opts.owner, opts.repo, f.path, opts.branch)
         return {
           action: exists ? 'update' : 'create',
@@ -131,12 +130,17 @@ export class GitLabGitProvider implements GitProvider {
       }),
     )
 
+    const deleteActions = (opts.deletions ?? []).map(path => ({
+      action: 'delete',
+      file_path: path,
+    }))
+
     await this.fetch(`/projects/${this.projectPath(opts.owner, opts.repo)}/repository/commits`, {
       method: 'POST',
       body: JSON.stringify({
         branch: opts.branch,
         commit_message: opts.message,
-        actions,
+        actions: [...upsertActions, ...deleteActions],
       }),
     })
   }

--- a/apps/web/src/lib/git-provider/index.ts
+++ b/apps/web/src/lib/git-provider/index.ts
@@ -49,6 +49,8 @@ export interface CommitFilesOptions {
   repo: string
   branch: string
   files: Array<{ path: string; content: string }>
+  /** Repo-relative paths to delete in the same commit */
+  deletions?: string[]
   message: string
 }
 

--- a/apps/web/src/lib/gitops.ts
+++ b/apps/web/src/lib/gitops.ts
@@ -29,7 +29,10 @@ import {
 export interface ManifestChange {
   /** Repo-relative path, e.g. 'deployments/nginx/deployment.yaml' */
   path: string
-  content: string
+  /** File content — omit when delete is true */
+  content?: string
+  /** When true, the file is deleted from the repo instead of created/updated */
+  delete?: boolean
 }
 
 export interface GitOpsChangeOptions {
@@ -96,11 +99,14 @@ export async function proposeChangeWithProvider(
   await provider.createBranch(opts.owner, opts.repo, branch, 'main')
 
   // 2. Commit all changed files in one atomic commit
+  const upserts = opts.changes.filter(c => !c.delete && c.content !== undefined) as Array<{ path: string; content: string }>
+  const deletions = opts.changes.filter(c => c.delete).map(c => c.path)
   await provider.commitFiles({
     owner: opts.owner,
     repo: opts.repo,
     branch,
-    files: opts.changes,
+    files: upserts,
+    deletions,
     message: opts.title,
   })
 

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -2024,6 +2024,8 @@ BEFORE proposing: call gitops_ls to check what paths already exist so you match 
 
 Path conventions: pass service-relative paths (e.g. "tailscale/deployment.yaml") — the tool automatically prepends the correct watched directory (e.g. "deployments/"). Paths that escape the watched directory are REJECTED.
 
+To delete files: set delete: true on the change item and omit content. You can mix deletions and upserts in a single PR (e.g. remove an old service and add a replacement atomically).
+
 For Kubernetes manifests: always include namespace, use pinned image tags, include CrowdSec + Authentik middleware on all public ingresses.
 For Docker Compose: use self-contained services (no host bind mounts for config files).`,
   inputSchema: {
@@ -2039,9 +2041,10 @@ For Docker Compose: use self-contained services (no host bind mounts for config 
           type: 'object',
           properties: {
             path:    { type: 'string', description: 'Service-relative file path — do NOT include the watched directory prefix. E.g. "tailscale/deployment.yaml", not "deployments/tailscale/deployment.yaml". The tool places it under the correct directory automatically.' },
-            content: { type: 'string', description: 'Full file content' },
+            content: { type: 'string', description: 'Full file content. Required unless delete is true.' },
+            delete:  { type: 'boolean', description: 'Set to true to delete this file from the repo. Omit content when deleting.' },
           },
-          required: ['path', 'content'],
+          required: ['path'],
         },
       },
     },
@@ -2053,10 +2056,14 @@ For Docker Compose: use self-contained services (no host bind mounts for config 
   category: 'gitops',
   handler: async (args) => {
     const { environment_id, title, reasoning, operation_description, changes } =
-      args as { environment_id?: string; title?: string; reasoning?: string; operation_description?: string; changes?: Array<{ path: string; content: string }> }
+      args as { environment_id?: string; title?: string; reasoning?: string; operation_description?: string; changes?: Array<{ path: string; content?: string; delete?: boolean }> }
 
     if (!environment_id || !title || !reasoning || !operation_description || !changes?.length) {
       return 'Error: environment_id, title, reasoning, operation_description, and changes are all required'
+    }
+    const invalid = changes.filter(c => !c.delete && !c.content)
+    if (invalid.length > 0) {
+      return `Error: the following changes are missing content (set delete: true to delete a file, or provide content to upsert):\n${invalid.map(c => `  - ${c.path}`).join('\n')}`
     }
     try {
       const { proposeChange } = await import('@/lib/gitops')
@@ -2073,7 +2080,7 @@ For Docker Compose: use self-contained services (no host bind mounts for config 
             ...c,
             path: c.path.startsWith(`${repoPath}/`) ? c.path : `${repoPath}/${c.path}`,
           }))
-        : changes
+        : changes as Array<{ path: string; content?: string; delete?: boolean }>
 
       if (repoPath) {
         const escaping = normalizedChanges.filter(c => !c.path.startsWith(`${repoPath}/`))


### PR DESCRIPTION
## Summary

- Agents had no way to delete files from the GitOps repo — `gitops_propose` only supported create/update
- Alpha hit this limitation today trying to clean up `deployments/whoami/` and had to ask the user to do it manually
- Adds `delete: true` per change item so deletions are part of the same atomic PR as any other changes

## Changes

- `CommitFilesOptions` gets `deletions?: string[]`
- **Gitea**: `DELETE /contents/{path}` with file SHA (fetched first, skipped if already gone)
- **GitHub**: tree items with `sha: null` remove the file (native Trees API support)
- **GitLab**: `action: 'delete'` in the commits API actions array
- `ManifestChange`: `content` is now optional, `delete?: boolean` added
- `gitops_propose` schema: `content` optional, `delete` field added, validation rejects items with neither
- Description updated to document the delete capability

## Test plan

- [ ] Agent can delete a single file via `gitops_propose` with `delete: true`
- [ ] Agent can mix deletes and upserts in one PR (e.g. remove old service, add replacement)
- [ ] Deleting a file that doesn't exist is a no-op (Gitea skips gracefully)
- [ ] Existing create/update behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)