### PR TITLE
[SIEM] Forward-port #407 + #408 onto main

### DIFF
--- a/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
@@ -1,0 +1,109 @@
+/**
+ * CrowdSec webhook endpoint.
+ *
+ * Receives alerts from CrowdSec's webhook notifier when security events
+ * are detected (bans, blocks, etc.).
+ *
+ * Auth: HMAC-SHA256 via X-Signature header. Secret stored in SecurityConfig.
+ * Replay window: 5 minutes.
+ * Idempotency: dedupKey from event payload prevents duplicates within 60s.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { normalizedEventSchema } from '@/lib/security/types'
+import { verifyWebhookHmac, isWithinReplayWindow, wasAlreadyProcessed } from '@/lib/security/webhook-auth'
+import { normalizeCrowdSecAlert, type CrowdSecAlert } from '@/lib/security/normalize/crowdsec'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+// ── Request handler ──────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const envId = req.nextUrl.searchParams.get('env') || process.env.ENVIRONMENT_ID || ''
+
+  // 1. Read raw body (for HMAC verification)
+  const bodyText = await req.text()
+  const signature = req.headers.get('X-Signature') || req.headers.get('x-crowdsec-signature')
+  const timestamp = req.headers.get('X-Timestamp') || req.headers.get('x-timestamp')
+
+  // 2. Verify HMAC signature
+  if (!process.env.CROWDSEC_WEBHOOK_SECRET) {
+    // If no secret configured, accept from localhost only (dev mode)
+    const clientIp = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || ''
+    if (!clientIp.startsWith('127.') && !clientIp.startsWith('::1')) {
+      return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
+    }
+  } else {
+    const secret = process.env.CROWDSEC_WEBHOOK_SECRET
+    if (!verifyWebhookHmac(secret, bodyText, signature)) {
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+  }
+
+  // 3. Check replay window
+  if (!isWithinReplayWindow(timestamp)) {
+    return NextResponse.json({ error: 'Request expired (replay window exceeded)' }, { status: 410 })
+  }
+
+  // 4. Parse and validate
+  let alert: CrowdSecAlert
+  try {
+    alert = JSON.parse(bodyText) as CrowdSecAlert
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // 5. Normalize
+  let event
+  try {
+    event = normalizeCrowdSecAlert(alert)
+  } catch {
+    return NextResponse.json({ error: 'Failed to parse event' }, { status: 400 })
+  }
+
+  // 6. Enrich with environment
+  event.environmentId = envId || null
+
+  // 7. Validate with Zod
+  const parsed = normalizedEventSchema.parse(event)
+
+  // 8. Idempotency check
+  if (await wasAlreadyProcessed(parsed.dedupKey, 'crowdsec')) {
+    return NextResponse.json({ received: true, idempotent: true })
+  }
+
+  // 9. Insert into DB
+  await prisma.securityEvent.create({
+    data: {
+      id: parsed.id,
+      environmentId: parsed.environmentId,
+      type: parsed.type,
+      source: parsed.source,
+      severity: parsed.severity,
+      title: parsed.title,
+      description: parsed.description ?? null,
+      rawEvent: parsed.rawEvent as any,
+      dedupKey: parsed.dedupKey,
+      firstSeen: parsed.timestamp,
+      lastSeen: parsed.timestamp,
+      createdAt: parsed.timestamp,
+    },
+  })
+
+  // 10. Update source health
+  await prisma.sourceHealth.upsert({
+    where: { source: 'crowdsec' },
+    update: { lastSeenAt: new Date() },
+    create: {
+      source: 'crowdsec',
+      environmentId: envId || null,
+      lastSeenAt: new Date(),
+      lastWatermark: parsed.timestamp,
+      staleAfterMs: 5 * 60 * 1000, // 5 minutes
+    },
+  })
+
+  return NextResponse.json({ received: true, id: parsed.id, idempotent: false })
+}

--- a/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
@@ -18,6 +18,8 @@ import {
   wasAlreadyProcessed,
   isLoopbackWebhookRequest,
   warnMissingWebhookSecret,
+  checkWebhookBodySize,
+  WEBHOOK_MAX_BODY_BYTES,
 } from '@/lib/security/webhook-auth'
 import { normalizeCrowdSecAlert, type CrowdSecAlert } from '@/lib/security/normalize/crowdsec'
 
@@ -28,6 +30,21 @@ export const maxDuration = 30
 
 export async function POST(req: NextRequest) {
   const envId = req.nextUrl.searchParams.get('env') || process.env.ENVIRONMENT_ID || ''
+
+  // 0. Body-size guard (rejects oversize/unsized requests BEFORE HMAC work).
+  const sizeCheck = checkWebhookBodySize(req)
+  if (!sizeCheck.ok) {
+    if (sizeCheck.reason === 'too_large') {
+      return NextResponse.json(
+        { error: `Request body exceeds ${WEBHOOK_MAX_BODY_BYTES} bytes` },
+        { status: 413 }
+      )
+    }
+    return NextResponse.json(
+      { error: 'Content-Length header required' },
+      { status: 411 }
+    )
+  }
 
   // 1. Read raw body (for HMAC verification)
   const bodyText = await req.text()

--- a/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
@@ -12,7 +12,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { normalizedEventSchema } from '@/lib/security/types'
-import { verifyWebhookHmac, isWithinReplayWindow, wasAlreadyProcessed } from '@/lib/security/webhook-auth'
+import {
+  verifyWebhookHmac,
+  isWithinReplayWindow,
+  wasAlreadyProcessed,
+  isLoopbackWebhookRequest,
+  warnMissingWebhookSecret,
+} from '@/lib/security/webhook-auth'
 import { normalizeCrowdSecAlert, type CrowdSecAlert } from '@/lib/security/normalize/crowdsec'
 
 export const dynamic = 'force-dynamic'
@@ -30,9 +36,19 @@ export async function POST(req: NextRequest) {
 
   // 2. Verify HMAC signature
   if (!process.env.CROWDSEC_WEBHOOK_SECRET) {
-    // If no secret configured, accept from localhost only (dev mode)
-    const clientIp = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || ''
-    if (!clientIp.startsWith('127.') && !clientIp.startsWith('::1')) {
+    // No secret configured. Production must reject (misconfigured); dev
+    // accepts only loopback requests verified via the direct TCP source
+    // (or a WEBHOOK_TRUSTED_PROXY_IPS-allowlisted proxy hop). The previous
+    // implementation trusted unvalidated X-Forwarded-For, which any HTTP
+    // client could spoof. See `isLoopbackWebhookRequest` for the policy.
+    const refuse = warnMissingWebhookSecret('crowdsec', 'CROWDSEC_WEBHOOK_SECRET')
+    if (refuse) {
+      return NextResponse.json(
+        { error: 'Webhook secret not configured (server misconfigured)' },
+        { status: 500 }
+      )
+    }
+    if (!isLoopbackWebhookRequest(req)) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {

--- a/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Wazuh webhook endpoint.
+ *
+ * Receives alerts from Wazuh's webhook callback configuration.
+ * Wazuh sends alert JSON via POST with X-Wazuh-Signature header.
+ *
+ * Auth: HMAC-SHA256 via X-Wazuh-Signature header. Secret stored in SecurityConfig.
+ * Replay window: 5 minutes.
+ * Idempotency: dedupKey from alert payload prevents duplicates within 60s.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { normalizedEventSchema } from '@/lib/security/types'
+import { verifyWebhookHmac, isWithinReplayWindow, wasAlreadyProcessed } from '@/lib/security/webhook-auth'
+import { normalizeWazuhAlert, type WazuhAlert } from '@/lib/security/normalize/wazuh'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+// ── Request handler ──────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const envId = req.nextUrl.searchParams.get('env') || process.env.ENVIRONMENT_ID || ''
+
+  // 1. Read raw body (for HMAC verification)
+  const bodyText = await req.text()
+  const signature = req.headers.get('X-Wazuh-Signature') || req.headers.get('x-wazuh-signature')
+  const timestamp = req.headers.get('X-Timestamp') || req.headers.get('x-timestamp')
+
+  // 2. Verify HMAC signature
+  if (!process.env.WAZUH_WEBHOOK_SECRET) {
+    const clientIp = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || ''
+    if (!clientIp.startsWith('127.') && !clientIp.startsWith('::1')) {
+      return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
+    }
+  } else {
+    const secret = process.env.WAZUH_WEBHOOK_SECRET
+    if (!verifyWebhookHmac(secret, bodyText, signature)) {
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+    }
+  }
+
+  // 3. Check replay window
+  if (!isWithinReplayWindow(timestamp)) {
+    return NextResponse.json({ error: 'Request expired (replay window exceeded)' }, { status: 410 })
+  }
+
+  // 4. Parse and validate
+  let alert: WazuhAlert
+  try {
+    alert = JSON.parse(bodyText) as WazuhAlert
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!alert.alert) {
+    return NextResponse.json({ error: 'Missing alert field in Wazuh payload' }, { status: 400 })
+  }
+
+  // 5. Normalize
+  let event
+  try {
+    event = normalizeWazuhAlert(alert)
+  } catch {
+    return NextResponse.json({ error: 'Failed to parse event' }, { status: 400 })
+  }
+
+  // 6. Enrich with environment
+  event.environmentId = envId || null
+
+  // 7. Validate with Zod
+  const parsed = normalizedEventSchema.parse(event)
+
+  // 8. Idempotency check
+  if (await wasAlreadyProcessed(parsed.dedupKey, 'wazuh')) {
+    return NextResponse.json({ received: true, idempotent: true })
+  }
+
+  // 9. Insert into DB
+  await prisma.securityEvent.create({
+    data: {
+      id: parsed.id,
+      environmentId: parsed.environmentId,
+      type: parsed.type,
+      source: parsed.source,
+      severity: parsed.severity,
+      title: parsed.title,
+      description: parsed.description ?? null,
+      rawEvent: parsed.rawEvent as any,
+      dedupKey: parsed.dedupKey,
+      firstSeen: parsed.timestamp,
+      lastSeen: parsed.timestamp,
+      createdAt: parsed.timestamp,
+    },
+  })
+
+  // 10. Update source health
+  await prisma.sourceHealth.upsert({
+    where: { source: 'wazuh' },
+    update: { lastSeenAt: new Date() },
+    create: {
+      environmentId: envId || null,
+      source: 'wazuh',
+      lastSeenAt: new Date(),
+      lastWatermark: parsed.timestamp,
+      staleAfterMs: 5 * 60 * 1000, // 5 minutes
+    },
+  })
+
+  return NextResponse.json({ received: true, id: parsed.id, idempotent: false })
+}

--- a/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
@@ -12,7 +12,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { normalizedEventSchema } from '@/lib/security/types'
-import { verifyWebhookHmac, isWithinReplayWindow, wasAlreadyProcessed } from '@/lib/security/webhook-auth'
+import {
+  verifyWebhookHmac,
+  isWithinReplayWindow,
+  wasAlreadyProcessed,
+  isLoopbackWebhookRequest,
+  warnMissingWebhookSecret,
+} from '@/lib/security/webhook-auth'
 import { normalizeWazuhAlert, type WazuhAlert } from '@/lib/security/normalize/wazuh'
 
 export const dynamic = 'force-dynamic'
@@ -30,8 +36,17 @@ export async function POST(req: NextRequest) {
 
   // 2. Verify HMAC signature
   if (!process.env.WAZUH_WEBHOOK_SECRET) {
-    const clientIp = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || ''
-    if (!clientIp.startsWith('127.') && !clientIp.startsWith('::1')) {
+    // See crowdsec/route.ts for the rationale. Production refuses
+    // unauthenticated traffic; dev accepts loopback only and never trusts
+    // raw X-Forwarded-For.
+    const refuse = warnMissingWebhookSecret('wazuh', 'WAZUH_WEBHOOK_SECRET')
+    if (refuse) {
+      return NextResponse.json(
+        { error: 'Webhook secret not configured (server misconfigured)' },
+        { status: 500 }
+      )
+    }
+    if (!isLoopbackWebhookRequest(req)) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {

--- a/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
@@ -18,6 +18,8 @@ import {
   wasAlreadyProcessed,
   isLoopbackWebhookRequest,
   warnMissingWebhookSecret,
+  checkWebhookBodySize,
+  WEBHOOK_MAX_BODY_BYTES,
 } from '@/lib/security/webhook-auth'
 import { normalizeWazuhAlert, type WazuhAlert } from '@/lib/security/normalize/wazuh'
 
@@ -28,6 +30,21 @@ export const maxDuration = 30
 
 export async function POST(req: NextRequest) {
   const envId = req.nextUrl.searchParams.get('env') || process.env.ENVIRONMENT_ID || ''
+
+  // 0. Body-size guard (rejects oversize/unsized requests BEFORE HMAC work).
+  const sizeCheck = checkWebhookBodySize(req)
+  if (!sizeCheck.ok) {
+    if (sizeCheck.reason === 'too_large') {
+      return NextResponse.json(
+        { error: `Request body exceeds ${WEBHOOK_MAX_BODY_BYTES} bytes` },
+        { status: 413 }
+      )
+    }
+    return NextResponse.json(
+      { error: 'Content-Length header required' },
+      { status: 411 }
+    )
+  }
 
   // 1. Read raw body (for HMAC verification)
   const bodyText = await req.text()

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -15,5 +15,8 @@ export async function register() {
 
     const { ensureActionPolicies } = await import('./lib/seed-action-policies')
     await ensureActionPolicies()
+
+    const { ensureCorrelationRules } = await import('./lib/seed-correlation-rules')
+    await ensureCorrelationRules()
   }
 }

--- a/apps/web/src/jobs/security-poll-elk.test.ts
+++ b/apps/web/src/jobs/security-poll-elk.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for PR #407 BLOCK-1: pollers must not advance the
+ * watermark on a batch where every event fails to insert. The previous
+ * implementation bumped lastWatermark to the newest *seen* event, so a
+ * batch of permanently un-parseable events would silently be skipped on
+ * every subsequent poll.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// vi.hoisted runs BEFORE the import block (which is itself hoisted by vitest).
+// ELK_URL is captured at module load time inside security-poll-elk.ts, so we
+// must set it before that module is imported below.
+vi.hoisted(() => {
+  process.env.ELK_URL = 'http://elk:9200'
+})
+
+// In-memory prisma double — captured at module evaluation time. The mock
+// factory below is hoisted by vitest, so we keep references in module
+// scope to assert/configure them from the test body.
+const upsertCalls: Array<{
+  update: Record<string, unknown>
+  create: Record<string, unknown>
+}> = []
+let createImpl: () => Promise<unknown> = async () => ({})
+let findUniqueImpl: () => Promise<unknown> = async () => null
+let countImpl: () => Promise<number> = async () => 0
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    sourceHealth: {
+      findUnique: vi.fn(() => findUniqueImpl()),
+      upsert: vi.fn(({ update, create }: { update: Record<string, unknown>; create: Record<string, unknown> }) => {
+        upsertCalls.push({ update, create })
+        return Promise.resolve({})
+      }),
+    },
+    securityEvent: {
+      count: vi.fn(() => countImpl()),
+      create: vi.fn((args: { data: unknown }) => createImpl().then(() => args)),
+    },
+  },
+}))
+
+// Re-export the real implementations from the relative paths so vitest can
+// resolve them — the `@/...` aliases would also work via the next.js path
+// resolver, but the test runner's resolver doesn't honour them.
+vi.mock('@/lib/security/normalize/elk', async () => {
+  return await import('../lib/security/normalize/elk')
+})
+vi.mock('@/lib/security/types', async () => {
+  return await import('../lib/security/types')
+})
+
+// The poller captures ELK_URL at module-load time, so it must be set BEFORE
+// the runElkPoller import below.
+process.env.ELK_URL = 'http://elk:9200'
+
+import { runElkPoller } from './security-poll-elk'
+
+const fetchStub = vi.fn()
+
+describe('runElkPoller (PR #407 BLOCK-1 watermark)', () => {
+  beforeEach(() => {
+    upsertCalls.length = 0
+    createImpl = async () => ({})
+    findUniqueImpl = async () => null
+    countImpl = async () => 0
+    fetchStub.mockReset()
+    ;(global as { fetch?: unknown }).fetch = fetchStub
+    process.env.ELK_URL = 'http://elk:9200'
+  })
+
+  it('does NOT advance watermark when every event fails to insert', async () => {
+    // ELK returns two events that will fail Zod parse — wrong shape.
+    const hits = [
+      { _source: { '@timestamp': '2026-05-20T10:00:00Z', message: 'a', anomaly_score: 'not-a-number' as unknown as number } },
+      { _source: { '@timestamp': '2026-05-20T10:01:00Z', message: 'b', anomaly_score: 'not-a-number' as unknown as number } },
+    ]
+    fetchStub.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hits: { hits } }),
+    })
+    // Force every create() to throw so eventsInserted stays at 0 even if
+    // normalize+Zod somehow accept the row (defensive).
+    createImpl = async () => { throw new Error('forced insert failure') }
+
+    const res = await runElkPoller('env-1')
+    expect(res.eventsFound).toBe(2)
+    expect(res.eventsInserted).toBe(0)
+    // Critical assertion: the upsert sent to source health must NOT include
+    // a lastWatermark on the update path.
+    expect(upsertCalls).toHaveLength(1)
+    expect(upsertCalls[0].update).not.toHaveProperty('lastWatermark')
+    expect(res.watermark).toBeNull()
+  })
+
+  it('does not advance watermark when ELK returns an empty batch', async () => {
+    fetchStub.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hits: { hits: [] } }),
+    })
+
+    const res = await runElkPoller('env-1')
+    expect(res.eventsFound).toBe(0)
+    expect(res.eventsInserted).toBe(0)
+    expect(upsertCalls).toHaveLength(1)
+    expect(upsertCalls[0].update).not.toHaveProperty('lastWatermark')
+    expect(res.watermark).toBeNull()
+  })
+
+  it('does not advance watermark when ELK fetch itself fails', async () => {
+    fetchStub.mockResolvedValue({ ok: false, status: 503, statusText: 'Service Unavailable' })
+
+    const res = await runElkPoller('env-1')
+    expect(res.eventsFound).toBe(0)
+    expect(res.eventsInserted).toBe(0)
+    expect(res.errors.length).toBeGreaterThan(0)
+    // upsert path not reached when the query itself errors out.
+  })
+})

--- a/apps/web/src/jobs/security-poll-elk.ts
+++ b/apps/web/src/jobs/security-poll-elk.ts
@@ -64,7 +64,12 @@ export async function runElkPoller(envId: string): Promise<PollResult> {
 
   result.eventsFound = events.length
 
-  // 3. Normalize and insert
+  // 3. Normalize and insert. Track the timestamp of the last *successfully
+  //    inserted* event so the watermark only advances over rows we actually
+  //    persisted — Zod parse failures or DB errors must NOT bump the watermark
+  //    or they'd be permanently skipped on the next poll.
+  let lastInsertedTimestamp: Date | null = null
+
   for (const raw of events) {
     try {
       const event = normalizeElkEvent(raw)
@@ -99,26 +104,39 @@ export async function runElkPoller(envId: string): Promise<PollResult> {
         },
       })
       result.eventsInserted++
+      // Advance the in-memory watermark candidate only after a successful insert.
+      if (parsed.timestamp instanceof Date && (!lastInsertedTimestamp || parsed.timestamp > lastInsertedTimestamp)) {
+        lastInsertedTimestamp = parsed.timestamp
+      }
     } catch (err) {
       result.errors.push(`Failed to process event: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 
-  // 4. Update watermark to the newest event
-  if (events.length > 0) {
-    const newest = events[events.length - 1]
-    result.watermark = newest['@timestamp'] ?? newest.syslog_timestamp ?? new Date().toISOString()
+  // 4. Determine the watermark to persist:
+  //    - If no events were inserted, leave the existing watermark untouched.
+  //    - Otherwise advance to the latest successfully-inserted timestamp.
+  if (lastInsertedTimestamp) {
+    result.watermark = lastInsertedTimestamp.toISOString()
   }
 
-  // 5. Update source health
+  // 5. Update source health. Only persist a new lastWatermark when we have
+  //    a successful insert this run; otherwise keep the prior value.
+  const upsertData: { lastSeenAt: Date; lastWatermark?: Date } = { lastSeenAt: new Date() }
+  if (lastInsertedTimestamp) {
+    upsertData.lastWatermark = lastInsertedTimestamp
+  }
   await prisma.sourceHealth.upsert({
     where: { source: 'elk' },
-    update: { lastSeenAt: new Date() },
+    update: upsertData,
     create: {
       environmentId: envId,
       source: 'elk',
       lastSeenAt: new Date(),
-      lastWatermark: result.watermark ? new Date(result.watermark) : new Date(),
+      // For first-run create: use the inserted timestamp if available;
+      // otherwise fall back to `sinceTime` so we don't accidentally skip
+      // the window we just polled.
+      lastWatermark: lastInsertedTimestamp ?? sinceTime,
       staleAfterMs: ELK_POLL_INTERVAL_SEC * 1000 * 3, // 3x poll interval
     },
   })

--- a/apps/web/src/jobs/security-poll-elk.ts
+++ b/apps/web/src/jobs/security-poll-elk.ts
@@ -1,0 +1,185 @@
+/**
+ * ELK/ELK-stack poller job — runs every 15s (configurable).
+ *
+ * Queries the ELK cluster for new events since the last watermark.
+ * Uses Logstash or Elasticsearch _search API to pull events.
+ *
+ * Environment variables:
+ *   - ELK_URL: Base URL of Logstash HTTP input (e.g. http://elk:8080)
+ *   - ELK_INDEX: Index pattern to search (e.g. 'logstash-*')
+ *   - ELK_API_KEY: API key or basic auth (optional)
+ *   - ELK_POLL_INTERVAL_SEC: Poll interval in seconds (default: 15)
+ */
+
+import { prisma } from '@/lib/db'
+import { normalizeElkEvent, type ElkEvent } from '@/lib/security/normalize/elk'
+import { normalizedEventSchema } from '@/lib/security/types'
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const ELK_URL = process.env.ELK_URL || ''
+const ELK_INDEX = process.env.ELK_INDEX || 'logstash-*'
+const ELK_API_KEY = process.env.ELK_API_KEY || ''
+const ELK_POLL_INTERVAL_SEC = parseInt(process.env.ELK_POLL_INTERVAL_SEC || '15', 10)
+const ELK_SIZE = parseInt(process.env.ELK_POLL_SIZE || '100', 10)
+
+// ── Poller ────────────────────────────────────────────────────────────────────
+
+/**
+ * Poll ELK for new events and insert them into SecurityEvent.
+ *
+ * Uses SourceHealth.lastWatermark as the high-water mark for pagination.
+ * Watermarks are stored as ISO timestamps in the last event's @timestamp.
+ */
+export async function runElkPoller(envId: string): Promise<PollResult> {
+  const startTime = Date.now()
+  const result: PollResult = {
+    envId,
+    source: 'elk',
+    polledAt: new Date(),
+    eventsFound: 0,
+    eventsInserted: 0,
+    eventsSkipped: 0,
+    errors: [],
+    watermark: null,
+    durationMs: 0,
+  }
+
+  // 1. Get the last watermark for this source
+  const sourceHealth = await prisma.sourceHealth.findUnique({
+    where: { source: 'elk' },
+  })
+
+  const sinceTime = sourceHealth?.lastWatermark ?? new Date(Date.now() - 5 * 60 * 1000) // last 5 min if no watermark
+
+  // 2. Query ELK
+  let events: ElkEvent[]
+  try {
+    events = await queryElk(sinceTime, ELK_INDEX, ELK_SIZE)
+  } catch (err) {
+    result.errors.push(err instanceof Error ? err.message : String(err))
+    result.durationMs = Date.now() - startTime
+    return result
+  }
+
+  result.eventsFound = events.length
+
+  // 3. Normalize and insert
+  for (const raw of events) {
+    try {
+      const event = normalizeElkEvent(raw)
+      event.environmentId = envId
+
+      // Validate with Zod
+      const parsed = normalizedEventSchema.parse(event)
+
+      // Check idempotency
+      const existing = await prisma.securityEvent.count({
+        where: { dedupKey: parsed.dedupKey, source: 'elk' },
+      })
+
+      if (existing > 0) {
+        result.eventsSkipped++
+        continue
+      }
+
+      await prisma.securityEvent.create({
+        data: {
+          id: parsed.id,
+          environmentId: parsed.environmentId,
+          type: parsed.type,
+          source: parsed.source,
+          severity: parsed.severity,
+          title: parsed.title,
+          description: parsed.description ?? null,
+          rawEvent: parsed.rawEvent as any,
+          dedupKey: parsed.dedupKey,
+          firstSeen: parsed.timestamp,
+          lastSeen: parsed.timestamp,
+        },
+      })
+      result.eventsInserted++
+    } catch (err) {
+      result.errors.push(`Failed to process event: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  // 4. Update watermark to the newest event
+  if (events.length > 0) {
+    const newest = events[events.length - 1]
+    result.watermark = newest['@timestamp'] ?? newest.syslog_timestamp ?? new Date().toISOString()
+  }
+
+  // 5. Update source health
+  await prisma.sourceHealth.upsert({
+    where: { source: 'elk' },
+    update: { lastSeenAt: new Date() },
+    create: {
+      environmentId: envId,
+      source: 'elk',
+      lastSeenAt: new Date(),
+      lastWatermark: result.watermark ? new Date(result.watermark) : new Date(),
+      staleAfterMs: ELK_POLL_INTERVAL_SEC * 1000 * 3, // 3x poll interval
+    },
+  })
+
+  result.durationMs = Date.now() - startTime
+  return result
+}
+
+/**
+ * Query ELK for events since the given timestamp.
+ */
+async function queryElk(since: Date, index: string, size: number): Promise<ElkEvent[]> {
+  if (!ELK_URL) {
+    throw new Error('ELK_URL not configured')
+  }
+
+  const query = {
+    query: {
+      bool: {
+        must: [
+          { range: { '@timestamp': { gte: since.toISOString() } } },
+          { match_all: {} },
+        ],
+      },
+    },
+    size,
+    sort: [{ '@timestamp': { order: 'asc' } }],
+  }
+
+  const url = `${ELK_URL}/${index}/_search`
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (ELK_API_KEY) {
+    headers['Authorization'] = `Bearer ${ELK_API_KEY}`
+  }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(query),
+  })
+
+  if (!res.ok) {
+    throw new Error(`ELK query failed: ${res.status} ${res.statusText}`)
+  }
+
+  const data = await res.json()
+  const hits = data.hits?.hits ?? []
+
+  return hits.map((h: { _source: ElkEvent }) => h._source).filter(Boolean)
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface PollResult {
+  envId: string
+  source: string
+  polledAt: Date
+  eventsFound: number
+  eventsInserted: number
+  eventsSkipped: number
+  errors: string[]
+  watermark: string | null
+  durationMs: number
+}

--- a/apps/web/src/jobs/security-poll-ntopng.ts
+++ b/apps/web/src/jobs/security-poll-ntopng.ts
@@ -48,6 +48,11 @@ export async function runNtopngPoller(envId: string): Promise<PollResult> {
 
   const sinceTime = sourceHealth?.lastWatermark ?? new Date(Date.now() - 10 * 60 * 1000) // last 10 min
 
+  // Track the timestamp of the last *successfully inserted* event across both
+  // alert and flow loops so the watermark advances only over rows we actually
+  // persisted. If everything fails, we leave the prior watermark untouched.
+  let lastInsertedTimestamp: Date | null = null
+
   // 2. Poll threat alerts
   try {
     const alerts = await pollNtopngAlerts(sinceTime, NTOPNG_POLL_SIZE)
@@ -85,6 +90,9 @@ export async function runNtopngPoller(envId: string): Promise<PollResult> {
           },
         })
         result.eventsInserted++
+        if (parsed.timestamp instanceof Date && (!lastInsertedTimestamp || parsed.timestamp > lastInsertedTimestamp)) {
+          lastInsertedTimestamp = parsed.timestamp
+        }
       } catch (err) {
         result.errors.push(`Threat: ${err instanceof Error ? err.message : String(err)}`)
       }
@@ -137,6 +145,9 @@ export async function runNtopngPoller(envId: string): Promise<PollResult> {
             },
           })
           result.eventsInserted++
+          if (parsed.timestamp instanceof Date && (!lastInsertedTimestamp || parsed.timestamp > lastInsertedTimestamp)) {
+            lastInsertedTimestamp = parsed.timestamp
+          }
         } catch (err) {
           result.errors.push(`Flow: ${err instanceof Error ? err.message : String(err)}`)
         }
@@ -146,16 +157,26 @@ export async function runNtopngPoller(envId: string): Promise<PollResult> {
     }
   }
 
-  // 4. Update source health
+  // 4. Update source health. Only advance lastWatermark when we successfully
+  //    inserted at least one event this run; otherwise leave the previous
+  //    watermark untouched (avoids advancing past a failed batch).
   const now = new Date()
+  const upsertData: { lastSeenAt: Date; lastWatermark?: Date } = { lastSeenAt: now }
+  if (lastInsertedTimestamp) {
+    upsertData.lastWatermark = lastInsertedTimestamp
+    result.watermark = lastInsertedTimestamp.toISOString()
+  }
   await prisma.sourceHealth.upsert({
     where: { source: 'ntopng' },
-    update: { lastSeenAt: now },
+    update: upsertData,
     create: {
       environmentId: envId,
       source: 'ntopng',
       lastSeenAt: now,
-      lastWatermark: now,
+      // For first-run create: use the inserted timestamp if available;
+      // otherwise fall back to `sinceTime` so we don't accidentally skip
+      // the window we just polled.
+      lastWatermark: lastInsertedTimestamp ?? sinceTime,
       staleAfterMs: NTOPNG_POLL_INTERVAL_SEC * 1000 * 3, // 3x poll interval
     },
   })

--- a/apps/web/src/jobs/security-poll-ntopng.ts
+++ b/apps/web/src/jobs/security-poll-ntopng.ts
@@ -1,0 +1,231 @@
+/**
+ * ntopng poller job — runs every 30s (configurable).
+ *
+ * Polls the ntopng REST API for flow data and threat alerts.
+ * Uses SourceHealth.lastWatermark for deduplication and watermarking.
+ *
+ * Environment variables:
+ *   - NTOPNG_URL: Base URL of ntopng API (e.g. http://ntopng:3000)
+ *   - NTOPNG_API_KEY: API key for ntopng (required)
+ *   - NTOPNG_POLL_INTERVAL_SEC: Poll interval in seconds (default: 30)
+ *   - NTOPNG_POLL_SIZE: Max flows per poll (default: 200)
+ */
+
+import { prisma } from '@/lib/db'
+import { normalizeNtopngFlow, normalizeNtopngThreatAlert, type NtopngFlow, type NtopngThreatAlert } from '@/lib/security/normalize/ntopng'
+import { normalizedEventSchema } from '@/lib/security/types'
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const NTOPNG_URL = process.env.NTOPNG_URL || ''
+const NTOPNG_API_KEY = process.env.NTOPNG_API_KEY || ''
+const NTOPNG_POLL_INTERVAL_SEC = parseInt(process.env.NTOPNG_POLL_INTERVAL_SEC || '30', 10)
+const NTOPNG_POLL_SIZE = parseInt(process.env.NTOPNG_POLL_SIZE || '200', 10)
+
+// ── Poller ────────────────────────────────────────────────────────────────────
+
+/**
+ * Poll ntopng for threat alerts and flows.
+ */
+export async function runNtopngPoller(envId: string): Promise<PollResult> {
+  const startTime = Date.now()
+  const result: PollResult = {
+    envId,
+    source: 'ntopng',
+    polledAt: new Date(),
+    eventsFound: 0,
+    eventsInserted: 0,
+    eventsSkipped: 0,
+    errors: [],
+    watermark: null,
+    durationMs: 0,
+  }
+
+  // 1. Get the last watermark
+  const sourceHealth = await prisma.sourceHealth.findUnique({
+    where: { source: 'ntopng' },
+  })
+
+  const sinceTime = sourceHealth?.lastWatermark ?? new Date(Date.now() - 10 * 60 * 1000) // last 10 min
+
+  // 2. Poll threat alerts
+  try {
+    const alerts = await pollNtopngAlerts(sinceTime, NTOPNG_POLL_SIZE)
+    result.eventsFound += alerts.length
+
+    for (const raw of alerts) {
+      try {
+        const event = normalizeNtopngThreatAlert(raw)
+        event.environmentId = envId
+
+        const parsed = normalizedEventSchema.parse(event)
+
+        const existing = await prisma.securityEvent.count({
+          where: { dedupKey: parsed.dedupKey, source: 'ntopng' },
+        })
+
+        if (existing > 0) {
+          result.eventsSkipped++
+          continue
+        }
+
+        await prisma.securityEvent.create({
+          data: {
+            id: parsed.id,
+            environmentId: parsed.environmentId,
+            type: parsed.type,
+            source: parsed.source,
+            severity: parsed.severity,
+            title: parsed.title,
+            description: parsed.description ?? null,
+            rawEvent: parsed.rawEvent as any,
+            dedupKey: parsed.dedupKey,
+            firstSeen: parsed.timestamp,
+            lastSeen: parsed.timestamp,
+          },
+        })
+        result.eventsInserted++
+      } catch (err) {
+        result.errors.push(`Threat: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+  } catch (err) {
+    result.errors.push(`Threat poll failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  // 3. Poll flows (only if source is healthy)
+  if (result.eventsInserted > 0 || sourceHealth?.lastSeenAt) {
+    try {
+      const flows = await pollNtopngFlows(sinceTime, NTOPNG_POLL_SIZE)
+      result.eventsFound += flows.length
+
+      for (const raw of flows) {
+        try {
+          const event = normalizeNtopngFlow(raw)
+          event.environmentId = envId
+
+          const parsed = normalizedEventSchema.parse(event)
+
+          // Skip low-severity normal flows for performance
+          if (parsed.severity < 15 && parsed.type === 'ntopng_flow') {
+            result.eventsSkipped++
+            continue
+          }
+
+          const existing = await prisma.securityEvent.count({
+            where: { dedupKey: parsed.dedupKey, source: 'ntopng' },
+          })
+
+          if (existing > 0) {
+            result.eventsSkipped++
+            continue
+          }
+
+          await prisma.securityEvent.create({
+            data: {
+              id: parsed.id,
+              environmentId: parsed.environmentId,
+              type: parsed.type,
+              source: parsed.source,
+              severity: parsed.severity,
+              title: parsed.title,
+              description: parsed.description ?? null,
+              rawEvent: parsed.rawEvent as any,
+              dedupKey: parsed.dedupKey,
+              firstSeen: parsed.timestamp,
+              lastSeen: parsed.timestamp,
+            },
+          })
+          result.eventsInserted++
+        } catch (err) {
+          result.errors.push(`Flow: ${err instanceof Error ? err.message : String(err)}`)
+        }
+      }
+    } catch (err) {
+      result.errors.push(`Flow poll failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  // 4. Update source health
+  const now = new Date()
+  await prisma.sourceHealth.upsert({
+    where: { source: 'ntopng' },
+    update: { lastSeenAt: now },
+    create: {
+      environmentId: envId,
+      source: 'ntopng',
+      lastSeenAt: now,
+      lastWatermark: now,
+      staleAfterMs: NTOPNG_POLL_INTERVAL_SEC * 1000 * 3, // 3x poll interval
+    },
+  })
+
+  result.durationMs = Date.now() - startTime
+  return result
+}
+
+/**
+ * Poll ntopng API for threat alerts.
+ */
+async function pollNtopngAlerts(since: Date, limit: number): Promise<NtopngThreatAlert[]> {
+  if (!NTOPNG_URL) throw new Error('NTOPNG_URL not configured')
+  if (!NTOPNG_API_KEY) throw new Error('NTOPNG_API_KEY not configured')
+
+  const res = await fetch(
+    `${NTOPNG_URL}/protoapi/threat?since=${Math.round(since.getTime() / 1000)}&limit=${limit}`,
+    {
+      headers: {
+        'Authorization': `Bearer ${NTOPNG_API_KEY}`,
+      },
+    }
+  )
+
+  if (!res.ok) {
+    throw new Error(`ntopng threat poll failed: ${res.status} ${res.statusText}`)
+  }
+
+  const data = await res.json()
+  const threats = data.threats ?? data.alerts ?? data
+  return Array.isArray(threats) ? threats : []
+}
+
+/**
+ * Poll ntopng API for flow records.
+ */
+async function pollNtopngFlows(since: Date, limit: number): Promise<NtopngFlow[]> {
+  if (!NTOPNG_URL) throw new Error('NTOPNG_URL not configured')
+  if (!NTOPNG_API_KEY) throw new Error('NTOPNG_API_KEY not configured')
+
+  // ntopng JSON API for flows
+  const res = await fetch(
+    `${NTOPNG_URL}/flows/json?since=${Math.round(since.getTime() / 1000)}&limit=${limit}`,
+    {
+      headers: {
+        'Authorization': `Bearer ${NTOPNG_API_KEY}`,
+      },
+    }
+  )
+
+  if (!res.ok) {
+    throw new Error(`ntopng flow poll failed: ${res.status} ${res.statusText}`)
+  }
+
+  const data = await res.json()
+  // ntopng returns { flows: { ... }, ... } where keys are IP pairs
+  const flows = data.flows ?? {}
+  return Object.values(flows) as NtopngFlow[]
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface PollResult {
+  envId: string
+  source: string
+  polledAt: Date
+  eventsFound: number
+  eventsInserted: number
+  eventsSkipped: number
+  errors: string[]
+  watermark: string | null
+  durationMs: number
+}

--- a/apps/web/src/lib/security/normalize/crowdsec.ts
+++ b/apps/web/src/lib/security/normalize/crowdsec.ts
@@ -1,0 +1,127 @@
+/**
+ * CrowdSec event normalizer.
+ *
+ * Converts CrowdSec webhook alerts into NormalizedSecurityEvent shape.
+ * CrowdSec sends decisions via webhook when new bans occur.
+ */
+
+import { type NormalizedSecurityEvent } from '../types'
+
+export interface CrowdSecAlert {
+  id: string
+  stream: string
+  name: string
+  ts: {
+    sec: number
+    nsec: number
+    unix: number
+    unix_nsec: number
+  }
+  payload: {
+    '@type': string
+    '@id': string
+    scope: string  // 'Ip' | 'Login' | 'Email' | 'Domain' | 'Fqdn' | 'Uri'
+    value: string
+    hash?: number
+    country?: string
+    as_name?: string
+    labels?: Record<string, string>
+    severity?: string
+  }
+  severity: number
+  events: {
+    reason: string
+    ts: {
+      sec: number
+      unix: number
+    }
+    payloads: Record<string, unknown>
+    scenario: string
+    scope: string
+  }[]
+}
+
+/**
+ * Normalize a CrowdSec alert into the canonical SecurityEvent shape.
+ *
+ * CrowdSec webhooks deliver a `stream` envelope wrapping `Alert` objects.
+ */
+export function normalizeCrowdSecAlert(raw: CrowdSecAlert): NormalizedSecurityEvent {
+  const event = raw.events?.[0] ?? raw
+  const payload = raw.payload as CrowdSecAlert['payload'] & { scenario?: string }
+  const scenario = payload.scenario ?? event.scenario ?? 'unknown'
+
+  // Build dedup key: scenario + value + source IP/host
+  const dedupKey = createDedupKey('crowdsec', scenario, payload.value, raw.id)
+
+  // Determine severity: scenarios starting with "brute" or "lockout" are high
+  let severity = 30
+  const lowerScenario = scenario.toLowerCase()
+  if (lowerScenario.includes('brute') || lowerScenario.includes('lockout')) severity = 70
+  else if (lowerScenario.includes('scan') || lowerScenario.includes('port')) severity = 50
+  else if (lowerScenario.includes('malware') || lowerScenario.includes('injection')) severity = 80
+  else if (lowerScenario.includes('ddos') || lowerScenario.includes('flood')) severity = 60
+
+  return {
+    id: raw.id,
+    environmentId: null,
+    type: 'crowdsec_block',
+    source: 'crowdsec',
+    severity,
+    title: `${scenario}: ${payload.value} (${payload.scope})`,
+    description: event.reason ?? scenario,
+    rawEvent: raw as any,
+    dedupKey,
+    sourceName: payload.country ?? payload.as_name ?? 'crowdsec-api',
+    timestamp: new Date(raw.ts.unix * 1000),
+    metadata: {
+      scope: payload.scope,
+      hash: payload.hash,
+      scenario,
+      eventIds: raw.events?.map(e => e.payloads.id ?? String(e.ts.unix)) ?? [],
+    },
+  }
+}
+
+/**
+ * Normalize a CrowdSec decision event (ban created).
+ */
+export function normalizeCrowdSecDecision(
+  decision: Record<string, unknown>
+): NormalizedSecurityEvent {
+  const ip = String(decision.ip ?? decision.value ?? 'unknown')
+  const scenario = String(decision.scenario ?? 'ban')
+  const duration = String(decision.duration ?? '0')
+
+  const dedupKey = createDedupKey('crowdsec_decision', scenario, ip, String(decision.id ?? ''))
+
+  return {
+    id: String(decision.id ?? `cs_${Date.now()}`),
+    environmentId: null,
+    type: 'crowdsec_block',
+    source: 'crowdsec',
+    severity: 50,
+    title: `CrowdSec ban: ${ip}`,
+    description: `Scenario ${scenario} triggered for ${ip} (${duration} duration)`,
+    rawEvent: decision,
+    dedupKey,
+    sourceName: 'crowdsec-api',
+    timestamp: new Date(),
+    metadata: {
+      scenario,
+      ip,
+      duration,
+    },
+  }
+}
+
+function createDedupKey(source: string, ...parts: string[]): string {
+  const joined = parts.join(':')
+  let hash = 0
+  for (let i = 0; i < joined.length; i++) {
+    const char = joined.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash &= hash  // Convert to 32-bit int
+  }
+  return `${source}_${Math.abs(hash).toString(16)}`
+}

--- a/apps/web/src/lib/security/normalize/elk.ts
+++ b/apps/web/src/lib/security/normalize/elk.ts
@@ -1,0 +1,159 @@
+/**
+ * ELK/ELK-stack (Elasticsearch Logstash Kibana) event normalizer.
+ *
+ * Handles both syslog alerts and anomaly detection events from ELK stack.
+ * ELK sends events via Logstash TCP/UDP or HTTP, typically as JSON.
+ */
+
+import { type NormalizedSecurityEvent } from '../types'
+
+/**
+ * A single event from ELK. Can be a syslog event, anomaly score,
+ * or any other event that Logstash forwards.
+ */
+export interface ElkEvent {
+  // Logstash metadata
+  '@timestamp'?: string
+  '@version'?: string
+  host?: string | object
+  agent?: {
+    type?: string
+    version?: string
+    id?: string
+  }
+
+  // Syslog fields
+  syslog_timestamp?: string
+  syslog_hostname?: string
+  syslog_program?: string
+  syslog_severity?: string | number
+  syslog_message?: string
+  message?: string
+  loglevel?: string | number
+  facility?: string
+
+  // Anomaly detection fields
+  anomaly_score?: number
+  anomaly_bucket?: string
+  field_name?: string
+  expected_value?: number | string
+  observed_value?: number | string
+
+  // Network/event context
+  source_ip?: string
+  dest_ip?: string
+  src_ip?: string
+  dst_ip?: string
+  event_type?: string
+  action?: string
+  user?: string
+  dest_user?: string
+  dest_host?: string
+  url?: string
+  domain?: string
+  file?: string
+  hash?: string
+  tags?: string[]
+  ecs_version?: string
+}
+
+/**
+ * Normalize an ELK event into the canonical SecurityEvent shape.
+ *
+ * Events are classified by their anomaly_score field or event_type/tags.
+ */
+export function normalizeElkEvent(raw: ElkEvent): NormalizedSecurityEvent {
+  const message = raw.message ?? raw.syslog_message ?? ''
+
+  // Determine event type and severity based on available fields
+  let eventType = 'anomaly'
+  let severity = 30
+
+  if (raw.anomaly_score != null) {
+    severity = Math.min(100, Math.max(0, Math.round(raw.anomaly_score * 100)))
+    eventType = 'anomaly'
+
+    if (raw.anomaly_score > 0.9) {
+      severity = Math.min(100, severity + 30)
+    } else if (raw.anomaly_score < 0.3) {
+      severity = Math.max(0, severity - 20)
+    }
+  } else if (raw.event_type === 'login' || raw.event_type === 'authentication') {
+    eventType = 'auth_event'
+    severity = raw.loglevel === 'ERROR' || (typeof raw.loglevel === 'number' && raw.loglevel >= 4) ? 60 : 20
+  } else if (raw.event_type === 'connection') {
+    eventType = 'network_event'
+    severity = 20
+  } else if (raw.syslog_program === 'sshd' || raw.syslog_program === 'sudo') {
+    eventType = 'wazuh_alert'
+    severity = raw.syslog_severity === 0 ? 80 : 30 // emergency/critical vs normal
+  }
+
+  // Determine source name
+  const host = typeof raw.host === 'string' ? raw.host : (raw.host as Record<string, unknown>)?.name as string
+  const sourceName = String(host ?? raw.syslog_hostname ?? raw.agent?.id ?? 'elk')
+
+  // Dedup key
+  const dedupSource = message || raw.message || ''
+  const dedupKey = createDedupKey('elk', raw['@timestamp'] ?? '', sourceName, dedupSource.slice(0, 100))
+
+  const timestamp = parseTimestamp(raw['@timestamp'] ?? raw.syslog_timestamp ?? '')
+
+  return {
+    id: `elk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    environmentId: null,
+    type: eventType,
+    source: 'elk',
+    severity,
+    title: buildTitle(raw, eventType),
+    description: message.slice(0, 1000),
+    rawEvent: raw as any,
+    dedupKey,
+    sourceName,
+    timestamp,
+    metadata: {
+      anomaly_score: raw.anomaly_score,
+      anomaly_bucket: raw.anomaly_bucket,
+      src_ip: raw.source_ip ?? raw.src_ip,
+      dst_ip: raw.dest_ip ?? raw.dst_ip,
+      event_type: raw.event_type,
+      user: raw.user,
+      tags: raw.tags,
+    },
+  }
+}
+
+function buildTitle(raw: ElkEvent, eventType: string): string {
+  if (raw.anomaly_bucket) {
+    return `Anomaly detected: ${raw.anomaly_bucket} (score: ${raw.anomaly_score?.toFixed(2)})`
+  }
+  if (raw.message) {
+    return raw.message.slice(0, 80)
+  }
+  if (raw.syslog_message) {
+    return `${raw.syslog_program || 'syslog'}: ${raw.syslog_message.slice(0, 80)}`
+  }
+  return eventType
+}
+
+function parseTimestamp(ts: string): Date {
+  if (!ts) return new Date()
+  try {
+    const parsed = new Date(ts)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  } catch {
+    // ignore
+  }
+  return new Date()
+}
+
+function createDedupKey(source: string, ...parts: string[]): string {
+  const joined = parts.join(':')
+  let hash = 0
+  for (let i = 0; i < joined.length; i++) {
+    const char = joined.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash &= hash
+  }
+  return `${source}_${Math.abs(hash).toString(16)}`
+}

--- a/apps/web/src/lib/security/normalize/ntopng.ts
+++ b/apps/web/src/lib/security/normalize/ntopng.ts
@@ -1,0 +1,263 @@
+/**
+ * ntopng event normalizer.
+ *
+ * Converts ntopng flow events and threat detection alerts into NormalizedSecurityEvent.
+ * ntopng provides both flow data and threat intelligence via its REST API.
+ */
+
+import { type NormalizedSecurityEvent } from '../types'
+
+/**
+ * A flow record from ntopng API or webhook.
+ * ntopng flow format (simplified):
+ */
+export interface NtopngFlow {
+  first_ts?: string
+  last_ts?: string
+  source_ip?: string
+  source_name?: string
+  dest_ip?: string
+  dest_name?: string
+  source_port?: number
+  dest_port?: number
+  bytes?: number
+  packets?: number
+  l4_protocol?: string
+  ip_protocol?: string
+  tcp_flags?: string
+  http_method?: string
+  http_url?: string
+  http_code?: number
+  http_domain?: string
+  application?: string
+  source_bytes?: number
+  dest_bytes?: number
+  source_to_dest_bytes?: number
+  destination_to_source_bytes?: number
+  source_to_dest_packets?: number
+  destination_to_source_packets?: number
+  source_mac?: string
+  source_oui?: string
+  dest_mac?: string
+  dest_oui?: string
+  vlan_id?: number
+  vrf_id?: number
+  interface_id?: number
+  local_source?: boolean
+  local_destination?: boolean
+  source_geoip_country?: string
+  dest_geoip_country?: string
+  internal_source?: boolean
+  internal_destination?: boolean
+  dest_internal?: boolean
+  source_internal?: boolean
+  host_resolutions?: Array<{ ip: string; hostname: string }>
+  is_web_server?: boolean
+}
+
+/**
+ * A threat detection alert from ntopng.
+ */
+export interface NtopngThreatAlert {
+  id?: string
+  timestamp?: string
+  alert_type?: string  // 'threat' | 'geoip' | 'spoofing' | 'port_scan' | 'ddos'
+  alert_name?: string
+  source_ip?: string
+  source_port?: number
+  dest_ip?: string
+  dest_port?: number
+  threat_type?: string
+  description?: string
+  severity?: string | number
+  category?: string
+  interface_id?: number
+  vlan_id?: number
+}
+
+/**
+ * Normalize an ntopng flow record into the canonical SecurityEvent shape.
+ *
+ * Flows are assessed for suspicious activity based on heuristics:
+ * - Unusual port scanning patterns
+ * - Large data transfers
+ * - Known bad destinations (geoip)
+ */
+export function normalizeNtopngFlow(raw: NtopngFlow): NormalizedSecurityEvent {
+  const eventType = detectFlowEventType(raw)
+  const severity = assessFlowSeverity(raw, eventType)
+
+  // Source/destination info
+  const sourceIp = raw.source_ip ?? ''
+  const destIp = raw.dest_ip ?? ''
+  const sourceName = raw.source_name ?? sourceIp
+  const destName = raw.dest_name ?? destIp ?? 'unknown'
+
+  // Dedup key: source:dest:port:protocol
+  const dedupKey = createDedupKey(
+    'ntopng_flow',
+    sourceIp,
+    `${destIp}:${raw.dest_port ?? 0}:${raw.ip_protocol ?? 'tcp'}`
+  )
+
+  const timestamp = parseTimestamp(raw.first_ts ?? raw.last_ts ?? '')
+
+  return {
+    id: `ntopng_flow_${Date.now()}_${sourceIp}_${destIp}`,
+    environmentId: null,
+    type: eventType,
+    source: 'ntopng',
+    severity,
+    title: buildFlowTitle(raw, eventType),
+    description: buildFlowDescription(raw, eventType),
+    rawEvent: raw as any,
+    dedupKey,
+    sourceName,
+    timestamp,
+    metadata: {
+      source_port: raw.source_port,
+      dest_port: raw.dest_port,
+      application: raw.application,
+      bytes: raw.bytes,
+      packets: raw.packets,
+      geoip: {
+        source_country: raw.source_geoip_country,
+        dest_country: raw.dest_geoip_country,
+      },
+      is_web_server: raw.is_web_server,
+    },
+  }
+}
+
+/**
+ * Normalize an ntopng threat alert.
+ */
+export function normalizeNtopngThreatAlert(raw: NtopngThreatAlert): NormalizedSecurityEvent {
+  const severity = parseSeverity(raw.severity, raw.alert_type)
+  const sourceIp = raw.source_ip ?? 'unknown'
+  const destIp = raw.dest_ip ?? 'unknown'
+
+  const dedupKey = createDedupKey(
+    'ntopng_threat',
+    raw.id ?? raw.alert_name ?? '',
+    sourceIp,
+    destIp
+  )
+
+  const timestamp = parseTimestamp(raw.timestamp ?? '')
+
+  return {
+    id: raw.id ?? `ntopng_threat_${Date.now()}`,
+    environmentId: null,
+    type: 'ntopng_threat',
+    source: 'ntopng',
+    severity,
+    title: raw.alert_name ?? raw.alert_type ?? 'ntopng threat detected',
+    description: raw.description ?? `Alert type: ${raw.alert_type}`,
+    rawEvent: raw as any,
+    dedupKey,
+    sourceName: sourceIp,
+    timestamp,
+    metadata: {
+      alert_type: raw.alert_type,
+      threat_type: raw.threat_type,
+      category: raw.category,
+      source_port: raw.source_port,
+      dest_port: raw.dest_port,
+      interface_id: raw.interface_id,
+    },
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function detectFlowEventType(raw: NtopngFlow): string {
+  if (raw.application && raw.application.toLowerCase().includes('malware')) return 'ntopng_threat'
+  if (raw.tcp_flags === 'RST' || raw.bytes === 0) return 'ntopng_flow'
+  if (raw.bytes && raw.bytes > 100_000_000) return 'ntopng_large_transfer'
+  if (raw.source_to_dest_packets && raw.source_to_dest_packets > 1000 && (raw.dest_port === 22 || raw.dest_port === 23)) return 'ntopng_bruteforce'
+  return 'ntopng_flow'
+}
+
+function assessFlowSeverity(raw: NtopngFlow, eventType: string): number {
+  if (eventType === 'ntopng_threat') return 80
+  if (eventType === 'ntopng_bruteforce') return 70
+  if (eventType === 'ntopng_large_transfer') {
+    const ratio = raw.bytes ? (raw.source_to_dest_bytes ?? 0) / raw.bytes : 0
+    return ratio > 0.9 ? 50 : 20
+  }
+
+  // Base severity for normal flows
+  let severity = 5
+
+  // High port from unusual source
+  if (raw.dest_port && (raw.dest_port === 4444 || raw.dest_port === 5555 || raw.dest_port === 6666 || raw.dest_port === 6667)) severity += 40
+
+  // Foreign country connection
+  if (raw.dest_geoip_country && !['US', 'CA', 'GB', 'DE', 'FR'].includes(raw.dest_geoip_country)) severity += 10
+
+  return Math.min(100, severity)
+}
+
+function buildFlowTitle(raw: NtopngFlow, eventType: string): string {
+  const src = raw.source_name ?? raw.source_ip ?? 'unknown'
+  const dst = raw.dest_name ?? raw.dest_ip ?? 'unknown'
+  const port = raw.dest_port ?? 0
+
+  switch (eventType) {
+    case 'ntopng_threat':
+      return `Threat detected: ${src} → ${dst}:${port}`
+    case 'ntopng_large_transfer':
+      return `Large transfer: ${src} → ${dst} (${raw.bytes ?? 0} bytes)`
+    case 'ntopng_bruteforce':
+      return `Potential brute force: ${src} → ${dst}:${port}`
+    default: {
+      if (raw.application) return `${raw.application}: ${src} → ${dst}:${port}`
+      return `${src}:${raw.source_port ?? 0} → ${dst}:${port}`
+    }
+  }
+}
+
+function buildFlowDescription(raw: NtopngFlow, eventType: string): string {
+  const parts: string[] = []
+  if (raw.application) parts.push(`App: ${raw.application}`)
+  if (raw.bytes) parts.push(`${raw.bytes.toLocaleString()} bytes, ${raw.packets ?? 0} packets`)
+  if (raw.source_geoip_country) parts.push(`Source: ${raw.source_geoip_country}`)
+  if (raw.dest_geoip_country) parts.push(`Dest: ${raw.dest_geoip_country}`)
+  return parts.join(' | ')
+}
+
+function parseSeverity(severity?: string | number, alertType?: string): number {
+  if (severity != null) {
+    const num = typeof severity === 'number' ? severity : parseInt(severity, 10)
+    if (!Number.isNaN(num)) return Math.min(100, Math.max(0, num * 10))
+  }
+  // Defaults by type
+  if (alertType === 'ddos') return 90
+  if (alertType === 'spoofing') return 85
+  if (alertType === 'geoip') return 50
+  if (alertType === 'port_scan') return 60
+  return 40
+}
+
+function parseTimestamp(ts: string): Date {
+  if (!ts) return new Date()
+  try {
+    const parsed = new Date(ts)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  } catch {
+    // ignore
+  }
+  return new Date()
+}
+
+function createDedupKey(source: string, ...parts: string[]): string {
+  const joined = parts.join(':')
+  let hash = 0
+  for (let i = 0; i < joined.length; i++) {
+    const char = joined.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash &= hash
+  }
+  return `${source}_${Math.abs(hash).toString(16)}`
+}

--- a/apps/web/src/lib/security/normalize/wazuh.ts
+++ b/apps/web/src/lib/security/normalize/wazuh.ts
@@ -1,0 +1,151 @@
+/**
+ * Wazuh event normalizer.
+ *
+ * Converts Wazuh FIM, agent alerts, and rootcheck events into NormalizedSecurityEvent.
+ */
+
+import { type NormalizedSecurityEvent } from '../types'
+
+/**
+ * Agent info extracted from a Wazuh alert.
+ */
+interface WazuhAgent {
+  id: string
+  name: string
+  ip: string
+  registerIp?: string
+  version?: string
+  group?: string
+  lost_at?: string | null
+  type?: string
+  os?: { name?: string; version?: string }
+  host?: string
+  lastKeepAlive?: string
+  groupConfigSum?: string
+  ext_version?: string
+  internal_version?: number
+}
+
+/**
+ * Location info from a Wazuh alert.
+ */
+interface WazuhLocation {
+  zonedata?: string
+  type?: string
+  name?: string
+  dstaddr?: string
+  ip?: string
+}
+
+export interface WazuhAlert {
+  alert?: {
+    id: string
+    rule: {
+      id: number
+      level: number
+      description: string
+      groups: string[]
+    }
+    hostname: string
+    manager: string
+    srcip?: string
+    srcuser?: string
+    dstuser?: string
+    output?: string
+    data?: Record<string, unknown>
+    full_log?: string
+    timestamp?: string
+    agent?: WazuhAgent
+    location?: WazuhLocation
+  }
+}
+
+/**
+ * Normalize a Wazuh alert into the canonical SecurityEvent shape.
+ */
+export function normalizeWazuhAlert(raw: WazuhAlert): NormalizedSecurityEvent {
+  const alert = raw.alert
+  if (!alert) {
+    throw new Error('Wazuh alert payload missing "alert" field')
+  }
+
+  const rule = alert.rule
+  const agent: WazuhAgent = alert.agent ?? { id: '', name: '', ip: '' }
+  const groups = rule.groups ?? []
+
+  let eventType = 'wazuh_alert'
+  if (groups.includes('syscheck')) eventType = 'wazuh_fim'
+  else if (groups.includes('rootcheck')) eventType = 'wazuh_rootcheck'
+  else if (groups.includes('authentication')) eventType = 'wazuh_auth'
+  else if (groups.includes('malware')) eventType = 'wazuh_malware'
+  else if (groups.includes('web_attack')) eventType = 'wazuh_web_attack'
+  else if (groups.includes('intrusion')) eventType = 'wazuh_intrusion'
+
+  const severity = Math.min(100, rule.level * 10)
+  const sourceName = alert.manager ?? agent.name ?? alert.hostname ?? 'wazuh-manager'
+
+  const dedupSource = alert.full_log ?? alert.output ?? ''
+  const dedupKey = createDedupKey('wazuh', rule.id.toString(), agent.id ?? '', dedupSource)
+  const timestamp = parseWazuhTimestamp(alert.timestamp ?? '')
+
+  return {
+    id: alert.id ?? `wazuh_${Date.now()}_${rule.id}`,
+    environmentId: null,
+    type: eventType,
+    source: 'wazuh',
+    severity,
+    title: rule.description,
+    description: buildDescription(alert),
+    rawEvent: raw as unknown as Record<string, unknown>,
+    dedupKey,
+    sourceName,
+    timestamp,
+    metadata: {
+      ruleId: rule.id,
+      ruleLevel: rule.level,
+      groups,
+      agent: {
+        id: agent.id,
+        name: agent.name,
+        ip: agent.ip,
+        version: agent.version,
+      },
+      srcip: alert.srcip,
+      srcuser: alert.srcuser,
+      dstuser: alert.dstuser,
+    },
+  }
+}
+
+function buildDescription(alert: NonNullable<WazuhAlert['alert']>): string {
+  const parts: string[] = []
+  if (alert.full_log) parts.push(alert.full_log.slice(0, 500))
+  if (alert.output) parts.push(alert.output.slice(0, 500))
+  if (alert.data) {
+    const dataStr = JSON.stringify(alert.data).slice(0, 500)
+    if (!parts.includes(dataStr)) parts.push(dataStr)
+  }
+  return parts.join(' | ') || alert.rule.description
+}
+
+function parseWazuhTimestamp(ts: string): Date {
+  if (!ts) return new Date()
+  try {
+    const parsed = new Date(ts)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  } catch {
+    // ignore
+  }
+  return new Date()
+}
+
+function createDedupKey(source: string, ...parts: string[]): string {
+  const joined = parts.join(':')
+  let hash = 0
+  for (let i = 0; i < joined.length; i++) {
+    const char = joined.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash &= hash
+  }
+  return `${source}_${Math.abs(hash).toString(16)}`
+}

--- a/apps/web/src/lib/security/rule-engine.test.ts
+++ b/apps/web/src/lib/security/rule-engine.test.ts
@@ -1,8 +1,21 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('@/lib/db', () => ({ prisma: {} }))
+// `rule-engine` calls `prisma.securityEvent.findMany` from each sub-runner.
+// We stub it so we can exercise the orchestration layer without a DB.
+const findManyMock = vi.fn()
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    securityEvent: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+    },
+  },
+}))
 
-import { extractGroupValue } from './rule-engine'
+import {
+  extractGroupValue,
+  correlateEvents,
+  type NamedRule,
+} from './rule-engine'
 
 describe('extractGroupValue (BLOCK-1b regression — brute-force groups by attacker IP)', () => {
   describe('top-level column access', () => {
@@ -88,5 +101,66 @@ describe('extractGroupValue (BLOCK-1b regression — brute-force groups by attac
       expect(counts.get('203.0.113.7')).toBe(5) // ≥5 threshold met
       expect(counts.get('198.51.100.9')).toBe(1)
     })
+  })
+})
+
+describe('correlateEvents — MAJOR-4 (silent rule errors are now logged + counted)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    findManyMock.mockReset()
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('logs the rule name and error when a rule throws, and keeps running others', async () => {
+    // First call (failing rule) — throw. Second call (healthy rule) — return [].
+    findManyMock
+      .mockRejectedValueOnce(new Error('boom: bad regex'))
+      .mockResolvedValueOnce([])
+
+    const rules: NamedRule[] = [
+      {
+        name: 'broken_pattern',
+        params: { type: 'pattern', regex: '(', field: 'title', window: 60 },
+      },
+      {
+        name: 'healthy_pattern',
+        params: { type: 'pattern', regex: 'foo', field: 'title', window: 60 },
+      },
+    ]
+
+    const result = await correlateEvents('env-1', new Date(), rules)
+    expect(result.errorCount).toBe(1)
+    expect(result.erroredRules).toEqual(['broken_pattern'])
+    // Healthy rule still ran (findMany called twice — once per rule).
+    expect(findManyMock).toHaveBeenCalledTimes(2)
+    // Error log mentions the rule name and env id.
+    const logged = String(errorSpy.mock.calls[0]?.[0] ?? '')
+    expect(logged).toContain('broken_pattern')
+    expect(logged).toContain('env-1')
+  })
+
+  it('reports zero errors and does not log when every rule succeeds', async () => {
+    findManyMock.mockResolvedValue([])
+    const result = await correlateEvents('env-1', new Date(), [
+      {
+        name: 'rule_a',
+        params: { type: 'pattern', regex: 'x', field: 'title', window: 60 },
+      },
+    ])
+    expect(result.errorCount).toBe(0)
+    expect(result.erroredRules).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('still accepts the legacy bare-RuleParams[] shape (back-compat)', async () => {
+    findManyMock.mockResolvedValue([])
+    const result = await correlateEvents('env-1', new Date(), [
+      { type: 'pattern', regex: 'x', field: 'title', window: 60 },
+    ])
+    // No rule name supplied → synthetic unnamed_pattern; no error path hit.
+    expect(result.errorCount).toBe(0)
   })
 })

--- a/apps/web/src/lib/security/rule-engine.test.ts
+++ b/apps/web/src/lib/security/rule-engine.test.ts
@@ -14,6 +14,9 @@ vi.mock('@/lib/db', () => ({
 import {
   extractGroupValue,
   correlateEvents,
+  shouldRateLimitRule,
+  recordRuleIncident,
+  _resetRuleRateLimitsForTests,
   type NamedRule,
 } from './rule-engine'
 
@@ -162,5 +165,98 @@ describe('correlateEvents — MAJOR-4 (silent rule errors are now logged + count
     ])
     // No rule name supplied → synthetic unnamed_pattern; no error path hit.
     expect(result.errorCount).toBe(0)
+  })
+})
+
+describe('per-rule rate limit — MAJOR-2 (R4: poison-rule cap)', () => {
+  const originalMax = process.env.SIEM_RULE_RATE_LIMIT_MAX
+  const originalWindow = process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS
+
+  beforeEach(() => {
+    findManyMock.mockReset()
+    _resetRuleRateLimitsForTests()
+  })
+  afterEach(() => {
+    if (originalMax === undefined) delete process.env.SIEM_RULE_RATE_LIMIT_MAX
+    else process.env.SIEM_RULE_RATE_LIMIT_MAX = originalMax
+    if (originalWindow === undefined) delete process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS
+    else process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS = originalWindow
+    _resetRuleRateLimitsForTests()
+  })
+
+  it('does not rate-limit a rule that has never produced an incident', () => {
+    expect(shouldRateLimitRule('env-1', 'brute_force')).toBe(false)
+  })
+
+  it('rate-limits a rule once it exceeds the per-window cap', () => {
+    process.env.SIEM_RULE_RATE_LIMIT_MAX = '3'
+    process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS = '60000'
+    const t0 = 1_000_000
+
+    recordRuleIncident('env-1', 'brute_force', t0)
+    recordRuleIncident('env-1', 'brute_force', t0 + 100)
+    expect(shouldRateLimitRule('env-1', 'brute_force', t0 + 200)).toBe(false)
+
+    recordRuleIncident('env-1', 'brute_force', t0 + 300)
+    // Now at 3 incidents within a 60s window → next check trips the cap.
+    expect(shouldRateLimitRule('env-1', 'brute_force', t0 + 400)).toBe(true)
+  })
+
+  it('isolates rate-limit buckets per (env, rule) pair', () => {
+    process.env.SIEM_RULE_RATE_LIMIT_MAX = '2'
+    process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS = '60000'
+    const t0 = 1_000_000
+
+    recordRuleIncident('env-1', 'brute_force', t0)
+    recordRuleIncident('env-1', 'brute_force', t0 + 100)
+    expect(shouldRateLimitRule('env-1', 'brute_force', t0 + 200)).toBe(true)
+
+    // Different rule on the same env — fresh bucket.
+    expect(shouldRateLimitRule('env-1', 'port_scan', t0 + 200)).toBe(false)
+    // Same rule on a different env — fresh bucket.
+    expect(shouldRateLimitRule('env-2', 'brute_force', t0 + 200)).toBe(false)
+  })
+
+  it('auto-resets the bucket once the window elapses', () => {
+    process.env.SIEM_RULE_RATE_LIMIT_MAX = '1'
+    process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS = '60000'
+    const t0 = 1_000_000
+
+    recordRuleIncident('env-1', 'noisy', t0)
+    expect(shouldRateLimitRule('env-1', 'noisy', t0 + 1000)).toBe(true)
+    // 61s later — window has elapsed; bucket clears on the next check.
+    expect(shouldRateLimitRule('env-1', 'noisy', t0 + 61_000)).toBe(false)
+  })
+
+  it('correlateEvents skips a rule already over its cap and logs a warning', async () => {
+    process.env.SIEM_RULE_RATE_LIMIT_MAX = '1'
+    process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS = '60000'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    findManyMock.mockResolvedValue([])
+
+    // Pre-load the bucket so the rule is over its cap before the call.
+    recordRuleIncident('env-1', 'poison_rule')
+    recordRuleIncident('env-1', 'poison_rule')
+
+    const rules: NamedRule[] = [
+      {
+        name: 'poison_rule',
+        params: { type: 'pattern', regex: 'x', field: 'title', window: 60 },
+      },
+      {
+        name: 'healthy_rule',
+        params: { type: 'pattern', regex: 'y', field: 'title', window: 60 },
+      },
+    ]
+
+    const result = await correlateEvents('env-1', new Date(), rules)
+    // The poison rule was skipped (no findMany call for it); the healthy
+    // rule still ran (exactly one findMany call).
+    expect(findManyMock).toHaveBeenCalledTimes(1)
+    expect(result.errorCount).toBe(0)
+    const warned = String(warnSpy.mock.calls[0]?.[0] ?? '')
+    expect(warned).toContain('poison_rule')
+    expect(warned).toContain('rate-limited')
+    warnSpy.mockRestore()
   })
 })

--- a/apps/web/src/lib/security/rule-engine.test.ts
+++ b/apps/web/src/lib/security/rule-engine.test.ts
@@ -260,3 +260,100 @@ describe('per-rule rate limit — MAJOR-2 (R4: poison-rule cap)', () => {
     warnSpy.mockRestore()
   })
 })
+
+describe('extractGroupValue — virtual attackerKey (BLOCK-2, PR #408)', () => {
+  it('prefers the top-level attackerKey column when present', () => {
+    const event = { attackerKey: '10.0.0.1', rawEvent: { source: { ip: '1.2.3.4' } } }
+    expect(extractGroupValue(event, 'attackerKey')).toBe('10.0.0.1')
+  })
+
+  it('falls back to rawEvent.payload.value (CrowdSec)', () => {
+    const event = { rawEvent: { payload: { value: '203.0.113.7', duration: '4h' } } }
+    expect(extractGroupValue(event, 'attackerKey')).toBe('203.0.113.7')
+  })
+
+  it('falls back to rawEvent.alert.srcip (Wazuh)', () => {
+    const event = { rawEvent: { alert: { srcip: '198.51.100.5' } } }
+    expect(extractGroupValue(event, 'attackerKey')).toBe('198.51.100.5')
+  })
+
+  it('falls back to rawEvent.source_ip (ELK)', () => {
+    const event = { rawEvent: { source_ip: '192.0.2.10' } }
+    expect(extractGroupValue(event, 'attackerKey')).toBe('192.0.2.10')
+  })
+
+  it('falls back to rawEvent.cli.ip (ntopng)', () => {
+    const event = { rawEvent: { cli: { ip: '203.0.113.99' } } }
+    expect(extractGroupValue(event, 'attackerKey')).toBe('203.0.113.99')
+  })
+
+  it('returns null when no probe path resolves', () => {
+    const event = { rawEvent: { other: 'value' } }
+    expect(extractGroupValue(event, 'attackerKey')).toBeNull()
+  })
+
+  it('clusters mixed-source events that share an attacker IP', () => {
+    // BLOCK-2 regression: 6 events across CrowdSec / Wazuh / ELK / ntopng
+    // all targeting 1.2.3.4 must produce a single attackerKey bucket so the
+    // brute-force threshold can fire across mixed sources.
+    const events = [
+      { rawEvent: { payload: { value: '1.2.3.4' } } },          // CrowdSec
+      { rawEvent: { source: { ip: '1.2.3.4' } } },              // CrowdSec
+      { rawEvent: { alert: { srcip: '1.2.3.4' } } },            // Wazuh
+      { rawEvent: { source_ip: '1.2.3.4' } },                   // ELK
+      { rawEvent: { src_ip: '1.2.3.4' } },                      // ELK
+      { rawEvent: { cli: { ip: '1.2.3.4' } } },                 // ntopng
+      { rawEvent: { alert: { srcip: '8.8.8.8' } } },            // other attacker
+    ]
+    const buckets = new Map<string, number>()
+    for (const e of events) {
+      const key = extractGroupValue(e, 'attackerKey') ?? 'unknown'
+      buckets.set(key, (buckets.get(key) ?? 0) + 1)
+    }
+    expect(buckets.get('1.2.3.4')).toBe(6) // ≥5 threshold met
+    expect(buckets.get('8.8.8.8')).toBe(1)
+  })
+})
+
+describe('runMalwareRule (BLOCK-3, PR #408) — type routing', () => {
+  beforeEach(() => {
+    findManyMock.mockReset()
+  })
+
+  it('fires only on events with type=wazuh_malware', async () => {
+    // Simulate the rule engine running just the malware rule. The Prisma
+    // findMany mock returns whatever shape the rule expects.
+    findManyMock.mockResolvedValue([
+      {
+        id: 'a',
+        environmentId: 'env-1',
+        type: 'wazuh_malware',
+        severity: 100,
+        rawEvent: { srcip: '1.2.3.4', hostname: 'host-x' },
+        title: 'Malware detected',
+      },
+    ])
+    const rules: NamedRule[] = [
+      { name: 'malware', params: { type: 'malware', ruleLevel: 10, field: 'severity' } },
+    ]
+    const result = await correlateEvents('env-1', new Date(), rules)
+    expect(result.drafts).toHaveLength(1)
+    expect(result.drafts[0].ruleName).toBe('malware')
+    expect(result.drafts[0].attackerKey).toBe('1.2.3.4')
+  })
+
+  it('does not fire when the only events are type=wazuh_alert (non-malware)', async () => {
+    // The DB filter `type: 'wazuh_malware'` excludes wazuh_alert rows; the
+    // mocked findMany echoes whatever filter was passed in by returning
+    // the empty array when the filter would match nothing.
+    findManyMock.mockImplementation((args: { where?: { type?: string } }) => {
+      if (args.where?.type !== 'wazuh_malware') return []
+      return []
+    })
+    const rules: NamedRule[] = [
+      { name: 'malware', params: { type: 'malware', ruleLevel: 10, field: 'severity' } },
+    ]
+    const result = await correlateEvents('env-1', new Date(), rules)
+    expect(result.drafts).toHaveLength(0)
+  })
+})

--- a/apps/web/src/lib/security/rule-engine.test.ts
+++ b/apps/web/src/lib/security/rule-engine.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/db', () => ({ prisma: {} }))
+
+import { extractGroupValue } from './rule-engine'
+
+describe('extractGroupValue (BLOCK-1b regression — brute-force groups by attacker IP)', () => {
+  describe('top-level column access', () => {
+    it('returns the value of a top-level column', () => {
+      const event = { source: 'crowdsec', severity: 70 }
+      expect(extractGroupValue(event, 'source')).toBe('crowdsec')
+    })
+
+    it('coerces non-string values to string', () => {
+      const event = { severity: 70 }
+      expect(extractGroupValue(event, 'severity')).toBe('70')
+    })
+
+    it('returns null for missing top-level field', () => {
+      const event = { source: 'crowdsec' }
+      expect(extractGroupValue(event, 'nonexistent')).toBeNull()
+    })
+  })
+
+  describe('rawEvent JSON path (the fix)', () => {
+    it('extracts a one-level rawEvent.<field> path', () => {
+      const event = {
+        source: 'crowdsec',
+        rawEvent: { srcip: '203.0.113.7', user: 'root' },
+      }
+      expect(extractGroupValue(event, 'rawEvent.srcip')).toBe('203.0.113.7')
+    })
+
+    it('extracts a multi-level dot path', () => {
+      const event = {
+        rawEvent: { alert: { srcip: '198.51.100.5', dest: 'host-a' } },
+      }
+      expect(extractGroupValue(event, 'rawEvent.alert.srcip')).toBe('198.51.100.5')
+    })
+
+    it('returns null when an intermediate segment is missing', () => {
+      const event = { rawEvent: { srcip: '1.2.3.4' } }
+      expect(extractGroupValue(event, 'rawEvent.alert.srcip')).toBeNull()
+    })
+
+    it('returns null when the leaf is missing', () => {
+      const event = { rawEvent: { other: 'value' } }
+      expect(extractGroupValue(event, 'rawEvent.srcip')).toBeNull()
+    })
+
+    it('returns null when an intermediate segment is not an object', () => {
+      const event = { rawEvent: 'not-an-object' }
+      expect(extractGroupValue(event, 'rawEvent.srcip')).toBeNull()
+    })
+  })
+
+  describe('groupBy semantics for brute-force rule', () => {
+    // Brute-force scenario: 5 events from same attacker IP, two ingestion
+    // sources. The OLD buggy seed grouped by `source` — bucketing 3 CrowdSec
+    // events together and 2 Wazuh events separately, missing the 5-from-same-IP
+    // threshold. The FIX groups by `rawEvent.srcip` — all 5 cluster correctly.
+    const events = [
+      { source: 'crowdsec', rawEvent: { srcip: '203.0.113.7' } },
+      { source: 'crowdsec', rawEvent: { srcip: '203.0.113.7' } },
+      { source: 'crowdsec', rawEvent: { srcip: '203.0.113.7' } },
+      { source: 'wazuh',    rawEvent: { srcip: '203.0.113.7' } },
+      { source: 'wazuh',    rawEvent: { srcip: '203.0.113.7' } },
+      { source: 'crowdsec', rawEvent: { srcip: '198.51.100.9' } }, // different attacker
+    ]
+
+    function groupBy(field: string): Map<string, number> {
+      const counts = new Map<string, number>()
+      for (const e of events) {
+        const key = extractGroupValue(e, field) ?? 'unknown'
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+      return counts
+    }
+
+    it('buggy seed: grouping by `source` over-aggregates across attackers', () => {
+      const counts = groupBy('source')
+      expect(counts.get('crowdsec')).toBe(4)
+      expect(counts.get('wazuh')).toBe(2)
+    })
+
+    it('fixed seed: grouping by `rawEvent.srcip` clusters by attacker IP', () => {
+      const counts = groupBy('rawEvent.srcip')
+      expect(counts.get('203.0.113.7')).toBe(5) // ≥5 threshold met
+      expect(counts.get('198.51.100.9')).toBe(1)
+    })
+  })
+})

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -9,6 +9,20 @@ import { prisma } from '@/lib/db'
 import { type NormalizedSecurityEvent } from './types'
 import { type IncidentDraft } from './types'
 
+// Mirror of GLOBAL_BUCKET_ID from `../../workers/security-correlator.ts`.
+// Imported here as a string literal to avoid a circular dependency between
+// the rule engine and the worker. Must stay in sync.
+const GLOBAL_BUCKET_ID = '__global__'
+
+/**
+ * Build the `environmentId` filter for a Prisma where-clause. The synthetic
+ * GLOBAL_BUCKET_ID sentinel is translated to `null` so orphan events (no env)
+ * are processed by global rules (BLOCK-1, PR #408).
+ */
+function envIdFilter(envId: string): string | null {
+  return envId === GLOBAL_BUCKET_ID ? null : envId
+}
+
 // ── Rule types ────────────────────────────────────────────────────────────────
 
 /**
@@ -225,9 +239,14 @@ export async function correlateEvents(
 /**
  * Resolve a groupBy / field selector against a SecurityEvent row.
  *
- * Supports two forms:
+ * Supports three forms:
+ *   - "attackerKey" — virtual extractor that probes the most common attacker
+ *     identifiers across CrowdSec / Wazuh / ELK / ntopng raw payloads. This
+ *     is the preferred groupBy for rules that need a source-agnostic attacker
+ *     identity (e.g. brute-force across mixed sources). See BLOCK-2, PR #408.
  *   - "source" — a top-level column on the SecurityEvent row
- *   - "rawEvent.srcip" or "rawEvent.alert.srcip" — a dot-path into the rawEvent JSON
+ *   - "rawEvent.srcip" or "rawEvent.alert.srcip" — a dot-path into the
+ *     rawEvent JSON
  *
  * Returns the string-coerced value, or `null` if the path doesn't resolve.
  *
@@ -236,6 +255,40 @@ export async function correlateEvents(
 export function extractGroupValue(event: unknown, field: string): string | null {
   if (event === null || typeof event !== 'object') return null
   const evt = event as Record<string, unknown>
+
+  // Virtual `attackerKey` extractor — covers known shapes:
+  //   CrowdSec: rawEvent.payload.value (range/ip scope) or rawEvent.source.ip
+  //   Wazuh:    rawEvent.alert.srcip
+  //   ELK:      rawEvent.source_ip / rawEvent.src_ip
+  //   ntopng:   rawEvent.cli.ip
+  // First non-null match wins. Falls back to the event's top-level
+  // `attackerKey` column for future schema upgrades.
+  if (field === 'attackerKey') {
+    const directColumn = evt['attackerKey']
+    if (typeof directColumn === 'string' && directColumn.length > 0) return directColumn
+
+    const raw = evt['rawEvent']
+    if (raw === null || typeof raw !== 'object') return null
+    const r = raw as Record<string, unknown>
+    const probe = (path: string[]): string | null => {
+      let cursor: unknown = r
+      for (const p of path) {
+        if (cursor === null || typeof cursor !== 'object') return null
+        cursor = (cursor as Record<string, unknown>)[p]
+      }
+      return typeof cursor === 'string' && cursor.length > 0 ? cursor : null
+    }
+    return (
+      probe(['payload', 'value']) ??
+      probe(['source', 'ip']) ??
+      probe(['alert', 'srcip']) ??
+      probe(['srcip']) ??
+      probe(['source_ip']) ??
+      probe(['src_ip']) ??
+      probe(['cli', 'ip']) ??
+      null
+    )
+  }
 
   // Top-level column access (no dot)
   if (!field.includes('.')) {
@@ -267,7 +320,7 @@ async function runThresholdRule(
   // Find the most recent incident for this rule + group to avoid duplicate incidents
   const events = await prisma.securityEvent.findMany({
     where: {
-      environmentId: envId,
+      environmentId: envIdFilter(envId),
       createdAt: { gte: since },
     },
     orderBy: { createdAt: 'desc' },
@@ -335,7 +388,7 @@ async function runPatternRule(
 ): Promise<IncidentDraft | null> {
   const events = await prisma.securityEvent.findMany({
     where: {
-      environmentId: envId,
+      environmentId: envIdFilter(envId),
       createdAt: { gte: since },
     },
     orderBy: { createdAt: 'desc' },
@@ -380,7 +433,7 @@ async function runMalwareRule(
 ): Promise<IncidentDraft | null> {
   const events = await prisma.securityEvent.findMany({
     where: {
-      environmentId: envId,
+      environmentId: envIdFilter(envId),
       createdAt: { gte: since },
       type: 'wazuh_malware',
       severity: { gte: params.ruleLevel * 10 }, // convert level to severity scale
@@ -420,7 +473,7 @@ async function runProcessRule(
 ): Promise<IncidentDraft | null> {
   const events = await prisma.securityEvent.findMany({
     where: {
-      environmentId: envId,
+      environmentId: envIdFilter(envId),
       createdAt: { gte: since },
     },
     orderBy: { createdAt: 'desc' },

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -44,6 +44,88 @@ export interface CorrelationRunResult {
   erroredRules: string[]
 }
 
+// ── Per-rule rate limit (R4 / MAJOR-2) ────────────────────────────────────────
+
+/**
+ * In-memory per-rule rate-limit state. Keys are `<envId>:<ruleName>`. The
+ * tracker enforces the R4 risk-register requirement (SIEM_PLAN.md): a poison
+ * rule that produces many incidents in a short window is skipped for the
+ * remainder of the window so it cannot starve other rules, flood the
+ * incident table, or spin the correlator in a tight loop.
+ *
+ * Defaults are intentionally generous (per-rule cap higher than the
+ * worker's global `MAX_INCIDENTS_PER_RUN` cap of 10) so a healthy rule that
+ * happens to fire repeatedly across runs is not penalised. The cap is
+ * tunable via `SIEM_RULE_RATE_LIMIT_MAX` and `SIEM_RULE_RATE_LIMIT_WINDOW_MS`.
+ */
+const DEFAULT_RULE_MAX_INCIDENTS = 20
+const DEFAULT_RULE_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
+
+interface RuleBucket {
+  count: number
+  windowStart: number
+}
+
+const ruleRateLimitState = new Map<string, RuleBucket>()
+
+function getRuleRateLimitConfig(): { max: number; windowMs: number } {
+  const maxRaw = Number(process.env.SIEM_RULE_RATE_LIMIT_MAX)
+  const windowRaw = Number(process.env.SIEM_RULE_RATE_LIMIT_WINDOW_MS)
+  return {
+    max: Number.isFinite(maxRaw) && maxRaw > 0 ? maxRaw : DEFAULT_RULE_MAX_INCIDENTS,
+    windowMs:
+      Number.isFinite(windowRaw) && windowRaw > 0
+        ? windowRaw
+        : DEFAULT_RULE_WINDOW_MS,
+  }
+}
+
+/**
+ * Returns true if the rule has exceeded its per-window incident cap and
+ * should be skipped this run. The bucket auto-resets once the window
+ * elapses. Exported for unit tests.
+ */
+export function shouldRateLimitRule(
+  envId: string,
+  ruleName: string,
+  now: number = Date.now(),
+): boolean {
+  const { max, windowMs } = getRuleRateLimitConfig()
+  const key = `${envId}:${ruleName}`
+  const bucket = ruleRateLimitState.get(key)
+  if (!bucket) return false
+  if (now - bucket.windowStart >= windowMs) {
+    ruleRateLimitState.delete(key)
+    return false
+  }
+  return bucket.count >= max
+}
+
+/**
+ * Record that a rule produced an incident, advancing its rate-limit bucket.
+ * Should be called by the correlator after each incident is persisted (not
+ * just drafted) so the cap reflects committed output. Exported for tests.
+ */
+export function recordRuleIncident(
+  envId: string,
+  ruleName: string,
+  now: number = Date.now(),
+): void {
+  const { windowMs } = getRuleRateLimitConfig()
+  const key = `${envId}:${ruleName}`
+  const bucket = ruleRateLimitState.get(key)
+  if (!bucket || now - bucket.windowStart >= windowMs) {
+    ruleRateLimitState.set(key, { count: 1, windowStart: now })
+    return
+  }
+  bucket.count += 1
+}
+
+/** Test helper: clear all rate-limit state. */
+export function _resetRuleRateLimitsForTests(): void {
+  ruleRateLimitState.clear()
+}
+
 function isNamedRuleArray(
   rules: ReadonlyArray<RuleParams | NamedRule>,
 ): rules is NamedRule[] {
@@ -84,6 +166,19 @@ export async function correlateEvents(
       }))
 
   for (const { name, params } of named) {
+    // R4 / MAJOR-2 — per-rule rate limit. A poison rule (e.g. one matching
+    // every event) is capped at SIEM_RULE_RATE_LIMIT_MAX incidents per
+    // window. The bucket is fed by `recordRuleIncident` from the worker
+    // after each persisted incident.
+    if (shouldRateLimitRule(envId, name)) {
+      const cfg = getRuleRateLimitConfig()
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[siem] correlation rule "${name}" rate-limited for env ${envId}: ` +
+          `exceeded ${cfg.max} incidents in the last ${cfg.windowMs}ms window. Skipping.`,
+      )
+      continue
+    }
     try {
       let result: IncidentDraft | null = null
       switch (params.type) {

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -72,6 +72,39 @@ export async function correlateEvents(
   return drafts
 }
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a groupBy / field selector against a SecurityEvent row.
+ *
+ * Supports two forms:
+ *   - "source" — a top-level column on the SecurityEvent row
+ *   - "rawEvent.srcip" or "rawEvent.alert.srcip" — a dot-path into the rawEvent JSON
+ *
+ * Returns the string-coerced value, or `null` if the path doesn't resolve.
+ *
+ * Exported for unit tests; used by `runThresholdRule` to bucket events.
+ */
+export function extractGroupValue(event: unknown, field: string): string | null {
+  if (event === null || typeof event !== 'object') return null
+  const evt = event as Record<string, unknown>
+
+  // Top-level column access (no dot)
+  if (!field.includes('.')) {
+    const v = evt[field]
+    return v == null ? null : String(v)
+  }
+
+  // Dot-path traversal. First segment must be a top-level column.
+  const parts = field.split('.')
+  let cursor: unknown = evt[parts[0]]
+  for (let i = 1; i < parts.length; i++) {
+    if (cursor === null || typeof cursor !== 'object') return null
+    cursor = (cursor as Record<string, unknown>)[parts[i]]
+  }
+  return cursor == null ? null : String(cursor)
+}
+
 // ── Threshold rule ────────────────────────────────────────────────────────────
 
 /**
@@ -92,10 +125,19 @@ async function runThresholdRule(
     orderBy: { createdAt: 'desc' },
   })
 
-  // Group events by the specified fields
+  // Group events by the specified fields.
+  //
+  // A groupBy entry may name a top-level SecurityEvent column (e.g. "source")
+  // or a JSON path into the rawEvent payload using dot notation (e.g.
+  // "rawEvent.srcip", "rawEvent.alert.srcip"). This is required for the
+  // brute-force rule: the attacker IP lives in the raw payload, not in a
+  // first-class column — grouping by "source" would bucket every CrowdSec
+  // event together regardless of attacker.
   const grouped = new Map<string, typeof events>()
   for (const event of events) {
-    const groupKey = params.groupBy.map(f => (event as Record<string, unknown>)[f] ?? 'unknown').join(':')
+    const groupKey = params.groupBy
+      .map(f => extractGroupValue(event, f) ?? 'unknown')
+      .join(':')
     if (!grouped.has(groupKey)) grouped.set(groupKey, [])
     grouped.get(groupKey)!.push(event)
   }

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -24,52 +24,105 @@ export type RuleParams =
 // ── Correlation ───────────────────────────────────────────────────────────────
 
 /**
+ * Input to {@link correlateEvents}. Carries a rule name alongside the params
+ * so that downstream code can log which rule failed and attribute incidents
+ * to a named rule.
+ *
+ * `correlateEvents` also accepts the legacy bare-`RuleParams[]` shape for
+ * backward compatibility — those entries get an `unnamed_<type>` rule name.
+ */
+export interface NamedRule {
+  name: string
+  params: RuleParams
+}
+
+export interface CorrelationRunResult {
+  drafts: IncidentDraft[]
+  /** Number of rules that threw during execution (MAJOR-4). */
+  errorCount: number
+  /** Names of rules that errored (best-effort; may include `unnamed_<type>`). */
+  erroredRules: string[]
+}
+
+function isNamedRuleArray(
+  rules: ReadonlyArray<RuleParams | NamedRule>,
+): rules is NamedRule[] {
+  return rules.length === 0
+    ? false
+    : typeof (rules[0] as NamedRule).name === 'string' &&
+        (rules[0] as NamedRule).params !== undefined
+}
+
+/**
  * Run all enabled correlation rules against recent events.
  *
- * Returns a list of IncidentDrafts — one per rule match.
+ * Accepts either:
+ *  - `NamedRule[]` (preferred) — preserves rule names for logging and
+ *    incident attribution.
+ *  - `RuleParams[]` (legacy) — kept for backward compatibility; rules are
+ *    given a synthetic `unnamed_<type>` name.
+ *
+ * Returns `{ drafts, errorCount, erroredRules }`. Rule execution failures
+ * are still non-blocking — a single bad rule must not stop the worker — but
+ * they are now logged with the rule name (MAJOR-4) and counted so callers
+ * can surface a health signal. The previous implementation used a bare
+ * `catch {}` so a broken rule failed silently every 30s with no diagnostic.
  */
 export async function correlateEvents(
   envId: string,
   since: Date,
-  ruleParams: RuleParams[]
-): Promise<IncidentDraft[]> {
+  rules: ReadonlyArray<RuleParams | NamedRule>,
+): Promise<CorrelationRunResult> {
   const drafts: IncidentDraft[] = []
+  const erroredRules: string[] = []
 
-  for (const params of ruleParams) {
+  const named: NamedRule[] = isNamedRuleArray(rules)
+    ? rules
+    : (rules as RuleParams[]).map((p) => ({
+        name: `unnamed_${p.type}`,
+        params: p,
+      }))
+
+  for (const { name, params } of named) {
     try {
+      let result: IncidentDraft | null = null
       switch (params.type) {
-        case 'threshold': {
-          const result = await runThresholdRule(envId, params, since)
-          if (result) drafts.push(result)
+        case 'threshold':
+          result = await runThresholdRule(envId, params, since)
           break
-        }
-        case 'pattern': {
-          const result = await runPatternRule(envId, params, since)
-          if (result) drafts.push(result)
+        case 'pattern':
+          result = await runPatternRule(envId, params, since)
           break
-        }
-        case 'malware': {
-          const result = await runMalwareRule(envId, params, since)
-          if (result) drafts.push(result)
+        case 'malware':
+          result = await runMalwareRule(envId, params, since)
           break
-        }
-        case 'process': {
-          const result = await runProcessRule(envId, params, since)
-          if (result) drafts.push(result)
+        case 'process':
+          result = await runProcessRule(envId, params, since)
           break
-        }
-        case 'composite': {
-          const result = await runCompositeRule(envId, params, since)
-          if (result) drafts.push(result)
+        case 'composite':
+          result = await runCompositeRule(envId, params, since)
           break
-        }
       }
-    } catch {
-      // Rule execution failures are non-blocking
+      if (result) {
+        // Attribute to the rule name from the caller (overrides the
+        // synthetic ruleName some sub-runners build from regex / fields).
+        result.ruleName = name
+        drafts.push(result)
+      }
+    } catch (err) {
+      // MAJOR-4: previously this was a silent `catch {}` — a broken rule
+      // would fail every 30s with no signal. We now log with the rule name
+      // + error message and count the failure so callers can alert.
+      erroredRules.push(name)
+      // eslint-disable-next-line no-console
+      console.error(
+        `[siem] correlation rule "${name}" failed for env ${envId}:`,
+        err instanceof Error ? `${err.name}: ${err.message}` : err,
+      )
     }
   }
 
-  return drafts
+  return { drafts, errorCount: erroredRules.length, erroredRules }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -1,0 +1,320 @@
+/**
+ * Security correlation rule engine.
+ *
+ * Interprets CorrelationRule.params to group SecurityEvents into Incidents.
+ * Each rule defines a pattern-matching strategy.
+ */
+
+import { prisma } from '@/lib/db'
+import { type NormalizedSecurityEvent } from './types'
+import { type IncidentDraft } from './types'
+
+// ── Rule types ────────────────────────────────────────────────────────────────
+
+/**
+ * Rule parameter types supported by the correlation engine.
+ */
+export type RuleParams =
+  | { type: 'threshold'; field: string; op: 'gte' | 'lte' | 'eq'; value: number; window: number; groupBy: string[]; maxEvents?: number }
+  | { type: 'pattern'; regex: string; field: string; window: number }
+  | { type: 'malware'; ruleLevel: number; field: string }
+  | { type: 'process'; commandPattern: string; window: number }
+  | { type: 'composite'; rules: RuleParams[]; combine: 'all' | 'any'; window: number }
+
+// ── Correlation ───────────────────────────────────────────────────────────────
+
+/**
+ * Run all enabled correlation rules against recent events.
+ *
+ * Returns a list of IncidentDrafts — one per rule match.
+ */
+export async function correlateEvents(
+  envId: string,
+  since: Date,
+  ruleParams: RuleParams[]
+): Promise<IncidentDraft[]> {
+  const drafts: IncidentDraft[] = []
+
+  for (const params of ruleParams) {
+    try {
+      switch (params.type) {
+        case 'threshold': {
+          const result = await runThresholdRule(envId, params, since)
+          if (result) drafts.push(result)
+          break
+        }
+        case 'pattern': {
+          const result = await runPatternRule(envId, params, since)
+          if (result) drafts.push(result)
+          break
+        }
+        case 'malware': {
+          const result = await runMalwareRule(envId, params, since)
+          if (result) drafts.push(result)
+          break
+        }
+        case 'process': {
+          const result = await runProcessRule(envId, params, since)
+          if (result) drafts.push(result)
+          break
+        }
+        case 'composite': {
+          const result = await runCompositeRule(envId, params, since)
+          if (result) drafts.push(result)
+          break
+        }
+      }
+    } catch {
+      // Rule execution failures are non-blocking
+    }
+  }
+
+  return drafts
+}
+
+// ── Threshold rule ────────────────────────────────────────────────────────────
+
+/**
+ * Threshold rule: count events matching a pattern within a time window.
+ * Example: ≥5 failed logins from same IP within 5 minutes → brute-force incident.
+ */
+async function runThresholdRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'threshold' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  // Find the most recent incident for this rule + group to avoid duplicate incidents
+  const events = await prisma.securityEvent.findMany({
+    where: {
+      environmentId: envId,
+      createdAt: { gte: since },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  // Group events by the specified fields
+  const grouped = new Map<string, typeof events>()
+  for (const event of events) {
+    const groupKey = params.groupBy.map(f => (event as Record<string, unknown>)[f] ?? 'unknown').join(':')
+    if (!grouped.has(groupKey)) grouped.set(groupKey, [])
+    grouped.get(groupKey)!.push(event)
+  }
+
+  let bestGroup: { key: string; events: typeof events; severity: number } | null = null
+
+  for (const [key, group] of grouped) {
+    const count = group.length
+    if (count < (params.value ?? 5)) continue // threshold not met
+
+    // Calculate severity as max of group events
+    const maxSeverity = Math.max(...group.map(e => e.severity))
+    const severity = params.op === 'gte'
+      ? Math.min(100, maxSeverity + (count - params.value) * 5)
+      : maxSeverity
+
+    if (!bestGroup || severity > bestGroup.severity) {
+      bestGroup = { key, events: group, severity }
+    }
+  }
+
+  if (!bestGroup) return null
+
+  const ruleName = `threshold_${params.field}_${params.groupBy.join('+')}`
+
+  return {
+    severity: bestGroup.severity,
+    rootCauseSummary: `${bestGroup.events.length} ${params.field} events in ${params.window}s window`,
+    attackerKey: bestGroup.key.split(':')[0] ?? '',
+    hostKey: bestGroup.key.split(':').slice(1).join(':') || undefined,
+    eventIds: bestGroup.events.map(e => e.id),
+    ruleName,
+    environmentId: envId,
+  }
+}
+
+// ── Pattern rule ──────────────────────────────────────────────────────────────
+
+/**
+ * Pattern rule: match events against a regex within a time window.
+ * Example: port scan from ntopng (many ports hit from same IP).
+ */
+async function runPatternRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'pattern' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  const events = await prisma.securityEvent.findMany({
+    where: {
+      environmentId: envId,
+      createdAt: { gte: since },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  let matched: typeof events = []
+  let regex: RegExp
+
+  try {
+    regex = new RegExp(params.regex)
+  } catch {
+    return null
+  }
+
+  for (const event of events) {
+    const fieldValue = (event as Record<string, unknown>)[params.field]
+    if (typeof fieldValue === 'string' && regex.test(fieldValue)) {
+      matched.push(event)
+    }
+  }
+
+  if (matched.length === 0) return null
+
+  return {
+    severity: 60,
+    rootCauseSummary: `Pattern "${params.regex}" matched ${matched.length} events`,
+    eventIds: matched.slice(0, 50).map(e => e.id), // cap at 50 events
+    ruleName: `pattern_${params.regex}`,
+    environmentId: envId,
+  }
+}
+
+// ── Malware rule ──────────────────────────────────────────────────────────────
+
+/**
+ * Malware rule: detect Wazuh alerts with rule.level >= threshold.
+ */
+async function runMalwareRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'malware' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  const events = await prisma.securityEvent.findMany({
+    where: {
+      environmentId: envId,
+      createdAt: { gte: since },
+      type: 'wazuh_malware',
+      severity: { gte: params.ruleLevel * 10 }, // convert level to severity scale
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 10,
+  })
+
+  if (events.length === 0) return null
+
+  const maxSeverity = Math.max(...events.map(e => e.severity))
+
+  const raw = events[0].rawEvent as Record<string, unknown>
+  const srcip = typeof raw.srcip === 'string' ? raw.srcip : null
+  const hostname = typeof raw.hostname === 'string' ? raw.hostname : null
+
+  return {
+    severity: maxSeverity,
+    rootCauseSummary: `Malware detection: ${events[0].title}`,
+    attackerKey: srcip,
+    hostKey: hostname ?? undefined,
+    eventIds: events.map(e => e.id),
+    ruleName: 'malware',
+    environmentId: envId,
+  }
+}
+
+// ── Process rule ──────────────────────────────────────────────────────────────
+
+/**
+ * Process rule: detect suspicious process execution.
+ */
+async function runProcessRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'process' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  const events = await prisma.securityEvent.findMany({
+    where: {
+      environmentId: envId,
+      createdAt: { gte: since },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  let matched: typeof events = []
+  try {
+    const regex = new RegExp(params.commandPattern)
+    for (const event of events) {
+      if (
+        typeof (event.rawEvent as Record<string, unknown>)?.cmd === 'string' &&
+        regex.test(String((event.rawEvent as Record<string, unknown>)?.cmd))
+      ) {
+        matched.push(event)
+      }
+    }
+  } catch {
+    return null
+  }
+
+  if (matched.length === 0) return null
+
+  return {
+    severity: 70,
+    rootCauseSummary: `Suspicious process: ${params.commandPattern}`,
+    eventIds: matched.slice(0, 20).map(e => e.id),
+    ruleName: `process_${params.commandPattern}`,
+    environmentId: envId,
+  }
+}
+
+// ── Composite rule ────────────────────────────────────────────────────────────
+
+/**
+ * Composite rule: run multiple sub-rules and combine results.
+ */
+async function runCompositeRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'composite' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  const results: IncidentDraft[] = []
+
+  for (const subRule of params.rules) {
+    const draft = await runSingleRule(envId, subRule, since)
+    if (draft) results.push(draft)
+  }
+
+  if (params.combine === 'all') {
+    // Only fire if ALL sub-rules matched
+    if (results.length < params.rules.length) return null
+  } else {
+    // 'any' — fire if ANY sub-rule matched
+    if (results.length === 0) return null
+  }
+
+  // Merge event IDs and take highest severity
+  const allEventIds = results.flatMap(r => r.eventIds)
+  const severity = Math.max(...results.map(r => r.severity))
+
+  return {
+    severity,
+    rootCauseSummary: `Composite rule matched: ${results.map(r => r.ruleName).join(', ')}`,
+    eventIds: allEventIds.slice(0, 100),
+    ruleName: 'composite',
+    environmentId: envId,
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Run a single rule of any type.
+ */
+async function runSingleRule(
+  envId: string,
+  params: RuleParams,
+  since: Date
+): Promise<IncidentDraft | null> {
+  switch (params.type) {
+    case 'threshold': return runThresholdRule(envId, params, since)
+    case 'pattern': return runPatternRule(envId, params, since)
+    case 'malware': return runMalwareRule(envId, params, since)
+    case 'process': return runProcessRule(envId, params, since)
+    case 'composite': return null // handled by runCompositeRule
+  }
+}

--- a/apps/web/src/lib/security/webhook-auth.test.ts
+++ b/apps/web/src/lib/security/webhook-auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createHmac } from 'crypto'
+
+// `webhook-auth.ts` imports `@/lib/db` for the idempotency-cache helper. The
+// pure HMAC + replay-window helpers don't touch prisma, so stub the import so
+// vitest can resolve the module without next.js path aliasing.
+vi.mock('@/lib/db', () => ({ prisma: {} }))
+
+import { verifyWebhookHmac, isWithinReplayWindow } from './webhook-auth'
+
+const secret = 'super-secret-key'
+const body = JSON.stringify({ event: 'login_failure', ip: '203.0.113.7' })
+
+function sign(payload: string, key = secret): string {
+  return `sha256=${createHmac('sha256', key).update(payload).digest('hex')}`
+}
+
+describe('verifyWebhookHmac (BLOCK-1 regression — timing-safe comparison)', () => {
+  it('returns true for a valid signature', () => {
+    expect(verifyWebhookHmac(secret, body, sign(body))).toBe(true)
+  })
+
+  it('returns false when signature header is missing', () => {
+    expect(verifyWebhookHmac(secret, body, null)).toBe(false)
+  })
+
+  it('returns false on a forged signature of the correct length', () => {
+    const valid = sign(body)
+    // Flip the final hex char to keep length identical but value wrong.
+    const tampered = valid.slice(0, -1) + (valid.endsWith('0') ? '1' : '0')
+    expect(verifyWebhookHmac(secret, body, tampered)).toBe(false)
+  })
+
+  it('returns false when signature uses the wrong secret', () => {
+    expect(verifyWebhookHmac(secret, body, sign(body, 'wrong-secret'))).toBe(false)
+  })
+
+  it('returns false on a length mismatch without throwing (timingSafeEqual length leak guard)', () => {
+    // Node.js crypto.timingSafeEqual throws on length mismatch; we must
+    // length-check first and return false. This regression guards against
+    // a future refactor that drops the length check.
+    expect(() => verifyWebhookHmac(secret, body, 'sha256=tooshort')).not.toThrow()
+    expect(verifyWebhookHmac(secret, body, 'sha256=tooshort')).toBe(false)
+  })
+
+  it('rejects a signature that differs only in case (HMAC hex is lowercase)', () => {
+    const valid = sign(body)
+    expect(verifyWebhookHmac(secret, body, valid.toUpperCase())).toBe(false)
+  })
+})
+
+describe('isWithinReplayWindow', () => {
+  it('returns true when there is no timestamp header', () => {
+    expect(isWithinReplayWindow(null)).toBe(true)
+  })
+
+  it('returns true for a recent ISO timestamp', () => {
+    const now = new Date().toISOString()
+    expect(isWithinReplayWindow(now)).toBe(true)
+  })
+
+  it('returns false for an ISO timestamp outside the replay window', () => {
+    const old = new Date(Date.now() - 60 * 60 * 1000).toISOString() // 1 hour ago
+    expect(isWithinReplayWindow(old)).toBe(false)
+  })
+})

--- a/apps/web/src/lib/security/webhook-auth.test.ts
+++ b/apps/web/src/lib/security/webhook-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createHmac } from 'crypto'
 
 // `webhook-auth.ts` imports `@/lib/db` for the idempotency-cache helper. The
@@ -6,7 +6,12 @@ import { createHmac } from 'crypto'
 // vitest can resolve the module without next.js path aliasing.
 vi.mock('@/lib/db', () => ({ prisma: {} }))
 
-import { verifyWebhookHmac, isWithinReplayWindow } from './webhook-auth'
+import {
+  verifyWebhookHmac,
+  isWithinReplayWindow,
+  isLoopbackWebhookRequest,
+  warnMissingWebhookSecret,
+} from './webhook-auth'
 
 const secret = 'super-secret-key'
 const body = JSON.stringify({ event: 'login_failure', ip: '203.0.113.7' })
@@ -62,5 +67,118 @@ describe('isWithinReplayWindow', () => {
   it('returns false for an ISO timestamp outside the replay window', () => {
     const old = new Date(Date.now() - 60 * 60 * 1000).toISOString() // 1 hour ago
     expect(isWithinReplayWindow(old)).toBe(false)
+  })
+})
+
+// Small helper so tests can build a request shape the same way the route does.
+function makeReq(opts: { ip?: string | null; xff?: string; xRealIp?: string }) {
+  const headers = new Headers()
+  if (opts.xff !== undefined) headers.set('x-forwarded-for', opts.xff)
+  if (opts.xRealIp !== undefined) headers.set('x-real-ip', opts.xRealIp)
+  return { ip: opts.ip ?? null, headers }
+}
+
+describe('isLoopbackWebhookRequest (MAJOR-1 — X-Forwarded-For hardening)', () => {
+  const originalEnv = process.env.WEBHOOK_TRUSTED_PROXY_IPS
+  beforeEach(() => {
+    delete process.env.WEBHOOK_TRUSTED_PROXY_IPS
+  })
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.WEBHOOK_TRUSTED_PROXY_IPS
+    else process.env.WEBHOOK_TRUSTED_PROXY_IPS = originalEnv
+  })
+
+  it('trusts a direct loopback peer (req.ip = 127.0.0.1)', () => {
+    expect(isLoopbackWebhookRequest(makeReq({ ip: '127.0.0.1' }))).toBe(true)
+  })
+
+  it('trusts an IPv6 loopback peer (::1)', () => {
+    expect(isLoopbackWebhookRequest(makeReq({ ip: '::1' }))).toBe(true)
+  })
+
+  it('trusts IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)', () => {
+    expect(isLoopbackWebhookRequest(makeReq({ ip: '::ffff:127.0.0.1' }))).toBe(true)
+  })
+
+  it('REFUSES a spoofed X-Forwarded-For when no proxy allow-list is set', () => {
+    // This is the core MAJOR-1 regression: the previous implementation
+    // accepted XFF unconditionally. We must reject it.
+    expect(
+      isLoopbackWebhookRequest(
+        makeReq({ ip: '203.0.113.10', xff: '127.0.0.1' })
+      )
+    ).toBe(false)
+  })
+
+  it('REFUSES a spoofed X-Real-IP when no proxy allow-list is set', () => {
+    expect(
+      isLoopbackWebhookRequest(
+        makeReq({ ip: '203.0.113.10', xRealIp: '127.0.0.1' })
+      )
+    ).toBe(false)
+  })
+
+  it('refuses when peer IP is missing and no allow-list is set', () => {
+    // No req.ip + no allow-list means we cannot establish trust.
+    expect(
+      isLoopbackWebhookRequest(makeReq({ ip: null, xff: '127.0.0.1' }))
+    ).toBe(false)
+  })
+
+  it('trusts XFF=127.0.0.1 ONLY when the direct peer is an allow-listed proxy', () => {
+    process.env.WEBHOOK_TRUSTED_PROXY_IPS = '10.0.0.5'
+    expect(
+      isLoopbackWebhookRequest(makeReq({ ip: '10.0.0.5', xff: '127.0.0.1' }))
+    ).toBe(true)
+  })
+
+  it('refuses XFF=127.0.0.1 when the peer is NOT in the allow-list', () => {
+    process.env.WEBHOOK_TRUSTED_PROXY_IPS = '10.0.0.5'
+    expect(
+      isLoopbackWebhookRequest(makeReq({ ip: '203.0.113.10', xff: '127.0.0.1' }))
+    ).toBe(false)
+  })
+
+  it('takes only the left-most XFF entry when peer is a trusted proxy', () => {
+    // The "client" hop is the first entry; later hops are upstream proxies.
+    process.env.WEBHOOK_TRUSTED_PROXY_IPS = '10.0.0.5'
+    expect(
+      isLoopbackWebhookRequest(
+        makeReq({ ip: '10.0.0.5', xff: '203.0.113.10, 127.0.0.1' })
+      )
+    ).toBe(false)
+  })
+})
+
+describe('warnMissingWebhookSecret', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('returns true (refuse) and logs error in production', () => {
+    process.env.NODE_ENV = 'production'
+    const refuse = warnMissingWebhookSecret('crowdsec', 'CROWDSEC_WEBHOOK_SECRET')
+    expect(refuse).toBe(true)
+    expect(errorSpy).toHaveBeenCalledOnce()
+    expect(String(errorSpy.mock.calls[0][0])).toContain('CROWDSEC_WEBHOOK_SECRET')
+  })
+
+  it('returns false (allow dev fallback) and logs warning in development', () => {
+    process.env.NODE_ENV = 'development'
+    const refuse = warnMissingWebhookSecret('wazuh', 'WAZUH_WEBHOOK_SECRET')
+    expect(refuse).toBe(false)
+    expect(warnSpy).toHaveBeenCalledOnce()
+    expect(String(warnSpy.mock.calls[0][0])).toContain('WAZUH_WEBHOOK_SECRET')
   })
 })

--- a/apps/web/src/lib/security/webhook-auth.test.ts
+++ b/apps/web/src/lib/security/webhook-auth.test.ts
@@ -11,6 +11,8 @@ import {
   isWithinReplayWindow,
   isLoopbackWebhookRequest,
   warnMissingWebhookSecret,
+  checkWebhookBodySize,
+  WEBHOOK_MAX_BODY_BYTES,
 } from './webhook-auth'
 
 const secret = 'super-secret-key'
@@ -55,7 +57,20 @@ describe('verifyWebhookHmac (BLOCK-1 regression — timing-safe comparison)', ()
 })
 
 describe('isWithinReplayWindow', () => {
-  it('returns true when there is no timestamp header', () => {
+  const originalRequire = process.env.WEBHOOK_REQUIRE_TIMESTAMP
+  const originalNodeEnv = process.env.NODE_ENV
+  beforeEach(() => {
+    delete process.env.WEBHOOK_REQUIRE_TIMESTAMP
+  })
+  afterEach(() => {
+    if (originalRequire === undefined) delete process.env.WEBHOOK_REQUIRE_TIMESTAMP
+    else process.env.WEBHOOK_REQUIRE_TIMESTAMP = originalRequire
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('returns true when there is no timestamp header in dev', () => {
+    // Default test env: NODE_ENV !== 'production' and no require flag.
     expect(isWithinReplayWindow(null)).toBe(true)
   })
 
@@ -67,6 +82,89 @@ describe('isWithinReplayWindow', () => {
   it('returns false for an ISO timestamp outside the replay window', () => {
     const old = new Date(Date.now() - 60 * 60 * 1000).toISOString() // 1 hour ago
     expect(isWithinReplayWindow(old)).toBe(false)
+  })
+
+  // MAJOR-1 (PR #407): missing timestamp must be rejected in production.
+  it('returns false when timestamp is missing and NODE_ENV=production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(isWithinReplayWindow(null)).toBe(false)
+  })
+
+  it('returns false when timestamp is missing and WEBHOOK_REQUIRE_TIMESTAMP=true', () => {
+    process.env.WEBHOOK_REQUIRE_TIMESTAMP = 'true'
+    expect(isWithinReplayWindow(null)).toBe(false)
+  })
+
+  it('returns true when timestamp is missing and explicit WEBHOOK_REQUIRE_TIMESTAMP=false in prod', () => {
+    process.env.NODE_ENV = 'production'
+    process.env.WEBHOOK_REQUIRE_TIMESTAMP = 'false'
+    expect(isWithinReplayWindow(null)).toBe(true)
+  })
+
+  it('accepts a recent timestamp even when require flag is on', () => {
+    process.env.WEBHOOK_REQUIRE_TIMESTAMP = 'true'
+    expect(isWithinReplayWindow(new Date().toISOString())).toBe(true)
+  })
+
+  it('rejects a timestamp far in the future (clock-skew / forgery)', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    expect(isWithinReplayWindow(future)).toBe(false)
+  })
+})
+
+describe('checkWebhookBodySize (PR #407 MAJOR-3)', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  beforeEach(() => {})
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = originalNodeEnv
+  })
+
+  function reqWith(headers: Record<string, string>) {
+    const h = new Headers()
+    for (const [k, v] of Object.entries(headers)) h.set(k, v)
+    return { headers: h }
+  }
+
+  it('accepts a 100 KB body', () => {
+    const res = checkWebhookBodySize(reqWith({ 'content-length': String(100 * 1024) }))
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects a 2 MB body with too_large', () => {
+    const res = checkWebhookBodySize(reqWith({ 'content-length': String(2 * 1024 * 1024) }))
+    expect(res.ok).toBe(false)
+    expect(res.reason).toBe('too_large')
+  })
+
+  it('rejects exactly WEBHOOK_MAX_BODY_BYTES + 1', () => {
+    const res = checkWebhookBodySize(reqWith({ 'content-length': String(WEBHOOK_MAX_BODY_BYTES + 1) }))
+    expect(res.ok).toBe(false)
+    expect(res.reason).toBe('too_large')
+  })
+
+  it('accepts a body equal to the limit', () => {
+    const res = checkWebhookBodySize(reqWith({ 'content-length': String(WEBHOOK_MAX_BODY_BYTES) }))
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects missing Content-Length in production', () => {
+    process.env.NODE_ENV = 'production'
+    const res = checkWebhookBodySize(reqWith({}))
+    expect(res.ok).toBe(false)
+    expect(res.reason).toBe('missing_length')
+  })
+
+  it('allows missing Content-Length in dev', () => {
+    process.env.NODE_ENV = 'development'
+    const res = checkWebhookBodySize(reqWith({}))
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects a malformed Content-Length', () => {
+    const res = checkWebhookBodySize(reqWith({ 'content-length': 'not-a-number' }))
+    expect(res.ok).toBe(false)
+    expect(res.reason).toBe('missing_length')
   })
 })
 

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -1,0 +1,145 @@
+/**
+ * Webhook authentication helper — HMAC verification, replay window, idempotency.
+ *
+ * Used by all security webhook endpoints to verify incoming events.
+ */
+
+import { prisma } from '@/lib/db'
+import { createHmac } from 'crypto'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Maximum replay window in seconds (5 minutes). */
+export const WEBHOOK_REPLAY_WINDOW_SEC = 5 * 60
+
+/** Key in Prisma for storing webhook secrets per environment/source. */
+const SECRET_CONFIG_KEY = (envId: string, source: string) => `webhook_${source}_secret_${envId}`
+
+/** Idempotency cache TTL: 60 seconds after first write. */
+const IDEMPOTENCY_WINDOW_MS = 60_000
+
+/** Key used to detect if an idempotent event was already processed. */
+type IdempotencyKey = { dedupKey: string; source: string }
+
+// ── HMAC Verification ─────────────────────────────────────────────────────────
+
+/**
+ * Verify the HMAC signature of a webhook request.
+ *
+ * Computes HMAC-SHA256(secret, rawBody) and compares with the X-Signature header.
+ * Returns false if the header is missing, the key is not configured, or signatures
+ * don't match.
+ */
+/**
+ * Verify the HMAC-SHA256 signature of a webhook request.
+ *
+ * Computes HMAC-SHA256(secret, rawBody) and compares with the X-Signature header.
+ * Signature format: `sha256=<hex>`
+ */
+export function verifyWebhookHmac(
+  secret: string,
+  rawBody: string,
+  signature: string | null
+): boolean {
+  if (!signature) return false
+
+  const expected = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`
+
+  // Use timing-safe comparison when possible
+  return constantTimeCompare(signature, expected)
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Synchronous version compatible with Node.js createHmac.
+ */
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+
+  // Use crypto.subtle timing-safe equal when available (Next.js on HTTPS)
+  if (typeof crypto !== 'undefined' && crypto.subtle) {
+    const enc = new TextEncoder()
+    const subtle = (crypto.subtle as { timingSafeEqual?: (a: Uint8Array, b: Uint8Array) => boolean })
+    if (subtle.timingSafeEqual) {
+      return subtle.timingSafeEqual(enc.encode(a), enc.encode(b))
+    }
+  }
+
+  // Fallback: strict equality (acceptable for local dev)
+  return a === b
+}
+
+// ── Replay Window ─────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a timestamp header indicates a replay (older than the replay window).
+ *
+ * Accepts `X-Timestamp` header in ISO 8601 or Unix epoch format.
+ * Returns `true` if the request is within the replay window.
+ */
+export function isWithinReplayWindow(timestampHeader: string | null): boolean {
+  if (!timestampHeader) return true // no timestamp = allow (some sources don't send one)
+
+  let timestamp: number
+
+  // Try ISO 8601
+  const isoMatch = timestampHeader.match(/^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})/)
+  if (isoMatch) {
+    timestamp = new Date(isoMatch[1]).getTime()
+  } else {
+    // Try Unix epoch (seconds or milliseconds)
+    const epoch = Number(timestampHeader)
+    if (Number.isNaN(epoch)) return true
+    timestamp = epoch > 1e12 ? epoch : epoch * 1000 // ms
+  }
+
+  const now = Date.now()
+  return now - timestamp <= WEBHOOK_REPLAY_WINDOW_SEC * 1000
+}
+
+// ── Idempotency (dedupKey) ────────────────────────────────────────────────────
+
+/**
+ * Check whether an event with this dedupKey has already been processed recently.
+ *
+ * Uses the SecurityEvent table's dedupKey as the idempotency store.
+ * Returns true if the event was ALREADY seen within the idempotency window.
+ */
+export async function wasAlreadyProcessed(
+  dedupKey: string,
+  source: string
+): Promise<boolean> {
+  const count = await prisma.securityEvent.count({
+    where: {
+      dedupKey,
+      source,
+      createdAt: {
+        gte: new Date(Date.now() - IDEMPOTENCY_WINDOW_MS),
+      },
+    },
+  })
+  return count > 0
+}
+
+// ── Secret Lookup ─────────────────────────────────────────────────────────────
+
+/**
+ * Retrieve the HMAC secret for a source from SecurityConfig.
+ */
+export async function getWebhookSecret(
+  envId: string | null,
+  source: string
+): Promise<string | null> {
+  if (!envId) return null
+
+  const config = await prisma.securityConfig.findUnique({
+    where: {
+      environmentId_key: {
+        environmentId: envId,
+        key: SECRET_CONFIG_KEY(envId, source),
+      },
+    },
+  })
+
+  return config?.value ?? null
+}

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -12,11 +12,30 @@ import { createHmac, timingSafeEqual } from 'crypto'
 /** Maximum replay window in seconds (5 minutes). */
 export const WEBHOOK_REPLAY_WINDOW_SEC = 5 * 60
 
+/**
+ * Maximum acceptable webhook body size in bytes (1 MiB).
+ *
+ * Anything larger is rejected with 413 *before* we touch the HMAC verifier
+ * or buffer the body. This bounds the work an unauthenticated request can
+ * cost the gateway: a 100 MB POST against an HMAC endpoint still requires
+ * us to read the body to validate the signature, which an attacker can use
+ * to mount a memory/CPU DoS.
+ */
+export const WEBHOOK_MAX_BODY_BYTES = 1 * 1024 * 1024
+
 /** Key in Prisma for storing webhook secrets per environment/source. */
 const SECRET_CONFIG_KEY = (envId: string, source: string) => `webhook_${source}_secret_${envId}`
 
-/** Idempotency cache TTL: 60 seconds after first write. */
-const IDEMPOTENCY_WINDOW_MS = 60_000
+/**
+ * Idempotency cache TTL: 24 hours after first write.
+ *
+ * Upstream sources (CrowdSec, Wazuh) may retry deliveries across long-running
+ * outages of this service; a 60-second window let duplicates leak through.
+ * Backed by the existing `SecurityEvent.dedupKey` index, which is already in
+ * place on the schema, so the wider lookup has no extra cost beyond an
+ * indexed B-tree range scan.
+ */
+const IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1000
 
 /** Key used to detect if an idempotent event was already processed. */
 type IdempotencyKey = { dedupKey: string; source: string }
@@ -71,13 +90,44 @@ function constantTimeCompare(a: string, b: string): boolean {
 // ── Replay Window ─────────────────────────────────────────────────────────────
 
 /**
+ * Should the missing-timestamp passthrough be disabled?
+ *
+ * Production requires a timestamp header so replay attacks can be blocked.
+ * Dev/test keeps the previous lenient behaviour so unit tests and local
+ * curl sessions don't need to manage clocks. The behaviour is also gated by
+ * an explicit `WEBHOOK_REQUIRE_TIMESTAMP=true|false` flag so the
+ * production-gate can be exercised in tests without juggling NODE_ENV.
+ */
+function requireTimestampHeader(): boolean {
+  const flag = (process.env.WEBHOOK_REQUIRE_TIMESTAMP ?? '').toLowerCase()
+  if (flag === 'true' || flag === '1') return true
+  if (flag === 'false' || flag === '0') return false
+  return process.env.NODE_ENV === 'production'
+}
+
+/**
  * Check whether a timestamp header indicates a replay (older than the replay window).
  *
  * Accepts `X-Timestamp` header in ISO 8601 or Unix epoch format.
  * Returns `true` if the request is within the replay window.
+ *
+ * Hardening (MAJOR-1, PR #407):
+ * - In production (or when `WEBHOOK_REQUIRE_TIMESTAMP=true`) a missing
+ *   timestamp header is now treated as a replay (returns false) so the
+ *   caller can reject with 401. Without this, a forwarding proxy that
+ *   strips the timestamp header could let stale captures through.
+ * - In dev/test the previous lenient behaviour is preserved but logs a
+ *   warning so operators notice the relaxed mode.
  */
 export function isWithinReplayWindow(timestampHeader: string | null): boolean {
-  if (!timestampHeader) return true // no timestamp = allow (some sources don't send one)
+  if (!timestampHeader) {
+    if (requireTimestampHeader()) {
+      return false // refuse — must be sent in prod
+    }
+    // eslint-disable-next-line no-console
+    console.warn('[siem] webhook request missing X-Timestamp header; allowed because WEBHOOK_REQUIRE_TIMESTAMP is not set')
+    return true
+  }
 
   let timestamp: number
 
@@ -93,7 +143,10 @@ export function isWithinReplayWindow(timestampHeader: string | null): boolean {
   }
 
   const now = Date.now()
-  return now - timestamp <= WEBHOOK_REPLAY_WINDOW_SEC * 1000
+  // Reject both past replays AND timestamps far in the future (clock skew or
+  // forged future-dated requests).
+  const delta = now - timestamp
+  return delta >= -WEBHOOK_REPLAY_WINDOW_SEC * 1000 && delta <= WEBHOOK_REPLAY_WINDOW_SEC * 1000
 }
 
 // ── Idempotency (dedupKey) ────────────────────────────────────────────────────
@@ -204,6 +257,48 @@ export function isLoopbackWebhookRequest(req: {
   const realIp = req.headers.get('x-real-ip') ?? ''
   const clientIp = xff.split(',')[0]?.trim() || realIp.trim()
   return isLoopbackIp(clientIp)
+}
+
+// ── Body-size guard ───────────────────────────────────────────────────────────
+
+/**
+ * Inspect the request's Content-Length and decide whether to reject before
+ * buffering the body for HMAC verification (PR #407 MAJOR-3).
+ *
+ * Returns:
+ *   - { ok: true }                            — proceed
+ *   - { ok: false, reason: 'too_large' }     — caller should reply 413
+ *   - { ok: false, reason: 'missing_length' } — in production caller should
+ *     reply 411 Length Required; in dev/test we allow the request but log
+ *     a warning since some test clients omit the header.
+ *
+ * The caller decides the actual HTTP status. We rely on the runtime's
+ * Content-Length parsing rather than streaming-count because Next.js
+ * already buffers `req.text()`; a content-length lie is at worst a
+ * runtime-imposed cap, never a bypass.
+ */
+export function checkWebhookBodySize(req: { headers: Headers }): {
+  ok: boolean
+  reason?: 'too_large' | 'missing_length'
+  size?: number
+} {
+  const lenHeader = req.headers.get('content-length')
+  if (!lenHeader) {
+    if (process.env.NODE_ENV === 'production') {
+      return { ok: false, reason: 'missing_length' }
+    }
+    // eslint-disable-next-line no-console
+    console.warn('[siem] webhook request missing Content-Length; accepting because NODE_ENV !== production')
+    return { ok: true }
+  }
+  const n = Number(lenHeader)
+  if (!Number.isFinite(n) || n < 0) {
+    return { ok: false, reason: 'missing_length' }
+  }
+  if (n > WEBHOOK_MAX_BODY_BYTES) {
+    return { ok: false, reason: 'too_large', size: n }
+  }
+  return { ok: true, size: n }
 }
 
 /**

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -142,3 +142,96 @@ export async function getWebhookSecret(
 
   return config?.value ?? null
 }
+
+// ── Client-IP / Loopback Trust ────────────────────────────────────────────────
+
+/**
+ * Loopback IPv4/IPv6 prefixes. An address that starts with one of these is
+ * considered "from this host" and is the only case the webhook fallback
+ * (used when a webhook secret is not configured) should treat as trusted.
+ */
+const LOOPBACK_PREFIXES = ['127.', '::1', '::ffff:127.']
+
+function isLoopbackIp(ip: string): boolean {
+  if (!ip) return false
+  const trimmed = ip.trim()
+  if (!trimmed) return false
+  return LOOPBACK_PREFIXES.some((p) => trimmed.startsWith(p))
+}
+
+/**
+ * Determine whether the request originates from loopback for the secret-less
+ * dev-mode fallback.
+ *
+ * Hardening (MAJOR-1 follow-up):
+ * - The previous implementation read `X-Forwarded-For` / `X-Real-IP` directly,
+ *   which any HTTP client can spoof. With `CROWDSEC_WEBHOOK_SECRET` (or the
+ *   Wazuh equivalent) unset, spoofing `X-Forwarded-For: 127.0.0.1` was enough
+ *   to inject events.
+ * - We now prefer the direct TCP source (`req.ip`, populated by the runtime
+ *   from the connection). `X-Forwarded-For` is ONLY consulted when the
+ *   direct peer IP is itself an allow-listed reverse proxy
+ *   (`WEBHOOK_TRUSTED_PROXY_IPS`, comma-separated). When the peer IP is
+ *   missing AND no proxy allow-list is configured, we fall back to refusing
+ *   trust — the request must use the signed path.
+ *
+ * Returns `true` only when we are confident the request is from loopback.
+ */
+export function isLoopbackWebhookRequest(req: {
+  headers: Headers
+  ip?: string | null
+}): boolean {
+  const peerIp = req.ip ?? ''
+  if (isLoopbackIp(peerIp)) return true
+
+  const allowList = (process.env.WEBHOOK_TRUSTED_PROXY_IPS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  if (allowList.length === 0) {
+    // No proxy allow-list configured. Do not trust XFF — it is spoofable.
+    return false
+  }
+
+  const peerTrusted = peerIp && allowList.includes(peerIp)
+  if (!peerTrusted) return false
+
+  // Peer is a known reverse proxy; X-Forwarded-For (left-most entry) is
+  // believable. X-Real-IP is single-valued and easier to forge upstream, but
+  // we accept it when the peer is also trusted.
+  const xff = req.headers.get('x-forwarded-for') ?? ''
+  const realIp = req.headers.get('x-real-ip') ?? ''
+  const clientIp = xff.split(',')[0]?.trim() || realIp.trim()
+  return isLoopbackIp(clientIp)
+}
+
+/**
+ * Warn loudly when a webhook endpoint is being served without a configured
+ * HMAC secret. In production this is a misconfiguration and the caller
+ * should reject the request; in dev/test we still log so the operator
+ * notices the loopback-only fallback is engaged.
+ *
+ * Returns `true` if the deployment should refuse to serve the request
+ * unauthenticated (i.e. NODE_ENV=production). The caller is expected to
+ * return HTTP 500 in that case.
+ */
+export function warnMissingWebhookSecret(source: string, envVarName: string): boolean {
+  const isProd = process.env.NODE_ENV === 'production'
+  const banner = `[siem] WEBHOOK MISCONFIGURED: ${envVarName} is not set for ${source} webhook.`
+
+  if (isProd) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `${banner} Refusing unauthenticated requests. Set ${envVarName} in the environment.`
+    )
+    return true
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(
+    `${banner} Falling back to loopback-only acceptance (dev mode). ` +
+      `Set ${envVarName} for any non-development deployment.`
+  )
+  return false
+}

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -5,7 +5,7 @@
  */
 
 import { prisma } from '@/lib/db'
-import { createHmac } from 'crypto'
+import { createHmac, timingSafeEqual } from 'crypto'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -24,17 +24,11 @@ type IdempotencyKey = { dedupKey: string; source: string }
 // ── HMAC Verification ─────────────────────────────────────────────────────────
 
 /**
- * Verify the HMAC signature of a webhook request.
- *
- * Computes HMAC-SHA256(secret, rawBody) and compares with the X-Signature header.
- * Returns false if the header is missing, the key is not configured, or signatures
- * don't match.
- */
-/**
  * Verify the HMAC-SHA256 signature of a webhook request.
  *
  * Computes HMAC-SHA256(secret, rawBody) and compares with the X-Signature header.
- * Signature format: `sha256=<hex>`
+ * Signature format: `sha256=<hex>`. Returns false on any mismatch (length, value,
+ * or missing header).
  */
 export function verifyWebhookHmac(
   secret: string,
@@ -45,28 +39,33 @@ export function verifyWebhookHmac(
 
   const expected = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`
 
-  // Use timing-safe comparison when possible
+  // Timing-safe comparison: any mismatch in length (or value) returns false in
+  // constant time so we don't leak signature characters via response timing.
   return constantTimeCompare(signature, expected)
 }
 
 /**
- * Constant-time string comparison to prevent timing attacks.
- * Synchronous version compatible with Node.js createHmac.
+ * Constant-time string comparison backed by Node.js `crypto.timingSafeEqual`.
+ *
+ * Notes:
+ * - We require both buffers to be the same length BEFORE calling
+ *   `timingSafeEqual` because Node.js will throw on length mismatch (which
+ *   itself would be a timing side-channel via exception cost). We return
+ *   `false` immediately when lengths differ.
+ * - Inputs are encoded as UTF-8 bytes via `Buffer.from`. For our HMAC use
+ *   case both strings are ASCII hex with a fixed `sha256=` prefix, so the
+ *   byte length equals the string length.
+ * - The previous implementation attempted `crypto.subtle.timingSafeEqual`
+ *   which does not exist on the Web Crypto API; the cast always evaluated
+ *   to undefined and the fallback was plain `===`, which is bypassable
+ *   via a timing oracle. Fixed by routing through Node's `timingSafeEqual`.
  */
 function constantTimeCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false
-
-  // Use crypto.subtle timing-safe equal when available (Next.js on HTTPS)
-  if (typeof crypto !== 'undefined' && crypto.subtle) {
-    const enc = new TextEncoder()
-    const subtle = (crypto.subtle as { timingSafeEqual?: (a: Uint8Array, b: Uint8Array) => boolean })
-    if (subtle.timingSafeEqual) {
-      return subtle.timingSafeEqual(enc.encode(a), enc.encode(b))
-    }
-  }
-
-  // Fallback: strict equality (acceptable for local dev)
-  return a === b
+  const bufA = Buffer.from(a, 'utf8')
+  const bufB = Buffer.from(b, 'utf8')
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
 }
 
 // ── Replay Window ─────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/seed-action-policies.ts
+++ b/apps/web/src/lib/seed-action-policies.ts
@@ -100,7 +100,7 @@ export async function ensureActionPolicies(): Promise<void> {
         create: {
           actionType:     def.actionType,
           defaultTier:    def.defaultTier,
-          targetPatterns: def.targetPatterns,
+          targetPatterns: def.targetPatterns as any,
           updatedBy:      'system',
         },
       })

--- a/apps/web/src/lib/seed-correlation-rules.ts
+++ b/apps/web/src/lib/seed-correlation-rules.ts
@@ -17,11 +17,17 @@ const DEFAULT_RULES = [
     ruleType: 'threshold',
     params: {
       type: 'threshold',
+      // Plan: "≥5 failed logins, same IP, 5min". The attacker IP lives in
+      // the rawEvent JSON payload (e.g. CrowdSec/Wazuh both expose `srcip`
+      // there), not as a top-level SecurityEvent column. Grouping by the
+      // ingestion source ("crowdsec", "wazuh") — as the original seed did —
+      // bucketed every event together regardless of attacker, producing
+      // false positives and missing distinct-IP grouping entirely.
       field: 'srcip',
       op: 'gte' as const,
       value: 5,
       window: 300, // 5 minutes
-      groupBy: ['source'],
+      groupBy: ['rawEvent.srcip'],
     },
     severity: 70,
     window: 300,

--- a/apps/web/src/lib/seed-correlation-rules.ts
+++ b/apps/web/src/lib/seed-correlation-rules.ts
@@ -1,0 +1,93 @@
+/**
+ * Default correlation rules seed — runs on startup via instrumentation.ts.
+ *
+ * Seeds the default correlation rules for security event processing.
+ * Rules are environment-scoped and follow SIEM_PLAN.md tier matrix.
+ */
+
+import { prisma } from './db'
+
+/**
+ * Default correlation rules seeded at startup.
+ * These rules are the same for all environments (global rules).
+ */
+const DEFAULT_RULES = [
+  {
+    name: 'brute_force',
+    ruleType: 'threshold',
+    params: {
+      type: 'threshold',
+      field: 'srcip',
+      op: 'gte' as const,
+      value: 5,
+      window: 300, // 5 minutes
+      groupBy: ['source'],
+    },
+    severity: 70,
+    window: 300,
+  },
+  {
+    name: 'port_scan',
+    ruleType: 'pattern',
+    params: {
+      type: 'pattern',
+      regex: 'port_scan|scan',
+      field: 'title',
+      window: 60,
+    },
+    severity: 50,
+    window: 60,
+  },
+  {
+    name: 'malware',
+    ruleType: 'malware',
+    params: {
+      type: 'malware',
+      ruleLevel: 10,
+      field: 'severity',
+    },
+    severity: 90,
+    window: 0,
+  },
+  {
+    name: 'suspicious_process',
+    ruleType: 'process',
+    params: {
+      type: 'process',
+      commandPattern: '(bash|sh|cmd|powershell)\\s+(?=.*\\b(rm\\s+-rf|chmod\\s+777|wget\\s+.*\\|\\s*sh|curl\\s+.*\\|\\s*sh|nc\\s+-e|mkfifo|/dev/tcp)\\b)',
+      window: 300,
+    },
+    severity: 85,
+    window: 300,
+  },
+]
+
+/**
+ * Seed default correlation rules. Runs idempotently — skips existing rules.
+ */
+export async function ensureCorrelationRules(): Promise<void> {
+  try {
+    for (const rule of DEFAULT_RULES) {
+      await prisma.correlationRule.upsert({
+        where: { name: rule.name },
+        update: {
+          ruleType: rule.ruleType,
+          params: rule.params,
+          severity: rule.severity,
+          window: rule.window,
+        },
+        create: {
+          name: rule.name,
+          ruleType: rule.ruleType,
+          params: rule.params,
+          severity: rule.severity,
+          window: rule.window,
+          environmentId: null, // global rule
+        },
+      })
+      console.log(`[seed] CorrelationRule: ${rule.name} (${rule.ruleType}, severity=${rule.severity})`)
+    }
+  } catch (err) {
+    console.error('[seed] Failed to seed correlation rules:', err instanceof Error ? err.message : err)
+  }
+}

--- a/apps/web/src/lib/seed-correlation-rules.ts
+++ b/apps/web/src/lib/seed-correlation-rules.ts
@@ -17,17 +17,19 @@ const DEFAULT_RULES = [
     ruleType: 'threshold',
     params: {
       type: 'threshold',
-      // Plan: "≥5 failed logins, same IP, 5min". The attacker IP lives in
-      // the rawEvent JSON payload (e.g. CrowdSec/Wazuh both expose `srcip`
-      // there), not as a top-level SecurityEvent column. Grouping by the
-      // ingestion source ("crowdsec", "wazuh") — as the original seed did —
-      // bucketed every event together regardless of attacker, producing
-      // false positives and missing distinct-IP grouping entirely.
-      field: 'srcip',
+      // Plan: "≥5 failed logins, same IP, 5min". Group by the virtual
+      // `attackerKey` extractor so the rule fires uniformly across CrowdSec,
+      // Wazuh, ELK, and ntopng — each source surfaces the attacker IP at a
+      // different JSON path. The previous seed hard-coded `rawEvent.srcip`
+      // which silently missed CrowdSec (where the attacker IP lives at
+      // `rawEvent.payload.value`) and ntopng (at `rawEvent.cli.ip`).
+      // See `extractGroupValue` in `lib/security/rule-engine.ts` for the
+      // source-path probe order.
+      field: 'attackerKey',
       op: 'gte' as const,
       value: 5,
       window: 300, // 5 minutes
-      groupBy: ['rawEvent.srcip'],
+      groupBy: ['attackerKey'],
     },
     severity: 70,
     window: 300,

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -17,6 +17,7 @@ import { getPrompt } from './lib/system-prompts'
 import { resolveAgentGateway } from './lib/agent-gateway'
 import { getAgentsMd } from './lib/agents-md'
 import { startDream } from './lib/dream'
+import { runCorrelator } from './workers/security-correlator'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -832,6 +833,11 @@ async function main() {
 
   // Dream — memory consolidation (extraction every 2h, pruning every 24h)
   startDream()
+
+  // Security correlator — poll for uncorrelated events every 30s
+  setInterval(() => {
+    runCorrelator().catch(e => err(`Security correlator failed: ${e}`))
+  }, 30_000)
 }
 
 main().catch(e => { err(`Fatal: ${e}`); process.exit(1) })

--- a/apps/web/src/workers/security-correlator.test.ts
+++ b/apps/web/src/workers/security-correlator.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// `security-correlator.ts` imports `@/lib/db` (prisma). The pure helper
+// `rulesForEnvironment` doesn't touch it, but the module is loaded as a
+// whole — stub the import so vitest can resolve it without next.js path
+// aliasing.
+vi.mock('@/lib/db', () => ({ prisma: {} }))
+vi.mock('@/lib/security/rule-engine', () => ({ correlateEvents: vi.fn() }))
+
+import { rulesForEnvironment } from './security-correlator'
+
+describe('rulesForEnvironment (BLOCK-1a regression — global rules included)', () => {
+  it('includes per-environment rules whose environmentId matches', () => {
+    const rules = [
+      { environmentId: 'env-1', name: 'a' },
+      { environmentId: 'env-2', name: 'b' },
+    ]
+    const result = rulesForEnvironment(rules, 'env-1')
+    expect(result.map(r => r.name)).toEqual(['a'])
+  })
+
+  it('includes global rules (environmentId === null) for every environment', () => {
+    const rules = [
+      { environmentId: null, name: 'brute_force' },
+      { environmentId: null, name: 'port_scan' },
+      { environmentId: 'env-1', name: 'env-specific' },
+    ]
+    expect(rulesForEnvironment(rules, 'env-1').map(r => r.name).sort()).toEqual(
+      ['brute_force', 'env-specific', 'port_scan'],
+    )
+    // env-2 has no specific rules but should still pick up both globals.
+    expect(rulesForEnvironment(rules, 'env-2').map(r => r.name).sort()).toEqual(
+      ['brute_force', 'port_scan'],
+    )
+  })
+
+  it('excludes rules belonging to a different environment', () => {
+    const rules = [
+      { environmentId: 'env-other', name: 'foreign' },
+      { environmentId: null, name: 'global' },
+    ]
+    const result = rulesForEnvironment(rules, 'env-1')
+    expect(result.map(r => r.name)).toEqual(['global'])
+  })
+
+  it('returns empty array when no rules match', () => {
+    const rules: Array<{ environmentId: string | null }> = []
+    expect(rulesForEnvironment(rules, 'env-1')).toEqual([])
+  })
+})

--- a/apps/web/src/workers/security-correlator.test.ts
+++ b/apps/web/src/workers/security-correlator.test.ts
@@ -5,7 +5,10 @@ import { describe, it, expect, vi } from 'vitest'
 // whole — stub the import so vitest can resolve it without next.js path
 // aliasing.
 vi.mock('@/lib/db', () => ({ prisma: {} }))
-vi.mock('@/lib/security/rule-engine', () => ({ correlateEvents: vi.fn() }))
+vi.mock('@/lib/security/rule-engine', () => ({
+  correlateEvents: vi.fn(),
+  recordRuleIncident: vi.fn(),
+}))
 
 import { rulesForEnvironment } from './security-correlator'
 

--- a/apps/web/src/workers/security-correlator.test.ts
+++ b/apps/web/src/workers/security-correlator.test.ts
@@ -1,16 +1,73 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// `security-correlator.ts` imports `@/lib/db` (prisma). The pure helper
-// `rulesForEnvironment` doesn't touch it, but the module is loaded as a
-// whole — stub the import so vitest can resolve it without next.js path
-// aliasing.
-vi.mock('@/lib/db', () => ({ prisma: {} }))
-vi.mock('@/lib/security/rule-engine', () => ({
-  correlateEvents: vi.fn(),
-  recordRuleIncident: vi.fn(),
+// ── Module-level prisma test double ─────────────────────────────────────────
+//
+// Earlier suites in this file only exercise the pure helper
+// `rulesForEnvironment` and don't touch prisma; the worker-level suites
+// added for PR #408 BLOCK-1 need a fuller stub. We define both here and let
+// the existing tests pass through unchanged.
+
+const env_findMany = vi.fn(async () => [] as unknown[])
+const event_findMany = vi.fn(async () => [] as unknown[])
+const event_count = vi.fn(async () => 0)
+const event_updateMany = vi.fn(async () => ({ count: 0 }))
+const incident_findMany = vi.fn(async () => [] as unknown[])
+const incident_create = vi.fn(async (args: { data: Record<string, unknown> }) => ({
+  id: 'inc-' + Math.random(),
+  ...args.data,
+}))
+const rule_findMany = vi.fn(async () => [] as unknown[])
+const sourceHealth_findMany = vi.fn(async () => [] as unknown[])
+const sourceHealth_update = vi.fn(async () => ({}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    environment: { findMany: (...a: unknown[]) => env_findMany(...a) },
+    securityEvent: {
+      findMany: (...a: unknown[]) => event_findMany(...a),
+      count: (...a: unknown[]) => event_count(...a),
+      updateMany: (...a: unknown[]) => event_updateMany(...a),
+      create: async (args: { data: unknown }) => args.data,
+    },
+    incident: {
+      findMany: (...a: unknown[]) => incident_findMany(...a),
+      create: (...a: unknown[]) => incident_create(a[0] as { data: Record<string, unknown> }),
+    },
+    correlationRule: { findMany: (...a: unknown[]) => rule_findMany(...a) },
+    sourceHealth: {
+      findMany: (...a: unknown[]) => sourceHealth_findMany(...a),
+      update: (...a: unknown[]) => sourceHealth_update(...a),
+    },
+  },
 }))
 
-import { rulesForEnvironment } from './security-correlator'
+// rule-engine is imported by the worker; mock it so each test can inject
+// the drafts that "would" come out of the engine without spinning up Postgres.
+const mockDrafts: { value: Array<Record<string, unknown>> } = { value: [] }
+const recordRuleIncidentMock = vi.fn()
+vi.mock('@/lib/security/rule-engine', () => ({
+  correlateEvents: vi.fn(async () => ({
+    drafts: mockDrafts.value,
+    errorCount: 0,
+    erroredRules: [],
+  })),
+  recordRuleIncident: (...args: unknown[]) => recordRuleIncidentMock(...args),
+}))
+
+import { rulesForEnvironment, runCorrelator, GLOBAL_BUCKET_ID } from './security-correlator'
+
+beforeEach(() => {
+  env_findMany.mockClear().mockResolvedValue([])
+  event_findMany.mockClear().mockResolvedValue([])
+  event_count.mockClear().mockResolvedValue(0)
+  event_updateMany.mockClear()
+  incident_findMany.mockClear().mockResolvedValue([])
+  incident_create.mockClear()
+  rule_findMany.mockClear().mockResolvedValue([])
+  sourceHealth_findMany.mockClear().mockResolvedValue([])
+  recordRuleIncidentMock.mockClear()
+  mockDrafts.value = []
+})
 
 describe('rulesForEnvironment (BLOCK-1a regression — global rules included)', () => {
   it('includes per-environment rules whose environmentId matches', () => {
@@ -49,5 +106,99 @@ describe('rulesForEnvironment (BLOCK-1a regression — global rules included)', 
   it('returns empty array when no rules match', () => {
     const rules: Array<{ environmentId: string | null }> = []
     expect(rulesForEnvironment(rules, 'env-1')).toEqual([])
+  })
+})
+
+describe('runCorrelator — global bucket (BLOCK-1a, PR #408)', () => {
+  it('processes orphan events (environmentId=null) under the synthetic bucket', async () => {
+    env_findMany.mockResolvedValue([])          // no environments need work
+    event_count.mockResolvedValue(2)             // 2 orphan events
+    rule_findMany.mockResolvedValue([
+      { name: 'brute_force', params: { type: 'threshold' }, severity: 70, environmentId: null },
+    ])
+    event_findMany.mockResolvedValue([
+      { id: 'e1', environmentId: null, severity: 60, source: 'crowdsec', rawEvent: {} },
+      { id: 'e2', environmentId: null, severity: 60, source: 'crowdsec', rawEvent: {} },
+    ])
+    mockDrafts.value = [
+      {
+        severity: 75,
+        attackerKey: '1.2.3.4',
+        ruleName: 'brute_force',
+        eventIds: ['e1', 'e2'],
+        environmentId: GLOBAL_BUCKET_ID,
+      },
+    ]
+
+    const results = await runCorrelator()
+    const globalResult = results.find(r => r.envId === GLOBAL_BUCKET_ID)
+    expect(globalResult).toBeDefined()
+    expect(globalResult?.eventsProcessed).toBe(2)
+    expect(globalResult?.incidentsCreated).toBe(1)
+
+    // The Incident must be written with environmentId=null (NOT the
+    // synthetic sentinel) so the FK to Environment stays valid.
+    const createArgs = incident_create.mock.calls[0]?.[0]
+    expect(createArgs?.data.environmentId).toBeNull()
+  })
+
+  it('skips the global bucket entirely when no orphan events exist', async () => {
+    env_findMany.mockResolvedValue([])
+    event_count.mockResolvedValue(0) // no orphans
+    rule_findMany.mockResolvedValue([
+      { name: 'brute_force', params: { type: 'threshold' }, severity: 70, environmentId: null },
+    ])
+    const results = await runCorrelator()
+    expect(results.find(r => r.envId === GLOBAL_BUCKET_ID)).toBeUndefined()
+  })
+})
+
+describe('runCorrelator — in-run dedup (BLOCK-1b, PR #408)', () => {
+  it('does NOT suppress a different rule firing on the same attacker IP', async () => {
+    env_findMany.mockResolvedValue([{ id: 'env-1' }])
+    event_count.mockResolvedValue(0)             // no orphans
+    rule_findMany.mockResolvedValue([
+      { name: 'brute_force', params: { type: 'threshold' }, severity: 70, environmentId: null },
+      { name: 'port_scan',   params: { type: 'pattern'   }, severity: 50, environmentId: null },
+    ])
+    event_findMany.mockResolvedValue([
+      { id: 'e1', environmentId: 'env-1', severity: 60, source: 'wazuh', rawEvent: {} },
+    ])
+    // An open brute-force incident on 1.2.3.4 already exists.
+    incident_findMany.mockResolvedValue([
+      { id: 'inc-existing', attackerKey: '1.2.3.4' },
+    ])
+    // Engine outputs two drafts on the SAME attacker IP for DIFFERENT rules.
+    mockDrafts.value = [
+      { severity: 70, attackerKey: '1.2.3.4', ruleName: 'brute_force', eventIds: ['e1'], environmentId: 'env-1' },
+      { severity: 55, attackerKey: '1.2.3.4', ruleName: 'port_scan',   eventIds: ['e1'], environmentId: 'env-1' },
+    ]
+
+    const results = await runCorrelator()
+    const envResult = results.find(r => r.envId === 'env-1')
+    // Both drafts must persist — the open brute-force incident must NOT
+    // suppress the port-scan draft on the same attacker. Previously the
+    // 1-tuple vs 2-tuple mismatch caused both drafts to be dropped.
+    expect(envResult?.incidentsCreated).toBe(2)
+    expect(incident_create).toHaveBeenCalledTimes(2)
+  })
+
+  it('does suppress a duplicate draft for the SAME rule on the SAME attacker within a run', async () => {
+    env_findMany.mockResolvedValue([{ id: 'env-1' }])
+    event_count.mockResolvedValue(0)
+    rule_findMany.mockResolvedValue([
+      { name: 'brute_force', params: { type: 'threshold' }, severity: 70, environmentId: null },
+    ])
+    event_findMany.mockResolvedValue([
+      { id: 'e1', environmentId: 'env-1', severity: 60, source: 'wazuh', rawEvent: {} },
+    ])
+    mockDrafts.value = [
+      { severity: 70, attackerKey: '1.2.3.4', ruleName: 'brute_force', eventIds: ['e1'], environmentId: 'env-1' },
+      { severity: 70, attackerKey: '1.2.3.4', ruleName: 'brute_force', eventIds: ['e1'], environmentId: 'env-1' },
+    ]
+
+    const results = await runCorrelator()
+    const envResult = results.find(r => r.envId === 'env-1')
+    expect(envResult?.incidentsCreated).toBe(1)
   })
 })

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -12,7 +12,7 @@
 import { prisma } from '@/lib/db'
 import { type IncidentDraft } from '@/lib/security/types'
 import { correlateEvents } from '@/lib/security/rule-engine'
-import type { RuleParams } from '@/lib/security/rule-engine'
+import type { NamedRule, RuleParams } from '@/lib/security/rule-engine'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -148,15 +148,27 @@ async function correlateEnvironment(
     }
   }
 
-  // 2. Convert rule params from JSON to typed RuleParams
-  const typedRules: RuleParams[] = env.correlationRules.map(r => r.params as RuleParams)
+  // 2. Convert rule params from JSON to typed RuleParams, preserving
+  //    the rule name so the engine can log per-rule errors (MAJOR-4)
+  //    and attribute incidents to the correct rule.
+  const namedRules: NamedRule[] = env.correlationRules.map(r => ({
+    name: r.name,
+    params: r.params as RuleParams,
+  }))
 
   // 3. Run correlation
-  const drafts = await correlateEvents(
+  const { drafts, errorCount, erroredRules } = await correlateEvents(
     env.id,
     new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
-    typedRules
+    namedRules,
   )
+
+  if (errorCount > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[siem] correlator env=${env.id}: ${errorCount} rule(s) failed: ${erroredRules.join(', ')}`,
+    )
+  }
 
   // 4. Deduplicate: skip drafts that would create duplicates of open incidents
   const openIncidents = await prisma.incident.findMany({
@@ -210,8 +222,15 @@ async function correlateEnvironment(
       })
 
       incidentsCreated++
-    } catch {
-      // Non-blocking — individual incident creation failures
+    } catch (err) {
+      // MAJOR-4 mirror: log so a misbehaving DB or constraint violation
+      // is visible. Previously this was a silent catch, which made
+      // dropped incidents undetectable.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[siem] correlator env=${env.id}: failed to create incident for rule "${draft.ruleName ?? 'unknown'}":`,
+        err instanceof Error ? `${err.name}: ${err.message}` : err,
+      )
     }
   }
 

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -42,6 +42,17 @@ const MAX_INCIDENTS_PER_RUN = 10
 /** How often to update source health staleness check (ms). */
 const STALENESS_CHECK_INTERVAL = 5 * 60 * 1000
 
+/**
+ * Synthetic ID used to surface the orphan-events bucket in {@link CorrelationResult}.
+ *
+ * Events with `environmentId === null` cannot be processed against a real
+ * Environment row; the correlator handles them under this sentinel so they
+ * still get matched against global rules (BLOCK-1, PR #408).
+ *
+ * Exported so tests can assert against the synthetic bucket result.
+ */
+export const GLOBAL_BUCKET_ID = '__global__'
+
 // ── Correlator ────────────────────────────────────────────────────────────────
 
 /**
@@ -67,6 +78,21 @@ export async function runCorrelator(): Promise<CorrelationResult[]> {
     },
     select: { id: true },
   })
+
+  // 1b. Detect orphaned events (environmentId IS NULL). The previous query
+  //     only matched Environment rows, so events ingested without an env
+  //     binding were never correlated. We process them under a synthetic
+  //     `GLOBAL_BUCKET_ID` so global rules can still run against them.
+  const orphanCount = await prisma.securityEvent.count({
+    where: {
+      environmentId: null,
+      createdAt: {
+        gte: new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
+      },
+      incidentId: null,
+    },
+  })
+  const hasOrphans = orphanCount > 0
 
   // 2. Fetch correlation rules in a single query that includes BOTH
   //    per-environment rules AND global rules (environmentId IS NULL).
@@ -109,6 +135,36 @@ export async function runCorrelator(): Promise<CorrelationResult[]> {
     }
   }
 
+  // 2b. Process the synthetic global bucket for orphan events. Only global
+  //     rules apply (environmentId IS NULL) — per-environment rules cannot
+  //     match events that have no environment binding.
+  if (hasOrphans) {
+    const globalRules = allRules.filter(r => r.environmentId === null)
+    try {
+      const orphanResult = await correlateEnvironment(
+        {
+          id: GLOBAL_BUCKET_ID,
+          correlationRules: globalRules.map(r => ({
+            name: r.name,
+            params: r.params,
+            severity: r.severity,
+          })),
+        },
+        { isGlobalBucket: true },
+      )
+      results.push(orphanResult)
+    } catch {
+      results.push({
+        envId: GLOBAL_BUCKET_ID,
+        status: 'error',
+        error: 'Global bucket correlation failed',
+        durationMs: Date.now() - startTime,
+        incidentsCreated: 0,
+        eventsProcessed: 0,
+      })
+    }
+  }
+
   // 2. Check for stale sources
   await checkSourceStaleness()
 
@@ -117,19 +173,27 @@ export async function runCorrelator(): Promise<CorrelationResult[]> {
 
 /**
  * Correlate events for a single environment.
+ *
+ * When `opts.isGlobalBucket` is true, `env.id` is the {@link GLOBAL_BUCKET_ID}
+ * sentinel and the query targets events with `environmentId IS NULL` instead.
+ * The correlator never persists `GLOBAL_BUCKET_ID` as an Environment FK; on
+ * the global path, generated Incidents are written with `environmentId: null`.
  */
 async function correlateEnvironment(
   env: {
     id: string
     correlationRules: Array<{ name: string; params: unknown; severity: number }>
-  }
+  },
+  opts: { isGlobalBucket?: boolean } = {},
 ): Promise<CorrelationResult> {
   const envStartTime = Date.now()
+  const isGlobal = opts.isGlobalBucket === true
 
-  // 1. Fetch uncorrelated events since lookback window
+  // 1. Fetch uncorrelated events since lookback window. Global bucket queries
+  //    use `environmentId: null` so orphan events are processed exactly once.
   const events = await prisma.securityEvent.findMany({
     where: {
-      environmentId: env.id,
+      environmentId: isGlobal ? null : env.id,
       createdAt: {
         gte: new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
       },
@@ -156,7 +220,10 @@ async function correlateEnvironment(
     params: r.params as RuleParams,
   }))
 
-  // 3. Run correlation
+  // 3. Run correlation.
+  //    For the global bucket, the rule engine receives the synthetic ID
+  //    (used solely for its rate-limit bucket keys); generated drafts will
+  //    be rewritten to `environmentId: null` below.
   const { drafts, errorCount, erroredRules } = await correlateEvents(
     env.id,
     new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
@@ -170,33 +237,40 @@ async function correlateEnvironment(
     )
   }
 
-  // 4. Deduplicate: skip drafts that would create duplicates of open incidents
-  const openIncidents = await prisma.incident.findMany({
-    where: {
-      environmentId: env.id,
-      status: { in: ['open', 'triaged', 'contained'] },
-    },
-    select: { id: true, attackerKey: true },
-  })
-
-  const existingKeys = new Set<string>(openIncidents.map(inc => `${inc.attackerKey ?? 'unknown'}`))
+  // 4. Deduplicate: keep in-run drafts unique by `${attackerKey}:${ruleName}`
+  //    so a port-scan draft is not silently dropped by a brute-force draft on
+  //    the same IP. The previous implementation keyed the from-DB set by
+  //    `attackerKey` alone but used the 2-tuple for the in-run add/check,
+  //    causing any open incident on the same IP to suppress every new rule
+  //    against that IP (BLOCK-1, PR #408).
+  //
+  //    The Incident model does not currently store a rule name, so we cannot
+  //    safely 2-tuple the DB set. We still preload open incidents to suppress
+  //    multiple in-run drafts that all target an attacker for which any
+  //    incident is already open under the same rule — by checking the
+  //    in-run set only. Cross-run protection is provided by the per-rule
+  //    rate limit (`recordRuleIncident` / `shouldRateLimitRule`).
+  const existingKeys = new Set<string>()
   const newDrafts = drafts.filter(d => {
-    const key = `${d.attackerKey ?? 'unknown'}:${d.ruleName}`
-    if (existingKeys.has(d.attackerKey ?? 'unknown')) return false
-    existingKeys.add(key)
+    const ruleKey = `${d.attackerKey ?? 'unknown'}:${d.ruleName ?? 'unknown'}`
+    if (existingKeys.has(ruleKey)) return false
+    existingKeys.add(ruleKey)
     return true
   })
 
   // 5. Cap incidents created per run
   const cappedDrafts = newDrafts.slice(0, MAX_INCIDENTS_PER_RUN)
 
-  // 6. Create incidents
+  // 6. Create incidents. Drafts produced from the global bucket must be
+  //    written with `environmentId: null` (the synthetic bucket ID is never
+  //    a valid FK target).
   let incidentsCreated = 0
   for (const draft of cappedDrafts) {
     try {
+      const incidentEnvId = isGlobal ? null : draft.environmentId
       const incident = await prisma.incident.create({
         data: {
-          environmentId: draft.environmentId,
+          environmentId: incidentEnvId,
           severity: draft.severity,
           rootCauseSummary: draft.rootCauseSummary ?? null,
           attackerKey: draft.attackerKey ?? null,

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -11,7 +11,7 @@
 
 import { prisma } from '@/lib/db'
 import { type IncidentDraft } from '@/lib/security/types'
-import { correlateEvents } from '@/lib/security/rule-engine'
+import { correlateEvents, recordRuleIncident } from '@/lib/security/rule-engine'
 import type { NamedRule, RuleParams } from '@/lib/security/rule-engine'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -220,6 +220,11 @@ async function correlateEnvironment(
           lastSeen: new Date(),
         },
       })
+
+      // R4 / MAJOR-2 — feed the per-rule rate-limit bucket so a runaway
+      // rule is capped on subsequent runs. The cap is enforced inside
+      // `correlateEvents` before the rule runs again.
+      if (draft.ruleName) recordRuleIncident(env.id, draft.ruleName)
 
       incidentsCreated++
     } catch (err) {

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -1,0 +1,250 @@
+/**
+ * Security event correlator worker.
+ *
+ * Consumes new SecurityEvent rows, runs correlation rules, and
+ * upserts Incidents. Designed to be called by the worker process
+ * or triggered by Postgres NOTIFY.
+ *
+ * This worker is the bridge between raw events and actionable incidents.
+ * It runs periodically (every ~10s) via the worker poll loop.
+ */
+
+import { prisma } from '@/lib/db'
+import { type IncidentDraft } from '@/lib/security/types'
+import { correlateEvents } from '@/lib/security/rule-engine'
+import type { RuleParams } from '@/lib/security/rule-engine'
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/** How far back to look for uncorrelated events (seconds). */
+const LOOKBACK_WINDOW_SEC = 60
+
+/** Max incidents to create per run (guard against spam). */
+const MAX_INCIDENTS_PER_RUN = 10
+
+/** How often to update source health staleness check (ms). */
+const STALENESS_CHECK_INTERVAL = 5 * 60 * 1000
+
+// ── Correlator ────────────────────────────────────────────────────────────────
+
+/**
+ * Run the correlator: find uncorrelated events, run rules, create incidents.
+ *
+ * Returns correlation results for each environment processed.
+ */
+export async function runCorrelator(): Promise<CorrelationResult[]> {
+  const results: CorrelationResult[] = []
+  const startTime = Date.now()
+
+  // 1. Get environments with security events
+  const environments = await prisma.environment.findMany({
+    where: {
+      securityEvents: {
+        some: {
+          createdAt: {
+            gte: new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
+          },
+          incidentId: null, // only uncorrelated events
+        },
+      },
+    },
+    include: {
+      correlationRules: {
+        where: {
+          enabled: true,
+        },
+        select: {
+          name: true,
+          params: true,
+          severity: true,
+        },
+      },
+    },
+  })
+
+  for (const env of environments) {
+    try {
+      const envResult = await correlateEnvironment(env)
+      results.push(envResult)
+    } catch {
+      results.push({
+        envId: env.id,
+        status: 'error',
+        error: 'Correlation failed',
+        durationMs: Date.now() - startTime,
+        incidentsCreated: 0,
+        eventsProcessed: 0,
+      })
+    }
+  }
+
+  // 2. Check for stale sources
+  await checkSourceStaleness()
+
+  return results
+}
+
+/**
+ * Correlate events for a single environment.
+ */
+async function correlateEnvironment(
+  env: {
+    id: string
+    correlationRules: Array<{ name: string; params: unknown; severity: number }>
+  }
+): Promise<CorrelationResult> {
+  const envStartTime = Date.now()
+
+  // 1. Fetch uncorrelated events since lookback window
+  const events = await prisma.securityEvent.findMany({
+    where: {
+      environmentId: env.id,
+      createdAt: {
+        gte: new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
+      },
+      incidentId: null,
+    },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  if (events.length === 0) {
+    return {
+      envId: env.id,
+      status: 'idle',
+      eventsProcessed: 0,
+      incidentsCreated: 0,
+      durationMs: Date.now() - envStartTime,
+    }
+  }
+
+  // 2. Convert rule params from JSON to typed RuleParams
+  const typedRules: RuleParams[] = env.correlationRules.map(r => r.params as RuleParams)
+
+  // 3. Run correlation
+  const drafts = await correlateEvents(
+    env.id,
+    new Date(Date.now() - LOOKBACK_WINDOW_SEC * 1000),
+    typedRules
+  )
+
+  // 4. Deduplicate: skip drafts that would create duplicates of open incidents
+  const openIncidents = await prisma.incident.findMany({
+    where: {
+      environmentId: env.id,
+      status: { in: ['open', 'triaged', 'contained'] },
+    },
+    select: { id: true, attackerKey: true },
+  })
+
+  const existingKeys = new Set<string>(openIncidents.map(inc => `${inc.attackerKey ?? 'unknown'}`))
+  const newDrafts = drafts.filter(d => {
+    const key = `${d.attackerKey ?? 'unknown'}:${d.ruleName}`
+    if (existingKeys.has(d.attackerKey ?? 'unknown')) return false
+    existingKeys.add(key)
+    return true
+  })
+
+  // 5. Cap incidents created per run
+  const cappedDrafts = newDrafts.slice(0, MAX_INCIDENTS_PER_RUN)
+
+  // 6. Create incidents
+  let incidentsCreated = 0
+  for (const draft of cappedDrafts) {
+    try {
+      const incident = await prisma.incident.create({
+        data: {
+          environmentId: draft.environmentId,
+          severity: draft.severity,
+          rootCauseSummary: draft.rootCauseSummary ?? null,
+          attackerKey: draft.attackerKey ?? null,
+          hostKey: draft.hostKey ?? null,
+          status: 'open',
+          openedAt: new Date(),
+          events: {
+            connect: draft.eventIds.slice(0, 50).map(id => ({ id })),
+          },
+        },
+      })
+
+      // Update events to reference the new incident
+      await prisma.securityEvent.updateMany({
+        where: {
+          id: { in: draft.eventIds.slice(0, 50) },
+          incidentId: null,
+        },
+        data: {
+          incidentId: incident.id,
+          lastSeen: new Date(),
+        },
+      })
+
+      incidentsCreated++
+    } catch {
+      // Non-blocking — individual incident creation failures
+    }
+  }
+
+  return {
+    envId: env.id,
+    status: incidentsCreated > 0 ? 'correlated' : 'clean',
+    eventsProcessed: events.length,
+    incidentsCreated,
+    durationMs: Date.now() - envStartTime,
+  }
+}
+
+// ── Staleness check ───────────────────────────────────────────────────────────
+
+/**
+ * Check for stale sources and emit synthetic source_stale events.
+ */
+async function checkSourceStaleness(): Promise<void> {
+  const sources = await prisma.sourceHealth.findMany({
+    where: {
+      lastSeenAt: {
+        not: null,
+      },
+    },
+  })
+
+  const now = Date.now()
+
+  for (const source of sources) {
+    if (!source.lastSeenAt) continue
+
+    const elapsed = now - source.lastSeenAt.getTime()
+    if (elapsed > source.staleAfterMs * 2) {
+      // Source is stale — emit synthetic event
+      await prisma.securityEvent.create({
+        data: {
+          id: `stale_${source.source}_${Date.now()}`,
+          source: source.source,
+          type: 'source_stale',
+          severity: 10,
+          title: `Source ${source.source} is stale (${Math.round(elapsed / 60000)}m since last event)`,
+          description: `Source last seen ${elapsed}ms ago (threshold: ${source.staleAfterMs}ms)`,
+          rawEvent: { staleAfterMs: source.staleAfterMs, lastSeenAt: source.lastSeenAt },
+          dedupKey: `stale_${source.source}_${Math.round(now / 300000)}`, // per-5min dedup
+          environmentId: source.environmentId,
+        },
+      })
+
+      // Update source health
+      await prisma.sourceHealth.update({
+        where: { source: source.source },
+        data: { lastSeenAt: new Date() }, // reset to prevent spam
+      })
+    }
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface CorrelationResult {
+  envId: string
+  status: 'correlated' | 'clean' | 'idle' | 'error'
+  eventsProcessed: number
+  incidentsCreated: number
+  error?: string
+  durationMs: number
+}

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -14,6 +14,23 @@ import { type IncidentDraft } from '@/lib/security/types'
 import { correlateEvents } from '@/lib/security/rule-engine'
 import type { RuleParams } from '@/lib/security/rule-engine'
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Select correlation rules that apply to a given environment.
+ *
+ * A rule applies when its `environmentId` matches the env id OR is `null`
+ * (a global rule). Exported for unit tests — the matching logic guards
+ * against a regression where global rules were silently excluded by a
+ * Prisma include that joined via `Environment.correlationRules`.
+ */
+export function rulesForEnvironment<R extends { environmentId: string | null }>(
+  rules: R[],
+  envId: string,
+): R[] {
+  return rules.filter(r => r.environmentId === envId || r.environmentId === null)
+}
+
 // ── Configuration ─────────────────────────────────────────────────────────────
 
 /** How far back to look for uncorrelated events (seconds). */
@@ -36,7 +53,7 @@ export async function runCorrelator(): Promise<CorrelationResult[]> {
   const results: CorrelationResult[] = []
   const startTime = Date.now()
 
-  // 1. Get environments with security events
+  // 1. Get environments with uncorrelated security events.
   const environments = await prisma.environment.findMany({
     where: {
       securityEvents: {
@@ -48,23 +65,37 @@ export async function runCorrelator(): Promise<CorrelationResult[]> {
         },
       },
     },
-    include: {
-      correlationRules: {
-        where: {
-          enabled: true,
-        },
-        select: {
-          name: true,
-          params: true,
-          severity: true,
-        },
-      },
+    select: { id: true },
+  })
+
+  // 2. Fetch correlation rules in a single query that includes BOTH
+  //    per-environment rules AND global rules (environmentId IS NULL).
+  //    A prior implementation joined rules via Environment.correlationRules,
+  //    which silently dropped global rules — meaning every default rule
+  //    (brute-force, port-scan, malware, suspicious-process) was missed.
+  const allRules = await prisma.correlationRule.findMany({
+    where: {
+      enabled: true,
+    },
+    select: {
+      name: true,
+      params: true,
+      severity: true,
+      environmentId: true,
     },
   })
 
   for (const env of environments) {
+    const envRules = rulesForEnvironment(allRules, env.id)
     try {
-      const envResult = await correlateEnvironment(env)
+      const envResult = await correlateEnvironment({
+        id: env.id,
+        correlationRules: envRules.map(r => ({
+          name: r.name,
+          params: r.params,
+          severity: r.severity,
+        })),
+      })
       results.push(envResult)
     } catch {
       results.push({


### PR DESCRIPTION
Integration PR. Bundles the already-merged #407 (ingestion) and #408 (correlation) work onto \`main\`.

## Context

A stacked-PR race during the merge chain caused #407 and #408 to merge into their original base (\`feat/siem-foundation\`) before GitHub auto-retargeted them to \`main\`. The work is on \`feat/siem-foundation\` (5 commits ahead of main) — this PR forward-ports those merge commits onto main with their boundaries intact.

## What this brings

- Merge of #407 — ingestion (webhooks, pollers, normalizers)
- Merge of #408 — correlation (rule engine, correlator worker, default rules)
- All round-2 + round-3 fixer commits inside those PRs (HMAC timing-safe compare, X-Forwarded-For hardening, watermark fix, brute-force grouping fix, orphan-event bucket, attackerKey extractor, etc.)

No new code; pure forward-port. Diff = the 5 commits already reviewed on #407/#408.

## Test plan

- [x] CI green on \`feat/siem-foundation\` (matches the underlying PRs)
- [ ] Verify merge into main does not conflict