### PR TITLE
fix(web): add security webhooks to middleware PUBLIC_PATHS

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -94,6 +94,7 @@ const PUBLIC_PATHS = [
   '/api/notes/embed',       // embed rebuild — bypassed via x-embed-token header
   '/api/environments/join', // gateway registration — no session, token IS the auth
   '/api/webhooks',          // git provider webhooks — HMAC signature is the auth
+  '/api/monitoring/security/webhooks', // security source webhooks (Falco, CrowdSec, Wazuh) — HMAC is the auth
   '/_next',
   '/favicon.ico',
 ]


### PR DESCRIPTION
## Summary

- All security source webhooks (`/api/monitoring/security/webhooks/falco`, `/crowdsec`, `/wazuh`) were returning 307 → `/login` because NextAuth middleware wasn't aware they're public
- These routes authenticate via HMAC signature at the handler level — same pattern as \`/api/webhooks\` (git provider)
- Adding the prefix to \`PUBLIC_PATHS\` unblocks all inbound security traffic

## Root cause

\`PUBLIC_PATHS\` had \`/api/webhooks\` for git but not for the security monitoring webhooks added in Phase 1/2 — an oversight in the original webhook PRs.

## Test plan

- [ ] CI passes
- [ ] After deploy: \`curl -X POST http://localhost:3000/api/monitoring/security/webhooks/falco\` returns 400/401 (not 307)
- [ ] Synthetic Falco event lands as a SecurityEvent row

🤖 Generated with [Claude Code](https://claude.com/claude-code)