### PR TITLE
fix(web): migration 14 targets chat_messages (not ChatMessage)

### DIFF
--- a/apps/web/prisma/migrations/14_chatmessage_incident_link/migration.sql
+++ b/apps/web/prisma/migrations/14_chatmessage_incident_link/migration.sql
@@ -3,22 +3,25 @@
 -- Allows the correlator to explicitly associate chat messages with an
 -- incident, enabling the UI to look up incident chat by the typed
 -- field rather than parsing a text substring from the message body.
+--
+-- NOTE: the Prisma model `ChatMessage` is mapped to physical table
+-- `chat_messages` via @@map. Always use the snake_case table name here.
 
--- Check if the column already exists (idempotent for safe re-runs)
 DO $migrate$
 BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'ChatMessage' AND column_name = 'incidentId'
+    WHERE table_name = 'chat_messages' AND column_name = 'incidentId'
   ) THEN
-    ALTER TABLE "ChatMessage" ADD COLUMN "incidentId" TEXT;
-    -- Add FK constraint
-    ALTER TABLE "ChatMessage"
-      ADD CONSTRAINT "ChatMessage_incidentId_fkey"
+    ALTER TABLE "chat_messages" ADD COLUMN "incidentId" TEXT;
+
+    ALTER TABLE "chat_messages"
+      ADD CONSTRAINT "chat_messages_incidentId_fkey"
       FOREIGN KEY ("incidentId") REFERENCES "Incident"("id")
       ON DELETE SET NULL;
-    -- Add index for fast lookups
-    CREATE INDEX IF NOT EXISTS "ChatMessage_incidentId_idx" ON "ChatMessage"("incidentId");
+
+    CREATE INDEX IF NOT EXISTS "chat_messages_incidentId_idx"
+      ON "chat_messages"("incidentId");
   END IF;
 END;
 $migrate$;


### PR DESCRIPTION
## Summary
- Migration `14_chatmessage_incident_link` was failing in prod with `relation "ChatMessage" does not exist` and blocking every later migration (including `15_siem_cascade_on_delete`).
- The Prisma model `ChatMessage` is mapped to physical table `chat_messages` via `@@map`. The migration SQL must use the snake_case table name; this PR rewrites it to do so, and renames the FK constraint and index to match the existing `chat_messages_*` naming convention.

## Prod recovery (already done)
- Applied the corrected DDL manually against `deploy-postgres-1` (`incidentId` column, FK to `Incident.id ON DELETE SET NULL`, index `chat_messages_incidentId_idx`).
- Marked the failed `_prisma_migrations` row as finished so Prisma stops retrying.
- Restarted `deploy-orion-1`; health endpoint reports `db: true`.

This PR exists so future fresh deploys / new envs don't hit the same wall.

## Test plan
- [x] Verified post-fix: `\\d chat_messages` shows `incidentId TEXT`, `chat_messages_incidentId_fkey`, and `chat_messages_incidentId_idx`.
- [x] Verified `deploy-orion-1` healthy after restart.
- [ ] CI runs cleanly.
- [ ] On a fresh DB, `prisma migrate deploy` applies 14 and 15 in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)