### PR TITLE
fix(deploy): vector data-dir permissions + config-change recreate

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,2 +1,3 @@
 vault-unseal-keys/
 vault-proxy/certs/
+vector-data/

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -244,9 +244,24 @@ else
 fi
 
 # ── Start Vector shipper ────────────────────────────────────────────────────
+# Two non-obvious requirements for vector to actually deliver:
+#   1. Its data_dir (/var/lib/vector inside the container) must be writable by
+#      UID 1000. We bind-mount ./vector-data and chown it here. A named volume
+#      would be root-owned and vector would fail with permission denied on
+#      checkpoint writes.
+#   2. The vector.toml config is mounted as a file. Docker pins file bind-mounts
+#      to the host inode at container-create time, so when a deploy rewrites
+#      vector.toml via git checkout, the running container keeps reading the
+#      OLD content. --force-recreate gives the container a fresh inode binding
+#      to the new file. This is why config-only PRs were not landing until
+#      someone manually `docker restart`ed vector.
 echo ""
+echo "Preparing vector data dir..."
+mkdir -p "$DEPLOY_DIR/vector-data"
+chown -R 1000:1000 "$DEPLOY_DIR/vector-data" 2>/dev/null || true
+
 echo "Starting Vector host telemetry shipper..."
-$COMPOSE up -d vector 2>/dev/null || echo "NOTE: Vector service failed to start (check compose logs)."
+$COMPOSE up -d --force-recreate vector 2>/dev/null || echo "NOTE: Vector service failed to start (check compose logs)."
 
 if [[ -n "${SETUP_TOKEN:-}" ]]; then
   echo ""

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -585,7 +585,10 @@ services:
       - /var/log/journal:/var/log/journal:ro
       - vault-audit:/vault/audit:ro
       - ./host-agent/vector.toml:/etc/vector/vector.toml:ro
-      - vector-data:/var/lib/vector
+      # Bind-mount (not a named volume) so bootstrap can chown it to 1000:1000
+      # before vector starts. Named volumes are root-owned by default; vector
+      # runs as 1000:1000 and would otherwise fail to write checkpoints.
+      - ./vector-data:/var/lib/vector
     deploy:
       resources:
         limits:
@@ -605,5 +608,4 @@ volumes:
   redis-sentinel-3-data:
   argocd-server-data:
   argocd-redis-data:
-  vector-data:
   vault-audit:


### PR DESCRIPTION
## Summary
Two interlocking bugs that kept vector failing even after every prior fix landed.

### 1. Permission denied on \`/var/lib/vector\`
After #432 fixed the VRL syntax, vector restarted into:

\`\`\`
Configuration error. error=Source \"journald_auth\": Could not create
  subdirectory \"journald_auth\" inside of data dir \"/var/lib/vector\":
  Permission denied (os error 13)
\`\`\`

The container runs as \`1000:1000\` (per compose \`user:\` directive). Named volumes inherit root ownership on first compose-up, so vector couldn't write its checkpoint files.

**Fix:** Replace the \`vector-data\` named volume with a host bind-mount under \`deploy/vector-data/\`, and chown it in \`bootstrap.sh\` before vector starts. Bind-mount perms come from the host fs.

### 2. File bind-mount inode pinning
Docker pins single-file bind-mounts to the host inode at container-create time. When \`git checkout\` rewrites \`vector.toml\` on the host (new inode), the running container keeps reading the OLD inode's contents.

That's why #432 \"merged but didn't take effect\" — every deploy ran \`docker compose up -d\` (idempotent — no changes detected → no recreate), so vector kept its stale inode binding and kept producing the same E651 errors. The only thing that worked was a manual \`docker restart deploy-vector-1\`.

**Fix:** \`docker compose up -d --force-recreate vector\` in bootstrap.sh's vector startup step. Forces a new container with a fresh inode binding to the current host file.

## Why both in one PR
Bug 2 means bug 1 wouldn't be fully observed until vector ALSO got force-recreated. Shipping just one means the next deploy still ends in a restart loop. Both together = first deploy where Phase 1 actually flows data.

## Validation plan
- [ ] Deploy fires automatically after merge
- [ ] \`docker ps\` shows \`deploy-vector-1\` \`Up\`, not \`Restarting\`
- [ ] \`docker logs deploy-vector-1 | head\` shows \`Vector has started\`, \`Healthcheck passed\`, no E651 or perms errors
- [ ] Within ~60s, \`SELECT count(*) FROM \"SecurityEvent\"\` > 0
- [ ] \`SELECT source FROM \"SourceHealth\"\` shows \`host_agent\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)