### PR TITLE
docs(security): document host_agent SIEM source + secret rotation

### DIFF
--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -45,3 +45,23 @@ have been addressed. See `SOC2_STATUS.md` for per-finding status.
 | `apps/gateway/src/tool-runner.ts` | Tool execution + injection prevention |
 | `docs/soc2/SECURITY_FINDINGS.md` | Full audit findings (19 items) |
 | `apps/web/src/lib/RATE-LIMITING.md` | Rate limiting architecture + config |
+
+## SIEM Telemetry Sources
+
+| Source | Producer | Authentication | Secret |
+|--------|----------|----------------|--------|
+| `host_agent` | Vector container on the Orion host (`deploy/host-agent/vector.toml`) → POST `/api/monitoring/security/webhooks/host-agent` | HMAC-SHA256 over body, 5-min replay window | `SecurityConfig.HOST_AGENT_WEBHOOK_SECRET` |
+| `gateway_audit` | In-process gateway dispatcher (`apps/gateway/src/gateway-audit.ts`) — writes `SecurityEvent` rows directly via the orion audit webhook | HMAC over body | `GATEWAY_AUDIT_SECRET` |
+| `crowdsec` / `wazuh` | External (not deployed yet — Phase 2+) | HMAC per source | Per-source `SecurityConfig` row |
+| `elk` / `ntopng` | Internal pollers (`apps/web/src/jobs/security-poll-*.ts`) | n/a (in-process) | n/a |
+
+### Secret rotation — `HOST_AGENT_WEBHOOK_SECRET`
+
+1. Generate new value: `openssl rand -hex 32`
+2. Update `SecurityConfig` row (`key='HOST_AGENT_WEBHOOK_SECRET'`) with the new value.
+3. Update Vault KV: `vault kv put secret/orion/host-agent webhook_secret=<new>`.
+4. Update `.env` on the Orion host and the env file the vector container reads.
+5. Restart vector: `docker compose restart vector`.
+6. Old secret stops being accepted on next webhook request.
+
+The bootstrap script (`deploy/bootstrap.sh`) generates this on first install and seeds the `SecurityConfig` row; subsequent rotations are manual per the steps above.

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -48,20 +48,27 @@ have been addressed. See `SOC2_STATUS.md` for per-finding status.
 
 ## SIEM Telemetry Sources
 
-| Source | Producer | Authentication | Secret |
-|--------|----------|----------------|--------|
-| `host_agent` | Vector container on the Orion host (`deploy/host-agent/vector.toml`) → POST `/api/monitoring/security/webhooks/host-agent` | HMAC-SHA256 over body, 5-min replay window | `SecurityConfig.HOST_AGENT_WEBHOOK_SECRET` |
-| `gateway_audit` | In-process gateway dispatcher (`apps/gateway/src/gateway-audit.ts`) — writes `SecurityEvent` rows directly via the orion audit webhook | HMAC over body | `GATEWAY_AUDIT_SECRET` |
-| `crowdsec` / `wazuh` | External (not deployed yet — Phase 2+) | HMAC per source | Per-source `SecurityConfig` row |
+| Source | Producer | Authentication | Secret source |
+|--------|----------|----------------|---------------|
+| `host_agent` | Vector container on the Orion host (`deploy/host-agent/vector.toml`) → POST `/api/monitoring/security/webhooks/host-agent` | HMAC-SHA256 over body, 5-min replay window | `HOST_AGENT_WEBHOOK_SECRET` env var (from `deploy/.env`, injected via `deploy/docker-compose.yml`) — read by both vector and the orion webhook route |
+| `gateway_audit` | In-process gateway dispatcher (`apps/gateway/src/gateway-audit.ts`) — writes `SecurityEvent` rows directly via the orion audit webhook | HMAC over body | `GATEWAY_AUDIT_SECRET` env var |
+| `crowdsec` / `wazuh` | External (not deployed yet — Phase 2+) | HMAC per source | Per-source `SecurityConfig` row (via `getWebhookSecret` in `webhook-auth.ts`) |
 | `elk` / `ntopng` | Internal pollers (`apps/web/src/jobs/security-poll-*.ts`) | n/a (in-process) | n/a |
+
+> Note: `bootstrap.sh` also seeds a `SecurityConfig` row keyed `HOST_AGENT_WEBHOOK_SECRET` for forward compatibility, but the host-agent webhook route currently reads the env var directly. Don't rely on the DB row alone — the env var is load-bearing.
 
 ### Secret rotation — `HOST_AGENT_WEBHOOK_SECRET`
 
-1. Generate new value: `openssl rand -hex 32`
-2. Update `SecurityConfig` row (`key='HOST_AGENT_WEBHOOK_SECRET'`) with the new value.
-3. Update Vault KV: `vault kv put secret/orion/host-agent webhook_secret=<new>`.
-4. Update `.env` on the Orion host and the env file the vector container reads.
-5. Restart vector: `docker compose restart vector`.
-6. Old secret stops being accepted on next webhook request.
+Both producer (vector) and verifier (orion webhook route) read the same env var, so they must be updated and restarted together.
 
-The bootstrap script (`deploy/bootstrap.sh`) generates this on first install and seeds the `SecurityConfig` row; subsequent rotations are manual per the steps above.
+1. Generate new value: `openssl rand -hex 32`
+2. Update `deploy/.env` with the new value (replace the `HOST_AGENT_WEBHOOK_SECRET=...` line).
+3. (Optional) Mirror to Vault KV: `vault kv put secret/orion/host-agent webhook_secret=<new>`.
+4. (Optional) Update the `SecurityConfig` row of the same key — currently unused at runtime, but keep it in sync if you want the row to remain accurate.
+5. Restart **both** services so they pick up the new env value:
+   `docker compose up -d orion vector` (or `docker compose restart orion vector`).
+6. Old secret stops being accepted on the next batch.
+
+If you only restart vector, every signed batch will 401 against the orion route until orion is also restarted. If you only restart orion, vector keeps signing with the old value until it's restarted too.
+
+The bootstrap script (`deploy/bootstrap.sh`) generates this on first install; subsequent rotations are manual per the steps above.


### PR DESCRIPTION
## Summary
- Adds a SIEM Telemetry Sources table to `SECURITY_NOTES.md` covering Phase 1's new sources (`host_agent`, `gateway_audit`) and the future external ones (`crowdsec`, `wazuh`, `elk`, `ntopng`).
- Documents the rotation procedure for `HOST_AGENT_WEBHOOK_SECRET`.

## Why
Plan step 8 of `.claude/plans/giggly-sniffing-parasol.md` called for documenting the new source + secret rotation. Until now `SECURITY_NOTES.md` had no mention of `host_agent` or the bootstrap-minted secret.

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Rotation steps are accurate against current `deploy/bootstrap.sh` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)