### PR TITLE
feat: add storage_stats agent tool for Alpha

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -14,28 +14,20 @@ FROM node:22-alpine
 ARG TARGETARCH
 WORKDIR /app
 
-RUN apk add --no-cache curl docker-cli bash
-
-# Install kubectl — architecture-aware (default amd64 for plain docker build)
-RUN ARCH=${TARGETARCH:-amd64} \
-    && KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt) \
-    && curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
-         -o /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
-
-# Install talosctl — architecture-aware (version pinned)
+ARG KUBECTL_VERSION=1.33.1
 ARG TALOSCTL_VERSION=1.13.2
-RUN ARCH=${TARGETARCH:-amd64} \
+ARG HELM_VERSION=4.2.0
+
+# Install all tools in one layer — pinned versions = stable cache hits
+RUN apk add --no-cache curl docker-cli bash \
+    && ARCH=${TARGETARCH:-amd64} \
+    && curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+         -o /usr/local/bin/kubectl \
     && curl -fsSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-linux-${ARCH}" \
          -o /usr/local/bin/talosctl \
-    && chmod +x /usr/local/bin/talosctl
-
-# Install helm — architecture-aware (version pinned)
-ARG HELM_VERSION=4.2.0
-RUN ARCH=${TARGETARCH:-amd64} \
     && curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" \
          | tar -xz --strip-components=1 -C /usr/local/bin "linux-${ARCH}/helm" \
-    && chmod +x /usr/local/bin/helm
+    && chmod +x /usr/local/bin/kubectl /usr/local/bin/talosctl /usr/local/bin/helm
 
 COPY package*.json ./
 RUN npm install --omit=dev --legacy-peer-deps

--- a/apps/gateway/src/builtin-tools/kubernetes.ts
+++ b/apps/gateway/src/builtin-tools/kubernetes.ts
@@ -352,6 +352,72 @@ export const kubernetesTools = ([
   },
 
   {
+    name: 'storage_stats',
+    description: 'Get storage capacity stats for the cluster. Auto-detects Longhorn or Rook-Ceph and returns total/used/free bytes per node.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    async execute(_args: Record<string, unknown>) {
+      // Helper: check if a namespace exists
+      async function nsExists(ns: string): Promise<boolean> {
+        try { await kubectl(['get', 'namespace', ns, '--ignore-not-found']); return true } catch { return false }
+      }
+
+      const [hasLonghorn, hasCeph] = await Promise.all([
+        nsExists('longhorn-system'),
+        nsExists('rook-ceph'),
+      ])
+
+      if (hasLonghorn) {
+        const json = await kubectl(['get', 'nodes.longhorn.io', '-n', 'longhorn-system', '-o', 'json'])
+        const list = JSON.parse(json) as { items?: unknown[] }
+        const items = list.items ?? []
+        const nodes: Array<{ name: string; totalGiB: number; usedGiB: number; freeGiB: number }> = []
+        let clusterTotal = 0, clusterFree = 0
+        for (const node of items as any[]) {
+          const diskStatus = node.status?.diskStatus ?? {}
+          let total = 0, free = 0
+          for (const disk of Object.values(diskStatus) as any[]) {
+            total += disk.storageMaximum   ?? 0
+            free  += disk.storageAvailable ?? 0
+          }
+          if (total > 0) {
+            const toGiB = (b: number) => Math.round(b / 1073741824 * 10) / 10
+            nodes.push({ name: node.metadata?.name ?? 'unknown', totalGiB: toGiB(total), usedGiB: toGiB(total - free), freeGiB: toGiB(free) })
+            clusterTotal += total
+            clusterFree  += free
+          }
+        }
+        const toGiB = (b: number) => Math.round(b / 1073741824 * 10) / 10
+        const usedPct = clusterTotal > 0 ? Math.round((clusterTotal - clusterFree) / clusterTotal * 100) : 0
+        const lines = [
+          `Storage provider: Longhorn`,
+          `Cluster: ${toGiB(clusterTotal)} GiB total, ${toGiB(clusterTotal - clusterFree)} GiB used (${usedPct}%), ${toGiB(clusterFree)} GiB free`,
+          '',
+          'Per-node breakdown:',
+          ...nodes.map(n => `  ${n.name}: ${n.totalGiB} GiB total, ${n.usedGiB} GiB used, ${n.freeGiB} GiB free`),
+        ]
+        return lines.join('\n')
+      }
+
+      if (hasCeph) {
+        const json = await kubectl(['get', 'cephcluster', 'rook-ceph', '-n', 'rook-ceph', '-o', 'json'])
+        const cluster = JSON.parse(json) as any
+        const cap = cluster.status?.ceph?.capacity ?? {}
+        const toGiB = (b: number) => Math.round(b / 1073741824 * 10) / 10
+        const total = cap.bytesTotal     ?? 0
+        const used  = cap.bytesUsed      ?? 0
+        const free  = cap.bytesAvailable ?? 0
+        const usedPct = total > 0 ? Math.round(used / total * 100) : 0
+        return `Storage provider: Rook-Ceph\nCluster: ${toGiB(total)} GiB total, ${toGiB(used)} GiB used (${usedPct}%), ${toGiB(free)} GiB free`
+      }
+
+      return 'No storage provider detected (checked: longhorn-system, rook-ceph namespaces)'
+    },
+  },
+
+  {
     name: 'helm_upgrade_install',
     description: 'Install or upgrade a Helm chart (helm upgrade --install)',
     inputSchema: {

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 # the migration file was updated (e.g. IF NOT EXISTS added after the fact).
 echo "Checking for failed migrations to resolve..."
 node /app/node_modules/prisma/build/index.js migrate resolve --rolled-back 10_nebula_table 2>/dev/null || true
+node /app/node_modules/prisma/build/index.js migrate resolve --rolled-back 11_seed_storage_stats_tool 2>/dev/null || true
 
 echo "Running database migrations..."
 for i in 1 2 3 4 5 6 7 8; do

--- a/apps/web/prisma/migrations/11_seed_storage_stats_tool/migration.sql
+++ b/apps/web/prisma/migrations/11_seed_storage_stats_tool/migration.sql
@@ -1,0 +1,28 @@
+-- Seed storage_stats tool into existing cluster and localhost environments.
+-- Idempotent: skips environments that already have the tool.
+INSERT INTO "McpTool" (
+  "id", "environmentId", "name", "description",
+  "inputSchema", "execType", "execConfig",
+  "enabled", "builtIn", "status",
+  "createdAt", "updatedAt"
+)
+SELECT
+  gen_random_uuid()::text,
+  e."id",
+  'storage_stats',
+  'Get storage capacity stats for the cluster. Auto-detects Longhorn or Rook-Ceph and returns total/used/free bytes per node.',
+  '{"type":"object","properties":{}}'::jsonb,
+  'builtin',
+  '{"fn":"storage_stats"}'::jsonb,
+  true,
+  true,
+  'active',
+  NOW(),
+  NOW()
+FROM "Environment" e
+WHERE e."type" IN ('cluster', 'localhost')
+  AND NOT EXISTS (
+    SELECT 1 FROM "McpTool" t
+    WHERE t."environmentId" = e."id"
+      AND t."name" = 'storage_stats'
+  );

--- a/apps/web/src/lib/default-tools.ts
+++ b/apps/web/src/lib/default-tools.ts
@@ -200,6 +200,17 @@ export const KUBERNETES_DEFAULT_TOOLS: DefaultTool[] = [
     builtIn: true,
   },
   {
+    name: 'storage_stats',
+    description: 'Get storage capacity stats for the cluster. Auto-detects Longhorn or Rook-Ceph and returns total/used/free bytes per node.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    execType: 'builtin',
+    execConfig: { fn: 'storage_stats' },
+    builtIn: true,
+  },
+  {
     name: 'helm_upgrade_install',
     description: 'Install or upgrade a Helm chart (helm upgrade --install)',
     inputSchema: {


### PR DESCRIPTION
## Summary

- Adds `storage_stats` builtin tool to the gateway — auto-detects Longhorn or Rook-Ceph and returns per-node GiB capacity (total/used/free %)
- Registers the tool in `default-tools.ts` so new cluster/localhost environments get it automatically
- Migration 11 seeds `storage_stats` into **existing** cluster/localhost environments (so Alpha gets it immediately after deploy without needing to recreate the environment)
- `entrypoint.sh` pre-resolves migration 11 to handle any prior failed attempts
- Consolidates the gateway Dockerfile's three separate `RUN` tool-install layers into one (pinned versions, fewer layers, stable cache)

## Test plan

- [ ] Deploy — confirm CI passes and containers come up
- [ ] Check Alpha's tool list includes `storage_stats`
- [ ] Ask Alpha: "what is the cluster storage usage?" — should see Longhorn per-node breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)