### PR TITLE
fix(web): use findFirst+id for SecurityConfig null-environmentId cache rows

### DIFF
--- a/apps/web/src/lib/security/cve-enrichment.ts
+++ b/apps/web/src/lib/security/cve-enrichment.ts
@@ -49,8 +49,8 @@ export interface KevCatalog {
 export async function fetchKevCatalog(): Promise<KevCatalog> {
   // 1. Try cache first.
   const [cacheRow, updatedAtRow] = await Promise.all([
-    prisma.securityConfig.findUnique({ where: { environmentId_key: { environmentId: null, key: KEV_CACHE_KEY } } }),
-    prisma.securityConfig.findUnique({ where: { environmentId_key: { environmentId: null, key: KEV_CACHE_UPDATED_AT_KEY } } }),
+    prisma.securityConfig.findFirst({ where: { environmentId: null, key: KEV_CACHE_KEY } }),
+    prisma.securityConfig.findFirst({ where: { environmentId: null, key: KEV_CACHE_UPDATED_AT_KEY } }),
   ])
   const updatedAtMs = updatedAtRow ? Number(updatedAtRow.value) : 0
   const isFresh = Date.now() - updatedAtMs < KEV_CACHE_TTL_MS
@@ -76,16 +76,16 @@ export async function fetchKevCatalog(): Promise<KevCatalog> {
 
   // 3. Cache it.
   try {
-    await prisma.securityConfig.upsert({
-      where: { environmentId_key: { environmentId: null, key: KEV_CACHE_KEY } },
-      update: { value: fetched },
-      create: { key: KEV_CACHE_KEY, value: fetched, environmentId: null },
-    })
-    await prisma.securityConfig.upsert({
-      where: { environmentId_key: { environmentId: null, key: KEV_CACHE_UPDATED_AT_KEY } },
-      update: { value: String(Date.now()) },
-      create: { key: KEV_CACHE_UPDATED_AT_KEY, value: String(Date.now()), environmentId: null },
-    })
+    if (cacheRow) {
+      await prisma.securityConfig.update({ where: { id: cacheRow.id }, data: { value: fetched } })
+    } else {
+      await prisma.securityConfig.create({ data: { key: KEV_CACHE_KEY, value: fetched, environmentId: null } })
+    }
+    if (updatedAtRow) {
+      await prisma.securityConfig.update({ where: { id: updatedAtRow.id }, data: { value: String(Date.now()) } })
+    } else {
+      await prisma.securityConfig.create({ data: { key: KEV_CACHE_UPDATED_AT_KEY, value: String(Date.now()), environmentId: null } })
+    }
   } catch {
     /* cache write failure is non-fatal — just won't speed up next call */
   }


### PR DESCRIPTION
## Summary

- Prisma's generated compound unique input (`environmentId_key`) types `environmentId` as `string`, not `string | null` — even though the field is nullable — because SQL cannot use NULL in unique key lookups
- `cve-enrichment.ts` stores the global KEV cache with `environmentId: null`; the previous fix using `environmentId_key: { environmentId: null, key }` still fails TypeScript
- Solution: `findFirst` (accepts `null` in a regular where clause) for reads, and find-then-update-or-create keyed on `id` for writes

## Test plan

- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)