### PR TITLE
fix(web): green up production build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "next-auth": "^4.24.13",
     "node-cron": "^4.2.1",
     "otplib": "^13.4.0",
+    "pg": "^8.13.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -46,7 +47,6 @@
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",
     "three": "^0.184.0",
-    "pg": "^8.13.0",
     "ws": "^8.18.0",
     "yaml": "^2.9.0",
     "zod": "^3.25.0"
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@types/node": "^22.10.1",
     "@types/node-cron": "^3.0.11",
+    "@types/pg": "^8.20.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",

--- a/apps/web/src/app/api/monitoring/security/stream/route.ts
+++ b/apps/web/src/app/api/monitoring/security/stream/route.ts
@@ -18,7 +18,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { TextEncoder } from 'util'
-import { Client } from 'pg'
+import { Client, type Notification } from 'pg'
 import { type StreamChannel, type NotifyMessage } from '@/lib/security/stream-utils'
 
 export const dynamic = 'force-dynamic'
@@ -86,11 +86,11 @@ export async function GET(request: NextRequest) {
 
       // Listen for NOTIFY messages
       const pgChannel = pgChannelFor(channel)
-      let listener: ((name: string, payload: string) => void) | null = null
+      let listener: ((msg: Notification) => void) | null = null
 
-      const onNotify = (name: string, payload: string) => {
+      const onNotify = (msg: Notification) => {
         // NOTIFY payload format: "<id>:<type>" (e.g. "abc123:created")
-        const [id, type] = payload.split(':')
+        const [id, type] = (msg.payload ?? '').split(':')
         if (!id) return
 
         const frame: NotifyMessage = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "next-auth": "^4.24.13",
         "node-cron": "^4.2.1",
         "otplib": "^13.4.0",
+        "pg": "^8.13.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -73,6 +74,7 @@
       "devDependencies": {
         "@types/node": "^22.10.1",
         "@types/node-cron": "^3.0.11",
+        "@types/pg": "^8.20.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/ws": "^8.5.13",
@@ -2691,6 +2693,18 @@
       "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",


### PR DESCRIPTION
## Summary
- Restores `npm run build:web` (was failing with three sequential type errors)
- Adds the `pg` runtime dep + `serverExternalPackages` (commit b41dc6c), extracts pure helpers out of two route files so Next's type-checker stops treating them as route exports (8bdbbe1, dfb5bf5), then adds `@types/pg` and fixes the pg `'notification'` handler signature (d23b87b)

## What was broken
1. `Could not find a declaration file for module 'pg'` — fixed by adding `@types/pg` devDependency.
2. `Argument of type '(name: string, payload: string) => void' is not assignable to parameter of type '(message: Notification) => void'` — pg emits a single `Notification` object; updated `onNotify` to destructure `msg.payload`.
3. `'incidentId' does not exist on ChatMessageCreateInput` — generated Prisma client was stale relative to `schema.prisma` (which has `ChatMessage.incidentId`); `prisma generate` resolved it. No file change required for this one.

## Test plan
- [x] `npm run build:web` completes (Next compile + worker esbuild both succeed locally)
- [ ] CI green on this branch
- [ ] Smoke-test SSE `/api/monitoring/security/stream` against a real Postgres NOTIFY after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)