### PR TITLE
fix(deploy): custom vector image + DOCKER_GID detection

### DIFF
--- a/.github/workflows/build-vector.yml
+++ b/.github/workflows/build-vector.yml
@@ -1,0 +1,46 @@
+name: Build ORION Vector
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/host-agent/Dockerfile'
+      - '.github/workflows/build-vector.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/orion-vector
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, x64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: deploy/host-agent
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ name: Deploy ORION
 
 on:
   workflow_run:
-    workflows: ["Build ORION Web", "Build ORION Gateway"]
+    workflows: ["Build ORION Web", "Build ORION Gateway", "Build ORION Vector"]
     types: [completed]
     branches: [main]
   push:

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -44,6 +44,11 @@ GITEA_WEBHOOK_SECRET=
 # Generate: openssl rand -hex 32
 LOCALHOST_JOIN_TOKEN=change-me-generate-with-openssl-rand-hex-32
 
+# GID of the docker group on the host. The vector container uses `group_add`
+# to gain read access to /var/run/docker.sock for the docker_edge_logs source.
+# Auto-detected by bootstrap.sh from `stat -c %g /var/run/docker.sock`.
+DOCKER_GID=
+
 # ── Claude (optional — for OAuth flow) ────────────────────────────────────────
 # Set if using Claude API key auth instead of OAuth
 ANTHROPIC_API_KEY=

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -128,6 +128,20 @@ fi
 # ── Fix coredns dir ownership (ORION runs as uid=1001, needs write access) ────
 chown -R 1001:1001 "$DEPLOY_DIR/coredns" 2>/dev/null || true
 
+# ── Detect docker.sock GID for vector / orion / gateway docker access ─────────
+# The vector container runs as 1000:1000 with group_add to gain access to
+# /var/run/docker.sock. The compose default of 999 is a guess — actual GID
+# varies per host (e.g. Debian ships 988). Write the real value to .env so
+# compose substitutes it correctly on every `up -d`.
+if [[ -S /var/run/docker.sock ]]; then
+  DETECTED_DOCKER_GID=$(stat -c %g /var/run/docker.sock)
+  if ! grep -q "^DOCKER_GID=${DETECTED_DOCKER_GID}$" "$DEPLOY_DIR/.env"; then
+    sed -i '/^DOCKER_GID=/d' "$DEPLOY_DIR/.env"
+    echo "DOCKER_GID=${DETECTED_DOCKER_GID}" >> "$DEPLOY_DIR/.env"
+    echo "Set DOCKER_GID=${DETECTED_DOCKER_GID} (detected from /var/run/docker.sock)."
+  fi
+fi
+
 # ── Validate required vars ────────────────────────────────────────────────────
 source "$DEPLOY_DIR/.env"
 MISSING=()

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -564,7 +564,10 @@ services:
   #
   # This is the shipper described in gigly-sniffing-parasol.md (PR2).
   vector:
-    image: timberio/vector:0.39.0-debian
+    # Custom image: timberio/vector:0.39.0-debian + docker CLI (no daemon).
+    # The docker_lifecycle source `exec`s `docker events`; stock image has no
+    # docker binary. See deploy/host-agent/Dockerfile.
+    image: ghcr.io/${GITHUB_ORG}/orion-vector:${ORION_VERSION:-latest}
     # The image's default config path is /etc/vector/vector.yaml, which exists
     # in the image as a demo-logs generator. Without --config, vector loads
     # that demo and ships fake events. Point it explicitly at the mounted TOML.

--- a/deploy/host-agent/Dockerfile
+++ b/deploy/host-agent/Dockerfile
@@ -1,0 +1,26 @@
+# Custom Vector image for the ORION host-agent telemetry shipper.
+#
+# Why we don't use timberio/vector:0.39.0-debian directly:
+# The `docker_lifecycle` source in vector.toml uses `type = "exec"` and runs
+# `docker events --format ...` to stream container lifecycle events (oom, die,
+# kill, restart, start) — Vector has no native source for these. The official
+# image doesn't ship with the docker CLI, so the exec fails with ENOENT.
+#
+# This image adds *just the docker client* (not the daemon). The container
+# uses the host's /var/run/docker.sock for daemon communication.
+FROM timberio/vector:0.39.0-debian
+
+USER root
+
+ARG DOCKER_VERSION=26.1.5
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin docker/docker && \
+    chmod 755 /usr/local/bin/docker && \
+    apt-get purge -y curl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+USER vector


### PR DESCRIPTION
## Summary
Two Phase-1 vector sources were broken after vector finally booted (#433):

1. \`docker_lifecycle\` (\`exec docker events\`) — ENOENT because timberio/vector ships without the docker CLI.
2. \`docker_edge_logs\` — can't connect to \`/var/run/docker.sock\` because compose's \`group_add: \${DOCKER_GID:-999}\` is a guess; actual docker group GID on this host is **988**.

## Fix
- **Custom image:** \`deploy/host-agent/Dockerfile\` extends \`timberio/vector:0.39.0-debian\` with the docker static client binary (no daemon). New \`.github/workflows/build-vector.yml\` publishes \`ghcr.io/\${GITHUB_ORG}/orion-vector:latest\` on changes to the Dockerfile.
- **GID detection:** \`bootstrap.sh\` reads \`stat -c %g /var/run/docker.sock\` and writes the real value to \`deploy/.env\` so compose substitutes the correct value on every \`up -d\`. Documented in \`.env.example\`.
- **Deploy pipeline:** \`deploy.yml\`'s \`workflow_run\` trigger list includes the new build-vector workflow so vector image changes flow through the same automatic deploy.

## After merge
- \`docker_lifecycle\`: vector can shell out to \`docker events\` → oom/die/kill/restart/start events ship to \`/api/monitoring/security/webhooks/host-agent\`
- \`docker_edge_logs\`: vector connects to docker.sock → tails traefik/authentik containers when they exist
- \`journald_auth\`: unchanged, keeps working (just quiet without real auth activity)
- \`vault_audit\`: unchanged, depends on Vault API activity + audit device enabled (bootstrap handles the latter)

## Test plan
- [ ] build-vector workflow fires and pushes \`ghcr.io/\${GITHUB_ORG}/orion-vector:latest\`
- [ ] deploy.yml fires after build-vector completes
- [ ] \`docker logs deploy-vector-1\` shows no \`Unable to exec docker events\` errors
- [ ] \`docker logs deploy-vector-1\` shows no \`Listing currently running containers failed\` errors (or fails only because target containers don't exist, not perms)
- [ ] \`stat -c %g /var/run/docker.sock\` matches \`DOCKER_GID\` line in \`/opt/orion/deploy/.env\`
- [ ] First docker container restart on the host produces a \`docker.container.*\` SecurityEvent

🤖 Generated with [Claude Code](https://claude.com/claude-code)