### PR TITLE
fix: handle missing SETUP_TOKEN gracefully in bootstrap.sh

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -156,7 +156,7 @@ GITHUB_ORG="${GITHUB_ORG}" $COMPOSE up -d
 echo ""
 echo "Waiting for ORION to start (up to 30s)..."
 for i in $(seq 1 6); do
-  SETUP_TOKEN=$(GITHUB_ORG="${GITHUB_ORG}" $COMPOSE logs orion 2>&1 | grep "SETUP_TOKEN" | tail -1 | awk '{print $NF}')
+  SETUP_TOKEN=$(GITHUB_ORG="${GITHUB_ORG}" $COMPOSE logs orion 2>&1 | grep "SETUP_TOKEN" | tail -1 | awk '{print $NF}') || true
   [[ -n "$SETUP_TOKEN" ]] && break
   sleep 5
 done


### PR DESCRIPTION
## Summary
- `grep` returns exit code 1 when `SETUP_TOKEN` is absent from ORION logs (already-provisioned instances)
- This propagated through the pipeline into the command substitution and caused `set -euo pipefail` to abort `bootstrap.sh` immediately after the first loop iteration
- Added `|| true` to make the assignment non-fatal when the token isn't found

## Test plan
- [ ] Ran `bootstrap.sh` locally — exits 0 on already-provisioned instance
- [ ] Deploy workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)