### PR TITLE
fix: make Nebula migration idempotent (IF NOT EXISTS)

### DIFF
--- a/apps/web/prisma/migrations/10_nebula_table/migration.sql
+++ b/apps/web/prisma/migrations/10_nebula_table/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "Nebula" (
+CREATE TABLE IF NOT EXISTS "Nebula" (
   "id"          TEXT NOT NULL,
   "name"        TEXT NOT NULL,
   "displayName" TEXT NOT NULL,
@@ -17,4 +17,4 @@ CREATE TABLE "Nebula" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Nebula_name_key" ON "Nebula"("name");
+CREATE UNIQUE INDEX IF NOT EXISTS "Nebula_name_key" ON "Nebula"("name");


### PR DESCRIPTION
## Summary

The `10_nebula_table` migration was failing in CI with:

```
Error: P3009 — migrate found failed migrations in the target database
Database error code: 42P07 — relation "Nebula" already exists
```

The table was created manually before the migration ran, so Prisma's migration recorded a failure and refused to apply further migrations, blocking `deploy-orion-1` from starting.

## Fix

Added `IF NOT EXISTS` to both the `CREATE TABLE` and `CREATE UNIQUE INDEX` statements, making the migration idempotent regardless of prior state.

## Test plan
- [ ] CI pipeline completes — `deploy-orion-1` starts healthy
- [ ] `docker logs deploy-orion-1` shows migrations applied successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)