### PR TITLE
ci: self-bootstrapping deploy pipeline

### DIFF
--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy ORION Gateway
+name: Build ORION Gateway
 
 on:
   push:
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-gateway
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -34,7 +33,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        id: build
         uses: docker/build-push-action@v7
         with:
           context: apps/gateway
@@ -45,14 +43,3 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    needs: build
-    runs-on: [self-hosted, linux, x64]
-    steps:
-      - name: Deploy Gateway
-        run: |
-          cd /opt/orion/deploy
-          docker compose pull --quiet
-          docker compose up -d --remove-orphans
-          echo "Gateway restarted"

--- a/.github/workflows/build-gateway.yml
+++ b/.github/workflows/build-gateway.yml
@@ -12,12 +12,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-gateway
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy ORION Web
+name: Build ORION Web
 
 on:
   push:
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-web
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -34,7 +33,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        id: build
         uses: docker/build-push-action@v7
         with:
           context: apps/web
@@ -45,25 +43,3 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  deploy:
-    needs: build
-    runs-on: [self-hosted, linux, x64]
-    steps:
-      - name: Deploy ORION
-        env:
-          COMPOSE_PROFILES: gitea
-        run: |
-          cd /opt/orion/deploy
-          docker compose pull --quiet
-          docker compose up -d --remove-orphans
-          echo "Waiting for ORION health check..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
-              echo "ORION is healthy!"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "WARNING: Health check timed out"
-          exit 0

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -12,12 +12,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/orion-web
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,13 @@ concurrency:
   group: deploy-orion
   cancel-in-progress: false
 
+# Deploy needs no GITHUB_TOKEN privileges. It git-fetches via the host's own
+# credentials and pulls images via the host's docker config; the workflow
+# token is not used for either. contents: read is the conventional explicit
+# minimum baseline (equivalent to the default for repos created Feb 2023+).
+permissions:
+  contents: read
+
 jobs:
   deploy:
     # Skip if triggered by a failed upstream build.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy ORION
+
+# Single canonical deploy. Fires whenever:
+#   1. Either image-build workflow completes on main (so new app code lands)
+#   2. Any push to main that touches deploy/** (so compose / bootstrap / vector
+#      config changes land even when no app code changed)
+#   3. Manually via workflow_dispatch
+#
+# Concurrency=deploy-orion serializes runs so two near-simultaneous triggers
+# don't race against each other on the host.
+#
+# Bootstrap is idempotent — re-running on every deploy is the design. It
+# generates any missing secrets, enables the Vault file audit device, pulls
+# latest images, and runs `docker compose up -d` which picks up any new
+# services (e.g. vector) added to docker-compose.yml.
+
+on:
+  workflow_run:
+    workflows: ["Build ORION Web", "Build ORION Gateway"]
+    types: [completed]
+    branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-orion
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    # Skip if triggered by a failed upstream build.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Sync /opt/orion to origin/main
+        run: |
+          cd /opt/orion
+          git fetch --depth 1 origin main
+          git checkout -B main origin/main
+
+      - name: Bootstrap and start stack
+        # bootstrap.sh:
+        #   - generates any missing secrets in deploy/.env (idempotent grep guards)
+        #   - seeds Vault KV + SecurityConfig where applicable
+        #   - enables Vault file audit device
+        #   - docker compose pull + up -d (picks up new services like vector)
+        #   - creates Gitea admin + token if using bundled profile
+        run: |
+          cd /opt/orion/deploy
+          ./bootstrap.sh
+
+      - name: Wait for ORION health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+              echo "ORION is healthy."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "WARNING: health check timed out after 60s — ORION may still be starting"
+          exit 0


### PR DESCRIPTION
## Summary
- Splits the two existing build-and-deploy workflows into three: \`build-web.yml\` (image only), \`build-gateway.yml\` (image only), and a new \`deploy.yml\` that is the single canonical deploy.
- \`deploy.yml\` syncs \`/opt/orion\` to \`origin/main\` and runs \`bootstrap.sh\` — so any merge to main (app code OR deploy config) brings the host into the state main describes, including standing up any new compose services.

## Why
Phase 1 of the SIEM (\`.claude/plans/giggly-sniffing-parasol.md\`) ran into a real friction point: even after the code merged, the host-agent pipeline didn't actually come online. Root cause was the CI deploy step, which only ran \`docker compose pull && up -d\` against a stale \`/opt/orion/deploy/\`:

- The new \`vector\` compose service from PR #418 wasn't in the on-host \`docker-compose.yml\`, so \`up -d\` had nothing new to start.
- \`HOST_AGENT_WEBHOOK_SECRET\` and \`GATEWAY_AUDIT_SECRET\` were never minted in \`deploy/.env\` because \`bootstrap.sh\` wasn't part of the deploy.
- Vault file audit device wasn't enabled.
- Pushes that touched only \`deploy/**\` didn't trigger any workflow.

After this PR, every merge to main:
1. Builds whichever image(s) changed (existing behavior).
2. \`git fetch && checkout -B main origin/main\` in \`/opt/orion\` to pick up new compose / bootstrap / vector config.
3. Runs \`bootstrap.sh\` — idempotent, grep-guarded for every secret, generates anything missing.
4. \`docker compose up -d\` picks up any new services (e.g. vector).
5. Waits on \`/api/health\`.

## Design notes
- \`deploy.yml\` triggers on \`workflow_run\` completion of either build workflow AND on push-to-main with \`deploy/**\` changes — so app code AND deploy config both reach the host.
- \`concurrency: deploy-orion\` serializes near-simultaneous triggers (e.g. when a PR changes both web and gateway).
- \`if:\` guard skips deploy when the upstream build failed.
- Self-hosted runner already has the access it needs (writes to \`/opt/orion\`, runs docker).

## Test plan
- [ ] Merge this PR
- [ ] Confirm \`deploy.yml\` fires (will be triggered by the deploy/** path filter since this PR touches workflows, but also runs build workflows since it touches \`.github/workflows/\`)
- [ ] Confirm \`/opt/orion\` ends up on \`origin/main\` after the run
- [ ] Confirm \`vector\` container is running afterward
- [ ] Confirm \`HOST_AGENT_WEBHOOK_SECRET\` is now set in \`deploy/.env\`
- [ ] Confirm \`SecurityEvent\` rows start appearing once vector ships its first batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)