### PR TITLE
fix(vector): replace pinned docker tarball with docker:27-cli multi-stage copy

### DIFF
--- a/deploy/host-agent/Dockerfile
+++ b/deploy/host-agent/Dockerfile
@@ -8,19 +8,12 @@
 #
 # This image adds *just the docker client* (not the daemon). The container
 # uses the host's /var/run/docker.sock for daemon communication.
+#
+# We copy the docker binary from the official docker:cli image rather than
+# fetching a pinned tar URL, which avoids 404s as old versions are removed
+# from the download server.
+FROM docker:27-cli AS docker-cli
+
 FROM timberio/vector:0.39.0-debian
-
-USER root
-
-ARG DOCKER_VERSION=26.1.5
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
-    curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
-        | tar -xz --strip-components=1 -C /usr/local/bin docker/docker && \
-    chmod 755 /usr/local/bin/docker && \
-    apt-get purge -y curl && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
 USER vector


### PR DESCRIPTION
## Summary

- `deploy/host-agent/Dockerfile` was downloading `docker-26.1.5.tgz` from Docker's static binary server, which now returns 404 — old versions are removed as new ones are released
- Replace with a multi-stage build: copy `/usr/local/bin/docker` from the official `docker:27-cli` image (Alpine-based, statically linked binary works fine in the Debian Vector base)
- Eliminates the apt-get/curl dance entirely; no URL to rot

## Test plan

- [ ] Build ORION Vector CI passes and pushes `ghcr.io/richard-callis/orion-vector:latest`
- [ ] Deploy ORION succeeds after the vector image is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)