### PR TITLE
fix(web): GatewayClient token type error in security-poll-k8s

### DIFF
--- a/apps/web/src/jobs/security-poll-k8s.ts
+++ b/apps/web/src/jobs/security-poll-k8s.ts
@@ -74,7 +74,7 @@ export async function runK8sPoller(env: {
     return result
   }
 
-  const client = new GatewayClient(env.gatewayUrl, env.gatewayToken ?? null)
+  const client = new GatewayClient(env.gatewayUrl, env.gatewayToken ?? '')
 
   // 1. Get the last watermark
   const health = await prisma.environmentSourceHealth.findUnique({


### PR DESCRIPTION
## Summary

- `GatewayClient` constructor expects `token: string`, but `env.gatewayToken ?? null` yields `string | null`, causing a TypeScript compile error
- Fixes the build failure introduced in #446
- One-char change: replace `?? null` with `?? ''`

## Root cause

`apps/web/src/jobs/security-poll-k8s.ts:77` — `env.gatewayToken` is typed `string | null` from the Prisma select. The `?? null` fallback was a no-op and the resulting `string | null` didn't satisfy the `string` parameter of `GatewayClient`.

## Test plan

- [ ] CI build passes (was the only failure)
- [ ] No behaviour change — an env with no token will still fail authentication at the gateway, same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)