### PR TITLE
fix(siem): journald source matches by _COMM, not _SYSTEMD_UNIT

### DIFF
--- a/deploy/host-agent/vector.toml
+++ b/deploy/host-agent/vector.toml
@@ -24,10 +24,19 @@ address = "127.0.0.1:8686"
 
 # ── Source 1: journald (auth events) ─────────────────────────────────────────
 # Collects auth-related systemd journal entries.
+#
+# We filter by _COMM (process name) rather than _SYSTEMD_UNIT because:
+#   - PAM-driven auth events (sshd session opens, sudo failures) are written
+#     by the bare binary in journald, not attributed to a unit
+#   - SSH unit name varies by distro (sshd.service on RHEL, ssh.service on
+#     Debian/Ubuntu) — _COMM=sshd is portable
+#   - sudo is a binary, not a service — _SYSTEMD_UNIT=sudo never matches
 
 [sources.journald_auth]
 type = "journald"
-include_units = ["sshd.service", "sudo", "gdm-password", "login"]
+
+[sources.journald_auth.include_matches]
+_COMM = ["sshd", "sudo", "su", "login", "passwd"]
 
 # ── Source 2: Docker Events API (container lifecycle events) ─────────────────
 # Streams Docker lifecycle events (oom, die, restart, kill, start) via exec.


### PR DESCRIPTION
## Summary
The journald source filter never matches anything on this host (or any Debian/Ubuntu host). Auth events are tagged with \`_COMM=sshd\` / \`_COMM=sudo\` in journald, not under \`_SYSTEMD_UNIT\`. Switching to \`include_matches._COMM\` makes the filter portable across distros and actually catch what we want.

## Evidence
On the live orion host (Debian):

\`\`\`
$ journalctl _SYSTEMD_UNIT=ssh.service       # empty
$ journalctl _COMM=sshd                       # plenty of pam_unix(sshd:session) entries
$ journalctl _COMM=sudo                       # actual sudo events
\`\`\`

The original \`include_units = [\"sshd.service\", \"sudo\", \"gdm-password\", \"login\"]\` doesn't match because:
- SSH unit is \`ssh.service\` on Debian, not \`sshd.service\`
- \`sudo\` is a binary, not a unit — no \`_SYSTEMD_UNIT=sudo\` ever exists
- \`gdm-password\` / \`login\` aren't running on server hosts
- Even on RHEL, PAM-driven auth events have \`_COMM=sshd\` with no unit attribution

## Fix
Replace \`include_units\` with \`include_matches._COMM = [\"sshd\", \"sudo\", \"su\", \"login\", \"passwd\"]\`. Validated against vector locally — no parse errors, source starts cleanly.

## Why this matters for Phase 1 closure
After #434 lands, vector has docker CLI + correct docker.sock GID. \`docker_lifecycle\` produces data on any container restart; \`gateway_audit\` produces data on any agent write-tier tool call. This PR is what makes \`journald_auth\` actually emit data on this host too — 3 of 5 sources producing data, which is a defensible Phase 1 closure.

(\`vault_audit\` and \`docker_edge_logs\` are silent for infrastructure reasons that are out of Phase 1 scope: Vault audit device requires root token at enable-time; edge containers — traefik/authentik — don't exist in this compose stack.)

## Test plan
- [ ] After deploy, \`journalctl _COMM=sshd -f\` shows entries
- [ ] \`docker exec deploy-vector-1 vector tap journald_auth\` shows journald events flowing through
- [ ] \`ssh fakeuser@<host>\` from anywhere → \`ssh.failed_password\` SecurityEvent within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)