### PR TITLE
feat: room goals — replace metadata string with RoomGoal DB model

### DIFF
--- a/apps/web/prisma/migrations/10_room_goals/migration.sql
+++ b/apps/web/prisma/migrations/10_room_goals/migration.sql
@@ -1,0 +1,22 @@
+-- Add RoomGoal model: tracks goals set in chat rooms with full history,
+-- status, completion summary, and who set them.
+
+CREATE TABLE "room_goals" (
+    "id" TEXT NOT NULL,
+    "roomId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "completionSummary" TEXT,
+    "startMessageId" TEXT,
+    "setBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "room_goals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "room_goals_roomId_status_idx" ON "room_goals"("roomId", "status");
+CREATE INDEX "room_goals_roomId_createdAt_idx" ON "room_goals"("roomId", "createdAt");
+
+ALTER TABLE "room_goals" ADD CONSTRAINT "room_goals_roomId_fkey"
+    FOREIGN KEY ("roomId") REFERENCES "chat_rooms"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -764,9 +764,27 @@ model ChatRoom {
   messages      ChatMessage[]
   metadata      Json?    // { ringLeaderAgentId?: string, knowledgeScope: "global" | "room" | "mixed" }
   roomKnowledge RoomKnowledge[]
+  goals         RoomGoal[]
 
   @@unique([featureId])
   @@map("chat_rooms")
+}
+
+model RoomGoal {
+  id                String    @id @default(cuid())
+  roomId            String
+  room              ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  text              String    @db.Text
+  status            String    @default("active")  // "active" | "completed" | "abandoned"
+  completionSummary String?   @db.Text
+  startMessageId    String?   // ID of the "goal set" system ChatMessage — for future jump-to
+  setBy             String?   // userId or agentId that created this goal
+  createdAt         DateTime  @default(now())
+  completedAt       DateTime?
+
+  @@index([roomId, status])
+  @@index([roomId, createdAt])
+  @@map("room_goals")
 }
 
 model ChatRoomMember {

--- a/apps/web/src/app/api/chatrooms/[id]/goals/[goalId]/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/goals/[goalId]/route.ts
@@ -1,0 +1,56 @@
+/**
+ * /api/chatrooms/[id]/goals/[goalId]
+ *
+ * PATCH — Complete or abandon a specific goal
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; goalId: string }> }
+) {
+  const { id, goalId } = await params
+  await getServerSession(authOptions)
+
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const status = typeof body.status === 'string' ? body.status : ''
+  if (status !== 'completed' && status !== 'abandoned') {
+    return NextResponse.json({ error: 'status must be "completed" or "abandoned"' }, { status: 400 })
+  }
+  const completionSummary = typeof body.completionSummary === 'string' ? body.completionSummary.trim() || null : null
+
+  const goal = await prisma.roomGoal.findUnique({ where: { id: goalId } })
+  if (!goal || goal.roomId !== id) {
+    return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
+  }
+
+  const updated = await prisma.roomGoal.update({
+    where: { id: goalId },
+    data: { status, completionSummary, completedAt: new Date() },
+  })
+
+  const systemContent = status === 'completed'
+    ? `✓ Goal completed${completionSummary ? `: ${completionSummary}` : ''}`
+    : `✗ Goal abandoned${completionSummary ? `: ${completionSummary}` : ''}`
+
+  const msg = await prisma.chatMessage.create({
+    data: { roomId: id, senderType: 'system', content: systemContent },
+  })
+
+  try {
+    const { publishChatMessage } = await import('@/lib/chat-redis')
+    await publishChatMessage(id, {
+      id: msg.id,
+      senderType: 'system',
+      content: msg.content,
+      attachments: null,
+      sender: { type: 'system', id: null, name: 'System' },
+      createdAt: msg.createdAt.toISOString(),
+    })
+  } catch { /* redis optional */ }
+
+  return NextResponse.json({ goal: updated })
+}

--- a/apps/web/src/app/api/chatrooms/[id]/goals/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/goals/route.ts
@@ -1,0 +1,84 @@
+/**
+ * /api/chatrooms/[id]/goals
+ *
+ * GET  — Return all goals for the room ordered by createdAt desc
+ * POST — Create a new active goal (abandons any existing active goal first)
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  const room = await prisma.chatRoom.findUnique({ where: { id }, select: { id: true } })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  const goals = await prisma.roomGoal.findMany({
+    where: { roomId: id },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return NextResponse.json({ goals })
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>
+  const text = typeof body.text === 'string' ? body.text.trim() : ''
+  if (!text) return NextResponse.json({ error: 'text is required' }, { status: 400 })
+
+  const room = await prisma.chatRoom.findUnique({ where: { id }, select: { id: true } })
+  if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  // Abandon any existing active goal
+  await prisma.roomGoal.updateMany({
+    where: { roomId: id, status: 'active' },
+    data: { status: 'abandoned', completedAt: new Date() },
+  })
+
+  // Create new goal
+  const goal = await prisma.roomGoal.create({
+    data: {
+      roomId: id,
+      text,
+      status: 'active',
+      setBy: userId ?? null,
+    },
+  })
+
+  // Post system message and store its ID on the goal
+  const msg = await prisma.chatMessage.create({
+    data: { roomId: id, senderType: 'system', content: `🎯 Goal set: ${text}` },
+  })
+
+  const goalWithMsg = await prisma.roomGoal.update({
+    where: { id: goal.id },
+    data: { startMessageId: msg.id },
+  })
+
+  // Publish via Redis SSE so UI updates in real-time
+  try {
+    const { publishChatMessage } = await import('@/lib/chat-redis')
+    await publishChatMessage(id, {
+      id: msg.id,
+      senderType: 'system',
+      content: msg.content,
+      attachments: null,
+      sender: { type: 'system', id: null, name: 'System' },
+      createdAt: msg.createdAt.toISOString(),
+    })
+  } catch { /* redis optional */ }
+
+  return NextResponse.json({ goal: goalWithMsg }, { status: 201 })
+}

--- a/apps/web/src/app/api/chatrooms/[id]/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   const { searchParams } = new URL(_req.url)
   const messageLimit = Math.min(parseInt(searchParams.get('messages') ?? '50') || 50, 200)
 
-  const [room, totalMessages] = await Promise.all([
+  const [room, totalMessages, activeGoal] = await Promise.all([
     prisma.chatRoom.findUnique({
       where: { id },
       include: {
@@ -45,6 +45,11 @@ export async function GET(
       },
     }),
     prisma.chatMessage.count({ where: { roomId: id } }),
+    prisma.roomGoal.findFirst({
+      where: { roomId: id, status: 'active' },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, text: true, status: true, createdAt: true },
+    }),
   ])
 
   if (!room) {
@@ -75,6 +80,9 @@ export async function GET(
     updatedAt: room.updatedAt.toISOString(),
     members, messages,
     totalMessages,
+    activeGoal: activeGoal
+      ? { ...activeGoal, createdAt: activeGoal.createdAt.toISOString() }
+      : null,
   })
 }
 

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -59,6 +59,7 @@ interface RoomDetail {
   totalMessages?: number
   members?: RoomMember[]
   messages?: RoomMessage[]
+  activeGoal?: { id: string; text: string; status: string; createdAt: string } | null
 }
 
 interface InviteOption {
@@ -101,6 +102,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   const [savedPlanMsgId, setSavedPlanMsgId] = useState<string | null>(null)
   const [planToast, setPlanToast] = useState<{ msgId: string; prevPlan: string | null } | null>(null)
   const [hoveredMsgId, setHoveredMsgId] = useState<string | null>(null)
+  const [showSetGoal, setShowSetGoal] = useState(false)
+  const [goalInput, setGoalInput] = useState('')
+  const [settingGoal, setSettingGoal] = useState(false)
+  const [showCompleteGoal, setShowCompleteGoal] = useState(false)
+  const [goalSummaryInput, setGoalSummaryInput] = useState('')
+  const [completingGoal, setCompletingGoal] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
@@ -200,6 +207,15 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               totalMessages: (prev.totalMessages || 0) + 1,
             }
           })
+
+          // Reload room data when a goal system message arrives so banner updates
+          if (
+            message.senderType === 'system' &&
+            typeof message.content === 'string' &&
+            (message.content.startsWith('🎯') || message.content.startsWith('✓ Goal') || message.content.startsWith('✗ Goal'))
+          ) {
+            loadRoom()
+          }
         } catch (e) {
           console.error('[RoomChat] Error parsing SSE message:', e)
         }
@@ -360,6 +376,50 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
     else onMobileBack()
   }, [roomId, onLeave, onMobileBack])
 
+  const handleSetGoal = useCallback(async () => {
+    if (!goalInput.trim() || settingGoal) return
+    setSettingGoal(true)
+    try {
+      await fetch(`/api/chatrooms/${roomId}/goals`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: goalInput.trim() }),
+      })
+      setGoalInput('')
+      setShowSetGoal(false)
+      await loadRoom()
+    } catch { /* ignore */ }
+    setSettingGoal(false)
+  }, [roomId, goalInput, settingGoal, loadRoom])
+
+  const handleCompleteGoal = useCallback(async () => {
+    if (!room?.activeGoal || completingGoal) return
+    setCompletingGoal(true)
+    try {
+      await fetch(`/api/chatrooms/${roomId}/goals/${room.activeGoal.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'completed', completionSummary: goalSummaryInput.trim() || undefined }),
+      })
+      setGoalSummaryInput('')
+      setShowCompleteGoal(false)
+      await loadRoom()
+    } catch { /* ignore */ }
+    setCompletingGoal(false)
+  }, [room, roomId, goalSummaryInput, completingGoal, loadRoom])
+
+  const handleAbandonGoal = useCallback(async () => {
+    if (!room?.activeGoal) return
+    try {
+      await fetch(`/api/chatrooms/${roomId}/goals/${room.activeGoal.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'abandoned' }),
+      })
+      await loadRoom()
+    } catch { /* ignore */ }
+  }, [room, roomId, loadRoom])
+
   // Filter invite list by search
   const filteredUsers = inviteUsers.filter(u =>
     !inviteSearch || (u.name || u.username || '').toLowerCase().includes(inviteSearch.toLowerCase())
@@ -385,6 +445,14 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           >
             <Plus size={14} />
           </button>
+          {/* Set Goal button */}
+          <button
+            onClick={() => { setShowSetGoal(v => !v); setGoalInput('') }}
+            className={`p-1.5 rounded hover:bg-bg-raised transition-colors ${room?.activeGoal ? 'text-accent' : 'text-text-muted hover:text-accent'}`}
+            title={room?.activeGoal ? `Active goal: ${room.activeGoal.text}` : 'Set goal'}
+          >
+            <BookmarkCheck size={14} />
+          </button>
           {/* Leave room button */}
           <button
             onClick={() => setShowLeaveConfirm(true)}
@@ -395,6 +463,30 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           </button>
         </div>
       </div>
+
+      {/* Set Goal inline input */}
+      {showSetGoal && (
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle flex-shrink-0 bg-bg-raised">
+          <input
+            autoFocus
+            value={goalInput}
+            onChange={e => setGoalInput(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleSetGoal(); if (e.key === 'Escape') setShowSetGoal(false) }}
+            placeholder="Describe the goal for this room…"
+            className="flex-1 text-xs bg-bg-sidebar border border-border-subtle rounded px-2.5 py-1.5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+          />
+          <button
+            onClick={handleSetGoal}
+            disabled={!goalInput.trim() || settingGoal}
+            className="text-xs px-3 py-1.5 rounded bg-accent/20 text-accent hover:bg-accent/30 disabled:opacity-40 transition-colors"
+          >
+            {settingGoal ? 'Setting…' : 'Set'}
+          </button>
+          <button onClick={() => setShowSetGoal(false)} className="p-1 text-text-muted hover:text-text-primary">
+            <X size={13} />
+          </button>
+        </div>
+      )}
 
       {/* Members bar */}
       {room?.members && room.members.length > 0 && (
@@ -407,6 +499,58 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               {m.role === 'lead' && <span className="text-accent">.</span>}
             </span>
           ))}
+        </div>
+      )}
+
+      {/* Active goal banner */}
+      {room?.activeGoal && (
+        <div className="flex-shrink-0 border-b border-border-subtle">
+          <div className="flex items-center justify-between px-4 py-2 bg-accent/5">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-accent flex-shrink-0">🎯</span>
+              <span className="text-xs text-text-primary truncate">{room.activeGoal.text}</span>
+              <span className="text-xs text-text-muted flex-shrink-0">
+                · {Math.round((Date.now() - new Date(room.activeGoal.createdAt).getTime()) / 60000)}m ago
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+              <button
+                onClick={() => { setShowCompleteGoal(v => !v); setGoalSummaryInput('') }}
+                className="text-[11px] px-2 py-0.5 rounded bg-status-healthy/15 text-status-healthy hover:bg-status-healthy/25 transition-colors"
+              >
+                Complete ✓
+              </button>
+              <button
+                onClick={handleAbandonGoal}
+                className="text-[11px] px-2 py-0.5 rounded bg-status-error/10 text-status-error hover:bg-status-error/20 transition-colors"
+              >
+                Abandon ×
+              </button>
+            </div>
+          </div>
+          {/* Complete summary input */}
+          {showCompleteGoal && (
+            <div className="flex items-center gap-2 px-4 py-2 bg-bg-raised border-t border-border-subtle">
+              <input
+                autoFocus
+                value={goalSummaryInput}
+                onChange={e => setGoalSummaryInput(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') handleCompleteGoal(); if (e.key === 'Escape') setShowCompleteGoal(false) }}
+                placeholder="Optional: describe what was accomplished…"
+                className="flex-1 text-xs bg-bg-sidebar border border-border-subtle rounded px-2.5 py-1.5 text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              />
+              <button
+                onClick={handleCompleteGoal}
+                disabled={completingGoal}
+                className="text-xs px-3 py-1.5 rounded bg-status-healthy/20 text-status-healthy hover:bg-status-healthy/30 disabled:opacity-40 transition-colors"
+              >
+                {completingGoal ? 'Saving…' : 'Confirm'}
+              </button>
+              <button onClick={() => setShowCompleteGoal(false)} className="p-1 text-text-muted hover:text-text-primary">
+                <X size={13} />
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -656,7 +656,12 @@ export async function triggerRoomAgentReplies(
   // delegate to specialists or answer directly.
   const roomMeta = (room?.metadata ?? {}) as Record<string, unknown>
   const ringLeaderId = roomMeta?.ringLeaderAgentId as string | undefined
-  const activeGoal   = (roomMeta?.activeGoal as string | undefined) || undefined
+  // TODO: remove metadata.activeGoal fallback — deprecated in favour of RoomGoal table
+  const activeGoalRecord = await prisma.roomGoal.findFirst({
+    where: { roomId, status: 'active' },
+    orderBy: { createdAt: 'desc' },
+  })
+  const activeGoal = activeGoalRecord?.text
   const mentionedNames  = parseMentions(triggerContent)
   const isEveryone      = mentionedNames.some(n => n.toLowerCase() === 'everyone')
   const isDirect        = agentMembers.length === 1  // 1-on-1 room — always reply

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -577,10 +577,29 @@ async function handleSetGoal(args: unknown, ctx: ToolExecutionContext): Promise<
   const room = await ctx.prisma.chatRoom.findUnique({ where: { id: room_id } })
   if (!room) return `Error: room ${room_id} not found`
 
-  const meta = (room.metadata ?? {}) as Record<string, unknown>
-  await ctx.prisma.chatRoom.update({
-    where: { id: room_id },
-    data: { metadata: { ...meta, activeGoal: goal.trim() } },
+  // Abandon any existing active goal
+  await ctx.prisma.roomGoal.updateMany({
+    where: { roomId: room_id, status: 'active' },
+    data: { status: 'abandoned', completedAt: new Date() },
+  })
+
+  // Create new goal record
+  const newGoal = await ctx.prisma.roomGoal.create({
+    data: {
+      roomId: room_id,
+      text: goal.trim(),
+      status: 'active',
+      setBy: ctx.agentId ?? ctx.userId ?? null,
+    },
+  })
+
+  // Post system message and capture its ID
+  const msg = await ctx.prisma.chatMessage.create({
+    data: { roomId: room_id, senderType: 'system', content: `🎯 Goal set: ${goal.trim()}` },
+  })
+  await ctx.prisma.roomGoal.update({
+    where: { id: newGoal.id },
+    data: { startMessageId: msg.id },
   })
 
   return `Goal set in room "${room.name}": ${goal.trim()}`
@@ -596,15 +615,27 @@ async function handleCompleteGoal(args: unknown, ctx: ToolExecutionContext): Pro
   const room = await ctx.prisma.chatRoom.findUnique({ where: { id: room_id } })
   if (!room) return `Error: room ${room_id} not found`
 
-  const meta = (room.metadata ?? {}) as Record<string, unknown>
-  const { activeGoal, ...rest } = meta
-  await ctx.prisma.chatRoom.update({
-    where: { id: room_id },
-    data: { metadata: rest as Record<string, unknown> & object },
+  const activeGoalRecord = await ctx.prisma.roomGoal.findFirst({
+    where: { roomId: room_id, status: 'active' },
+    orderBy: { createdAt: 'desc' },
+  })
+  if (!activeGoalRecord) return `Error: no active goal found in room ${room_id}`
+
+  await ctx.prisma.roomGoal.update({
+    where: { id: activeGoalRecord.id },
+    data: {
+      status: 'completed',
+      completionSummary: verification_summary.trim(),
+      completedAt: new Date(),
+    },
   })
 
-  if (ctx.agentId) await auditLog(ctx.agentId, `✅ Goal complete in room **${room.name}**: ${activeGoal ?? '(unknown)'} — Verification: ${verification_summary.trim()}`)
-  return `Goal "${activeGoal ?? '(none)'}" marked complete. Verification: ${verification_summary.trim()}`
+  await ctx.prisma.chatMessage.create({
+    data: { roomId: room_id, senderType: 'system', content: `✓ Goal completed: ${verification_summary.trim()}` },
+  })
+
+  if (ctx.agentId) await auditLog(ctx.agentId, `✅ Goal complete in room **${room.name}**: ${activeGoalRecord.text} — Verification: ${verification_summary.trim()}`)
+  return `Goal "${activeGoalRecord.text}" marked complete. Verification: ${verification_summary.trim()}`
 }
 
 async function handleCreateFeature(args: unknown, ctx: ToolExecutionContext): Promise<string> {


### PR DESCRIPTION
## Summary

- **Schema**: new `RoomGoal` model (`room_goals` table) with `status`, `completionSummary`, `startMessageId`, `setBy`, timestamps. Migration `10_room_goals` included.
- **API**: `GET/POST /api/chatrooms/[id]/goals` (list + create), `PATCH /api/chatrooms/[id]/goals/[goalId]` (complete/abandon). `GET /api/chatrooms/[id]` now returns `activeGoal`.
- **Worker**: `room-agents.ts` reads `activeGoal` from `RoomGoal` table instead of `room.metadata`. `orion_set_goal` / `orion_complete_goal` tools in `tool-registry.ts` write to the new table (system messages posted, `startMessageId` captured for future jump-to).
- **UI** (`RoomChat.tsx`): `BookmarkCheck` Set Goal button in header (lit accent when goal active), inline goal input, sticky banner between header and messages with **Complete ✓** / **Abandon ×** actions and optional completion summary input. Banner reloads via SSE on goal system messages.

## Out of scope (v2)
- Goal history drawer
- Jump-to-message from history
- Cross-room goals board

## Test plan
- [ ] Set a goal via the button — banner appears, system message posted in room
- [ ] Agent uses `orion_set_goal` tool — banner appears, old goal auto-abandoned
- [ ] Click Complete ✓, enter summary, confirm — banner clears, system message posted
- [ ] Click Abandon × — banner clears immediately
- [ ] Agent uses `orion_complete_goal` — banner clears, verification summary stored
- [ ] `GET /api/chatrooms/[id]` returns `activeGoal` field (or null when none)
- [ ] `GET /api/chatrooms/[id]/goals` returns full goal history

🤖 Generated with [Claude Code](https://claude.com/claude-code)