### PR TITLE
feat(gateway): gateway tool-call audit emitter (PR4)

### DIFF
--- a/apps/gateway/src/gateway-audit.test.ts
+++ b/apps/gateway/src/gateway-audit.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { getToolSeverity, buildAuditEvent } from './gateway-audit'
+
+describe('getToolSeverity', () => {
+  it('returns 80 for write-tier tools', () => {
+    expect(getToolSeverity('crowdsec_decision_create')).toBe(80)
+    expect(getToolSeverity('crowdsec_decision_delete')).toBe(80)
+    expect(getToolSeverity('wazuh_active_response')).toBe(80)
+    expect(getToolSeverity('firewall_block')).toBe(80)
+  })
+
+  it('returns 60 for security_propose_action', () => {
+    expect(getToolSeverity('security_propose_action')).toBe(60)
+  })
+
+  it('returns 20 for read-tier security tools', () => {
+    expect(getToolSeverity('crowdsec_blocks')).toBe(20)
+    expect(getToolSeverity('ntopng_threats')).toBe(20)
+    expect(getToolSeverity('elk_flow_search')).toBe(20)
+  })
+
+  it('returns 10 for unknown tools', () => {
+    expect(getToolSeverity('some_unknown_tool')).toBe(10)
+  })
+})
+
+describe('buildAuditEvent', () => {
+  it('creates a correct audit event for a successful tool call', () => {
+    const event = buildAuditEvent({
+      toolName: 'crowdsec_decision_create',
+      result: JSON.stringify({ success: true, ip: '1.2.3.4' }),
+      args: { ip: '1.2.3.4' },
+      error: false,
+    })
+
+    expect(event.type).toBe('agent.tool.invoked')
+    expect(event.source).toBe('gateway_audit')
+    expect(event.severity).toBe(80)
+    expect(event.toolName).toBe('crowdsec_decision_create')
+    expect(event.title).toBe('Tool executed: crowdsec_decision_create')
+    expect(event.rawEvent.error).toBe(false)
+  })
+
+  it('creates an audit event for a failed tool call', () => {
+    const event = buildAuditEvent({
+      toolName: 'firewall_block',
+      result: 'Error: timeout',
+      args: { cidr: '10.0.0.0/24' },
+      error: true,
+    })
+
+    expect(event.severity).toBe(80)
+    expect(event.title).toBe('Tool failed: firewall_block')
+    expect(event.rawEvent.error).toBe(true)
+  })
+
+  it('truncates result to 1000 chars', () => {
+    const longResult = 'x'.repeat(2000)
+    const event = buildAuditEvent({
+      toolName: 'elk_syslog_search',
+      result: longResult,
+      args: {},
+      error: false,
+    })
+
+    expect(event.rawEvent.result.length).toBe(1000)
+  })
+})

--- a/apps/gateway/src/gateway-audit.ts
+++ b/apps/gateway/src/gateway-audit.ts
@@ -46,7 +46,7 @@ export interface GatewayAuditEvent {
   rawEvent: Record<string, unknown>
 }
 
-const WEBHOOK_URL = process.env.GATEWAY_AUDIT_EVENT_URL ?? '/api/monitoring/security/events'
+const WEBHOOK_URL = process.env.GATEWAY_AUDIT_EVENT_URL ?? 'http://orion:3000/api/monitoring/security/events'
 const WEBHOOK_SECRET = process.env.GATEWAY_AUDIT_SECRET
 const GATEWAY_ID = process.env.ENVIRONMENT_ID || process.env.HOSTNAME || 'unknown'
 
@@ -109,19 +109,21 @@ export function buildAuditEvent({
   args,
   gatewayId,
   error,
+  agent,
 }: {
   toolName: string
   result: string
   args: Record<string, unknown>
   gatewayId?: string
   error?: boolean
+  agent?: string
 }): GatewayAuditEvent {
   return {
     type: 'agent.tool.invoked',
     source: 'gateway_audit',
     severity: getToolSeverity(toolName),
     toolName,
-    agent: 'unknown',
+    agent: agent ?? 'unknown',
     gatewayId,
     title: `Tool ${error ? 'failed' : 'executed'}: ${toolName}`,
     description: error ? `Tool ${toolName} execution failed` : `Tool ${toolName} completed successfully`,

--- a/apps/gateway/src/gateway-audit.ts
+++ b/apps/gateway/src/gateway-audit.ts
@@ -1,0 +1,134 @@
+/**
+ * Gateway audit event emitter.
+ *
+ * Emits SecurityEvent rows to the web app's ingestion endpoint after each
+ * tool execution. This provides the correlation rule for gateway tool-call
+ * audit (PR4): any single agent.tool.invoked event with severity >= 60
+ * opens an Incident for human review.
+ *
+ * Source: gateway_audit
+ * Type: agent.tool.invoked
+ */
+
+// Severity map: write-tier tools get high severity (triggers incident),
+// read-tier tools get low severity (logged but no incident).
+const TOOL_SEVERITY: Record<string, number> = {
+  // Write-tier: state-changing actions
+  crowdsec_decision_create: 80,
+  crowdsec_decision_delete: 80,
+  wazuh_active_response: 80,
+  firewall_block: 80,
+  // Policy-gated entry point
+  security_propose_action: 60,
+  // Read-tier: visibility only
+  crowdsec_blocks: 20,
+  crowdsec_suggestions: 20,
+  ntopng_threats: 20,
+  ntopng_top_talkers: 20,
+  elk_flow_search: 20,
+  elk_syslog_search: 20,
+  prometheus_query: 10,
+  prometheus_query_range: 10,
+}
+
+/** Default severity for unknown tools (no incident, but logged). */
+const DEFAULT_SEVERITY = 10
+
+export interface GatewayAuditEvent {
+  type: string
+  source: string
+  severity: number
+  toolName: string
+  agent: string
+  gatewayId?: string
+  title: string
+  description?: string
+  rawEvent: Record<string, unknown>
+}
+
+const WEBHOOK_URL = process.env.GATEWAY_AUDIT_EVENT_URL ?? '/api/monitoring/security/events'
+const WEBHOOK_SECRET = process.env.GATEWAY_AUDIT_SECRET
+const GATEWAY_ID = process.env.ENVIRONMENT_ID || process.env.HOSTNAME || 'unknown'
+
+/**
+ * Emit a single gateway audit SecurityEvent to the web app.
+ * Non-blocking: fires and forgets with a short timeout.
+ */
+export async function emitGatewayAuditEvent(event: GatewayAuditEvent): Promise<void> {
+  if (!WEBHOOK_SECRET) {
+    // Dev mode: skip if no secret configured
+    return
+  }
+
+  const payload = {
+    type: event.type,
+    source: event.source,
+    severity: event.severity,
+    title: event.title,
+    description: event.description,
+    toolName: event.toolName,
+    agent: event.agent,
+    gatewayId: event.gatewayId || GATEWAY_ID,
+    rawEvent: {
+      toolName: event.toolName,
+      agent: event.agent,
+      severity: event.severity,
+      ...event.rawEvent,
+    },
+  }
+
+  // Non-blocking, 2s timeout
+  try {
+    await fetch(`${WEBHOOK_URL}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Gateway-Secret': WEBHOOK_SECRET,
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(2000),
+    })
+  } catch {
+    // Fire-and-forget: don't break tool execution on emit failure
+  }
+}
+
+/**
+ * Get severity for a tool name.
+ */
+export function getToolSeverity(toolName: string): number {
+  return TOOL_SEVERITY[toolName] ?? DEFAULT_SEVERITY
+}
+
+/**
+ * Build a gateway_audit event from tool execution context.
+ */
+export function buildAuditEvent({
+  toolName,
+  result,
+  args,
+  gatewayId,
+  error,
+}: {
+  toolName: string
+  result: string
+  args: Record<string, unknown>
+  gatewayId?: string
+  error?: boolean
+}): GatewayAuditEvent {
+  return {
+    type: 'agent.tool.invoked',
+    source: 'gateway_audit',
+    severity: getToolSeverity(toolName),
+    toolName,
+    agent: 'unknown',
+    gatewayId,
+    title: `Tool ${error ? 'failed' : 'executed'}: ${toolName}`,
+    description: error ? `Tool ${toolName} execution failed` : `Tool ${toolName} completed successfully`,
+    rawEvent: {
+      result: result.slice(0, 1000), // truncate to avoid bloating the event
+      args,
+      error,
+    },
+  }
+}

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -331,13 +331,15 @@ server.setRequestHandler(CallToolRequestSchema, async (req: unknown) => {
       result = await runTool(tool, args as Record<string, unknown>)
     }
     // Audit: fire-and-forget
-    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false }))
+    const sessionId = (req as any).sessionId ?? (req as any).params?.sessionId ?? 'unknown'
+    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false, agent: sessionId }))
     return { content: [{ type: 'text', text: result }] }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     // Audit: fire-and-forget (error path too)
     try {
-      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true }))
+      const sessionId = (req as any).sessionId ?? (req as any).params?.sessionId ?? 'unknown'
+      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true, agent: sessionId }))
     } catch { /* ignored */ }
     console.error(`[gateway] Tool ${name} failed:`, msg)
     return { content: [{ type: 'text', text: `Error: ${msg}` }], isError: true }
@@ -407,13 +409,15 @@ app.post('/tools/execute', requireAuth, async (req: Request, res: Response) => {
       result = await runTool(tool!, args)
     }
     // Audit: fire-and-forget
-    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false }))
+    const callerAgent = (req as any).agentId ?? req.body?.agent ?? 'rest-client'
+    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false, agent: callerAgent }))
     res.json({ result })
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
     // Audit: fire-and-forget (error path too)
     try {
-      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true }))
+      const callerAgent = (req as any).agentId ?? req.body?.agent ?? 'rest-client'
+      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true, agent: callerAgent }))
     } catch { /* ignored */ }
     res.status(500).json({ error: msg })
   }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -46,6 +46,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { OrionClient, type McpToolConfig } from './orion-client.js'
 import { runTool } from './tool-runner.js'
+import { emitGatewayAuditEvent, buildAuditEvent } from './gateway-audit.js'
 import { HooksEngine } from './hooks-engine.js'
 import { SkillLoader } from './skill-loader.js'
 import { kubernetesTools } from './builtin-tools/kubernetes.js'
@@ -322,16 +323,22 @@ server.setRequestHandler(CallToolRequestSchema, async (req: unknown) => {
   const tool = activeTools.find(t => t.name === name)
   if (!tool) return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true }
 
+  let result: string
   try {
-    let result: string
     if (tool.builtIn && BUILTIN_REGISTRY[name]) {
       result = await BUILTIN_REGISTRY[name].execute(args as Record<string, unknown>)
     } else {
       result = await runTool(tool, args as Record<string, unknown>)
     }
+    // Audit: fire-and-forget
+    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false }))
     return { content: [{ type: 'text', text: result }] }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
+    // Audit: fire-and-forget (error path too)
+    try {
+      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true }))
+    } catch { /* ignored */ }
     console.error(`[gateway] Tool ${name} failed:`, msg)
     return { content: [{ type: 'text', text: `Error: ${msg}` }], isError: true }
   }
@@ -399,9 +406,15 @@ app.post('/tools/execute', requireAuth, async (req: Request, res: Response) => {
     } else {
       result = await runTool(tool!, args)
     }
+    // Audit: fire-and-forget
+    emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result, args, error: false }))
     res.json({ result })
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
+    // Audit: fire-and-forget (error path too)
+    try {
+      emitGatewayAuditEvent(buildAuditEvent({ toolName: name, result: `Error: ${msg}`, args, error: true }))
+    } catch { /* ignored */ }
     res.status(500).json({ error: msg })
   }
 })

--- a/apps/web/src/app/api/monitoring/security/events/route.ts
+++ b/apps/web/src/app/api/monitoring/security/events/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import crypto from 'crypto'
 import { prisma } from '@/lib/db'
+import { constantTimeCompare } from '@/lib/security/webhook-auth'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
@@ -19,7 +20,7 @@ export const maxDuration = 30
 export async function POST(req: NextRequest) {
   // Auth: verify trusted internal secret
   const secret = req.headers.get('x-gateway-secret')
-  if (secret !== process.env.GATEWAY_AUDIT_SECRET) {
+  if (!constantTimeCompare(secret ?? '', process.env.GATEWAY_AUDIT_SECRET ?? '')) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
@@ -70,6 +71,17 @@ export async function POST(req: NextRequest) {
     })
     ids.push(eventId)
   }
+
+  await prisma.sourceHealth.upsert({
+    where: { source: 'gateway_audit' },
+    update: { lastSeenAt: now },
+    create: {
+      source: 'gateway_audit',
+      lastSeenAt: now,
+      lastWatermark: null,
+      staleAfterMs: 3600 * 1000, // 1 hour — gateway_audit only fires on writes
+    },
+  })
 
   return NextResponse.json({ accepted: ids.length, ids })
 }

--- a/apps/web/src/app/api/monitoring/security/events/route.ts
+++ b/apps/web/src/app/api/monitoring/security/events/route.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/monitoring/security/events
+ *
+ * Accepts security audit events from trusted internal services (gateway,
+ * host-agent Vector shipper). Creates SecurityEvent rows for correlation
+ * and incident generation.
+ *
+ * Auth: X-Gateway-Secret header matching process.env.GATEWAY_AUDIT_SECRET
+ * (same secret used by existing gateway auth for simplicity).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 30
+
+export async function POST(req: NextRequest) {
+  // Auth: verify trusted internal secret
+  const secret = req.headers.get('x-gateway-secret')
+  if (secret !== process.env.GATEWAY_AUDIT_SECRET) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // Accept both single events and batched events
+  const events = Array.isArray(body) ? body : [body]
+
+  const now = new Date()
+  const ids: string[] = []
+
+  for (const raw of events) {
+    if (typeof raw !== 'object' || raw === null) continue
+    const e = raw as Record<string, unknown>
+
+    const type = String(e.type ?? '')
+    const severity = typeof e.severity === 'number' ? e.severity : 0
+    const source = String(e.source ?? 'gateway_audit')
+    const title = String(e.title ?? `${type} event`)
+    const description = typeof e.description === 'string' ? e.description : null
+    const rawEvent = typeof e.rawEvent === 'object' && e.rawEvent !== null ? e.rawEvent as Record<string, unknown> : {}
+    const agent = typeof e.agent === 'string' ? e.agent : 'unknown'
+    const toolName = typeof e.toolName === 'string' ? e.toolName : 'unknown'
+
+    const eventId = crypto.randomUUID()
+    const dedupKey = crypto.createHash('sha256').update(`${source}:${toolName}:${agent}:${now.toISOString().slice(0, 19)}`).digest('hex')
+
+    await prisma.securityEvent.create({
+      data: {
+        id: eventId,
+        environmentId: null,
+        type,
+        source,
+        severity,
+        title,
+        description,
+        rawEvent: rawEvent as any,
+        dedupKey,
+        firstSeen: now,
+        lastSeen: now,
+        createdAt: now,
+      },
+    })
+    ids.push(eventId)
+  }
+
+  return NextResponse.json({ accepted: ids.length, ids })
+}

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -79,7 +79,7 @@ export function verifyWebhookHmac(
  *   to undefined and the fallback was plain `===`, which is bypassable
  *   via a timing oracle. Fixed by routing through Node's `timingSafeEqual`.
  */
-function constantTimeCompare(a: string, b: string): boolean {
+export function constantTimeCompare(a: string, b: string): boolean {
   if (a.length !== b.length) return false
   const bufA = Buffer.from(a, 'utf8')
   const bufB = Buffer.from(b, 'utf8')

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -92,6 +92,15 @@ prisma.securityConfig.upsert({
 " 2>/dev/null || echo "NOTE: Could not seed SecurityConfig (app may not be running yet — run bootstrap.sh again after first start)."
 fi
 
+# ── Auto-generate GATEWAY_AUDIT_SECRET if missing ──────────────────────────
+if ! grep -q "^GATEWAY_AUDIT_SECRET=" "$DEPLOY_DIR/.env" || \
+   grep -q "^GATEWAY_AUDIT_SECRET=$" "$DEPLOY_DIR/.env"; then
+  TOKEN=$(openssl rand -hex 32)
+  sed -i '/^GATEWAY_AUDIT_SECRET=/d' "$DEPLOY_DIR/.env"
+  echo "GATEWAY_AUDIT_SECRET=${TOKEN}" >> "$DEPLOY_DIR/.env"
+  echo "Generated GATEWAY_AUDIT_SECRET."
+fi
+
 # ── Auto-generate NEXTAUTH_SECRET if placeholder ──────────────────────────────
 if grep -q "^NEXTAUTH_SECRET=change-me" "$DEPLOY_DIR/.env"; then
   SECRET=$(openssl rand -base64 32)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       EMBED_TRIGGER_TOKEN: ${EMBED_TRIGGER_TOKEN:-}
       # Service token for gateway↔ORION authentication (SOC2: [AC-001])
       ORION_GATEWAY_TOKEN: ${ORION_GATEWAY_TOKEN:-}
+      # Shared secret for gateway-to-web security audit channel (PR4)
+      GATEWAY_AUDIT_SECRET: ${GATEWAY_AUDIT_SECRET:-}
       # Audit Log Archival (S3 Export) — SOC2 [L-001]
       AUDIT_EXPORT_S3_BACKEND: ${AUDIT_EXPORT_S3_BACKEND:-minio}
       AUDIT_EXPORT_S3_ENDPOINT: ${AUDIT_EXPORT_S3_ENDPOINT:-http://minio:9000}
@@ -107,6 +109,8 @@ services:
       GATEWAY_CREDS_FILE: /gateway-creds/credentials.json
       # Token to authenticate with ORION's API (e.g. for knowledge graph tools)
       ORION_GATEWAY_TOKEN: ${ORION_GATEWAY_TOKEN:-}
+      # Shared secret for gateway-to-web security audit channel (PR4)
+      GATEWAY_AUDIT_SECRET: ${GATEWAY_AUDIT_SECRET:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - gateway-creds:/gateway-creds


### PR DESCRIPTION
## Summary

- [x] **PR4: Gateway tool-call audit emitter** — Hook into the gateway dispatcher (both MCP and REST entry points) to emit SecurityEvent rows for every tool execution
- [x] Create `POST /api/monitoring/security/events` endpoint in the web app to receive and persist audit events
- [x] Add `GATEWAY_AUDIT_SECRET` env var generation in bootstrap.sh and docker-compose.yml

## Architecture

```
Agent → MCP/REST → Gateway Dispatcher → Tool Execution
                                      ├─→ emitGatewayAuditEvent (fire-and-forget)
                                      │     → POST /api/monitoring/security/events
                                      │           → SecurityEvent.create()
                                      │
                                      └─→ Return result to agent
```

## Severity Mapping

| Tool Category | Severity | Incident? |
|---|---|---|
| `crowdsec_decision_create/delete` | 80 | Yes |
| `wazuh_active_response` | 80 | Yes |
| `firewall_block` | 80 | Yes |
| `security_propose_action` | 60 | Yes |
| Read tools (crowdsec_blocks, ntopng, elk_*) | 20 | No |
| Prometheus queries | 10 | No |
| Unknown tools | 10 | No |

The correlation rule `gateway_audit_high_severity` (seeded in PR3) fires immediately on `agent.tool.invoked` events with `minSeverity=60`, creating an Incident for human review.

## Files Changed

- `apps/gateway/src/gateway-audit.ts` — New audit emitter utility with severity map
- `apps/gateway/src/gateway-audit.test.ts` — 7 unit tests
- `apps/gateway/src/index.ts` — Hook emit into MCP handler and REST `/tools/execute`
- `apps/web/src/app/api/monitoring/security/events/route.ts` — New ingest endpoint
- `deploy/bootstrap.sh` — GATEWAY_AUDIT_SECRET generation
- `deploy/docker-compose.yml` — GATEWAY_AUDIT_SECRET in orion + gateway services

## Testing

- Gateway TypeScript compiles cleanly (`tsc --noEmit`)
- Gateway tests: 242 pass (6 pre-existing failures, unrelated)
- New gateway-audit.test.ts: 7/7 passing
- Web app security tests: 19/19 passing