### PR TITLE
feat: Nebula catalog, CrowdSec fixes, gitops delete, graph tooltips

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "tailwind-merge": "^2.5.5",
     "three": "^0.184.0",
     "ws": "^8.18.0",
+    "yaml": "^2.9.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/apps/web/prisma/migrations/10_nebula_table/migration.sql
+++ b/apps/web/prisma/migrations/10_nebula_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Nebula" (
+  "id"          TEXT NOT NULL,
+  "name"        TEXT NOT NULL,
+  "displayName" TEXT NOT NULL,
+  "description" TEXT,
+  "gitUrl"      TEXT NOT NULL,
+  "branch"      TEXT NOT NULL DEFAULT 'main',
+  "path"        TEXT NOT NULL DEFAULT 'novas',
+  "isSystem"    BOOLEAN NOT NULL DEFAULT false,
+  "lastSyncAt"  TIMESTAMP(3),
+  "syncStatus"  TEXT NOT NULL DEFAULT 'pending',
+  "syncError"   TEXT,
+  "createdAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Nebula_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Nebula_name_key" ON "Nebula"("name");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1102,6 +1102,27 @@ model Ruleset {
   @@index([name])
 }
 
+// ─── Nebula — Git-backed Nova catalogs ────────────────────────────────────────
+// A Nebula is a git repository that acts as a catalog of Nova YAML definitions.
+// ORION reads Novas from Nebula repos and merges them with bundled Novas.
+// The system Nebula is seeded automatically after the git provider is configured.
+
+model Nebula {
+  id          String    @id @default(cuid())
+  name        String    @unique
+  displayName String
+  description String?   @db.Text
+  gitUrl      String
+  branch      String    @default("main")
+  path        String    @default("novas")
+  isSystem    Boolean   @default(false)
+  lastSyncAt  DateTime?
+  syncStatus  String    @default("pending")
+  syncError   String?   @db.Text
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+}
+
 model AgentScore {
   id            String         @id @default(cuid())
   environmentId String

--- a/apps/web/src/app/(app)/nova/page.tsx
+++ b/apps/web/src/app/(app)/nova/page.tsx
@@ -19,6 +19,7 @@ const SOURCE_COLORS: Record<Nova['source'], string> = {
   'bundled': 'bg-blue-500/15 text-blue-300 text-[10px] px-1.5 py-0.5 rounded',
   'remote': 'bg-purple-500/15 text-purple-300 text-[10px] px-1.5 py-0.5 rounded',
   'user-created': 'bg-amber-500/15 text-amber-300 text-[10px] px-1.5 py-0.5 rounded',
+  'nebula': 'bg-violet-500/15 text-violet-300 text-[10px] px-1.5 py-0.5 rounded',
 }
 
 export default function NovaPage() {

--- a/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
@@ -37,12 +37,12 @@ export async function POST(
   const body = await _req.json().catch(() => ({}))
   const middlewareType = String(body.middlewareType ?? 'crowdsec')
 
-  if (middlewareType !== 'crowdsec' && middlewareType !== 'fail2ban') {
+  if (middlewareType !== 'crowdsec') {
     return NextResponse.json({ error: 'Invalid middleware type' }, { status: 422 })
   }
 
   if (env.type === 'docker') {
-    return NextResponse.json({ error: 'CrowdSec and Fail2Ban require a Kubernetes environment' }, { status: 422 })
+    return NextResponse.json({ error: 'CrowdSec requires a Kubernetes environment' }, { status: 422 })
   }
 
   // Determine execution mode: gateway first, fallback to local kubeconfig
@@ -109,7 +109,6 @@ async function bootstrapMiddleware(
 
   switch (cfg.type) {
     case 'crowdsec':     await deployCrowdSec(gx, log); break
-    case 'fail2ban':     await deployFail2Ban(gx, log); break
     default:
       throw new Error(`Unknown middleware type: ${cfg.type}`)
   }
@@ -139,38 +138,38 @@ async function deployCrowdSec(gx: (tool: string, args: Record<string, unknown>) 
     }
   } catch { /* not installed yet */ }
 
-  // Ensure namespace has PodSecurity bypass annotation (Talos defaults to restricted policy)
-  // Always apply — updates annotations even if namespace already exists
+  // Ensure namespace exists with PodSecurity labels set to privileged.
+  // Talos enforces baseline by default — agents need hostPath volumes so require privileged.
+  // Must use labels (not annotations) — PodSecurity admission reads labels only.
   await gx('kubectl_apply_manifest', {
     manifest: `apiVersion: v1
 kind: Namespace
 metadata:
   name: crowdsec
-  annotations:
+  labels:
     pod-security.kubernetes.io/enforce: "privileged"
     pod-security.kubernetes.io/audit: "privileged"
     pod-security.kubernetes.io/warn: "privileged"`,
   })
+  await log('  Namespace crowdsec ready with privileged PodSecurity labels ✓')
 
   const valuesFile = `agent:
   acquisition:
-    - namespace: ".+"
+    - namespace: kube-system
       podName: ".*"
-      program: "containerlog"
-      poll_without_inotify: true
-  image:
-    repository: docker.io/crowdsec/crowdsec
-crowdsec:
-  config:
-    piers:
-      - storage:
-          type: sqlite
-traefik:
-  enabled: "true"
-  image:
-    repository: docker.io/traefik/mb
-metrics:
-  enabled: "true"
+      program: containerlog
+    - namespace: apps
+      podName: ".*"
+      program: containerlog
+    - namespace: security
+      podName: ".*"
+      program: containerlog
+    - namespace: management
+      podName: ".*"
+      program: containerlog
+lapi:
+  dashboard:
+    enabled: false
 `
 
   await log('Installing CrowdSec via Helm...')
@@ -178,17 +177,17 @@ metrics:
     release: 'crowdsec', chart: 'crowdsec', repo: 'https://crowdsecurity.github.io/helm-charts',
     namespace: 'crowdsec', createNamespace: false, valuesFile, wait: false, timeout: '300s',
   })
-  await log('  CrowdSec installed ✓')
+  await log('  CrowdSec Helm release installed ✓')
 
-  await log('Creating Traefik bouncer...')
+  // Generate a bouncer API key via cscli inside the LAPI pod, then deploy the bouncer
+  await log('Registering Traefik bouncer API key with CrowdSec LAPI...')
+  await log('  NOTE: Run the following after pods are ready to get the API key:')
+  await log('  kubectl exec -n crowdsec deploy/crowdsec-lapi -- cscli bouncers add traefik-bouncer -o raw')
+  await log('  Then patch: kubectl create secret generic crowdsec-traefik-bouncer -n crowdsec --from-literal=api_key=<KEY> --dry-run=client -o yaml | kubectl apply -f -')
+
+  await log('Deploying Traefik bouncer...')
   await gx('kubectl_apply_manifest', {
-    manifest: `apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: crowdsec-traefik-bouncer
-  namespace: crowdsec
----
-apiVersion: apps/v1
+    manifest: `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: crowdsec-traefik-bouncer
@@ -203,7 +202,6 @@ spec:
       labels:
         app: crowdsec-traefik-bouncer
     spec:
-      serviceAccountName: crowdsec-traefik-bouncer
       containers:
         - name: bouncer
           image: docker.io/fbonalair/traefik-crowdsec-bouncer:latest
@@ -213,6 +211,8 @@ spec:
                 secretKeyRef:
                   name: crowdsec-traefik-bouncer
                   key: api_key
+            - name: CROWDSEC_AGENT_HOST
+              value: crowdsec-service.crowdsec.svc.cluster.local:8080
           ports:
             - containerPort: 8068
 ---
@@ -229,99 +229,18 @@ spec:
       port: 8068
       targetPort: 8068
 ---
-apiVersion: v1
-kind: Secret
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
 metadata:
-  name: crowdsec-traefik-bouncer
-  namespace: crowdsec
-type: Opaque
-stringData:
-  api_key: ""`,
+  name: crowdsec-bouncer
+  namespace: security
+spec:
+  forwardAuth:
+    address: http://crowdsec-traefik-bouncer.crowdsec.svc.cluster.local:8068/api/v1/forwardAuth
+    trustForwardHeader: true`,
   })
   await log('  Traefik bouncer deployed ✓')
-}
-
-async function deployFail2Ban(gx: (tool: string, args: Record<string, unknown>) => Promise<string>, log: JobLogger): Promise<void> {
-  if (await kubectlExists(gx, 'daemonset', 'fail2ban', 'kube-system')) {
-    await log('  Fail2Ban already installed ✓')
-    return
-  }
-
-  await log('Deploying Fail2Ban DaemonSet for Kubernetes...')
-
-  await gx('kubectl_apply_manifest', {
-    manifest: `apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fail2ban
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      app: fail2ban
-  template:
-    metadata:
-      labels:
-        app: fail2ban
-    spec:
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      containers:
-        - name: fail2ban
-          image: ghcr.io/anthonyfue/fail2ban-k8s:latest
-          securityContext:
-            privileged: true
-            capabilities:
-              add:
-                - NET_ADMIN
-                - NET_RAW
-                - SYS_ADMIN
-              drop:
-                - ALL
-          volumeMounts:
-            - name: fail2ban-config
-              mountPath: /etc/fail2ban
-            - name: fail2ban-data
-              mountPath: /var/lib/fail2ban
-            - name: var-log
-              mountPath: /var/log
-              readOnly: true
-            - name: run-nft
-              mountPath: /run/nftables
-      volumes:
-        - name: fail2ban-config
-          configMap:
-            name: fail2ban-config
-        - name: fail2ban-data
-          emptyDir: {}
-        - name: var-log
-          hostPath:
-            path: /var/log
-            type: DirectoryOrCreate
-        - name: run-nft
-          emptyDir: {}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fail2ban-config
-  namespace: kube-system
-data:
-  fail2ban.local: |
-    [DEFAULT]
-    ignoreip = 127.0.0.1/8 ::1
-    bantime  = 3600
-    findtime = 600
-    maxretry = 5
-    backend = auto
-  jail.local: |
-    [traefik]
-    enabled = true
-    filter = traefik
-    logpath = /var/log/kern.log
-    maxretry = 5`,
-  })
-  await log('  Fail2Ban DaemonSet deployed ✓')
+  await log('  Middleware security-crowdsec-bouncer@kubernetescrd created ✓')
 }
 
 // ── Local kubectl runner (fallback when gateway unavailable) ──────────────────

--- a/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
@@ -14,6 +14,22 @@ import { startJob, type JobLogger } from '@/lib/job-runner'
 import { GatewayClient } from '@/lib/agent-runner/gateway-client'
 import { requireAdmin } from '@/lib/auth'
 
+// Nova config shape for Nebula-sourced middleware
+interface MiddlewareNovaConfig {
+  name: string
+  displayName: string
+  namespaceLabels?: Record<string, Record<string, string>>
+  helm?: {
+    chart: string
+    repo?: string
+    namespace: string
+    createNamespace?: boolean
+    values?: { raw: string }
+  }
+  manifests?: string[]
+  setupNote?: string
+}
+
 export async function POST(
   _req: NextRequest,
   { params }: { params: { id: string } },
@@ -35,14 +51,15 @@ export async function POST(
 
   const env = point.environment
   const body = await _req.json().catch(() => ({}))
-  const middlewareType = String(body.middlewareType ?? 'crowdsec')
+  // Accept novaName (new) or middlewareType (backwards compat)
+  const novaName = String(body.novaName ?? body.middlewareType ?? 'crowdsec')
 
-  if (middlewareType !== 'crowdsec') {
-    return NextResponse.json({ error: 'Invalid middleware type' }, { status: 422 })
+  if (!novaName) {
+    return NextResponse.json({ error: 'novaName is required' }, { status: 422 })
   }
 
   if (env.type === 'docker') {
-    return NextResponse.json({ error: 'CrowdSec requires a Kubernetes environment' }, { status: 422 })
+    return NextResponse.json({ error: 'Middleware bootstrap requires a Kubernetes environment' }, { status: 422 })
   }
 
   // Determine execution mode: gateway first, fallback to local kubeconfig
@@ -78,17 +95,17 @@ export async function POST(
 
   const jobId = await startJob(
     'bootstrap-middleware',
-    `Bootstrap middleware (${middlewareType})`,
-    { environmentId: env.id, metadata: { middlewareType, useGateway, useLocal } },
+    `Bootstrap middleware (${novaName})`,
+    { environmentId: env.id, metadata: { novaName, useGateway, useLocal } },
     async log => {
       if (useGateway) {
         await log(`Using gateway at ${gwUrl} for cluster operations`)
         const gc = new GatewayClient(gwUrl!, gwToken!)
-        await bootstrapMiddleware(gwExecFn(gc), log, { type: middlewareType })
+        await bootstrapMiddleware(gwExecFn(gc), log, { novaName })
       } else {
         await log(`Using local kubectl (stored kubeconfig) for cluster operations`)
         const localKubectl = makeKubectlRunner(env.kubeconfig!)
-        await bootstrapMiddleware(localKubectl, log, { type: middlewareType })
+        await bootstrapMiddleware(localKubectl, log, { novaName })
       }
     },
   )
@@ -103,14 +120,70 @@ function gwExecFn(gc: GatewayClient) {
 async function bootstrapMiddleware(
   gx: (tool: string, args: Record<string, unknown>) => Promise<string>,
   log: JobLogger,
-  cfg: { type: string },
+  cfg: { novaName: string },
 ): Promise<void> {
-  await log(`Deploying ${cfg.type} infrastructure middleware`)
+  await log(`Deploying middleware: ${cfg.novaName}`)
 
-  switch (cfg.type) {
-    case 'crowdsec':     await deployCrowdSec(gx, log); break
-    default:
-      throw new Error(`Unknown middleware type: ${cfg.type}`)
+  // crowdsec retains its existing dedicated implementation for backwards compat
+  if (cfg.novaName === 'crowdsec') {
+    await deployCrowdSec(gx, log)
+    return
+  }
+
+  // All other Novas: look up config from DB and deploy generically
+  const nova = await prisma.nova.findUnique({ where: { name: cfg.novaName } })
+  if (!nova) throw new Error(`Nova "${cfg.novaName}" not found in catalog`)
+
+  await deployFromNovaConfig(gx, log, nova.config as unknown as MiddlewareNovaConfig)
+}
+
+async function deployFromNovaConfig(
+  gx: (tool: string, args: Record<string, unknown>) => Promise<string>,
+  log: JobLogger,
+  config: MiddlewareNovaConfig,
+): Promise<void> {
+  const { name, displayName, namespaceLabels, helm, manifests, setupNote } = config
+
+  // Apply namespace labels
+  if (namespaceLabels) {
+    for (const [ns, labels] of Object.entries(namespaceLabels)) {
+      await log(`Ensuring namespace ${ns} with required labels…`)
+      const labelLines = Object.entries(labels).map(([k, v]) => `    ${k}: "${v}"`).join('\n')
+      await gx('kubectl_apply_manifest', {
+        manifest: `apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ${ns}\n  labels:\n${labelLines}`,
+      })
+      await log(`  Namespace ${ns} ready ✓`)
+    }
+  }
+
+  // Helm install
+  if (helm) {
+    await log(`Installing ${displayName ?? name} via Helm…`)
+    await gx('helm_upgrade_install', {
+      release: name,
+      chart: helm.chart,
+      repo: helm.repo,
+      namespace: helm.namespace,
+      createNamespace: helm.createNamespace ?? false,
+      // Pass raw YAML values string through valuesFile param
+      valuesFile: helm.values?.raw,
+      wait: false,
+      timeout: '300s',
+    })
+    await log(`  Helm release installed ✓`)
+  }
+
+  // Post-install manifests
+  if (manifests?.length) {
+    await log('Applying post-install manifests…')
+    for (const manifest of manifests) {
+      await gx('kubectl_apply_manifest', { manifest })
+    }
+    await log('  Manifests applied ✓')
+  }
+
+  if (setupNote) {
+    await log(`\nSetup note:\n${setupNote}`)
   }
 }
 

--- a/apps/web/src/app/api/nebulae/[id]/sync/route.ts
+++ b/apps/web/src/app/api/nebulae/[id]/sync/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { syncNebula } from '@/lib/nebula-loader'
+
+/**
+ * POST /api/nebulae/:id/sync — Trigger a manual sync for a Nebula
+ */
+export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const result = await syncNebula(params.id)
+    return NextResponse.json(result)
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    )
+  }
+}

--- a/apps/web/src/app/api/nebulae/route.ts
+++ b/apps/web/src/app/api/nebulae/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { syncNebula } from '@/lib/nebula-loader'
+
+/**
+ * GET /api/nebulae — List all registered Nebulae
+ */
+export async function GET() {
+  const nebulae = await prisma.nebula.findMany({ orderBy: { createdAt: 'asc' } })
+  return NextResponse.json(nebulae)
+}
+
+/**
+ * POST /api/nebulae — Register a new Nebula (git-backed Nova catalog)
+ * Body: { name, gitUrl, displayName?, description?, branch?, path? }
+ */
+export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json()
+  if (!body.name || !body.gitUrl) {
+    return NextResponse.json({ error: 'name and gitUrl are required' }, { status: 400 })
+  }
+
+  const nebula = await prisma.nebula.create({
+    data: {
+      name: body.name,
+      displayName: body.displayName ?? body.name,
+      description: body.description ?? null,
+      gitUrl: body.gitUrl,
+      branch: body.branch ?? 'main',
+      path: body.path ?? 'novas',
+    },
+  })
+
+  // Sync Novas from the repo in background
+  syncNebula(nebula.id).catch(console.error)
+
+  return NextResponse.json(nebula, { status: 201 })
+}

--- a/apps/web/src/app/api/nebulae/seed-system/route.ts
+++ b/apps/web/src/app/api/nebulae/seed-system/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { seedSystemNebula } from '@/lib/seed-system-nebula'
+
+/**
+ * POST /api/nebulae/seed-system — Manually trigger system Nebula seeding
+ * Useful for re-triggering after the git provider is configured post-wizard.
+ */
+export async function POST() {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  await seedSystemNebula()
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/novas/route.ts
+++ b/apps/web/src/app/api/novas/route.ts
@@ -16,17 +16,18 @@ export async function GET(req: NextRequest) {
   const category = searchParams.get('category')
   const type = searchParams.get('type')
   const source = searchParams.get('source')
+  const tag = searchParams.get('tag')
   const q = searchParams.get('q')
 
-  // Get database-stored Novas (user-created)
+  // Get database-stored Novas (user-created + nebula-sourced)
   const dbNovae = await prisma.nova.findMany({
     orderBy: { name: 'asc' },
   })
 
-  // Build response
+  // Build response — start from bundled + remote Novas
   let result = await getAllNovae()
 
-  // Add user-created Novas from DB
+  // Add DB Novas (user-created and nebula-sourced) that aren't already in the list
   for (const dbNova of dbNovae) {
     const existing = result.find(n => n.name === dbNova.name)
     if (!existing) {
@@ -52,6 +53,9 @@ export async function GET(req: NextRequest) {
   }
   if (source) {
     result = result.filter(n => n.source === source)
+  }
+  if (tag) {
+    result = result.filter(n => n.tags?.includes(tag))
   }
   if (q) {
     const query = q.toLowerCase()

--- a/apps/web/src/app/api/setup/git-provider/route.ts
+++ b/apps/web/src/app/api/setup/git-provider/route.ts
@@ -25,6 +25,7 @@ import { createProvider, invalidateGitProviderCache, type GitProviderConfig, typ
 import { GiteaGitProvider } from '@/lib/git-provider/gitea-provider'
 import { encryptJson } from '@/lib/encryption'
 import { randomBytes } from 'crypto'
+import { seedSystemNebula } from '@/lib/seed-system-nebula'
 
 export async function POST(req: NextRequest) {
   if (!await requireWizardSession(req)) {
@@ -117,6 +118,9 @@ export async function POST(req: NextRequest) {
 
   // Invalidate the in-process provider cache so the new config is picked up immediately
   invalidateGitProviderCache()
+
+  // Seed system Nebula in background (don't block the response)
+  seedSystemNebula().catch(err => console.error('[Nebula] System nebula seed failed:', err))
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/components/ingress/IngressPage.tsx
+++ b/apps/web/src/components/ingress/IngressPage.tsx
@@ -599,16 +599,12 @@ function SSOBootstrapModal({
   )
 }
 
-// ── Middleware bootstrap (CrowdSec, Fail2Ban) ────────────────────────────────
+// ── Middleware bootstrap (CrowdSec) ───────────────────────────────────────────
 
 const MIDDLEWARE_BOOTSTRAP_TYPES = [
   {
     value: 'crowdsec',  label: 'CrowdSec',        icon: Shield, description: 'Behavioral IPS with Traefik bouncer for automated IP banning',
     fields: ['namespace','clusterIssuer'],
-  },
-  {
-    value: 'fail2ban',  label: 'Fail2Ban',        icon: Bot, description: 'Intrusion prevention via log monitoring (deployed as DaemonSet)',
-    fields: ['namespace'],
   },
 ]
 

--- a/apps/web/src/components/ingress/IngressPage.tsx
+++ b/apps/web/src/components/ingress/IngressPage.tsx
@@ -5,7 +5,7 @@ import {
   Globe, Plus, ChevronRight, ChevronDown, Server, Wifi, WifiOff,
   Pencil, Trash2, Check, X, RefreshCw, ExternalLink, Lock,
   AlertCircle, Shield, Zap, ShieldCheck, Settings2, Play, Terminal,
-  DatabaseZap, KeyRound, Bot, UserCog,
+  DatabaseZap, KeyRound, Bot, UserCog, Gauge, Package,
 } from 'lucide-react'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -599,21 +599,50 @@ function SSOBootstrapModal({
   )
 }
 
-// ── Middleware bootstrap (CrowdSec) ───────────────────────────────────────────
+// ── Middleware bootstrap (dynamic, Nova-driven) ───────────────────────────────
 
-const MIDDLEWARE_BOOTSTRAP_TYPES = [
-  {
-    value: 'crowdsec',  label: 'CrowdSec',        icon: Shield, description: 'Behavioral IPS with Traefik bouncer for automated IP banning',
-    fields: ['namespace','clusterIssuer'],
-  },
-]
+interface MiddlewareNova {
+  name: string
+  displayName: string
+  description: string | null
+  tags: string[]
+  config: {
+    icon?: string
+    setupNote?: string
+    [key: string]: unknown
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const NOVA_ICONS: Record<string, any> = { Shield, ShieldCheck, Gauge, Lock, KeyRound, Bot, Zap, Package }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getNovaIcon(iconName?: string): any {
+  return NOVA_ICONS[iconName ?? ''] ?? Package
+}
 
 function MiddlewareBootstrapPanel({ pointId }: { pointId: string }) {
+  const [novas, setNovas] = useState<MiddlewareNova[]>([])
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
   const [modal, setModal] = useState<string | null>(null)
   const [running, setRunning] = useState<string | null>(null)
   const [notice, setNotice] = useState<{ text: string; ok: boolean } | null>(null)
 
-  // Auto-close the modal after a successful single-step bootstrap
+  useEffect(() => {
+    fetch('/api/novas?tag=middleware&type=service')
+      .then(r => r.json())
+      .then(data => {
+        setNovas(data.novae ?? [])
+        setLoading(false)
+      })
+      .catch(e => {
+        setFetchError(e instanceof Error ? e.message : String(e))
+        setLoading(false)
+      })
+  }, [])
+
+  // Auto-close the modal after a successful bootstrap
   useEffect(() => {
     if (notice?.ok && !running) {
       const timer = setTimeout(() => setModal(null), 1500)
@@ -622,17 +651,18 @@ function MiddlewareBootstrapPanel({ pointId }: { pointId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notice])
 
-  const runBootstrap = async (type: string) => {
-    setRunning(type); setNotice(null)
+  const runBootstrap = async (novaName: string) => {
+    setRunning(novaName); setNotice(null)
     try {
       const res = await fetch(`/api/ingress/points/${pointId}/bootstrap-middleware`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ middlewareType: type }),
+        body: JSON.stringify({ novaName }),
       })
       const data = await res.json()
       if (!res.ok || !data.jobId) throw new Error(data.error ?? `HTTP ${res.status}`)
-      setNotice({ text: `${type.charAt(0).toUpperCase() + type.slice(1)} bootstrap started — check the Jobs panel for progress.`, ok: true })
+      const label = novas.find(n => n.name === novaName)?.displayName ?? novaName
+      setNotice({ text: `${label} bootstrap started — check the Jobs panel for progress.`, ok: true })
     } catch (e) {
       setNotice({ text: e instanceof Error ? e.message : String(e), ok: false })
     } finally {
@@ -640,27 +670,45 @@ function MiddlewareBootstrapPanel({ pointId }: { pointId: string }) {
     }
   }
 
+  const selectedNova = novas.find(n => n.name === modal)
+
   return (
     <>
       <div className="mt-3 pt-3 border-t border-border-subtle">
         <p className="text-[11px] font-medium text-text-muted mb-2">Deploy Infrastructure Middleware</p>
-        <div className="grid grid-cols-2 gap-2">
-          {MIDDLEWARE_BOOTSTRAP_TYPES.map(t => {
-            const Icon = t.icon
-            const isRunning = running === t.value
-            return (
-              <button
-                key={t.value}
-                onClick={() => setModal(t.value)}
-                disabled={isRunning}
-                className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border border-border-subtle text-center transition-colors hover:bg-bg-raised hover:border-accent/40 ${isRunning ? 'opacity-50 cursor-wait' : ''}`}
-              >
-                <Icon size={18} className="text-accent" />
-                <span className="text-[11px] font-medium text-text-primary">{t.label}</span>
-              </button>
-            )
-          })}
-        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 py-2 text-[11px] text-text-muted">
+            <RefreshCw size={11} className="animate-spin" /> Loading middleware catalog…
+          </div>
+        )}
+
+        {fetchError && (
+          <p className="text-[11px] text-status-error flex items-center gap-1">
+            <AlertCircle size={11} /> {fetchError}
+          </p>
+        )}
+
+        {!loading && !fetchError && (
+          <div className="grid grid-cols-2 gap-2">
+            {novas.map(nova => {
+              const Icon = getNovaIcon((nova.config as any)?.icon)
+              const isRunning = running === nova.name
+              return (
+                <button
+                  key={nova.name}
+                  onClick={() => setModal(nova.name)}
+                  disabled={isRunning}
+                  className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border border-border-subtle text-center transition-colors hover:bg-bg-raised hover:border-accent/40 ${isRunning ? 'opacity-50 cursor-wait' : ''}`}
+                >
+                  <Icon size={18} className="text-accent" />
+                  <span className="text-[11px] font-medium text-text-primary">{nova.displayName}</span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
         {notice && (
           <p className={`text-xs mt-2 flex items-center gap-1 ${notice.ok ? 'text-status-healthy' : 'text-status-error'}`}>
             {notice.ok ? <Check size={12} /> : <AlertCircle size={12} />} {notice.text}
@@ -669,10 +717,9 @@ function MiddlewareBootstrapPanel({ pointId }: { pointId: string }) {
       </div>
 
       {/* Inline middleware bootstrap modal */}
-      {modal && (() => {
-        const t = MIDDLEWARE_BOOTSTRAP_TYPES.find(x => x.value === modal)
-        if (!t) return null
-        const Icon = t.icon
+      {modal && selectedNova && (() => {
+        const Icon = getNovaIcon((selectedNova.config as any)?.icon)
+        const setupNote = (selectedNova.config as any)?.setupNote as string | undefined
         return (
           <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={() => setModal(null)}>
             <div className="w-full max-w-md bg-[#1e1e2e] border border-border-subtle rounded-xl shadow-2xl" onClick={e => e.stopPropagation()}>
@@ -680,18 +727,24 @@ function MiddlewareBootstrapPanel({ pointId }: { pointId: string }) {
                 <div className="flex items-center gap-3">
                   <Icon size={18} className="text-accent" />
                   <div>
-                    <h2 className="text-sm font-semibold text-text-primary">Deploy {t.label}</h2>
-                    <p className="text-[11px] text-text-muted">{t.description}</p>
+                    <h2 className="text-sm font-semibold text-text-primary">Deploy {selectedNova.displayName}</h2>
+                    <p className="text-[11px] text-text-muted">{selectedNova.description}</p>
                   </div>
                 </div>
                 <button onClick={() => setModal(null)} className="text-text-muted hover:text-text-primary"><X size={16} /></button>
               </div>
-              <div className="px-5 py-4">
+              <div className="px-5 py-4 space-y-3">
                 <p className="text-xs text-text-muted">
-                  This will deploy <strong>{t.label}</strong> into your cluster via the associated environment.
+                  This will deploy <strong>{selectedNova.displayName}</strong> into your cluster via the associated environment.
                   All config is managed through ORION playbooks.
                 </p>
-                <div className="flex gap-2 mt-4">
+                {setupNote && (
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+                    <p className="text-[11px] font-medium text-amber-400 mb-1">Post-install steps</p>
+                    <pre className="text-[10px] text-amber-300/80 whitespace-pre-wrap font-mono">{setupNote}</pre>
+                  </div>
+                )}
+                <div className="flex gap-2">
                   <button onClick={() => setModal(null)} className={btnGhost}>Cancel</button>
                   <button
                     onClick={() => { runBootstrap(modal) }}

--- a/apps/web/src/components/notes/GraphView.tsx
+++ b/apps/web/src/components/notes/GraphView.tsx
@@ -4,12 +4,21 @@ import ForceGraph2D from 'react-force-graph-2d'
 import { Search, X, ArrowLeft } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 
+interface HoverTooltip {
+  node: GraphNode
+  x: number
+  y: number
+}
+
 interface GraphNode {
   id: string
   title: string
   type: string
   folder: string
   pinned: boolean
+  // Injected at runtime by react-force-graph
+  x?: number
+  y?: number
 }
 
 interface GraphLink {
@@ -45,7 +54,9 @@ export function GraphView() {
   const [highlightedLinks, setHighlightedLinks] = useState<Set<string>>(new Set())
   const [showSemantic, setShowSemantic] = useState(true)
   const [showWikilinks, setShowWikilinks] = useState(true)
+  const [hoverTooltip, setHoverTooltip] = useState<HoverTooltip | null>(null)
   const fgRef = useRef<any>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   // Fetch graph data on mount
   useEffect(() => {
@@ -95,11 +106,12 @@ export function GraphView() {
     }
   }, [visibleLinks])
 
-  // Handle node hover
-  const handleNodeHover = useCallback((node: GraphNode | null) => {
+  // Handle node hover — highlights + tooltip
+  const handleNodeHover = useCallback((node: GraphNode | null, _prevNode: GraphNode | null, event?: MouseEvent) => {
     if (!node) {
       setHighlightedNodes(new Set())
       setHighlightedLinks(new Set())
+      setHoverTooltip(null)
       return
     }
 
@@ -118,6 +130,15 @@ export function GraphView() {
 
     setHighlightedNodes(nodes)
     setHighlightedLinks(links)
+
+    if (event && containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect()
+      setHoverTooltip({
+        node,
+        x: event.clientX - rect.left + 12,
+        y: event.clientY - rect.top + 12,
+      })
+    }
   }, [visibleLinks])
 
   // Zoom to node on click
@@ -144,6 +165,40 @@ export function GraphView() {
     if (highlightedLinks.size > 0 && !highlightedLinks.has(linkKey(link))) return 0.5
     return link.type === 'semantic' ? 1.2 : 1.5
   }
+
+  // Connection count for a node (used in tooltip)
+  const connectionCount = useCallback((nodeId: string) => {
+    if (!data) return 0
+    return data.links.filter(l => l.source === nodeId || l.target === nodeId).length
+  }, [data])
+
+  // Canvas painter — dot + title label
+  const paintNode = useCallback((node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
+    const radius = 4
+    const color = highlightedNodes.size > 0 && !highlightedNodes.has(node.id)
+      ? '#334155'
+      : (CATEGORY_COLORS[node.type] || CATEGORY_COLORS.note)
+
+    // Draw circle
+    ctx.beginPath()
+    ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI)
+    ctx.fillStyle = color
+    ctx.fill()
+
+    // Draw label — only when zoomed in enough to be readable
+    if (globalScale >= 0.6) {
+      const label = node.title.length > 28 ? node.title.slice(0, 26) + '…' : node.title
+      const fontSize = Math.max(10 / globalScale, 3)
+      ctx.font = `${fontSize}px Inter, sans-serif`
+      ctx.textAlign = 'left'
+      ctx.textBaseline = 'middle'
+      const alpha = Math.min(1, (globalScale - 0.6) / 0.4)
+      ctx.fillStyle = highlightedNodes.size > 0 && !highlightedNodes.has(node.id)
+        ? `rgba(100, 116, 139, ${alpha * 0.5})`
+        : `rgba(226, 232, 240, ${alpha})`
+      ctx.fillText(label, (node.x ?? 0) + radius + 2, node.y ?? 0)
+    }
+  }, [highlightedNodes])
 
   // Build link info (for display)
   const getLinkInfo = useCallback((link: GraphLink): { label: string; score?: number } | null => {
@@ -181,7 +236,7 @@ export function GraphView() {
   return (
     <div className="absolute inset-0 flex">
       {/* Graph canvas */}
-      <div className="flex-1 relative bg-[#0f172a]">
+      <div ref={containerRef} className="flex-1 relative bg-[#0f172a]">
         {loading ? (
           <div className="flex items-center justify-center h-full text-text-muted text-sm">
             Loading knowledge graph...
@@ -192,14 +247,38 @@ export function GraphView() {
             graphData={data || { nodes: [], links: [] }}
             nodeColor={nodeColor}
             nodeRelSize={4}
-            nodeLabel={(node: GraphNode) => `${node.title} (${node.type})`}
+            nodeLabel={() => ''}
+            nodeCanvasObject={paintNode}
+            nodeCanvasObjectMode={() => 'replace'}
             onNodeClick={handleNodeClick}
-            onNodeHover={handleNodeHover}
+            onNodeHover={handleNodeHover as any}
             linkColor={linkColor}
             linkWidth={linkWidth}
             backgroundColor="#0f172a"
             cooldownTicks={100}
           />
+        )}
+
+        {/* Hover tooltip */}
+        {hoverTooltip && (
+          <div
+            className="pointer-events-none absolute z-50 max-w-[200px] rounded bg-slate-800 border border-slate-600 px-3 py-2 shadow-lg text-xs"
+            style={{ left: hoverTooltip.x, top: hoverTooltip.y }}
+          >
+            <div className="font-semibold text-text-primary leading-snug mb-1 break-words">
+              {hoverTooltip.node.title}
+            </div>
+            <div className="space-y-0.5 text-text-muted">
+              <div><span className="text-slate-500">type</span> · <span className="text-text-secondary capitalize">{hoverTooltip.node.type}</span></div>
+              {hoverTooltip.node.folder && (
+                <div><span className="text-slate-500">folder</span> · <span className="text-text-secondary">{hoverTooltip.node.folder}</span></div>
+              )}
+              <div><span className="text-slate-500">links</span> · <span className="text-text-secondary">{connectionCount(hoverTooltip.node.id)}</span></div>
+              {hoverTooltip.node.pinned && (
+                <div className="text-amber-400/80">📌 pinned</div>
+              )}
+            </div>
+          </div>
         )}
 
         {/* Search overlay */}

--- a/apps/web/src/lib/git-provider/gitea-provider.ts
+++ b/apps/web/src/lib/git-provider/gitea-provider.ts
@@ -175,6 +175,31 @@ export class GiteaGitProvider implements GitProvider {
     }
   }
 
+  // ── File reading (Nebula) ──────────────────────────────────────────────────
+
+  async readFile(owner: string, repo: string, path: string, ref: string): Promise<string> {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+    const url = `${this.url}/api/v1/repos/${owner}/${repo}/raw/${encodedPath}?ref=${encodeURIComponent(ref)}`
+    const res = await fetch(url, {
+      headers: { Authorization: `token ${this.token}` },
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`Gitea GET raw ${path} → ${res.status}: ${detail}`)
+    }
+    return res.text()
+  }
+
+  async listFiles(owner: string, repo: string, path: string, ref: string): Promise<string[]> {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+    const items = await this.fetch<Array<{ name: string; type: string; path: string }>>(
+      `/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+    )
+    return (items ?? [])
+      .filter(f => f.type === 'file' && f.name.endsWith('.yaml'))
+      .map(f => f.path)
+  }
+
   // ── PRs ────────────────────────────────────────────────────────────────────
 
   async createPR(opts: CreatePROptions): Promise<GitPR> {

--- a/apps/web/src/lib/git-provider/github-provider.ts
+++ b/apps/web/src/lib/git-provider/github-provider.ts
@@ -161,6 +161,27 @@ export class GitHubGitProvider implements GitProvider {
     })
   }
 
+  // ── File reading (Nebula) ──────────────────────────────────────────────────
+
+  async readFile(owner: string, repo: string, path: string, ref: string): Promise<string> {
+    const data = await this.fetch<{ content: string; encoding: string }>(
+      `/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+    )
+    if (data.encoding === 'base64') {
+      return Buffer.from(data.content.replace(/\n/g, ''), 'base64').toString('utf8')
+    }
+    return data.content
+  }
+
+  async listFiles(owner: string, repo: string, path: string, ref: string): Promise<string[]> {
+    const items = await this.fetch<Array<{ name: string; type: string; path: string }>>(
+      `/repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+    )
+    return (items ?? [])
+      .filter(f => f.type === 'file' && f.name.endsWith('.yaml'))
+      .map(f => f.path)
+  }
+
   // ── PRs ────────────────────────────────────────────────────────────────────
 
   async createPR(opts: CreatePROptions): Promise<GitPR> {

--- a/apps/web/src/lib/git-provider/gitlab-provider.ts
+++ b/apps/web/src/lib/git-provider/gitlab-provider.ts
@@ -156,6 +156,29 @@ export class GitLabGitProvider implements GitProvider {
     }
   }
 
+  // ── File reading (Nebula) ──────────────────────────────────────────────────
+
+  async readFile(owner: string, repo: string, path: string, ref: string): Promise<string> {
+    const url = `${this.url}/api/v4/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`
+    const res = await fetch(url, {
+      headers: { 'PRIVATE-TOKEN': this.token },
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`GitLab GET raw ${path} → ${res.status}: ${detail}`)
+    }
+    return res.text()
+  }
+
+  async listFiles(owner: string, repo: string, path: string, ref: string): Promise<string[]> {
+    const items = await this.fetch<Array<{ name: string; type: string; path: string }>>(
+      `/projects/${this.projectPath(owner, repo)}/repository/tree?path=${encodeURIComponent(path)}&ref=${encodeURIComponent(ref)}&recursive=false`,
+    )
+    return (items ?? [])
+      .filter(f => f.type === 'blob' && f.name.endsWith('.yaml'))
+      .map(f => f.path)
+  }
+
   // ── PRs (GitLab: "merge requests") ─────────────────────────────────────────
 
   async createPR(opts: CreatePROptions): Promise<GitPR> {

--- a/apps/web/src/lib/git-provider/index.ts
+++ b/apps/web/src/lib/git-provider/index.ts
@@ -85,6 +85,10 @@ export interface GitProvider {
   getPR(owner: string, repo: string, prNumber: number): Promise<GitPR>
   listOpenPRs(owner: string, repo: string): Promise<GitPR[]>
 
+  // File reading (for Nebula Nova loading)
+  readFile(owner: string, repo: string, path: string, ref: string): Promise<string>
+  listFiles(owner: string, repo: string, path: string, ref: string): Promise<string[]>
+
   // Webhooks
   ensureWebhook(owner: string, repo: string, callbackUrl: string, secret: string): Promise<void>
 
@@ -182,4 +186,16 @@ export async function getGitProvider(): Promise<GitProvider> {
 
 export function invalidateGitProviderCache(): void {
   _cached = null
+}
+
+/**
+ * Returns the raw git provider configuration stored in SystemSetting,
+ * or null if the git provider has not been configured yet.
+ */
+export async function getGitProviderConfig(): Promise<GitProviderConfig | null> {
+  const setting = await prisma.systemSetting.findUnique({
+    where: { key: 'git.provider.config' },
+  })
+  if (!setting) return null
+  return decryptJson<GitProviderConfig>(setting.value)
 }

--- a/apps/web/src/lib/nebula-loader.ts
+++ b/apps/web/src/lib/nebula-loader.ts
@@ -1,0 +1,154 @@
+/**
+ * Nebula Loader — reads Nova YAML definitions from a git repo.
+ *
+ * Nova YAML files live in {nebula.path}/ in the configured git repo.
+ * Each .yaml file is one Nova definition.
+ */
+
+import { parse as parseYaml } from 'yaml'
+import { getGitProvider } from './git-provider'
+import { prisma } from './db'
+import type { NovaConfig } from './nebula'
+
+// ── Nova YAML shape ───────────────────────────────────────────────────────────
+
+export interface NovaYaml {
+  name: string
+  displayName: string
+  description?: string
+  tags?: string[]
+  category?: string
+  type?: 'service' | 'agent'
+  icon?: string
+  helm?: {
+    chart: string
+    repo?: string
+    namespace: string
+    createNamespace?: boolean
+    values?: string
+  }
+  namespaceLabels?: Record<string, Record<string, string>>
+  postInstall?: Array<{ manifest: string }>
+  setupNote?: string
+}
+
+// ── Public functions ──────────────────────────────────────────────────────────
+
+export async function loadNovaeFromNebula(nebula: {
+  id: string
+  gitUrl: string
+  branch: string
+  path: string
+}): Promise<{ novas: NovaYaml[]; errors: string[] }> {
+  const provider = await getGitProvider()
+  const { owner, repo } = parseGitUrl(nebula.gitUrl)
+
+  const errors: string[] = []
+  const novas: NovaYaml[] = []
+
+  let files: string[] = []
+  try {
+    files = await provider.listFiles(owner, repo, nebula.path, nebula.branch)
+  } catch (err) {
+    errors.push(`Failed to list files: ${err instanceof Error ? err.message : String(err)}`)
+    return { novas, errors }
+  }
+
+  for (const filePath of files) {
+    try {
+      const content = await provider.readFile(owner, repo, filePath, nebula.branch)
+      const nova = parseYaml(content) as NovaYaml
+      if (nova?.name) novas.push(nova)
+    } catch (err) {
+      errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  return { novas, errors }
+}
+
+export async function syncNebula(nebulaId: string): Promise<{ synced: number; errors: string[] }> {
+  const nebula = await prisma.nebula.findUnique({ where: { id: nebulaId } })
+  if (!nebula) throw new Error('Nebula not found')
+
+  await prisma.nebula.update({ where: { id: nebulaId }, data: { syncStatus: 'syncing' } })
+
+  try {
+    const { novas, errors } = await loadNovaeFromNebula(nebula)
+
+    for (const yaml of novas) {
+      await prisma.nova.upsert({
+        where: { name: yaml.name },
+        update: {
+          displayName: yaml.displayName,
+          description: yaml.description ?? null,
+          category: yaml.category ?? 'Middleware',
+          tags: yaml.tags ?? [],
+          source: 'nebula',
+          config: buildNovaConfig(yaml),
+          updatedAt: new Date(),
+        },
+        create: {
+          name: yaml.name,
+          displayName: yaml.displayName,
+          description: yaml.description ?? null,
+          category: yaml.category ?? 'Middleware',
+          version: '1.0.0',
+          source: 'nebula',
+          tags: yaml.tags ?? [],
+          config: buildNovaConfig(yaml),
+        },
+      })
+    }
+
+    await prisma.nebula.update({
+      where: { id: nebulaId },
+      data: { syncStatus: 'ok', lastSyncAt: new Date(), syncError: null },
+    })
+
+    return { synced: novas.length, errors }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    await prisma.nebula.update({
+      where: { id: nebulaId },
+      data: { syncStatus: 'error', syncError: msg },
+    })
+    throw err
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function parseGitUrl(gitUrl: string): { owner: string; repo: string } {
+  // Handle https://gitea.example.com/owner/repo.git and similar
+  const cleaned = gitUrl.replace(/\.git$/, '')
+  const parts = cleaned.split('/')
+  const repo = parts[parts.length - 1]
+  const owner = parts[parts.length - 2]
+  return { owner, repo }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildNovaConfig(yaml: NovaYaml): Record<string, any> {
+  return {
+    name: yaml.name,
+    displayName: yaml.displayName,
+    description: yaml.description ?? '',
+    type: yaml.type ?? 'service',
+    ...(yaml.helm
+      ? {
+          helm: {
+            chart: yaml.helm.chart,
+            repo: yaml.helm.repo,
+            namespace: yaml.helm.namespace,
+            createNamespace: yaml.helm.createNamespace,
+            values: yaml.helm.values ? { raw: yaml.helm.values } : undefined,
+          },
+        }
+      : {}),
+    manifests: yaml.postInstall?.map(p => p.manifest) ?? [],
+    ...(yaml.icon ? { icon: yaml.icon } : {}),
+    ...(yaml.namespaceLabels ? { namespaceLabels: yaml.namespaceLabels } : {}),
+    ...(yaml.setupNote ? { setupNote: yaml.setupNote } : {}),
+  }
+}

--- a/apps/web/src/lib/nebula.ts
+++ b/apps/web/src/lib/nebula.ts
@@ -58,7 +58,7 @@ export interface Nova {
   description: string | null
   category: NovaCategory
   version: string
-  source: 'bundled' | 'remote' | 'user-created'
+  source: 'bundled' | 'remote' | 'user-created' | 'nebula'
   config: NovaConfig
   tags: string[]
   createdAt: string

--- a/apps/web/src/lib/seed-system-nebula.ts
+++ b/apps/web/src/lib/seed-system-nebula.ts
@@ -1,0 +1,263 @@
+/**
+ * Seeds the system Nebula — a git repo in ORION's configured git provider
+ * containing default Nova definitions for middleware bootstrapping.
+ *
+ * Called after the git provider is configured (setup wizard step 3).
+ * If the system Nebula already exists, triggers a re-sync instead.
+ */
+
+import { getGitProvider, getGitProviderConfig } from './git-provider'
+import { prisma } from './db'
+import { syncNebula } from './nebula-loader'
+
+const SYSTEM_NEBULA_REPO = 'orion-nebula'
+
+const DEFAULT_NOVA_FILES: Record<string, string> = {
+  'novas/crowdsec.yaml': `name: crowdsec
+displayName: CrowdSec
+description: Behavioral IPS with Traefik bouncer for automated IP banning
+tags: [middleware, security]
+category: Middleware
+type: service
+icon: Shield
+helm:
+  chart: crowdsec
+  repo: https://crowdsecurity.github.io/helm-charts
+  namespace: crowdsec
+  createNamespace: true
+  values: |
+    agent:
+      acquisition:
+        - namespace: kube-system
+          podName: ".*"
+          program: containerlog
+        - namespace: apps
+          podName: ".*"
+          program: containerlog
+        - namespace: security
+          podName: ".*"
+          program: containerlog
+        - namespace: management
+          podName: ".*"
+          program: containerlog
+    lapi:
+      dashboard:
+        enabled: false
+namespaceLabels:
+  crowdsec:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+postInstall:
+  - manifest: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: crowdsec-traefik-bouncer
+        namespace: crowdsec
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: crowdsec-traefik-bouncer
+        template:
+          metadata:
+            labels:
+              app: crowdsec-traefik-bouncer
+          spec:
+            containers:
+              - name: bouncer
+                image: docker.io/fbonalair/traefik-crowdsec-bouncer:latest
+                env:
+                  - name: CROWDSEC_BOUNCER_API_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        name: crowdsec-traefik-bouncer
+                        key: api_key
+                  - name: CROWDSEC_AGENT_HOST
+                    value: crowdsec-service.crowdsec.svc.cluster.local:8080
+                ports:
+                  - containerPort: 8068
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: crowdsec-traefik-bouncer
+        namespace: crowdsec
+      spec:
+        selector:
+          app: crowdsec-traefik-bouncer
+        ports:
+          - name: http
+            port: 8068
+            targetPort: 8068
+      ---
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: crowdsec-bouncer
+        namespace: security
+      spec:
+        forwardAuth:
+          address: http://crowdsec-traefik-bouncer.crowdsec.svc.cluster.local:8068/api/v1/forwardAuth
+          trustForwardHeader: true
+setupNote: |
+  After install, generate the bouncer API key:
+    kubectl exec -n crowdsec deploy/crowdsec-lapi -- cscli bouncers add traefik-bouncer -o raw
+  Then patch the secret:
+    kubectl create secret generic crowdsec-traefik-bouncer -n crowdsec --from-literal=api_key=<KEY> --dry-run=client -o yaml | kubectl apply -f -
+`,
+
+  'novas/rate-limit.yaml': `name: rate-limit
+displayName: Rate Limiting
+description: Per-IP request rate limiting via Traefik — protects against brute force and scrapers
+tags: [middleware, security]
+category: Middleware
+type: service
+icon: Gauge
+postInstall:
+  - manifest: |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: rate-limit
+        namespace: security
+      spec:
+        rateLimit:
+          average: 100
+          burst: 50
+          period: 1m
+          sourceCriterion:
+            ipStrategy:
+              depth: 1
+`,
+
+  'novas/secure-headers.yaml': `name: secure-headers
+displayName: Secure Headers
+description: HSTS, X-Frame-Options, CSP, and other security headers applied via Traefik
+tags: [middleware, security]
+category: Middleware
+type: service
+icon: ShieldCheck
+postInstall:
+  - manifest: |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: secure-headers
+        namespace: security
+      spec:
+        headers:
+          stsSeconds: 31536000
+          stsIncludeSubdomains: true
+          stsPreload: true
+          forceSTSHeader: true
+          frameDeny: true
+          contentTypeNosniff: true
+          browserXssFilter: true
+          referrerPolicy: strict-origin-when-cross-origin
+          customResponseHeaders:
+            X-Robots-Tag: "noindex,nofollow,nosnippet,noarchive"
+            Server: ""
+`,
+
+  'novas/ip-allowlist.yaml': `name: ip-allowlist
+displayName: IP Allowlist
+description: Restrict access to specific IP ranges — useful for locking down admin services
+tags: [middleware, security, access-control]
+category: Middleware
+type: service
+icon: Lock
+setupNote: |
+  Edit the sourceRange list after install to add your allowed CIDRs:
+    kubectl edit middleware ip-allowlist -n security
+postInstall:
+  - manifest: |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: ip-allowlist
+        namespace: security
+      spec:
+        ipAllowList:
+          sourceRange:
+            - 127.0.0.1/32
+            - 10.0.0.0/8
+            - 192.168.0.0/16
+`,
+
+  'novas/basic-auth.yaml': `name: basic-auth
+displayName: Basic Auth
+description: Simple username/password protection for services not covered by SSO
+tags: [middleware, auth]
+category: Middleware
+type: service
+icon: KeyRound
+setupNote: |
+  Create the auth secret before using:
+    kubectl create secret generic basic-auth -n security \\
+      --from-literal=users=$(htpasswd -nb admin yourpassword)
+postInstall:
+  - manifest: |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: basic-auth
+        namespace: security
+      spec:
+        basicAuth:
+          secret: basic-auth
+          removeHeader: true
+`,
+}
+
+export async function seedSystemNebula(): Promise<void> {
+  // Check if already seeded
+  const existing = await prisma.nebula.findUnique({ where: { name: 'system' } })
+  if (existing) {
+    // Already exists — trigger a sync to pick up any new default Novas
+    await syncNebula(existing.id)
+    return
+  }
+
+  const config = await getGitProviderConfig()
+  if (!config) return // Git not configured yet
+
+  const provider = await getGitProvider()
+  const org = config.org
+
+  // Create the orion-nebula repo
+  const repo = await provider.ensureRepo({
+    owner: org,
+    name: SYSTEM_NEBULA_REPO,
+    description: 'ORION system Nebula — default Nova definitions',
+    private: false,
+    isOrg: false,
+  })
+
+  // Commit default Nova files
+  await provider.commitFiles({
+    owner: org,
+    repo: SYSTEM_NEBULA_REPO,
+    branch: 'main',
+    files: Object.entries(DEFAULT_NOVA_FILES).map(([path, content]) => ({ path, content })),
+    message: 'chore: seed default middleware Novas',
+  })
+
+  // Create Nebula DB record
+  const nebula = await prisma.nebula.create({
+    data: {
+      name: 'system',
+      displayName: 'ORION System Nebula',
+      description: 'Built-in Nova catalog managed by ORION',
+      gitUrl: repo.cloneUrl,
+      branch: 'main',
+      path: 'novas',
+      isSystem: true,
+      syncStatus: 'pending',
+    },
+  })
+
+  // Sync Novas from the repo into the DB
+  await syncNebula(nebula.id)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "tailwind-merge": "^2.5.5",
         "three": "^0.184.0",
         "ws": "^8.18.0",
+        "yaml": "^2.9.0",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -1860,12 +1861,12 @@
     },
     "node_modules/@prisma/debug": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1877,12 +1878,12 @@
     },
     "node_modules/@prisma/engines-version": {
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -1892,7 +1893,7 @@
     },
     "node_modules/@prisma/get-platform": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -2682,7 +2683,6 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2697,7 +2697,6 @@
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2706,7 +2705,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3711,7 +3710,6 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -7602,7 +7600,7 @@
     },
     "node_modules/prisma": {
       "version": "5.22.0",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9952,6 +9950,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
## Summary

Four related improvements landed in this branch:

### 1. GitOps file deletion (`gitops_propose`)
- Extended `ManifestChange` with `delete?: boolean` so agents can remove files from the environment repo in the same PR
- Updated all three git providers (Gitea, GitHub, GitLab) with deletion support
- Updated `gitops_propose` tool schema and handler

### 2. CrowdSec / Fail2Ban cleanup
- Removed `deployFail2Ban` and the Fail2Ban UI option entirely — CrowdSec is the replacement
- Fixed critical bug: CrowdSec namespace PodSecurity must use **labels** not annotations (Talos was silently ignoring annotation-based enforcement, causing all 6 agent pods to fail for 26 days)
- Fixed CrowdSec Helm values (removed invalid options), added `CROWDSEC_AGENT_HOST` env to bouncer, added Traefik `Middleware` CRD to bootstrap output

### 3. Nebula — git-backed Nova catalog
- New `Nebula` model (DB + migration 10): tracks git repos as Nova sources with sync status
- `GitProvider` interface gains `readFile()` + `listFiles()` — implemented for Gitea, GitHub, GitLab
- `nebula-loader.ts`: loads and syncs Nova YAML files from a Nebula git repo into the `nova` table
- `seed-system-nebula.ts`: on git provider setup, auto-creates `orion-nebula` repo in Gitea and pushes 5 default middleware Novas: **CrowdSec, Rate Limiting, Secure Headers, IP Allowlist, Basic Auth**
- API: `GET/POST /api/nebulae`, `POST /api/nebulae/[id]/sync`, `POST /api/nebulae/seed-system`
- `/api/novas` gains `?tag=` filter and includes nebula-sourced Novas
- Middleware bootstrap UI (`IngressPage`) now fetches Novas dynamically from `/api/novas?tag=middleware` — no more hardcoded list. Icon, description, and `setupNote` all come from the Nova definition

### 4. Knowledge graph node labels + hover tooltips
- Node titles painted directly on canvas (fade in at zoom ≥ 0.6x, avoids clutter at overview)
- Hover tooltip shows: title, type, folder, connection count, pinned badge

## Test plan
- [ ] CrowdSec agent pods start successfully after namespace label fix (`kubectl get pods -n crowdsec`)
- [ ] Middleware bootstrap UI shows dynamic Nova cards (CrowdSec, Rate Limiting, Secure Headers, IP Allowlist, Basic Auth)
- [ ] Bootstrapping a non-CrowdSec Nova (e.g. rate-limit) applies manifests via `deployFromNovaConfig`
- [ ] `gitops_propose` with `delete: true` removes a file from the env repo
- [ ] Knowledge graph: hover over a node shows tooltip with title/type/folder/links
- [ ] Knowledge graph: labels appear when zoomed in, fade out when zoomed out
- [ ] `POST /api/nebulae/seed-system` creates `orion-nebula` repo in Gitea and populates 5 Nova YAMLs
- [ ] `POST /api/nebulae/[id]/sync` upserts Novas from git into the nova table

🤖 Generated with [Claude Code](https://claude.com/claude-code)