### PR TITLE
fix(web): extract buildIdOnlyFrame out of stream route file

### DIFF
--- a/apps/web/src/app/api/monitoring/security/stream/route.test.ts
+++ b/apps/web/src/app/api/monitoring/security/stream/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { buildIdOnlyFrame, type NotifyMessage } from './route'
+import { buildIdOnlyFrame, type NotifyMessage } from '@/lib/security/stream-utils'
 
 describe('stream/route', () => {
   describe('buildIdOnlyFrame', () => {

--- a/apps/web/src/app/api/monitoring/security/stream/route.ts
+++ b/apps/web/src/app/api/monitoring/security/stream/route.ts
@@ -19,48 +19,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { TextEncoder } from 'util'
 import { Client } from 'pg'
+import { type StreamChannel, type NotifyMessage } from '@/lib/security/stream-utils'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300
 
 const encoder = new TextEncoder()
-
-// ── Channel types ─────────────────────────────────────────────────────────────
-
-type StreamChannel = 'incidents' | 'events' | 'approvals'
-
-/**
- * Per R7 (SIEM_PLAN.md Risk Register), SSE frames carry ID-only payloads.
- * Consumers fetch the full row via the REST endpoints (e.g. /incidents/[id]).
- * This:
- *   1. Sidesteps the 8 KB NOTIFY payload limit.
- *   2. Forces consumers through the read endpoints, where access control
- *      can filter sensitive fields per session/role.
- */
-export interface NotifyMessage {
-  channel: StreamChannel
-  payload: {
-    id: string
-    type: string // 'created' | 'updated' | 'deleted'
-    timestamp: string
-  }
-}
-
-/**
- * Build an ID-only SSE frame. Exported so tests can lock in the R7 invariant
- * (frames must never embed row data — only the ID for the consumer to fetch).
- */
-export function buildIdOnlyFrame(
-  channel: StreamChannel,
-  id: string,
-  type: 'created' | 'updated' | 'deleted' = 'created',
-  timestamp: string = new Date().toISOString()
-): NotifyMessage {
-  return {
-    channel,
-    payload: { id, type, timestamp },
-  }
-}
 
 // ── Channel → pg channel mapping ──────────────────────────────────────────────
 

--- a/apps/web/src/lib/security/stream-utils.ts
+++ b/apps/web/src/lib/security/stream-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Utility types and functions for the security SSE stream route.
+ * Extracted so they can be unit-tested without triggering Next.js
+ * route export validation (only HTTP verb handlers are valid exports).
+ */
+
+export type StreamChannel = 'incidents' | 'events' | 'approvals'
+
+/**
+ * Per R7 (SIEM_PLAN.md Risk Register), SSE frames carry ID-only payloads.
+ */
+export interface NotifyMessage {
+  channel: StreamChannel
+  payload: {
+    id: string
+    type: string
+    timestamp: string
+  }
+}
+
+/**
+ * Build an ID-only SSE frame. Kept here so tests can lock in the R7 invariant
+ * (frames must never embed row data — only the ID for the consumer to fetch).
+ */
+export function buildIdOnlyFrame(
+  channel: StreamChannel,
+  id: string,
+  type: 'created' | 'updated' | 'deleted' = 'created',
+  timestamp: string = new Date().toISOString()
+): NotifyMessage {
+  return {
+    channel,
+    payload: { id, type, timestamp },
+  }
+}


### PR DESCRIPTION
## Summary

- Next.js build fails: `"buildIdOnlyFrame" is not a valid Route export field`
- Same pattern as PR #422 — helper functions must not be exported from route files
- Extracted `buildIdOnlyFrame`, `NotifyMessage`, `StreamChannel` to `lib/security/stream-utils.ts`
- Updated `stream/route.ts` and `stream/route.test.ts` to import from new location
- 5/5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)