### PR TITLE
fix(siem): unblock Phase 1 — startup seed + vector config path

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -991,6 +991,8 @@ model ActionPolicy {
   defaultTier     String   // "auto" | "approve" | "escalate" | "notify"
   targetPatterns  Json?    // null or [{ pattern: string; tier: string; operator?: "strict" | "subnet" }]
   updatedBy       String?  // "system" | operator username
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
   auditRows       ActionAudit[]
 
   @@index([actionType])
@@ -1011,6 +1013,8 @@ model CorrelationRule {
   params        Json     // rule-specific params (window, threshold, etc.)
   severity      Int      // default severity for generated incidents (0-100)
   window        Int      // time window in seconds for rule evaluation
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   @@index([enabled])
   @@index([environmentId])

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -565,6 +565,10 @@ services:
   # This is the shipper described in gigly-sniffing-parasol.md (PR2).
   vector:
     image: timberio/vector:0.39.0-debian
+    # The image's default config path is /etc/vector/vector.yaml, which exists
+    # in the image as a demo-logs generator. Without --config, vector loads
+    # that demo and ships fake events. Point it explicitly at the mounted TOML.
+    command: ["--config", "/etc/vector/vector.toml"]
     restart: unless-stopped
     depends_on:
       orion:


### PR DESCRIPTION
## Summary
Two unrelated bugs prevented Phase 1 from producing data after the self-bootstrapping deploy (#428) finally got the stack up. Bundled because both block the same end state.

### 1. Seeders fail on startup
\`ensureActionPolicies()\` and \`ensureCorrelationRules()\` both error on every orion boot:

\`\`\`
[seed] Failed to seed correlation rules:
Invalid \`prisma.correlationRule.upsert()\` invocation:
Null constraint violation on the fields: (\`updatedAt\`)
\`\`\`

Migration \`12_siem_foundation_schema\` created \`ActionPolicy\` and \`CorrelationRule\` with NOT NULL \`createdAt\` / \`updatedAt\` columns, but those fields aren't in \`schema.prisma\`. Prisma omits them from inserts; DB rejects. Result: zero rules seeded, correlator runs with nothing to match.

Fix: add the fields back to the schema with \`@default(now())\` / \`@updatedAt\`. **No new migration needed** — the DB columns already exist with the right shape; this just re-aligns the schema.

### 2. Vector loads the wrong config
\`docker logs deploy-vector-1\` showed:
\`\`\`
Loading configs. paths=["/etc/vector/vector.yaml"]
\`\`\`
…even though our \`vector.toml\` is mounted at the same directory. The \`timberio/vector\` image ships with a default \`vector.yaml\` (a demo_logs generator). Without an explicit \`--config\`, Vector's discovery prefers \`vector.yaml\`. So instead of journald/docker/vault data, the container has been shipping fake \"KarimMove\" / \"meln1ks\" demo events — and not POSTing to orion at all because the demo config has no sink.

Fix: add \`command: [\"--config\", \"/etc/vector/vector.toml\"]\` to the compose service. Validated the TOML against \`vector validate\` before commit (loads clean).

## Test plan
- [ ] After merge + deploy, \`docker logs deploy-orion-1 | grep CorrelationRule\` shows 7 seeded rules, no \`Null constraint\` errors
- [ ] \`docker exec deploy-postgres-1 psql -U orion -d orion -c 'SELECT count(*) FROM \"CorrelationRule\"'\` returns 7
- [ ] Same for \`ActionPolicy\` (≥8 rows expected per \`seed-action-policies.ts\`)
- [ ] \`docker logs deploy-vector-1 | head\` shows \`Loaded [\"/etc/vector/vector.toml\"]\`, no demo data
- [ ] First webhook batch hits orion → \`SourceHealth\` row for \`host_agent\` appears, \`SecurityEvent.count > 0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)