### PR TITLE
fix(gateway): add .js extensions to ESM relative imports

### DIFF
--- a/apps/gateway/src/builtin-tools/security.ts
+++ b/apps/gateway/src/builtin-tools/security.ts
@@ -1,7 +1,7 @@
 import { promisify } from 'util'
 import { execFile } from 'child_process'
-import { redactSensitive } from '../lib/redact'
-import { verifyDecisionToken } from '../lib/decision-token'
+import { redactSensitive } from '../lib/redact.js'
+import { verifyDecisionToken } from '../lib/decision-token.js'
 
 const exec = promisify(execFile)
 

--- a/apps/gateway/src/hooks-engine.ts
+++ b/apps/gateway/src/hooks-engine.ts
@@ -9,7 +9,7 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 
-import { OrionClient } from './orion-client'
+import { OrionClient } from './orion-client.js'
 
 const execFileAsync = promisify(execFile)
 


### PR DESCRIPTION
## Summary
- Adds `.js` extension to three extensionless relative imports in the gateway (`builtin-tools/security.ts` × 2, `hooks-engine.ts` × 1).
- Node strict ESM rejects extensionless paths at runtime; tsc with `moduleResolution=bundler` does not rewrite them at build time.

## Why now
PR #420 (gateway tool-call audit) shipped two new extensionless imports in `builtin-tools/security.ts`. The deployed gateway image has been restart-looping ever since:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/dist/lib/redact'
  imported from /app/dist/builtin-tools/security.js
```

This blocks Phase 1's `gateway_audit` SIEM source — write-tier tool invocations cannot emit `SecurityEvent` rows while the gateway can't boot.

Also includes a pre-existing matching bug in `hooks-engine.ts` (`./orion-client` extensionless). That one happens to load after `security.ts` so it's masked today, but would surface once the first error is fixed.

## Test plan
- [ ] Gateway container starts (`docker logs deploy-gateway-1` shows ready, not ERR_MODULE_NOT_FOUND)
- [ ] Trigger any write-tier gateway tool and confirm a `SecurityEvent` with `source='gateway_audit'` lands
- [ ] `npm run build --workspace=apps/gateway` succeeds (tsc tolerates `.js` suffix on `.ts` sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)