### PR TITLE
fix: route ollama through OpenAI-compat endpoint, guard premature goal completion

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -9,7 +9,7 @@
  *
  * Supported LLM routes (same as streamAgentChat):
  *   claude / claude:<model>   — Claude Code SDK (OAuth credentials)
- *   ollama:<model>            — Ollama /api/chat
+ *   ollama:<model>            — Ollama /v1/chat/completions (OpenAI-compat, supports tool_calls)
  *   ext:<id>                  — ExternalModel lookup → Ollama or OpenAI-compatible
  *   gemini:<model>            — falls back to Claude for now
  */
@@ -852,10 +852,13 @@ export async function triggerRoomAgentReplies(
         } else if (llm.startsWith('ollama:')) {
           const model   = llm.slice('ollama:'.length)
           const baseUrl = await resolveOllamaBaseUrl()
-          if (toolsEnabled) {
-            console.warn(`[room-agents] ${agent.name} has tools enabled but ${llm} route does not support function calling — scope awareness injected but tool invocation unavailable`)
-          }
-          reply = await callOllamaChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, !!toolContext, buildGatewayCategorySummary(gatewayTools), activeGoal)
+          // Route through OpenAI-compat endpoint (/v1/chat/completions) so tool_calls
+          // JSON is supported. Ollama's /api/chat has no tools array — agents on that
+          // path can only hallucinate tool names as prose.
+          const result = await callOpenAIChat(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, model, baseUrl, null, toolContext, gateway, gatewayTools, activeGoal)
+          reply = result.reply
+          tokensUsed = result.tokensUsed
+          discoveredContextLimit = result.contextLimit
         } else {
           // claude / claude:<model> — routed through orion-claude sidecar.
           // When tools are enabled, the sidecar writes a per-request .mcp.json so Claude

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -558,8 +558,11 @@ async function handleSetGoal(args: unknown, ctx: ToolExecutionContext): Promise<
 }
 
 async function handleCompleteGoal(args: unknown, ctx: ToolExecutionContext): Promise<string> {
-  const { room_id } = parseArgs(args) as { room_id?: string }
+  const { room_id, verification_summary } = parseArgs(args) as { room_id?: string; verification_summary?: string }
   if (!room_id) return 'Error: room_id is required'
+  if (!verification_summary?.trim()) return 'Error: verification_summary is required — describe what you actually checked to confirm the goal is complete (pod status, endpoint tests, etc.)'
+  // Reject summaries that are too vague to be meaningful
+  if (verification_summary.trim().length < 20) return 'Error: verification_summary is too vague — describe the specific checks you ran and what they showed'
 
   const room = await ctx.prisma.chatRoom.findUnique({ where: { id: room_id } })
   if (!room) return `Error: room ${room_id} not found`
@@ -571,7 +574,8 @@ async function handleCompleteGoal(args: unknown, ctx: ToolExecutionContext): Pro
     data: { metadata: rest as Record<string, unknown> & object },
   })
 
-  return `Goal "${activeGoal ?? '(none)'}" marked complete and cleared from room "${room.name}"`
+  if (ctx.agentId) await auditLog(ctx.agentId, `✅ Goal complete in room **${room.name}**: ${activeGoal ?? '(unknown)'} — Verification: ${verification_summary.trim()}`)
+  return `Goal "${activeGoal ?? '(none)'}" marked complete. Verification: ${verification_summary.trim()}`
 }
 
 async function handleCreateFeature(args: unknown, ctx: ToolExecutionContext): Promise<string> {
@@ -1537,13 +1541,14 @@ registerTool({
 
 registerTool({
   name: 'orion_complete_goal',
-  description: 'Mark the active goal in a chat room as complete and clear it. Call this when the goal has been accomplished so agents can return to normal SILENT behavior.',
+  description: 'Mark the active goal in a chat room as complete and clear it. GUARD: Only call this after you have VERIFIED the goal is actually done — check pod status, test endpoints, confirm resources are healthy. Do NOT call this just because a PR was merged, a command was issued, or you believe the work should be done. You must have observed real evidence of success (e.g. kubectl_get_pods showing Running, HTTP 200 from the endpoint). Provide a verification_summary describing exactly what you checked.',
   inputSchema: {
     type: 'object',
     properties: {
-      room_id: { type: 'string', description: 'Chat room ID to clear the goal from' },
+      room_id:              { type: 'string', description: 'Chat room ID to clear the goal from' },
+      verification_summary: { type: 'string', description: 'What you actually checked to confirm the goal is complete. E.g. "kubectl_get_pods shows all 7 arr-stack pods Running; curl sonarr.khalisio.com returns 200". Required — vague answers will be rejected.' },
     },
-    required: ['room_id'],
+    required: ['room_id', 'verification_summary'],
   },
   tier: 'write',
   parallelSafe: false,


### PR DESCRIPTION
## Summary

- **Ollama tool calling**: The `ollama:` LLM path was using `/api/chat` which has no `tools` array — agents could only hallucinate tool names as prose text. Switched to `callOpenAIChat` which hits Ollama's `/v1/chat/completions` OpenAI-compatible endpoint. Agents on `ollama:` now get real structured `tool_calls` JSON, the full tool loop, fake-call detection, and tool result caching.

- **Premature goal completion guard**: `orion_complete_goal` previously required only a `room_id`. Agents were calling it immediately after proposing a PR — before verifying anything actually worked. Now requires a `verification_summary` (min 20 chars) describing what was actually checked (pod status, endpoint tests, etc.). Vague or missing summaries are rejected. The evidence is recorded in the audit log.

## Test plan

- [ ] Set Alpha's LLM to `ollama:<model>` and confirm tool calls execute as structured `tool_calls` rather than appearing as prose in chat
- [ ] Call `orion_complete_goal` without `verification_summary` — confirm rejection
- [ ] Call `orion_complete_goal` with a vague summary under 20 chars — confirm rejection
- [ ] Call `orion_complete_goal` with a real summary — confirm goal clears and audit log records it

🤖 Generated with [Claude Code](https://claude.com/claude-code)