### PR TITLE
feat(siem): VulnerabilityFinding model for CVE tracking

### DIFF
--- a/apps/web/prisma/migrations/17_vulnerability_finding/migration.sql
+++ b/apps/web/prisma/migrations/17_vulnerability_finding/migration.sql
@@ -1,0 +1,49 @@
+-- Migration: VulnerabilityFinding model + VulnStatus enum (Phase 3 PR10).
+
+CREATE TYPE "VulnStatus" AS ENUM ('open', 'fixed', 'accepted', 'false_positive');
+
+CREATE TABLE "VulnerabilityFinding" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+
+    "target" TEXT NOT NULL,
+    "packageName" TEXT NOT NULL,
+    "packageVersion" TEXT NOT NULL,
+    "fixedVersion" TEXT,
+
+    "cveId" TEXT NOT NULL,
+    "cvssScore" DOUBLE PRECISION,
+    "cvssVector" TEXT,
+    "attackVector" TEXT,
+    "attackComplexity" TEXT,
+
+    "epssScore" DOUBLE PRECISION,
+    "epssPercentile" DOUBLE PRECISION,
+    "isKev" BOOLEAN NOT NULL DEFAULT false,
+    "kevDueDate" TIMESTAMP(3),
+
+    "severity" INTEGER NOT NULL,
+    "status" "VulnStatus" NOT NULL DEFAULT 'open',
+
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "fixedAt" TIMESTAMP(3),
+
+    "rawTrivy" JSONB NOT NULL,
+
+    CONSTRAINT "VulnerabilityFinding_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "VulnerabilityFinding_environmentId_target_cveId_packageName_key"
+    ON "VulnerabilityFinding"("environmentId", "target", "cveId", "packageName");
+
+CREATE INDEX "VulnerabilityFinding_environmentId_idx" ON "VulnerabilityFinding"("environmentId");
+CREATE INDEX "VulnerabilityFinding_cveId_idx" ON "VulnerabilityFinding"("cveId");
+CREATE INDEX "VulnerabilityFinding_isKev_idx" ON "VulnerabilityFinding"("isKev");
+CREATE INDEX "VulnerabilityFinding_status_idx" ON "VulnerabilityFinding"("status");
+CREATE INDEX "VulnerabilityFinding_severity_idx" ON "VulnerabilityFinding"("severity");
+
+ALTER TABLE "VulnerabilityFinding"
+    ADD CONSTRAINT "VulnerabilityFinding_environmentId_fkey"
+    FOREIGN KEY ("environmentId") REFERENCES "Environment"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -131,6 +131,7 @@ model Environment {
   correlationRules         CorrelationRule[]
   sourceHealths            SourceHealth[]
   environmentSourceHealths EnvironmentSourceHealth[]
+  vulnerabilityFindings    VulnerabilityFinding[]
   suppressions             Suppression[]
 }
 
@@ -1075,6 +1076,67 @@ model EnvironmentSourceHealth {
   @@unique([environmentId, source])
   @@index([source])
   @@index([environmentId])
+}
+
+// ── Security: Vulnerability findings (Phase 3) ──────────────────────────────
+// Per-CVE-per-target rows produced by Trivy scans. Separate from SecurityEvent
+// because findings carry their own lifecycle (open → fixed/accepted/false_pos)
+// and need structured fields for querying (cvssScore, epssScore, isKev). A
+// SecurityEvent of type 'vuln.new' / 'vuln.escalated' / 'vuln.fixed' is emitted
+// alongside this row when the correlator should react.
+
+enum VulnStatus {
+  open
+  fixed
+  accepted
+  false_positive
+}
+
+model VulnerabilityFinding {
+  id            String      @id @default(cuid())
+  environmentId String
+  environment   Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  // target: identifies what was scanned.
+  //   "image:<repo>:<tag>"   for container images
+  //   "k8s:<ns>/<workload>"  for K8s workload misconfigurations
+  //   "host"                 for Orion host OS packages
+  target         String
+  packageName    String
+  packageVersion String
+  fixedVersion   String?
+
+  cveId           String
+  cvssScore       Float?
+  cvssVector      String?
+  attackVector    String? // NETWORK / ADJACENT / LOCAL / PHYSICAL
+  attackComplexity String?
+
+  epssScore     Float?
+  epssPercentile Float?
+  isKev         Boolean   @default(false)
+  kevDueDate    DateTime?
+
+  severity Int // 0-100, computed via attack-vector formula
+  status   VulnStatus @default(open)
+
+  firstSeenAt DateTime  @default(now())
+  // lastSeenAt is set explicitly by the scanner on each Trivy run that sees
+  // the finding — NOT @updatedAt. With @updatedAt this column would bump on
+  // status flips (open→accepted/false_positive) too, breaking "not seen
+  // for N days → auto-fixed" detection. Operator-driven status changes
+  // must leave lastSeenAt untouched.
+  lastSeenAt  DateTime
+  fixedAt     DateTime?
+
+  rawTrivy Json // full Trivy vulnerability object (for forensics)
+
+  @@unique([environmentId, target, cveId, packageName])
+  @@index([environmentId])
+  @@index([cveId])
+  @@index([isKev])
+  @@index([status])
+  @@index([severity])
 }
 
 // ── Security: Event suppressions ──────────────────────────────────────────────


### PR DESCRIPTION
Phase 3 PR10 — **stacked on #440 (PR9)**, first PR of the Phase 3 chain.

## Summary
New \`VulnerabilityFinding\` Prisma model + \`VulnStatus\` enum + migration 17. Purely additive — no existing models touched. Provides the persistent layer for Phase 3 PR13's scanner job.

## Why a new model vs. SecurityEvent
- Findings have their own lifecycle: open → fixed / accepted / false_positive.
- Need structured CVE fields for querying (\"what's affected by Log4Shell?\", \"show me all KEV-listed open findings\").
- Per-image dedup across scans — \`@@unique([environmentId, target, cveId, packageName])\` lets us upsert safely.
- A separate SecurityEvent (\`type=vuln.new\` / \`vuln.escalated\` / \`vuln.fixed\`) is emitted when the correlator should react. Avoids flooding the feed with one event per finding per scan.

## Fields
- Enrichment-ready: \`cvssScore\`, \`cvssVector\`, \`attackVector\`, \`epssScore\`, \`epssPercentile\`, \`isKev\`, \`kevDueDate\`, \`attackComplexity\`.
- \`target\` as prefixed string (\`image:...\` / \`k8s:...\` / \`host\`) — single column, no discriminator needed.
- \`rawTrivy JSONB\` for forensics — preserves the full Trivy finding.

## Stacking
- Base: #440 (PR9)
- Next: PR11 (\`feat/siem-trivy-gateway\`) — Trivy gateway tools
- Then: PR12 (\`feat/siem-cve-enrichment\`) — CISA KEV / EPSS / NVD clients
- Finally: PR13 (\`feat/siem-vuln-scanner\`) — scanner job that writes to this table

## SOC II touch points
- New table holds CVE intelligence + Trivy raw output. No PII. \`rawTrivy\` is bounded JSON (Trivy output is structured, no user-supplied free text).
- ON DELETE CASCADE on \`environmentId\` — findings die with their env.
- No code paths added by this PR — just schema.

## Test plan
- [x] \`prisma validate\` passes (confirmed locally)
- [ ] Migration applies cleanly on existing DB
- [ ] Prisma client regenerates with the new model + enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)