### PR TITLE
fix(web): update SecurityConfig queries to use compound unique key

### DIFF
--- a/apps/web/src/lib/security/cve-enrichment.ts
+++ b/apps/web/src/lib/security/cve-enrichment.ts
@@ -49,8 +49,8 @@ export interface KevCatalog {
 export async function fetchKevCatalog(): Promise<KevCatalog> {
   // 1. Try cache first.
   const [cacheRow, updatedAtRow] = await Promise.all([
-    prisma.securityConfig.findUnique({ where: { key: KEV_CACHE_KEY } }),
-    prisma.securityConfig.findUnique({ where: { key: KEV_CACHE_UPDATED_AT_KEY } }),
+    prisma.securityConfig.findUnique({ where: { environmentId_key: { environmentId: null, key: KEV_CACHE_KEY } } }),
+    prisma.securityConfig.findUnique({ where: { environmentId_key: { environmentId: null, key: KEV_CACHE_UPDATED_AT_KEY } } }),
   ])
   const updatedAtMs = updatedAtRow ? Number(updatedAtRow.value) : 0
   const isFresh = Date.now() - updatedAtMs < KEV_CACHE_TTL_MS
@@ -77,12 +77,12 @@ export async function fetchKevCatalog(): Promise<KevCatalog> {
   // 3. Cache it.
   try {
     await prisma.securityConfig.upsert({
-      where: { key: KEV_CACHE_KEY },
+      where: { environmentId_key: { environmentId: null, key: KEV_CACHE_KEY } },
       update: { value: fetched },
       create: { key: KEV_CACHE_KEY, value: fetched, environmentId: null },
     })
     await prisma.securityConfig.upsert({
-      where: { key: KEV_CACHE_UPDATED_AT_KEY },
+      where: { environmentId_key: { environmentId: null, key: KEV_CACHE_UPDATED_AT_KEY } },
       update: { value: String(Date.now()) },
       create: { key: KEV_CACHE_UPDATED_AT_KEY, value: String(Date.now()), environmentId: null },
     })


### PR DESCRIPTION
## Summary

- Migration #17 changed `SecurityConfig` from a `@@unique([key])` to `@@unique([environmentId, key])`, but `cve-enrichment.ts` still queries with `{ where: { key } }` which TypeScript (via Prisma's generated types) rejects
- Update all four callsites (2x `findUnique`, 2x `upsert`) to use `environmentId_key: { environmentId: null, key: ... }` — the global cache rows have no environment

## Test plan

- [ ] CI build passes (third and final type error from PR #446)

🤖 Generated with [Claude Code](https://claude.com/claude-code)