### PR TITLE
fix: prevent Alpha hallucinating tool calls, add room goals, tighten image auto-merge

### DIFF
--- a/apps/web/src/app/api/environments/[id]/storage/route.ts
+++ b/apps/web/src/app/api/environments/[id]/storage/route.ts
@@ -1,25 +1,64 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/auth'
+import { prisma } from '@/lib/db'
 
 /**
  * GET /api/environments/:id/storage
- * Returns Longhorn storage volume information for the environment's cluster.
+ * Returns Longhorn volume list for the environment's cluster via gateway.
  */
+
+async function gatewayExec(
+  gatewayUrl: string,
+  gatewayToken: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const res = await fetch(`${gatewayUrl}/tools/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${gatewayToken}` },
+    body: JSON.stringify({ name: toolName, arguments: args }),
+  })
+  if (!res.ok) throw new Error(`Gateway tool ${toolName} failed: ${res.status}`)
+  const data = await res.json() as { result?: string; error?: string }
+  if (data.error) throw new Error(data.error)
+  return data.result ?? ''
+}
+
 export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
+  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (!env.gatewayUrl || !env.gatewayToken) {
+    return NextResponse.json({ error: 'Gateway not connected' }, { status: 422 })
+  }
+
+  const { gatewayUrl, gatewayToken } = env
+
   try {
-    // TODO: Query Longhorn volumes from the cluster via kubeconfig
-    // For now, return empty response
-    return NextResponse.json({
-      volumes: [],
-      message: 'Storage integration coming soon',
+    // Check if Longhorn namespace exists
+    let hasLonghorn = false
+    try {
+      await gatewayExec(gatewayUrl, gatewayToken, 'kubectl_get', { resource: 'namespace', name: 'longhorn-system' })
+      hasLonghorn = true
+    } catch {
+      hasLonghorn = false
+    }
+
+    if (!hasLonghorn) {
+      return NextResponse.json({ volumes: [], provider: null })
+    }
+
+    const json = await gatewayExec(gatewayUrl, gatewayToken, 'kubectl_get', {
+      resource:  'volumes.longhorn.io',
+      namespace: 'longhorn-system',
+      output:    'json',
     })
-  } catch (error) {
-    return NextResponse.json(
-      { error: 'Failed to fetch storage information' },
-      { status: 500 }
-    )
+    const list = JSON.parse(json) as { items?: unknown[] }
+    return NextResponse.json({ volumes: list.items ?? [], provider: 'longhorn' })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: msg }, { status: 502 })
   }
 }

--- a/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
+++ b/apps/web/src/components/infrastructure/InfrastructureTabs.tsx
@@ -62,6 +62,38 @@ const stateColor = (s: string) =>
   s === 'attached' ? 'text-status-healthy' :
   s === 'detached' ? 'text-text-muted' : 'text-status-warning'
 
+interface StorageStats {
+  provider: 'longhorn' | 'ceph' | null
+  totalBytes: number
+  usedBytes:  number
+  freeBytes:  number
+  nodes: Array<{ name: string; totalBytes: number; usedBytes: number; freeBytes: number }>
+}
+
+function formatStorageBytes(bytes: number): string {
+  if (!bytes) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(1024))
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+function CapacityBar({ total, used, free }: { total: number; used: number; free: number }) {
+  const usedPct = total > 0 ? (used / total) * 100 : 0
+  const color = usedPct > 85 ? 'bg-status-error' : usedPct > 65 ? 'bg-status-warning' : 'bg-status-healthy'
+  return (
+    <div className="space-y-1.5">
+      <div className="h-2 w-full rounded-full bg-bg-raised overflow-hidden">
+        <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${usedPct.toFixed(1)}%` }} />
+      </div>
+      <div className="flex justify-between text-[10px] font-mono text-text-muted">
+        <span className="text-status-error">{formatStorageBytes(used)} used</span>
+        <span>{usedPct.toFixed(1)}%</span>
+        <span className="text-status-healthy">{formatStorageBytes(free)} free</span>
+      </div>
+    </div>
+  )
+}
+
 function StorageTab({ envId, loading, setLoading, error, setError }: {
   envId: string
   loading: boolean
@@ -70,21 +102,29 @@ function StorageTab({ envId, loading, setLoading, error, setError }: {
   setError: (v: string | null) => void
 }) {
   const [volumes, setVolumes] = useState<LonghornVolume[]>([])
+  const [stats, setStats] = useState<StorageStats | null>(null)
 
   const load = useCallback(async () => {
     if (!envId) return
     setLoading(true); setError(null)
     try {
-      const res = await fetch(`/api/environments/${envId}/storage`)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data = await res.json()
-      setVolumes(data.volumes ?? [])
+      const [volRes, statsRes] = await Promise.all([
+        fetch(`/api/environments/${envId}/storage`),
+        fetch(`/api/environments/${envId}/storage-stats`),
+      ])
+      if (!volRes.ok) throw new Error(`HTTP ${volRes.status}`)
+      const volData = await volRes.json()
+      setVolumes(volData.volumes ?? [])
+      if (statsRes.ok) {
+        const s = await statsRes.json() as StorageStats
+        setStats(s)
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       setLoading(false)
     }
-  }, [envId, setLoading])
+  }, [envId, setLoading, setError])
 
   useEffect(() => { load() }, [load])
 
@@ -93,10 +133,24 @@ function StorageTab({ envId, loading, setLoading, error, setError }: {
   const faulted = volumes.filter(v => v.status?.robustness === 'faulted').length
   const unknown = volumes.length - healthy - degraded - faulted
 
+  if (!envId) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-text-muted">
+        <HardDrive size={32} className="mb-3 opacity-30" />
+        <p className="text-sm">Select a cluster environment using the selector above</p>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-text-primary">Longhorn Volumes</h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">Longhorn Volumes</h2>
+          {stats?.provider && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded border border-accent/30 bg-accent/5 text-accent font-mono capitalize">{stats.provider}</span>
+          )}
+        </div>
         <button onClick={load} disabled={loading} className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-text-muted hover:text-text-primary border border-border-subtle hover:border-accent/50 disabled:opacity-50 transition-colors">
           <RefreshCw size={11} className={loading ? 'animate-spin' : ''} />
           Refresh
@@ -107,6 +161,37 @@ function StorageTab({ envId, loading, setLoading, error, setError }: {
         <div className="flex items-center gap-2 rounded-lg border border-status-error/30 bg-status-error/10 px-4 py-3 text-sm text-status-error">
           <ServerCrash size={14} />
           <span>{error}</span>
+        </div>
+      )}
+
+      {/* Capacity stats */}
+      {stats?.provider && stats.totalBytes > 0 && (
+        <div className="rounded-lg border border-border-subtle bg-bg-card p-4 space-y-3">
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-text-secondary">Cluster Capacity</span>
+            <span className="font-mono text-text-primary">{formatStorageBytes(stats.totalBytes)} total</span>
+          </div>
+          <CapacityBar total={stats.totalBytes} used={stats.usedBytes} free={stats.freeBytes} />
+          {stats.nodes.length > 0 && (
+            <div className="pt-2 border-t border-border-subtle space-y-2">
+              <p className="text-[10px] text-text-muted font-medium">Per node</p>
+              {stats.nodes.map(n => {
+                const pct = n.totalBytes > 0 ? (n.usedBytes / n.totalBytes) * 100 : 0
+                const color = pct > 85 ? 'bg-status-error' : pct > 65 ? 'bg-status-warning' : 'bg-accent'
+                return (
+                  <div key={n.name} className="space-y-0.5">
+                    <div className="flex justify-between text-[10px] font-mono">
+                      <span className="text-text-primary">{n.name}</span>
+                      <span className="text-text-muted">{formatStorageBytes(n.totalBytes)}</span>
+                    </div>
+                    <div className="h-1.5 w-full rounded-full bg-bg-raised overflow-hidden">
+                      <div className={`h-full rounded-full ${color}`} style={{ width: `${pct.toFixed(1)}%` }} />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </div>
       )}
 
@@ -885,8 +970,8 @@ export function InfrastructureTabs() {
         ))}
       </div>
 
-      {/* Toolbar — only show on overview tab */}
-      {activeTab === 'overview' && (
+      {/* Toolbar — show env selector on overview and storage tabs */}
+      {(activeTab === 'overview' || activeTab === 'storage' || activeTab === 'secrets') && (
         <>
           <div className="flex items-center gap-2">
             <select

--- a/apps/web/src/components/infrastructure/StorageStatsPanel.tsx
+++ b/apps/web/src/components/infrastructure/StorageStatsPanel.tsx
@@ -27,7 +27,7 @@ function UsageBar({ total, used, free }: { total: number; used: number; free: nu
   return (
     <div className="space-y-1.5">
       <div className="h-2 w-full rounded-full bg-bg-raised overflow-hidden">
-        <div className={`h-full rounded-full transition-all ${color}`} style={{ '--width': `${usedPct.toFixed(1)}%` } as React.CSSProperties} />
+        <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${usedPct.toFixed(1)}%` }} />
       </div>
       <div className="flex justify-between text-[10px] font-mono text-text-muted">
         <span className="text-status-error">{formatBytes(used)} used</span>
@@ -49,7 +49,7 @@ function NodeRow({ node }: { node: StorageNode }) {
         <span className="text-[10px] text-text-muted font-mono">{formatBytes(node.totalBytes)}</span>
       </div>
       <div className="h-1.5 w-full rounded-full bg-bg-raised overflow-hidden">
-        <div className={`h-full rounded-full ${color}`} style={{ '--width': `${pct.toFixed(1)}%` } as React.CSSProperties} />
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct.toFixed(1)}%` }} />
       </div>
       <div className="flex justify-between text-[10px] text-text-muted font-mono">
         <span>{formatBytes(node.usedBytes)} used</span>

--- a/apps/web/src/lib/gitops-policy.ts
+++ b/apps/web/src/lib/gitops-policy.ts
@@ -183,9 +183,20 @@ export function classifyManifest(manifest: string): OperationType {
   // Resource limits
   if (/\b(requests|limits):/i.test(manifest) && /\b(cpu|memory):/i.test(manifest)) return 'resource-limits'
 
-  // Image update — try to detect semver bump type
-  const imageMatch = manifest.match(/image:\s*\S+:(\d+)\.(\d+)\.(\d+)/i)
-  if (imageMatch) return 'image-update-patch' // conservative default for image changes
+  // Image update — only auto-classify if the tag is a proper semver string.
+  // Non-deterministic tags (latest, develop, nightly, edge, etc.) require review
+  // because you don't know what version you're actually pulling.
+  const imageMatch = manifest.match(/image:\s*\S+:(\S+)/i)
+  if (imageMatch) {
+    const tag = imageMatch[1].toLowerCase()
+    const nonDeterministicTags = /^(latest|develop|nightly|edge|unstable|main|master|snapshot|canary|beta|alpha|rc)$/
+    if (nonDeterministicTags.test(tag)) return 'unknown'
+    // Only classify as a versioned bump if the tag is semver-like
+    const semverMatch = tag.match(/^(\d+)\.(\d+)\.(\d+)/)
+    if (semverMatch) return 'image-update-patch'
+    // Unknown tag format — require review
+    return 'unknown'
+  }
 
   return 'unknown'
 }
@@ -217,7 +228,12 @@ export function classifyOperation(description: string): OperationType {
   if (d.includes('image') || d.includes('tag') || d.includes('upgrade')) {
     if (d.includes('major')) return 'image-update-major'
     if (d.includes('minor')) return 'image-update-minor'
-    return 'image-update-patch'
+    // Registry or repository changes, or non-deterministic tags — always review
+    if (d.includes('registry') || d.includes('repository') || d.includes('source') || d.includes('latest') || d.includes('develop') || d.includes('nightly')) return 'unknown'
+    // Only classify as patch if a semver-style bump is explicitly described
+    if (d.includes('patch') || /\d+\.\d+\.\d+/.test(d)) return 'image-update-patch'
+    // Ambiguous image change — require review
+    return 'unknown'
   }
 
   return 'unknown'

--- a/apps/web/src/lib/gitops-policy.ts
+++ b/apps/web/src/lib/gitops-policy.ts
@@ -231,7 +231,7 @@ export function classifyOperation(description: string): OperationType {
     // Registry or repository changes, or non-deterministic tags — always review
     if (d.includes('registry') || d.includes('repository') || d.includes('source') || d.includes('latest') || d.includes('develop') || d.includes('nightly')) return 'unknown'
     // Only classify as patch if a semver-style bump is explicitly described
-    if (d.includes('patch') || /\d+\.\d+\.\d+/.test(d)) return 'image-update-patch'
+    if (d.includes('patch') || /\d{1,10}\.\d{1,10}\.\d{1,10}/.test(d)) return 'image-update-patch'
     // Ambiguous image change — require review
     return 'unknown'
   }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -130,10 +130,10 @@ function buildSystemPrompt(
   agentBasePrompt: string,
   otherParticipants: string[],
   hasTools: boolean | 'legacy' | 'mcp' = false,
-  /** True for non-Claude (Ollama/OpenAI-compat) models — injects plan-first constraint */
-  localModel = false,
   /** Compact category summary built from gateway tools — injected when tools are enabled */
   gatewayCategorySummary = '',
+  /** Active room goal — when set, agent must respond with progress rather than going SILENT */
+  activeGoal?: string,
 ): string {
   const othersLine = otherParticipants.length > 0
     ? `Other participants in this chat: ${otherParticipants.join(', ')}`
@@ -145,7 +145,13 @@ function buildSystemPrompt(
     hasTools === 'mcp'              ? '\n\n## ORION Tools\nYou have ORION management tools available via MCP. Use them — do not describe hypothetical actions when you can call a tool to get real data.' :
     hasTools === 'legacy' || hasTools === true ? TOOLS_SYSTEM_ADDENDUM :
     ''
-  const planFirst = localModel && hasTools ? LOCAL_MODEL_PLAN_FIRST : ''
+  const planFirst = LOCAL_MODEL_PLAN_FIRST
+  const silentRule = activeGoal
+    ? `7. There is an ACTIVE GOAL in this room (see below). You MUST respond with progress or a status update. Do NOT reply SILENT while a goal is active.`
+    : `7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT`
+  const goalBlock = activeGoal
+    ? `\n\n## Active Goal\n${activeGoal}\nYou must keep working toward this goal and report progress. Only stop when the goal is explicitly marked complete.`
+    : ''
   return `IMPORTANT — YOUR ROLE:
 You are ${agentName}. You are ONE participant in a group chat.
 ${othersLine}
@@ -157,10 +163,10 @@ Rules you must follow without exception:
 4. Do NOT write scripts, screenplays, or simulated multi-turn exchanges.
 5. Do NOT invent what other participants might say next.
 6. ${mentionHint}
-7. If the conversation has naturally concluded or you have nothing meaningful to add, reply with exactly the single word: SILENT
+${silentRule}
 
 ---
-${agentBasePrompt}${toolAddendum}${gatewayCategorySummary}${planFirst}`
+${agentBasePrompt}${toolAddendum}${gatewayCategorySummary}${planFirst}${goalBlock}`
 }
 
 /**
@@ -194,12 +200,13 @@ async function callClaude(
   hasTools = false,
   agentId?: string,
   roomId?: string,
+  activeGoal?: string,
 ): Promise<string | null> {
   // Always enable MCP when in a room context — Claude should have the same tool access
   // as OpenAI-compatible agents. maxTurns controls depth; hasTools controls prompt framing.
   const useMcp = !!agentId && !!roomId
   const toolMode: false | 'legacy' | 'mcp' = useMcp ? 'mcp' : hasTools ? 'legacy' : false
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, toolMode)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, toolMode, '', activeGoal)
   const historyBlock = history.length
     ? history.map(e => `${e.name}: ${e.content}`).join('\n') + '\n\n'
     : ''
@@ -238,8 +245,9 @@ async function callOllamaChat(
   baseUrl: string,
   hasTools = false,
   gatewayCategorySummary = '',
+  activeGoal?: string,
 ): Promise<string | null> {
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true, gatewayCategorySummary)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, gatewayCategorySummary, activeGoal)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const res = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
@@ -331,10 +339,11 @@ async function callOpenAIChat(
   toolContext?: { roomId: string; agentId: string; llm: string },
   gateway?: AgentGateway | null,
   gatewayTools?: GatewayTool[],
+  activeGoal?: string,
 ): Promise<OpenAICallResult> {
   const hasTools = !!toolContext
   const gatewayCategorySummary = gatewayTools ? buildGatewayCategorySummary(gatewayTools) : ''
-  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, true, gatewayCategorySummary)
+  const sys = buildSystemPrompt(agentName, agentBasePrompt, otherParticipants, hasTools, gatewayCategorySummary, activeGoal)
   const chatMsgs = buildChatMessages(history, latestMessage)
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
@@ -647,6 +656,7 @@ export async function triggerRoomAgentReplies(
   // delegate to specialists or answer directly.
   const roomMeta = (room?.metadata ?? {}) as Record<string, unknown>
   const ringLeaderId = roomMeta?.ringLeaderAgentId as string | undefined
+  const activeGoal   = (roomMeta?.activeGoal as string | undefined) || undefined
   const mentionedNames  = parseMentions(triggerContent)
   const isEveryone      = mentionedNames.some(n => n.toLowerCase() === 'everyone')
   const isDirect        = agentMembers.length === 1  // 1-on-1 room — always reply
@@ -831,10 +841,10 @@ export async function triggerRoomAgentReplies(
           }
           const baseUrl = extModel.baseUrl ?? 'http://localhost:11434'
           if (extModel.provider === 'ollama') {
-            reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, !!toolContext)
+            reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, !!toolContext, '', activeGoal)
           } else {
             // openai / custom — OpenAI-compatible (supports tool calling + token tracking)
-            const result = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext, gateway, gatewayTools)
+            const result = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, extModel.modelId, baseUrl, extModel.apiKey, toolContext, gateway, gatewayTools, activeGoal)
             reply = result.reply
             tokensUsed = result.tokensUsed
             discoveredContextLimit = result.contextLimit
@@ -845,13 +855,13 @@ export async function triggerRoomAgentReplies(
           if (toolsEnabled) {
             console.warn(`[room-agents] ${agent.name} has tools enabled but ${llm} route does not support function calling — scope awareness injected but tool invocation unavailable`)
           }
-          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext, buildGatewayCategorySummary(gatewayTools))
+          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext, buildGatewayCategorySummary(gatewayTools), activeGoal)
         } else {
           // claude / claude:<model> — routed through orion-claude sidecar.
           // When tools are enabled, the sidecar writes a per-request .mcp.json so Claude
           // calls ORION tools natively via MCP (ORION is the harness, Claude is the brain).
           const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext, agent.id, roomId)
+          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext, agent.id, roomId, activeGoal)
           if (reply === null) {
             // Claude is unavailable — post a message on the agent's behalf rather than silently skipping
             console.warn(`[room-agents] ${agent.name}: Claude unavailable, posting unavailability notice`)
@@ -882,8 +892,15 @@ export async function triggerRoomAgentReplies(
         continue
       }
       if (reply.trim().toUpperCase() === 'SILENT') {
-        console.log(`[room-agents] ${agent.name} chose not to respond`)
-        continue
+        if (activeGoal) {
+          // Goal is active — SILENT is not allowed. Post a status nudge so the user
+          // knows the agent is still on the hook, then keep the goal visible.
+          console.warn(`[room-agents] ${agent.name} tried SILENT with active goal — forcing status reply`)
+          reply = `Still working on the goal: "${activeGoal}" — what's the current status?`
+        } else {
+          console.log(`[room-agents] ${agent.name} chose not to respond`)
+          continue
+        }
       }
 
       const message = await prisma.chatMessage.create({

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -540,6 +540,40 @@ async function handleSendMessage(args: unknown, ctx: ToolExecutionContext): Prom
   return `Message posted to room "${room.name}" (${room_id})`
 }
 
+async function handleSetGoal(args: unknown, ctx: ToolExecutionContext): Promise<string> {
+  const { room_id, goal } = parseArgs(args) as { room_id?: string; goal?: string }
+  if (!room_id) return 'Error: room_id is required'
+  if (!goal?.trim()) return 'Error: goal is required'
+
+  const room = await ctx.prisma.chatRoom.findUnique({ where: { id: room_id } })
+  if (!room) return `Error: room ${room_id} not found`
+
+  const meta = (room.metadata ?? {}) as Record<string, unknown>
+  await ctx.prisma.chatRoom.update({
+    where: { id: room_id },
+    data: { metadata: { ...meta, activeGoal: goal.trim() } },
+  })
+
+  return `Goal set in room "${room.name}": ${goal.trim()}`
+}
+
+async function handleCompleteGoal(args: unknown, ctx: ToolExecutionContext): Promise<string> {
+  const { room_id } = parseArgs(args) as { room_id?: string }
+  if (!room_id) return 'Error: room_id is required'
+
+  const room = await ctx.prisma.chatRoom.findUnique({ where: { id: room_id } })
+  if (!room) return `Error: room ${room_id} not found`
+
+  const meta = (room.metadata ?? {}) as Record<string, unknown>
+  const { activeGoal, ...rest } = meta
+  await ctx.prisma.chatRoom.update({
+    where: { id: room_id },
+    data: { metadata: rest as Record<string, unknown> & object },
+  })
+
+  return `Goal "${activeGoal ?? '(none)'}" marked complete and cleared from room "${room.name}"`
+}
+
 async function handleCreateFeature(args: unknown, ctx: ToolExecutionContext): Promise<string> {
   const { epicId, title, description } = parseArgs(args) as {
     epicId?: string
@@ -1481,6 +1515,41 @@ registerTool({
   availableIn: 'both',
   category: 'rooms',
   handler: handleSendMessage,
+})
+
+registerTool({
+  name: 'orion_set_goal',
+  description: 'Set an active goal for a chat room. While a goal is active, agents in the room must respond with progress rather than going silent. Use this when you want an agent to keep working until a task is explicitly done.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      room_id: { type: 'string', description: 'Chat room ID to set the goal in' },
+      goal:    { type: 'string', description: 'Clear description of what must be accomplished' },
+    },
+    required: ['room_id', 'goal'],
+  },
+  tier: 'write',
+  parallelSafe: false,
+  availableIn: 'both',
+  category: 'rooms',
+  handler: handleSetGoal,
+})
+
+registerTool({
+  name: 'orion_complete_goal',
+  description: 'Mark the active goal in a chat room as complete and clear it. Call this when the goal has been accomplished so agents can return to normal SILENT behavior.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      room_id: { type: 'string', description: 'Chat room ID to clear the goal from' },
+    },
+    required: ['room_id'],
+  },
+  tier: 'write',
+  parallelSafe: false,
+  availableIn: 'both',
+  category: 'rooms',
+  handler: handleCompleteGoal,
 })
 
 registerTool({


### PR DESCRIPTION
## Summary

- **Tool call hallucination fix**: `LOCAL_MODEL_PLAN_FIRST` (the XML prohibition + tool discipline block) was gated behind `localModel && hasTools`, so it was never injected for Claude agents and inconsistently applied elsewhere. Removed the gate entirely — all agents always get the instruction. Also removed the now-dead `localModel` parameter from `buildSystemPrompt` and its three call sites.

- **Room goals**: Agents (especially Alpha on a weak local LLM) would go SILENT mid-conversation when there was still work to do. Added `orion_set_goal` and `orion_complete_goal` tools that write `activeGoal` to `room.metadata`. When a goal is active: rule 7 flips from "reply SILENT if nothing to add" to "you MUST respond with progress"; any SILENT reply is intercepted and converted to a status nudge. Goal is cleared when the agent (or user) calls `orion_complete_goal`.

- **Image auto-merge policy**: Non-deterministic image tags (`latest`, `develop`, `nightly`, `edge`, `unstable`, `main`, `master`, `snapshot`, `canary`, `beta`, `alpha`, `rc`) now require human review instead of auto-merging as `image-update-patch`. Ambiguous image change descriptions in `classifyOperation` also default to `review` rather than `patch`. Fixes the case where a registry+tag change (e.g. `readarr/readarr:develop` → `lscr.io/linuxserver/readarr:latest`) was silently auto-merged.

## Test plan

- [ ] Verify Alpha responds in a 1-on-1 chat without going SILENT mid-task
- [ ] Set a goal via `orion_set_goal`, confirm agent keeps responding; call `orion_complete_goal`, confirm SILENT resumes
- [ ] Propose a GitOps change with `image: nginx:latest` — confirm it gets `needs-review` label, not `auto-merge`
- [ ] Propose a GitOps change with `image: nginx:1.25.3` — confirm it still auto-merges as patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)