### PR TITLE
fix: auto-resolve failed Nebula migration on startup

### DIFF
--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 set -e
+
+# Resolve any previously-failed migrations so Prisma doesn't refuse to proceed.
+# This handles the case where a migration was partially applied manually before
+# the migration file was updated (e.g. IF NOT EXISTS added after the fact).
+echo "Checking for failed migrations to resolve..."
+node /app/node_modules/prisma/build/index.js migrate resolve --rolled-back 10_nebula_table 2>/dev/null || true
+
 echo "Running database migrations..."
 for i in 1 2 3 4 5 6 7 8; do
   if node /app/node_modules/prisma/build/index.js migrate deploy; then

--- a/apps/web/prisma/migrations/10_nebula_table/migration.sql
+++ b/apps/web/prisma/migrations/10_nebula_table/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "Nebula" (
+CREATE TABLE IF NOT EXISTS "Nebula" (
   "id"          TEXT NOT NULL,
   "name"        TEXT NOT NULL,
   "displayName" TEXT NOT NULL,
@@ -17,4 +17,4 @@ CREATE TABLE "Nebula" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Nebula_name_key" ON "Nebula"("name");
+CREATE UNIQUE INDEX IF NOT EXISTS "Nebula_name_key" ON "Nebula"("name");


### PR DESCRIPTION
## Problem

CI kept failing with `deploy-orion-1 is unhealthy` even after #395 added `IF NOT EXISTS` to the migration SQL.

Root cause: Prisma P3009 — "migrate found failed migrations in the target database". When a migration record exists with `finished_at IS NULL` (failed), Prisma refuses to run *any* migrations until it's resolved. Retrying `migrate deploy` in a loop never fixes this — you need `migrate resolve` first.

The failed record was created when the original migration (without `IF NOT EXISTS`) ran against a DB that already had the `Nebula` table from a manual apply.

## Fix

Added a pre-flight `prisma migrate resolve --rolled-back 10_nebula_table` before the migration loop in `entrypoint.sh`. The `|| true` makes it a no-op on fresh databases or when the migration is already in a good state. After resolving the failed record, `migrate deploy` re-applies the migration cleanly (and `IF NOT EXISTS` from #395 ensures it succeeds even if the table exists).

## Test plan
- [ ] CI pipeline completes — `deploy-orion-1` starts healthy
- [ ] Fresh DB deploy works (|| true is a no-op, migration applies normally)
- [ ] Existing DB with failed record: resolved automatically, migration re-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)