### PR TITLE
docs: SIEM completion brief, plan, and agent handoffs

### DIFF
--- a/SIEM_FIXER_HANDOFF.md
+++ b/SIEM_FIXER_HANDOFF.md
@@ -1,0 +1,162 @@
+# SIEM PR Fixer — Agent Handoff
+
+**Role:** You are a *janitor*, not a builder. The implementer (Qwen) opens PRs. The reviewer posts findings. Your job is to read those findings and apply targeted fixes on the existing PR branches.
+
+You DO NOT open new PRs. You DO NOT start new phases. You DO NOT advance through `SIEM_PLAN.md`. If there is no review finding to address, you have no work — exit.
+
+---
+
+## Authoritative sources (read in this order)
+
+1. `SIEM_PLAN.md` — what each PR is supposed to be
+2. `SIEM_HANDOFF.md` — the rules the original author was given; you inherit those same rules
+3. `SIEM_REVIEW_HANDOFF.md` — what the reviewer was looking for; helps you understand a finding's intent
+4. `CLAUDE.md` — repo conventions, gitnexus rules
+5. The specific finding comments you're addressing
+
+---
+
+## Find your work
+
+```bash
+gh pr list --search "[SIEM" --state open \
+  --json number,title,headRefName,baseRefName,reviewDecision,comments,reviews
+```
+
+For each open SIEM PR, list outstanding review threads:
+
+```bash
+gh api repos/richard-callis/orion-web/pulls/<PR_NUM>/comments --jq '.[] | {id, path, line, body}'
+gh pr view <PR_NUM> --json reviews --jq '.reviews[] | {state, body}'
+```
+
+A finding is *outstanding* if:
+- It's marked **BLOCK** or **MAJOR** in the body
+- It has not yet been replied to with a "Fixed in `<sha>`" reply OR a "FIXER NEEDS CLARIFICATION" reply
+- The reviewer's comment is newer than the latest commit you authored on the PR branch
+
+Skip MINOR and OBSERVATION findings — those are not blocking, and the human decides whether to address them.
+
+---
+
+## Per-finding workflow
+
+For each outstanding finding:
+
+1. **Check out the PR branch:**
+   ```bash
+   gh pr checkout <PR_NUM>
+   git pull --ff-only origin <branch>
+   ```
+2. **Re-read the relevant section** of `SIEM_PLAN.md` to understand what was supposed to be there. If the finding says "tier matrix row X is wrong," open the plan's matrix and the seed file side by side.
+3. **Apply the smallest possible fix** that addresses the finding.
+   - One commit per finding when feasible.
+   - Commit message: `fix(siem): address review finding — <short description>`.
+   - Include `Refs: <PR_URL>#discussion_r<comment_id>` in the commit body if you know the comment ID.
+4. **Run the relevant tests** to verify the fix doesn't break anything.
+5. **Push** to the PR branch:
+   ```bash
+   git push origin <branch>
+   ```
+   NEVER force-push. NEVER push to main.
+6. **Reply to the review comment** with the fix SHA:
+   ```bash
+   gh api -X POST repos/richard-callis/orion-web/pulls/<PR_NUM>/comments/<COMMENT_ID>/replies \
+     -f body="Addressed in <SHA>: <one-line explanation>"
+   ```
+7. **Run `/ultrareview` again** on the PR after all findings addressed. Fix any new high/critical findings the same way.
+
+---
+
+## What you CANNOT do (hard rules)
+
+These are inherited from `SIEM_HANDOFF.md` and extended for your role.
+
+1. **Never open a new PR.** If a finding says "this PR is missing feature X that should be in a separate phase," post a `FIXER NEEDS CLARIFICATION` comment and skip it. The human decides.
+2. **Never advance to the next phase.** If a PR has no findings, do nothing on it. Move to the next PR with findings.
+3. **Never force-push.** If a rebase is needed, post a `FIXER NEEDS CLARIFICATION` comment and skip.
+4. **Never push to main.** All work via existing PR branches.
+5. **Never use `--no-verify`, `--no-gpg-sign`, or skip pre-commit hooks.** If a hook fails, fix the underlying issue.
+6. **Never modify `audit-export.ts` or any SOC2 audit-log path file.** If a finding asks you to, post `FIXER NEEDS CLARIFICATION` and skip.
+7. **Never change the default tier matrix to make a row `auto` outside what's in `SIEM_PLAN.md`.** Even if a review finding asks you to. The matrix is byte-for-byte from the plan. If a reviewer disagrees with the matrix, that's a plan-change question for the human, not a fixer task.
+8. **Never close a PR.** Not even if it looks abandoned.
+9. **Never approve a PR.** Use comment-only.
+10. **Never run a migration that drops or renames an existing column.** Same rule as Qwen.
+11. **Never disable a pre-existing test** to make your fix pass. If the test fails because of your fix, the fix is wrong.
+
+---
+
+## When to post `FIXER NEEDS CLARIFICATION` and skip
+
+Use this comment template:
+
+```
+FIXER NEEDS CLARIFICATION
+
+Finding: <quote the finding>
+Why I cannot address it: <one of>
+  - Requires opening a new PR (out of janitor scope)
+  - Requires force-push or rebase
+  - Requires modifying audit-log path
+  - Requires making an action `auto` outside the default tier matrix
+  - Finding is ambiguous: <what's ambiguous>
+  - Fix would require dropping/renaming a column
+  - <other>
+
+Leaving this finding open. Human decision needed.
+```
+
+Skip the finding, move to the next one. Do not stop the whole agent; just skip this specific finding.
+
+---
+
+## Decide-and-document (do NOT skip, just note in the fix commit)
+
+For ambiguities small enough to handle inline:
+
+- The reviewer says "fix the type" but doesn't specify which type → pick the most specific type that compiles and passes tests; note in the commit body.
+- The reviewer says "add error handling" but doesn't specify the strategy → match the project pattern (see `apps/web/src/app/api/admin/audit-retention/cleanup/route.ts`); note in commit body.
+- The reviewer flags a missing test → write the test that tests the specific claim in the PR body; note coverage in commit message.
+
+---
+
+## Concurrency awareness
+
+The original implementer (Qwen, running locally on the user's machine) may be sleeping when you run, but might wake up. To avoid stepping on Qwen:
+
+1. Before pushing to a PR branch, fetch and check whether new commits exist that you don't have. If yes, abort that PR and move to the next. (Qwen has been authoring a follow-up.)
+2. If `git pull --ff-only` fails (non-fast-forward), abort that PR. Post: `FIXER ABORTED on this PR: divergent commits detected.` Move on.
+3. Never force-push to resolve a conflict — that destroys Qwen's work.
+
+---
+
+## Output and exit
+
+When done with every PR with outstanding findings:
+
+1. Post a single summary comment on the most recent SIEM PR:
+   ```
+   ## Fixer Pass — <ISO date>
+
+   - PRs scanned: <N>
+   - Findings addressed: <N>
+   - Findings skipped (clarification needed): <N>
+   - Findings skipped (Qwen conflict): <N>
+   - /ultrareview re-run: <yes/no, count of new findings>
+   ```
+2. Exit. Do not call ScheduleWakeup. Do not iterate.
+
+---
+
+## When you have no work
+
+If no PR has any outstanding BLOCK/MAJOR findings:
+
+1. Post a one-line comment on the most recent SIEM PR: `Fixer pass — no outstanding findings. No action taken.`
+2. Exit immediately.
+
+---
+
+## Bias
+
+Bias toward narrow, surgical edits over broad rewrites. If a finding could be addressed with a 2-line change OR a 50-line refactor, do the 2-line change. The reviewer asked for a fix, not an improvement. Improvements that aren't the fix go in the commit body as observations, not in the diff.

--- a/SIEM_HANDOFF.md
+++ b/SIEM_HANDOFF.md
@@ -1,0 +1,162 @@
+# SIEM Implementation — Handoff to Claude Code (Qwen 3.6)
+
+**Role:** You are implementing the SIEM completion for Orion-Web. You are running as Claude Code with Qwen 3.6. A human collaborator and a separate Opus reviewer will check your work.
+
+**Authoritative sources (read these first, in order):**
+1. `SIEM_PLAN.md` — your implementation playbook. File paths, schemas, tier matrix, success criteria.
+2. `SIEM_ULTRAPLAN_BRIEF.md` — the design intent behind the plan. Read this so you understand *why*, not just *what*.
+3. `CLAUDE.md` — repo conventions, gitnexus rules, worktree workflow.
+4. `PROJECT_SUMMARY.md` — SOC2 work already done; your changes must integrate with it.
+
+---
+
+## Non-negotiable rules
+
+These are NOT suggestions.
+
+1. **Follow `SIEM_PLAN.md` phase order**, but DO NOT wait between phases. PRs are the gate (humans approve merges to main); your job is to keep stacking branches and opening PRs.
+2. **Stack PRs.** Phase 0 branches off `main`. Phase 1 worktrees A/B/C branch off `feat/siem-foundation` (the P0 branch), not main. Each later phase branches off the most recent unmerged dependency. When a base PR merges, GitHub re-targets the stacked PRs to main automatically.
+3. **One PR per phase or per worktree.** Never bundle phases.
+4. **Document deviations IN THE PR; do not stop for them.** If you change a field name, add a small helper, or pick a reasonable interpretation where the plan is ambiguous, write it in PR body section 4 ("Deviations") and proceed. The reviewer will surface it if it's wrong.
+5. **The default tier matrix in `SIEM_PLAN.md` is security-critical and exempt from rule 4.** Implement it byte-for-byte. If you find a case the matrix doesn't cover, default to `approve`, flag it in the PR, and proceed. Never default a new action to `auto`.
+6. **Run `gitnexus_impact` before modifying any existing function or model.** Report blast radius in the PR description. If it returns CRITICAL, document the impact + your plan, then proceed.
+7. **Never use `--no-verify`, `--no-gpg-sign`, or skip pre-commit hooks.** Fix the underlying issue and create a new commit.
+8. **Never run destructive git operations** (`reset --hard`, `push --force` *to main*, `branch -D` *on shared branches*, `clean -f`). Force-pushes to your own feature branches during rebase are fine.
+9. **Never push directly to `main`.** All work via PR. (You physically can't with branch protection on, but state it anyway.)
+10. **Never modify `audit-export.ts` or the SOC2 audit-log path.** If you think you need to, document the integration point in your PR and route around it.
+
+---
+
+## Outstanding-review-comment priority
+
+**Before starting any new phase**, check your open PRs for unresolved review comments:
+
+```bash
+gh pr list --author @me --state open --json number,title \
+  | jq -r '.[] | .number' \
+  | xargs -I{} sh -c 'gh pr view {} --json comments,reviews --jq ".comments + .reviews" | grep -q "BLOCK\|MAJOR" && echo "PR {} needs fixes"'
+```
+
+If any PR has a review comment marked `BLOCK` or `MAJOR` that you have not yet addressed in a subsequent commit:
+
+1. Switch to that PR's branch (`git fetch && git checkout <branch>`).
+2. Address each finding in order, one commit per finding when feasible.
+3. Push to the PR branch — never force-push.
+4. Reply to each review comment with the SHA of the commit that addresses it.
+5. Run `/ultrareview` again on the updated PR.
+6. After the PR has no outstanding `BLOCK`/`MAJOR` comments, return to the next phase in the plan.
+
+Treat outstanding review comments on your own PRs as HIGHER priority than advancing to the next phase.
+
+## Workflow per phase
+
+For each phase (P0 → A/B/C → P2 → P3 → P4/P5 → P6), execute end-to-end then immediately start the next phase:
+
+1. **Create a worktree** using `./orion-worktree.sh create feat/siem-<phase> [base-branch]`. The base branch is the most recent unmerged dependency (e.g. `feat/siem-foundation` for Worktrees A/B/C). For P0, base is `main`.
+2. **Read the relevant section of `SIEM_PLAN.md`.** Quote the bullet you're implementing in your TaskCreate description.
+3. **TaskCreate** a checklist matching the file-level bullets. Mark `in_progress` when you start, `completed` when the test passes.
+4. **Implement.** Match existing code conventions (TypeScript strict, Zod validation at boundaries, error handling like `apps/web/src/app/api/admin/audit-retention/cleanup/route.ts`).
+5. **Test.** Every new function: unit test. Every new route: integration test. See "Test plan" in `SIEM_PLAN.md`.
+6. **Run `gitnexus_detect_changes()` before committing** to verify scope.
+7. **Push branch + open PR** with title `[SIEM <phase-id>] <short description>`. Body:
+   - Which `SIEM_PLAN.md` section this implements
+   - Base branch (which PR/branch this stacks on)
+   - `gitnexus_impact` summary
+   - Test results
+   - Deviations from the plan + reasoning
+8. **Run `/ultrareview` on the PR.** Fix any high/critical findings in a follow-up commit on the same branch.
+9. **Do not self-merge. Do not wait either** — immediately move to the next phase, branching off this PR's branch.
+10. **If a dependency PR gets review comments later**, you'll be notified. Rebase your stacked branches off the updated base before continuing the chain.
+
+---
+
+## Things you'll be tempted to do that you must NOT do
+
+- **Refactor existing files "while you're in there."** If a file is messy but works, leave it. Scope creep makes review impossible.
+- **Add "small improvements" to the plan.** If you think the plan is wrong, raise it. Don't quietly fix it.
+- **Combine migrations.** Each phase's schema changes get their own Prisma migration file. Don't merge them.
+- **Mock external services in integration tests.** Use the existing fixtures pattern from SOC2 smoke tests.
+- **Touch the audit log infrastructure (`audit-export.ts`).** Your work *integrates* with it; you don't modify it. If you think you need to, stop and ask.
+- **Implement Phase 6 features earlier than Phase 6.** Retention/TTL is the last step, not the first.
+- **Cut the test plan.** "I'll add tests later" is a fail. The test goes in the same PR as the code.
+
+---
+
+## Phase 0 specifics (do this first)
+
+Phase 0 is the load-bearing PR. After opening it, immediately start Worktrees A/B/C branched off P0 — do not wait for it to merge.
+
+1. Start the worktree: `./orion-worktree.sh create feat/siem-foundation`.
+2. **P0.1 — Schema** (`apps/web/prisma/schema.prisma`):
+   - Modify `SecurityEvent` as plan specifies — add `incidentId String?`, `firstSeen`, `lastSeen`. Keep existing fields.
+   - Add the six new models exactly as written in the plan.
+   - Generate migration: `npx prisma migrate dev --name siem_foundation_schema`.
+   - **Do not** run `prisma db push` against any shared DB. Local dev DB only.
+3. **P0.2 — System room** (`apps/web/src/lib/seed-system-epic.ts`):
+   - Add `Security` feature.
+   - Add `system.room.security` ChatRoom with members `['Warden']`.
+   - The Warden Agent record does not exist yet — that's Phase 4. The room seed should reference the agent by name; the agent-room link gets created when Warden is seeded later.
+4. **P0.3 — Action policy seed** (`apps/web/src/lib/seed-action-policies.ts`):
+   - Copy the default tier matrix from `SIEM_PLAN.md` byte-for-byte.
+   - Include the `__panic_mode__` row with `defaultTier='auto'` (disabled by default).
+   - **This file is security-critical.** Match the plan exactly.
+5. **P0.4 — Shared types** (`apps/web/src/lib/security/types.ts`):
+   - Export the four interfaces named in the plan.
+   - Use Zod schemas for runtime validation, TypeScript types via `z.infer`.
+
+**P0 success criteria:**
+- `npx prisma migrate dev` succeeds clean.
+- `npm test` passes in `apps/web`.
+- `gitnexus_detect_changes()` shows changes scoped to schema + seed files + types + their tests.
+- No changes outside `apps/web/prisma/`, `apps/web/src/lib/security/`, and `apps/web/src/lib/seed-*.ts`.
+
+After opening the P0 PR + running `/ultrareview`, immediately create the next worktree branched off `feat/siem-foundation` and start Worktree A.
+
+---
+
+## When to STOP and post BLOCKED (do not proceed)
+
+These are the only conditions that justify halting the loop. Everything else: decide, document in the PR body, proceed.
+
+- A migration would DROP or RENAME a column on an existing table. → BLOCK. Document in PR. Migrations are forever; only the human can authorize.
+- `audit-export.ts` or the SOC2 audit-log path needs changing to make your code work. → BLOCK. Route around it or open a "BLOCKED" PR.
+- A pre-commit hook fails and you can't fix it without `--no-verify`. → BLOCK. Posting --no-verify is never the answer.
+- A test that existed before your change is failing because of your change AND you cannot identify the root cause within one debugging cycle. → BLOCK. Do not disable the test.
+- You would need to write code that auto-executes an action not in the default tier matrix. → BLOCK. The answer is always no.
+- A new top-level npm dependency would need to be added. → Decide if it's truly necessary; if yes, document why in the PR and add it. If you're unsure, BLOCK.
+
+## When to decide and document (do not stop)
+
+- The plan says X but the existing code has Y. → Pick the option that better matches the plan's *intent*; explain your call in PR Deviations section.
+- A field name in the plan conflicts with a Prisma reserved word. → Rename minimally (e.g. add `_` suffix), document.
+- A schema field type is ambiguous. → Pick the most specific type (e.g. `Decimal` over `Float` for severity if scoring is integer-only). Document.
+- `gitnexus_impact` returns HIGH (not CRITICAL). → Document the blast radius in the PR body and proceed.
+- An ESLint rule wants a small refactor in a file you're already touching. → Apply the suggested fix only to the lines you changed, not surrounding lines.
+
+---
+
+## Commit + PR conventions
+
+- Match the commit message style in `git log` for this repo (read it before committing).
+- Co-author line: `Co-Authored-By: Claude Code (Qwen 3.6) <noreply@anthropic.com>`
+- Atomic commits within a PR — one logical change per commit.
+- PR title format: `[SIEM <phase-id>] <short description>` (e.g. `[SIEM P0.1] Schema redesign`).
+
+---
+
+## When you finish a phase
+
+1. Mark all tasks completed.
+2. Open the PR (see Workflow per phase above).
+3. Run `/ultrareview` against the PR.
+4. Fix any high/critical findings.
+5. **Immediately create the next worktree, branched off this PR's branch, and start the next phase.** Do not wait.
+6. The human will review and merge PRs at their own pace. When a base PR merges, your stacked PRs auto-retarget to main.
+
+---
+
+## When you don't know what to do
+
+The plan is the source of truth. For most ambiguities: decide on the option closest to the plan's *intent*, document the call in your PR's Deviations section, and proceed. The reviewer will surface anything that's wrong; you don't need to pre-empt them.
+
+Only stop for the items in the "When to STOP and post BLOCKED" section. Everything else: keep shipping.

--- a/SIEM_PLAN.md
+++ b/SIEM_PLAN.md
@@ -1,0 +1,228 @@
+# SIEM Completion — Implementation Plan
+
+**Date prepared:** 2026-05-20
+**Companion to:** `SIEM_ULTRAPLAN_BRIEF.md`
+**Scope:** Complete the SIEM portion of Orion-Web as an agent-operated security stack.
+
+---
+
+## Build order with file-level granularity
+
+### Phase 0 — Foundations *(no parallelism; everything depends on this)*
+
+**P0.1 Schema redesign** — `apps/web/prisma/schema.prisma`
+- Repurpose `SecurityEvent` as raw normalized record (keep `dedupKey`, `rawEvent`; add `incidentId String?`, `firstSeen`/`lastSeen`)
+- New: `Incident` (id, status enum, severity, rootCauseSummary, attackerKey, hostKey, openedAt, closedAt)
+- New: `ActionAudit` (id, incidentId, actionType, target, tier, proposedBy, approvedBy, status: attempting|succeeded|failed|denied, payload, result, timestamps)
+- New: `ActionPolicy` (id, actionType, defaultTier, targetPatterns Json, updatedBy)
+- New: `CorrelationRule` (id, name, enabled, ruleType, params Json, severity, window)
+- New: `SourceHealth` (source, lastSeenAt, lastWatermark, staleAfterMs)
+- New: `Suppression` (id, matchPattern Json, reason, expiresAt)
+- Prisma migration + a one-shot data migration script for any existing rows
+
+**P0.2 System room seed** — `apps/web/src/lib/seed-system-epic.ts`
+- Add `Security` feature under System epic
+- Add `system.room.security` ChatRoom, members: `[Warden]` initially
+
+**P0.3 ActionPolicy defaults seed** — new `apps/web/src/lib/seed-action-policies.ts`
+- Inserts the default tier matrix (see "Recommendations on the open decisions" below)
+- Includes the `__panic_mode__` row
+
+**P0.4 Shared types** — `apps/web/src/lib/security/types.ts`
+- `NormalizedSecurityEvent`, `IncidentDraft`, `ActionRequest`, `ActionDecision`
+
+---
+
+### Phase 1 — Capability layer *(3 parallel worktrees after P0 merges)*
+
+**Worktree A — `feat/siem-gateway-tools`** (`apps/gateway/src/builtin-tools/security.ts`)
+- `crowdsec_decision_create({ ip, scope, duration, reason })` → POST `/v1/decisions`
+- `crowdsec_decision_delete({ decisionId })` → DELETE
+- `wazuh_active_response({ agent, command, args })` → POST `/active-response`
+- `firewall_block({ cidr, reason })` — stub if no fw API yet, behind feature flag
+- Tests in `security.test.ts` covering happy-path and error responses
+
+**Worktree B — `feat/siem-ingestion`**
+- Webhook endpoints:
+  - `apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts`
+  - `apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts`
+  - Shared `apps/web/src/lib/security/webhook-auth.ts` — HMAC verification, replay window, `dedupKey` idempotency
+- Pollers (use existing `src/jobs/` pattern that `audit-export-daily.ts` lives in):
+  - `apps/web/src/jobs/security-poll-elk.ts`
+  - `apps/web/src/jobs/security-poll-ntopng.ts`
+  - Watermarking via `SourceHealth.lastWatermark`
+- Source normalizers `apps/web/src/lib/security/normalize/{crowdsec,wazuh,elk,ntopng}.ts` → all return `NormalizedSecurityEvent`
+
+**Worktree C — `feat/siem-correlation`**
+- `apps/web/src/workers/security-correlator.ts` — consumes new `SecurityEvent` rows, runs rules, upserts `Incident`
+- `apps/web/src/lib/security/rule-engine.ts` — interprets `CorrelationRule.params`
+- Default rules seeded: brute-force (≥5 failed logins, same IP, 5min), recon (port scan from ntopng), malware (Wazuh `rule.level >= 10`), suspicious-process (Wazuh rootcheck)
+- Incident state machine: `open → triaged → contained → closed`, with timestamps
+
+> Coordination: A/B/C agree on the `NormalizedSecurityEvent` shape in P0.4 before splitting.
+
+---
+
+### Phase 2 — Decision/action layer
+
+- `apps/web/src/lib/security/action-service.ts` — `decide(action, target) → tier`, `execute(action) → ActionAudit`
+- Approval API:
+  - `apps/web/src/app/api/monitoring/security/approvals/route.ts` (GET pending list)
+  - `apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts` (POST approve/deny)
+- Action executor `apps/web/src/lib/security/action-executor.ts` — writes `ActionAudit` with `status='attempting'` before calling gateway, updates after
+- Rewrite `apps/web/src/app/api/monitoring/security/actions/route.ts` to delegate to action-service (kills dead `crowdsec_block_ip` reference)
+
+---
+
+### Phase 3 — Real-time push (outbound)
+
+- Postgres triggers (new Prisma migration): NOTIFY on insert/update for `SecurityEvent`, `Incident`, `ActionAudit`
+- Rewrite `apps/web/src/app/api/monitoring/security/stream/route.ts` to consume NOTIFY via a long-lived Postgres client. Payload = row ID only; consumer fetches.
+- Split streams: `?channel=incidents|events|approvals`
+
+---
+
+### Phase 4 — Warden agent
+
+- `apps/web/src/lib/seed-system-nebula.ts` — add `novas/warden.yaml` (system prompt: triage incidents → propose/execute per tier)
+- `apps/web/src/lib/seed-system-agents.ts` — seed Warden Agent record, tool whitelist: all security read + write tools + `chat_post`, subscribed to `system.room.security`
+- Verify existing room-agent runner (`src/lib/room-agents.ts`) picks up Warden on new-incident NOTIFY
+
+---
+
+### Phase 5 — Dashboard *(parallel with Phase 4)*
+
+- `apps/web/src/app/(app)/security/page.tsx` — incident-centric (replaces raw-event-first layout)
+- `apps/web/src/app/(app)/security/incidents/[id]/page.tsx` — drilldown with raw event timeline + Warden chatroom thread + action approval inline button
+- `apps/web/src/app/(app)/security/approvals/page.tsx` — operator approval queue
+- New `apps/web/src/components/security/SourceHealthPanel.tsx`
+- Refactor `SecurityDashboard.tsx`: tabs become `Incidents | Approvals | Flows | Sources | Settings`
+- Existing `AlertFeed.tsx` repurposed for raw-event drawer inside incident drilldown
+
+---
+
+### Phase 6 — Retention + tests
+
+- `apps/web/src/jobs/security-retention-daily.ts` — TTL 30d on `SecurityEvent`, 365d on `Incident` and `ActionAudit`, hook into existing S3 audit-export
+- Test suite (see Test plan below)
+
+---
+
+## Worktree parallelization
+
+```
+P0 (single branch)  ─────────►  merge
+                                  │
+            ┌─────────────────────┼─────────────────────┐
+   feat/siem-gateway-tools   feat/siem-ingestion   feat/siem-correlation
+   (Worktree A)              (Worktree B)          (Worktree C)
+            │                     │                     │
+            └─────────► merge order: A → B → C ◄────────┘
+                                  │
+                          feat/siem-actions  (P2)
+                                  │
+                          feat/siem-realtime (P3)
+                                  │
+              ┌───────────────────┴───────────────────┐
+       feat/siem-warden (P4)                 feat/siem-ui (P5)
+              └───────────────────┬───────────────────┘
+                          feat/siem-retention (P6)
+```
+
+Matches the SOC2 phase pattern in `PROJECT_SUMMARY.md`.
+
+---
+
+## Recommendations on the open decisions
+
+| Decision | Recommendation |
+|---|---|
+| Poll cadence | 15s ELK syslog, 30s ELK flow, 30s ntopng. Live in `SecurityConfig` per-env. |
+| Inbound auth | HMAC per source, secret in `SecurityConfig`. mTLS via reverse proxy deferred — overkill for v1. |
+| Policy granularity | Tier per action-type + optional `(action, targetPattern)` overrides in `ActionPolicy.targetPatterns`. |
+| Default tier matrix | See below |
+| Panic mode | Yes. `ActionPolicy` row with `actionType='__panic_mode__'`. When true, downgrades all `auto`/`notify` to `approve` at decide-time. |
+| Correlation engine | In-process Node worker. Postgres windowed CTEs as a per-rule *tactic* where useful, not the engine. |
+| Approval UX | Both: dedicated queue page + inline button on incident drilldown. |
+| Security room membership | Warden only at v1. Add Sentinel/Pulse later if cross-domain correlation chatter is useful. |
+| Source health | Derived from `SourceHealth.lastSeenAt`. Cron every 5min emits a synthetic `source_stale` `SecurityEvent` if no event in 2× expected interval. |
+| Webhook replay/backfill | Per-source `backfillOnRecover` flag. Default ON for CrowdSec (small replay window), OFF for Wazuh (potentially huge). Backfilled events skip correlation (historical only). |
+
+### Default tier matrix
+
+| Action type | Default tier | Target-pattern overrides |
+|---|---|---|
+| `crowdsec_decision_create` (ban IP) | `auto` | `approve` if IP ∈ home subnet (e.g. 10.0.0.0/8 + your LAN) |
+| `crowdsec_decision_delete` (unban) | `auto` | — |
+| `wazuh_active_response` | `approve` | `escalate` if target host matches `named-prod-*` |
+| `firewall_block` (subnet) | `approve` | `escalate` for subnets > /24 |
+| `investigate` (elk_flow_search) | `auto` | — |
+| `incident_close` | `notify` | — |
+| `suppression_add` | `approve` | — |
+| Anything labeled destructive on infra | `escalate` | — |
+
+---
+
+## Risk register
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| R1 | AI auto-blocks a legitimate home/LAN IP, locks user out | High | Home-subnet override forces `approve`. Static allowlist of known-good IPs in `Suppression`. |
+| R2 | Wazuh active-response runs against named-prod host | Catastrophic | `wazuh_active_response` always `approve`; named-prod pattern escalates further. Cannot be overridden to `auto`. |
+| R3 | Webhook secret leak → forged events trigger bogus actions | Medium | Per-source HMAC, secret rotation via `SecurityConfig`, log every failed signature, alert if rate > N/min |
+| R4 | Poison correlation rule → infinite incident loop | High | Per-rule rate limit, max incidents/window cap, validation on rule save |
+| R5 | ELK poller hammers ELK during an outage | Medium | Per-poller circuit breaker: 3 consecutive >5s requests → back off + emit `source_stale` |
+| R6 | Backfill dump on source recovery → spurious live incidents | Medium | Backfilled events bypass correlator if `@timestamp < now - 5min` |
+| R7 | Postgres NOTIFY 8KB payload limit | Low | NOTIFY carries only ID; consumer fetches the row |
+| R8 | Warden hallucinates an unknown tool | Low | Gateway already rejects unknown tools; add metric + alert if Warden tries unknown tool > 3/hr |
+| R9 | Action fails mid-execute, no audit row | High (compliance) | Write `ActionAudit` with `status='attempting'` BEFORE execution; update after |
+| R10 | Approval queue grows unbounded if operator AFK | Medium | TTL on pending approvals (e.g. 24h → auto-deny), Warden re-evaluates after deny |
+| R11 | Migration data loss on existing `SecurityEvent` rows | Low (currently empty) | Verify empty in prod before running; one-shot migration script is reversible |
+
+---
+
+## Test plan
+
+**Unit**
+- Each correlation rule with synthetic trigger sequences (brute-force, recon, malware, suspicious-process)
+- `decide(action, target)` resolver — every cell in default tier matrix
+- HMAC verification (valid, expired window, bad signature, replay)
+- Watermark advance per source
+
+**Worker integration (per worktree)**
+- Webhook → `SecurityEvent` → correlator → `Incident` → notify → Warden mock observes → action-service → `ActionAudit`
+- Poller with mock ELK responding "since X" → watermark advances correctly
+- Approval flow: high-tier action stays pending; POST approve → executes; POST deny → no execute, audit row
+
+**E2E smoke**
+- Real Postgres, mock CrowdSec server returns synthetic event → webhook fires → row appears → correlator groups → Warden posts to security room → human-approved action → gateway WRITE tool call → `ActionAudit.status='succeeded'`
+
+**Panic mode**
+- Flip `__panic_mode__` → confirm next `auto` request is queued for approval instead of executed
+
+**Failure modes**
+- Webhook with bad signature → 401 + audit log entry
+- Action executor failure → `ActionAudit.status='failed'`, Warden notified
+- Source poller circuit-breaker trip → `source_stale` event in dashboard
+
+**Regression**
+- All SOC2 smoke tests still pass (`SMOKE_TESTS_QUICK_START.sh all`)
+
+---
+
+## Success criteria for "complete"
+
+1. Real CrowdSec/Wazuh webhooks land `SecurityEvent` rows in DB in <1s
+2. ELK + ntopng pollers running with visible `SourceHealth.lastWatermark` advance
+3. Brute-force scenario (5 failed SSH from same IP within 5min) creates one `Incident`
+4. Warden posts to `system.room.security` with incident summary + proposed action within 30s
+5. `auto`-tier action executes; `ActionAudit` row written; visible in audit log + S3 export
+6. `approve`-tier action sits in approval queue until human approves, then executes
+7. Panic-mode toggle downgrades all `auto`/`notify` to `approve` immediately
+8. Source goes dark (mock killed) → `source_stale` event in <2× poll interval
+9. SSE stream uses LISTEN/NOTIFY (verified: no DB poll queries during idle)
+10. Every E2E smoke test passes; existing SOC2 tests pass; no new high/critical risk findings
+
+---
+
+**Scope estimate:** ~2–3 weeks with the parallelism described, comparable to SOC2 Phase 1.

--- a/SIEM_REVIEW_HANDOFF.md
+++ b/SIEM_REVIEW_HANDOFF.md
@@ -1,0 +1,204 @@
+# SIEM PR Review — Agent Handoff
+
+**Role:** You are an independent reviewer for the SIEM completion work in Orion-Web. The implementer (Claude Code running Qwen 3.6) has been opening stacked PRs autonomously per `SIEM_HANDOFF.md`. Your job is to review every open PR they've authored and post structured feedback.
+
+You are NOT the implementer. Do not write code. Do not fix things yourself. Surface findings; the human will decide what to fix.
+
+---
+
+## Authoritative sources (read in this order)
+
+1. `SIEM_PLAN.md` — what the implementation is supposed to be
+2. `SIEM_ULTRAPLAN_BRIEF.md` — design intent behind the plan
+3. `SIEM_HANDOFF.md` — the rules Qwen was given (you check that they were followed)
+4. `CLAUDE.md` — repo conventions, gitnexus rules
+5. `PROJECT_SUMMARY.md` — SOC2 work the SIEM must integrate with
+
+---
+
+## How to find the PRs
+
+```bash
+gh pr list --search "[SIEM" --state open --json number,title,headRefName,baseRefName,author
+```
+
+Order them by `[SIEM <phase-id>]` to get them in dependency order (P0.1 → P0.2 → P0.3 → P0.4 → A → B → C → P2 → P3 → P4 → P5 → P6). Review in that order — earlier PRs set context for later ones.
+
+For each PR, read:
+- The PR body (especially the Deviations section)
+- The full diff: `gh pr diff <number>`
+- The PR's own `/ultrareview` results if they were posted as comments
+
+---
+
+## Per-PR review checklist
+
+Walk through this for EVERY PR. Score each item PASS / FAIL / N/A. Do not skip items.
+
+### 1. Plan alignment
+- [ ] PR title matches `[SIEM <phase-id>] <description>` format
+- [ ] PR body cites the specific `SIEM_PLAN.md` section it implements
+- [ ] Diff scope is limited to that phase — no drive-by changes to unrelated files
+- [ ] Base branch correctly stacks on dependencies (P0 off main; A/B/C off P0; later phases off their deps)
+
+### 2. Security-critical: the tier matrix (Phase 0 / P0.3)
+This applies to whichever PR creates `seed-action-policies.ts`. Open `SIEM_PLAN.md` to the "Default tier matrix" table and diff it line-by-line against the seed file.
+
+- [ ] Every row in the plan's matrix is present in the seed
+- [ ] No row defaults to `auto` that wasn't `auto` in the plan
+- [ ] No action type exists in the seed that's NOT in the plan
+- [ ] `__panic_mode__` row exists with `defaultTier='auto'` (disabled by default)
+- [ ] Target-pattern overrides match the plan (home subnet → approve; named-prod → escalate)
+
+**If any of these fail: HARD BLOCK. This is the file most likely to cause a security incident.**
+
+### 3. Schema integrity (Phase 0 / P0.1)
+- [ ] All six new models exist with the fields the plan specifies
+- [ ] `SecurityEvent` was modified, not replaced — existing fields kept
+- [ ] Migration is forward-only, no DROP/RENAME on existing columns
+- [ ] Indexes present on `(environmentId, createdAt)` and similar where queries need them
+- [ ] No `prisma db push` artifacts (only `migrate dev` migrations)
+
+### 4. Gateway write tools (Worktree A)
+- [ ] All 4 tools added: `crowdsec_decision_create`, `crowdsec_decision_delete`, `wazuh_active_response`, `firewall_block` (or feature-flagged stub)
+- [ ] Tests cover happy-path + error responses
+- [ ] No tool can execute without the action-policy decision wrapper (i.e., tools are not callable directly from the action route)
+- [ ] Timeouts present (AbortSignal.timeout pattern matches existing tools)
+
+### 5. Ingestion (Worktree B)
+- [ ] Webhook routes for CrowdSec + Wazuh under `/api/monitoring/security/webhooks/{source}`
+- [ ] HMAC verification with replay window — bad signatures return 401 and log
+- [ ] Idempotent on `dedupKey` (re-posting same event does not create duplicate)
+- [ ] Pollers for ELK + ntopng with watermarking via `SourceHealth.lastWatermark`
+- [ ] Source normalizers all return `NormalizedSecurityEvent` shape
+
+### 6. Correlation engine (Worktree C)
+- [ ] Worker consumes new SecurityEvent rows (NOTIFY or queue, not poll)
+- [ ] All four default rules seeded (brute-force, recon, malware, suspicious-process)
+- [ ] Per-rule rate limit + max-incidents-per-window cap (poison-rule mitigation per Risk R4)
+- [ ] Backfilled events bypass live correlation if `@timestamp < now - 5min` (per R6)
+
+### 7. Action layer (Phase 2)
+- [ ] `decide(action, target)` looks up `ActionPolicy` first, applies target overrides
+- [ ] Panic mode flag is checked at decide-time
+- [ ] Executor writes `ActionAudit` with `status='attempting'` BEFORE gateway call (per R9)
+- [ ] Existing `/api/monitoring/security/actions/route.ts` is rewritten to delegate, not deleted
+
+### 8. Real-time push (Phase 3)
+- [ ] Postgres trigger NOTIFY on SecurityEvent/Incident/ActionAudit inserts
+- [ ] Stream route consumes NOTIFY via long-lived client, not interval poll
+- [ ] NOTIFY payloads are IDs only, not full rows (per R7)
+
+### 9. Warden seed (Phase 4)
+- [ ] Nova exists at `novas/warden.yaml` with system prompt covering: triage incidents, propose/execute actions per tier, post to security room
+- [ ] Agent record seeded with tool whitelist limited to security read + write tools + `chat_post`
+- [ ] Warden is subscribed to `system.room.security`, NOT Maintenance
+- [ ] No autonomous tool execution path that bypasses the action-policy decide step
+
+### 10. Dashboard (Phase 5)
+- [ ] Incident-centric layout — raw events are now drawer-only
+- [ ] Approval queue exists at its own route
+- [ ] Source health panel renders `SourceHealth` rows
+- [ ] Existing SOC2 routes/components were not touched
+
+### 11. Retention (Phase 6)
+- [ ] TTL 30d on `SecurityEvent`, 365d on `Incident`/`ActionAudit`
+- [ ] Hooks into existing `audit-export-daily.ts` pattern; does NOT modify it
+
+### 12. Universal checks (every PR)
+- [ ] PR body includes `gitnexus_impact` summary
+- [ ] PR body has a Deviations section (even if "none")
+- [ ] No `--no-verify` or hook-skipping in commit history
+- [ ] No `audit-export.ts` or SOC2 audit-log path modifications
+- [ ] New functions have unit tests; new routes have integration tests
+- [ ] No new npm dependencies without explicit justification in PR body
+- [ ] TypeScript strict, Zod at boundaries, matches `apps/web/src/app/api/admin/audit-retention/cleanup/route.ts` patterns
+
+---
+
+## Severity classification
+
+When you find an issue, classify it:
+
+- **BLOCK** — must be fixed before merge. Examples: tier matrix mismatch, audit-log modification, column drop in migration, missing security-critical test, action executable outside policy gate.
+- **MAJOR** — should be fixed before merge but not catastrophic. Examples: missing unit test, undocumented deviation, gitnexus_impact not reported, panic-mode logic gap.
+- **MINOR** — nice to fix but not gating. Examples: type narrowness, naming inconsistency, redundant code.
+- **OBSERVATION** — not an issue, just a note. Examples: "this approach is fine but here's an alternative for v2."
+
+---
+
+## Output format — what to post and where
+
+For each PR, post a **single review comment** with this exact structure:
+
+```
+## SIEM Review — [SIEM <phase-id>]
+
+**Verdict:** APPROVE | APPROVE_WITH_CHANGES | REQUEST_CHANGES | BLOCK
+
+**Checklist scores:**
+- Plan alignment: PASS/FAIL
+- Tier matrix (if applicable): PASS/FAIL
+- Schema integrity (if applicable): PASS/FAIL
+- [...other relevant sections...]
+- Universal checks: PASS/FAIL
+
+**Findings:**
+
+### BLOCK
+- [issue with file:line reference]
+
+### MAJOR
+- [issue with file:line reference]
+
+### MINOR
+- [issue]
+
+### OBSERVATION
+- [note]
+
+**Stack impact:** [Does this PR's issues affect PRs stacked on top? If yes, list which.]
+```
+
+Use `gh pr review <number> --comment --body "..."` or `gh pr comment <number> --body "..."`.
+
+After reviewing all PRs, post a **summary issue** titled `SIEM Review — <date>`:
+
+```
+gh issue create --title "SIEM Review — 2026-05-20" --body "..."
+```
+
+Summary body should include:
+- Total PRs reviewed
+- Count by verdict (APPROVE / CHANGES / BLOCK)
+- Top 3 cross-cutting concerns
+- Recommended merge order (or "do not merge any until BLOCK items resolved")
+- Link to each PR review
+
+---
+
+## What NOT to do
+
+- Do NOT push code or open follow-up PRs. You're a reviewer.
+- Do NOT approve via `gh pr review --approve`. Use comment-only. The human approves.
+- Do NOT close PRs. Even if a PR is clearly wrong, leave it open with a BLOCK comment.
+- Do NOT post the same finding on multiple PRs unless it actually appears in each.
+- Do NOT defer to "looks fine" if you didn't read the diff. Read every diff line.
+
+## Bias toward catching, not approving
+
+If you're uncertain whether something is a problem, post it as an OBSERVATION rather than skipping it. The human can dismiss false positives cheaply; they can't recover from a missed real issue cheaply.
+
+## Specific things you will be tempted to gloss over but MUST check
+
+- **The tier matrix file.** Open `SIEM_PLAN.md` to the matrix table, open the seed file, diff them in your head row-by-row. This is the file most likely to break security.
+- **Migration files.** Read the SQL. Look for `DROP COLUMN`, `ALTER TABLE ... DROP`, `RENAME COLUMN`, anything with `CASCADE`.
+- **Commit history within the PR.** Look for any commit message that mentions `--no-verify`, "skip hook", "force", or similar.
+- **Test files vs. test claims.** PR body says "tests added" — verify each test actually exists and actually tests the claim. Empty test functions count as FAIL.
+- **`gh pr view <num> --json files` vs. what the plan said should be touched.** Files outside the expected scope are red flags.
+
+---
+
+## When done
+
+Once all PRs reviewed and summary issue posted: nothing further. Exit.

--- a/SIEM_ULTRAPLAN_BRIEF.md
+++ b/SIEM_ULTRAPLAN_BRIEF.md
@@ -1,0 +1,90 @@
+# SIEM Completion — Ultraplan Brief
+
+**Date prepared:** 2026-05-20
+**Target:** `/ultraplan`
+**Scope:** Complete the SIEM portion of Orion-Web as an agent-operated security stack.
+
+---
+
+## Premise
+
+Orion-Web manages this homelab's infrastructure via AI agents. Security must be part of that loop: the AI needs to SEE security events and TAKE ACTION on them (block IPs, quarantine hosts, investigate flows) with human oversight where risk warrants it. The current SIEM scaffold is a human dashboard with empty tables and dead response actions — it must become an agent-first SIEM with a human approval/observation UI on top.
+
+## Repo
+
+`/home/rkhalis/orion-web` — monorepo with `apps/web` (Next.js + Prisma) and `apps/gateway` (tool execution).
+
+## Current state (verified by file read)
+
+- DB: `SecurityEvent` (severity 0-100, type, source, dedupKey, rawEvent, acknowledged) and `SecurityConfig` (per-env key/value). `apps/web/prisma/schema.prisma:881`.
+- Web API under `/api/monitoring/security/`:
+  - `overview` — counts off `SecurityEvent`
+  - `alerts` + `alerts/ack` — list/acknowledge
+  - `flows` — proxies `elk_flow_search` via gateway
+  - `actions` — block_ip/quarantine/investigate; calls `crowdsec_block_ip` which **does not exist** in gateway
+  - `stream` — SSE polling `SecurityEvent` every 5s
+- Web UI: `apps/web/src/components/security/{SecurityDashboard,AlertFeed,FlowTable,SecuritySettings}.tsx`
+- Gateway security tools (all read-only): `crowdsec_blocks`, `crowdsec_suggestions`, `ntopng_threats`, `ntopng_top_talkers`, `elk_flow_search`, `elk_syslog_search`, `wazuh_alerts`, `wazuh_rootcheck`, `prometheus_query[_range]`. `apps/gateway/src/builtin-tools/security.ts`.
+- System agent "Warden" is mentioned in `seed-system-agents.ts` and assigned to the Maintenance system chatroom, but is **not seeded** as a Nova/Agent. No prompt, no tool whitelist, no behavior.
+- No ingestion worker. No correlation layer. No approval flow. No audit trail for response actions.
+
+## Goal (v1 = production-grade, agent-first)
+
+1. **Ingest via push where natively supported; poll-as-adapter for sources that don't.** CrowdSec + Wazuh → webhook endpoints under `/api/monitoring/security/webhooks/{source}`, HMAC-authenticated, idempotent on `dedupKey`. ELK + ntopng → a thin internal poller per source that transforms polled results into the same internal event pipeline (no separate code path for downstream consumers). Source health derived from last-event timestamp regardless of mechanism.
+2. **Schema redesign**: separate raw events from derived `Incident`s; add `ActionAudit` (every proposed + executed action, with tier and approver); add `ActionPolicy` (action-type → risk tier, with target overrides); add `CorrelationRule` store; add `SourceHealth` view/table; add `Suppression`/`Allowlist`; add `system.room.security` to the system-room seed.
+3. **Correlation engine**: rule-based grouping (attacker IP, host, rule chain), severity scoring, dedup window, incident lifecycle (open → triaged → contained → closed).
+4. **Warden system agent**: seed Nova + Agent, subscribe to a **new dedicated `system.room.security` chatroom** (not Maintenance), post incident summaries, propose/announce response actions per their risk tier.
+5. **Risk-tiered response action layer (everything has a tier)**:
+   - New gateway WRITE tools: `crowdsec_decision_create` (ban), `crowdsec_decision_delete`, `wazuh_active_response` (isolate/kill), `firewall_block` if applicable.
+   - **Every action is tagged with a risk tier** in a DB-backed `ActionPolicy` table — editable without redeploy. Tiers (proposed): `auto` (AI executes immediately), `notify` (AI executes, posts to Security room for awareness), `approve` (AI proposes, human must approve in UI before execution), `escalate` (must be human-initiated; AI cannot propose).
+   - Bias toward letting the AI act: default most actions to `auto` or `notify` so Warden can do its job; reserve `approve`/`escalate` for high-blast-radius operations (whole-subnet blocks, host isolation of named-prod hosts, irreversible quarantine).
+   - Per-action overrides keyed on target (e.g., `block_ip` is `auto` for unknown IPs but `approve` for IPs inside the home subnet).
+   - Every executed/proposed action emits an `ActionAudit` row linked to the incident — even auto ones.
+6. **Real-time push end-to-end (with internal poll adapters where unavoidable)**:
+   - **Inbound (sources → orion)**: webhooks where native (CrowdSec, Wazuh). HMAC-signed, replay-safe, idempotent on `dedupKey`. ELK + ntopng run internal pollers that produce the same internal event records — invisible to downstream consumers.
+   - **Outbound (orion → clients/agents)**: replace 5s polling SSE with Postgres `LISTEN/NOTIFY` (or Redis pub/sub if already deployed) so dashboard + Warden both react instantly regardless of how the event arrived.
+7. **Dashboard polish**: incident-centric (not raw-event-centric), drilldowns, source health panel, action approval queue, agent activity log per incident.
+8. **Retention**: TTL on raw events, longer retention on incidents; align with existing AUDIT_EXPORT for compliance.
+
+## Constraints
+
+- Schema redesign is allowed and expected.
+- Must integrate cleanly with the existing system-epic/chatroom architecture (see `seed-system-epic.ts` and `seed-system-agents.ts`).
+- Must reuse the gateway tool pattern (don't fork into a separate runtime).
+- Must respect SOC2 work already done — audit log + S3 export; response actions should land in the same audit pipeline.
+- The reverse-proxy HMAC, S3-object-lock, Redis-Sentinel ops items in `PROJECT_SUMMARY.md` are unrelated; do not gate this work on them.
+
+## Decisions (locked 2026-05-20)
+
+- **Ingestion = push where native, internal poller-adapter where not.** CrowdSec + Wazuh push via webhook. ELK + ntopng are polled internally; downstream code sees the same event pipeline either way.
+- **Risk-tiered everything**: every action has a tier; default tier-set should let Warden act autonomously on the common path; humans only gate high-blast-radius operations.
+- **Dedicated Security chatroom** (`system.room.security`). Not Maintenance.
+
+## Open decisions still to surface in the plan
+
+- **Poll-adapter cadence + tuning**: ELK and ntopng pollers need per-source intervals (default ~30s for ntopng top-talkers / threats, ~15s for ELK syslog/flows on a small index). Plan should specify whether intervals are env-config or live in `SecurityConfig` (per-env). Watermarking strategy: store last-seen `@timestamp` per source in `SourceHealth` so pollers ask for "since X" rather than full re-scans.
+- **Inbound auth**: shared-secret HMAC per source, or mTLS via the same reverse proxy that already does SSO HMAC (see `SSO_HMAC.md`)? Reusing the proxy is cheaper to operate.
+- **Action policy granularity**: tier per action-type only, or `(action, source, target)` matrix? Recommend tier per action-type with optional `(action, target-pattern)` overrides — keeps the table small.
+- **Default tier assignments** (the actual table contents): which actions are `auto` vs `notify` vs `approve`? Plan should propose a starting matrix, not leave it for later.
+- **"Panic mode" / kill-switch**: a single env-var or DB row that downgrades all `auto`/`notify` to `approve` during incidents or pre-prod weeks. Likely yes — cheap to add.
+- **Correlation engine**: in-process Node worker (recommended), Postgres-only windowed CTEs, or a dedicated stream processor (overkill at homelab scale).
+- **Approval UX**: inline action button on the incident row vs. dedicated approval-queue route. Probably both — queue for the operator-on-shift, inline for incident drilldown.
+- **Security room membership**: Warden only, or also Sentinel (monitoring) and Pulse (cluster health) for cross-domain correlation chatter?
+- **Source health signal**: separate heartbeat job vs. derived from "last webhook received within N minutes". Derived is simpler.
+- **Webhook replay/backfill**: when a source recovers after downtime, do we ingest its missed-event backlog (via a one-shot fetch) or accept the gap? Likely a per-source `backfillOnRecover` flag.
+
+## Deliverable
+
+- Build order with file-level granularity (Schema → Gateway write tools → Ingestion workers → Correlation engine → Warden seed → API/SSE → UI → Tests).
+- Identify worktrees that can run in parallel (matches the SOC2 phase pattern in `PROJECT_SUMMARY.md`).
+- Risk register and mitigations (esp. autonomous block actions).
+- Test plan: source mocks, correlation rule unit tests, approval-flow integration test, end-to-end smoke (mock CrowdSec event → `SecurityEvent` → Incident → Warden post → human-approved action → audit row).
+- Success criteria for "complete".
+
+---
+
+## Author's tradeoff notes (not for the ultraplan prompt itself)
+
+- **Push vs poll ingestion** is the single biggest call. Polling is simpler and fits the existing gateway-tool pattern; push (webhooks) gets you sub-second latency but adds inbound auth/rate-limiting surface. For homelab scale, recommend polling first, design schema so push can be added later.
+- **Auto-approve risk tier** is the safety call. Defaulting everything to require-approval is safer but makes the AI feel performative. A narrow auto-approve list (e.g., "IP already on CrowdSec community blocklist with confidence > X") is the sweet spot.
+- **Warden in Security room vs Maintenance** — argue for a dedicated `system.room.security` room so Warden's incident chatter doesn't drown the maintenance feed.


### PR DESCRIPTION
## Summary
- Adds the five-doc set for the SIEM completion initiative
- Required upstream of the autonomous Qwen/reviewer/fixer agents — they read these docs from the repo

## Files
- `SIEM_ULTRAPLAN_BRIEF.md` — design intent
- `SIEM_PLAN.md` — phase-by-phase implementation spec
- `SIEM_HANDOFF.md` — operating manual for the implementer (Qwen 3.6)
- `SIEM_REVIEW_HANDOFF.md` — operating manual for the review agent (scheduled, 9:21 PM EDT)
- `SIEM_FIXER_HANDOFF.md` — operating manual for the fixer agent (scheduled, 2:21 AM EDT)

## Test plan
- [ ] Docs render correctly on GitHub
- [ ] No code changes; CI should pass trivially

🤖 Generated with [Claude Code](https://claude.com/claude-code)