### PR TITLE
fix: discard local changes before syncing /opt/orion to origin/main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           cd /opt/orion
           git fetch --depth 1 origin main
+          git reset --hard HEAD
           git checkout -B main origin/main
 
       - name: Bootstrap and start stack


### PR DESCRIPTION
## Summary
- `git checkout -B main origin/main` fails if any local files were modified between deploys (e.g. `bootstrap.sh` patched in-place)
- Adds `git reset --hard HEAD` before the checkout so the sync is always clean

## Test plan
- [ ] Deploy workflow completes without "local changes would be overwritten" error after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)