### PR TITLE
fix(web): extract computeSourceStatus out of route file

### DIFF
--- a/apps/web/src/app/api/monitoring/security/sources/route.test.ts
+++ b/apps/web/src/app/api/monitoring/security/sources/route.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { computeSourceStatus } from './route'
+import { computeSourceStatus } from '@/lib/security/source-health-utils'
 
 describe('computeSourceStatus', () => {
   const STALE_MS = 60_000 // 1 min for tests

--- a/apps/web/src/app/api/monitoring/security/sources/route.ts
+++ b/apps/web/src/app/api/monitoring/security/sources/route.ts
@@ -6,31 +6,9 @@
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { computeSourceStatus } from '@/lib/security/source-health-utils'
 
 export const dynamic = 'force-dynamic'
-
-/**
- * Compute the source health status from the last-seen timestamp and the
- * configured `staleAfterMs` threshold. Exported so the SIEM Review B3 invariant
- * (the 'down' branch must be reachable) is locked in unit tests.
- *
- * Ladder:
- *   - lastSeenAt missing (0)      → 'down'
- *   - elapsed > staleAfterMs * 2  → 'down'
- *   - elapsed > staleAfterMs      → 'stale'
- *   - otherwise                    → 'healthy'
- */
-export function computeSourceStatus(
-  lastSeenMs: number,
-  nowMs: number,
-  staleAfterMs: number,
-): 'healthy' | 'stale' | 'down' {
-  if (lastSeenMs === 0) return 'down'
-  const elapsed = nowMs - lastSeenMs
-  if (elapsed > staleAfterMs * 2) return 'down'
-  if (elapsed > staleAfterMs) return 'stale'
-  return 'healthy'
-}
 
 export async function GET() {
   const sources = await prisma.sourceHealth.findMany({

--- a/apps/web/src/lib/security/source-health-utils.ts
+++ b/apps/web/src/lib/security/source-health-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Utility functions for SourceHealth status computation.
+ * Extracted from sources/route.ts so they can be unit-tested without
+ * triggering Next.js route export validation.
+ */
+
+/**
+ * Compute the source health status from the last-seen timestamp and the
+ * configured `staleAfterMs` threshold.
+ *
+ * Ladder:
+ *   - lastSeenAt missing (0)      → 'down'
+ *   - elapsed > staleAfterMs * 2  → 'down'
+ *   - elapsed > staleAfterMs      → 'stale'
+ *   - otherwise                    → 'healthy'
+ */
+export function computeSourceStatus(
+  lastSeenMs: number,
+  nowMs: number,
+  staleAfterMs: number,
+): 'healthy' | 'stale' | 'down' {
+  if (lastSeenMs === 0) return 'down'
+  const elapsed = nowMs - lastSeenMs
+  if (elapsed > staleAfterMs * 2) return 'down'
+  if (elapsed > staleAfterMs) return 'stale'
+  return 'healthy'
+}


### PR DESCRIPTION
## Summary

- Next.js build fails: `"computeSourceStatus" is not a valid Route export field`
- Extracted function to `lib/security/source-health-utils.ts`
- Updated `sources/route.ts` and `sources/route.test.ts` to import from the new location
- 8/8 tests pass

## Test plan
- [x] Unit tests pass locally
- [ ] CI Build & Deploy ORION Web passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)