### PR TITLE
fix(security): unblock all security event sources

### DIFF
--- a/apps/web/src/app/api/monitoring/security/webhooks/falco/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/falco/route.ts
@@ -27,7 +27,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import {
-  verifyWebhookHmac,
+  constantTimeCompare,
   isWithinReplayWindow,
   isLoopbackWebhookRequest,
   warnMissingWebhookSecret,
@@ -74,7 +74,9 @@ export async function POST(req: NextRequest) {
     req.headers.get('X-Signature')
   const timestamp = req.headers.get('X-Timestamp') || req.headers.get('x-timestamp')
 
-  // 2. Verify HMAC
+  // 2. Verify token — Falcosidekick sends the raw secret as a custom header
+  // (it cannot compute HMAC). We do a constant-time equality check instead of
+  // HMAC to avoid timing oracles while matching what Falcosidekick actually sends.
   if (!process.env.FALCO_WEBHOOK_SECRET) {
     const refuse = warnMissingWebhookSecret('falco', 'FALCO_WEBHOOK_SECRET')
     if (refuse) {
@@ -87,8 +89,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {
-    const secret = process.env.FALCO_WEBHOOK_SECRET
-    if (!verifyWebhookHmac(secret, bodyText, signature)) {
+    if (!constantTimeCompare(signature ?? '', process.env.FALCO_WEBHOOK_SECRET)) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
     }
   }
@@ -146,23 +147,32 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Resolve 'host' to the real localhost environment UUID.
+  // EnvironmentSourceHealth.environmentId is a non-nullable FK — the literal
+  // string 'host' would cause a constraint violation.
+  const sourceHealthEnvId: string | null = environmentId === 'host'
+    ? (await prisma.environment.findFirst({ where: { type: 'localhost' }, select: { id: true } }))?.id ?? null
+    : environmentId
+
   const now = new Date()
 
   // 7. Heartbeat path — bump lastSeenAt only, no SecurityEvent
   if (isHeartbeat(alert)) {
-    await prisma.environmentSourceHealth.upsert({
-      where: {
-        environmentId_source: { environmentId, source: FALCO_SOURCE },
-      },
-      update: { lastSeenAt: now },
-      create: {
-        environmentId,
-        source: FALCO_SOURCE,
-        lastSeenAt: now,
-        lastWatermark: null,
-        staleAfterMs: FALCO_STALE_AFTER_MS,
-      },
-    })
+    if (sourceHealthEnvId) {
+      await prisma.environmentSourceHealth.upsert({
+        where: {
+          environmentId_source: { environmentId: sourceHealthEnvId, source: FALCO_SOURCE },
+        },
+        update: { lastSeenAt: now },
+        create: {
+          environmentId: sourceHealthEnvId,
+          source: FALCO_SOURCE,
+          lastSeenAt: now,
+          lastWatermark: null,
+          staleAfterMs: FALCO_STALE_AFTER_MS,
+        },
+      })
+    }
     return NextResponse.json({ received: true, kind: 'heartbeat', environmentId })
   }
 
@@ -201,20 +211,22 @@ export async function POST(req: NextRequest) {
     inserted = true
   }
 
-  // 9. Bump EnvironmentSourceHealth — both heartbeat and real alerts count
-  await prisma.environmentSourceHealth.upsert({
-    where: {
-      environmentId_source: { environmentId, source: FALCO_SOURCE },
-    },
-    update: { lastSeenAt: now },
-    create: {
-      environmentId,
-      source: FALCO_SOURCE,
-      lastSeenAt: now,
-      lastWatermark: null,
-      staleAfterMs: FALCO_STALE_AFTER_MS,
-    },
-  })
+  // 9. Bump EnvironmentSourceHealth — skip if we couldn't resolve a real env UUID
+  if (sourceHealthEnvId) {
+    await prisma.environmentSourceHealth.upsert({
+      where: {
+        environmentId_source: { environmentId: sourceHealthEnvId, source: FALCO_SOURCE },
+      },
+      update: { lastSeenAt: now },
+      create: {
+        environmentId: sourceHealthEnvId,
+        source: FALCO_SOURCE,
+        lastSeenAt: now,
+        lastWatermark: null,
+        staleAfterMs: FALCO_STALE_AFTER_MS,
+      },
+    })
+  }
 
   return NextResponse.json({
     received: true,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       ORION_CLAUDE_URL: ${ORION_CLAUDE_URL:-http://orion-claude:3100}
       # MCP service token — shared with orion-claude so Claude can call ORION tools via MCP
       ORION_MCP_TOKEN: ${ORION_MCP_TOKEN:-}
+      # Host-agent webhook secret — must match the value passed to the vector service
+      HOST_AGENT_WEBHOOK_SECRET: ${HOST_AGENT_WEBHOOK_SECRET:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/deploy/host-agent/falco/falco.yaml
+++ b/deploy/host-agent/falco/falco.yaml
@@ -5,9 +5,10 @@
 # Custom rules tuned to Orion workloads (e.g., alert if gateway reads
 # /root/.kube) are out of scope for Phase 2.
 #
-# Output goes to Falcosidekick via gRPC. Falco does NOT POST directly to
-# Orion — Falcosidekick handles HMAC signing, retries, and customfields
-# injection.
+# Output: Falco POSTs JSON to Falcosidekick on port 2801 (http_output).
+# Falcosidekick then forwards to the Orion webhook with retries and
+# CUSTOMFIELDS injection. gRPC output is disabled — Falcosidekick 2.x
+# in its default mode receives HTTP POSTs from Falco, not gRPC streams.
 
 # ── Rule files ──────────────────────────────────────────────────────────────
 rules_file:
@@ -15,27 +16,32 @@ rules_file:
   - /etc/falco/falco_rules.local.yaml
 
 # ── Engine / driver ─────────────────────────────────────────────────────────
-# Modern eBPF (CO-RE) — no kernel module install required.
+# Legacy eBPF — broader kernel support than modern_ebpf (CO-RE).
+# modern_ebpf segfaults on this kernel build (6.8); ebpf probe is downloaded
+# by falco-no-driver at startup for the running kernel.
 engine:
-  kind: modern_ebpf
-  modern_ebpf:
-    cpus_for_each_buffer: 2
+  kind: ebpf
+  ebpf:
+    probe: ""
 
 # ── Output channels ─────────────────────────────────────────────────────────
-# gRPC: Falcosidekick subscribes to this and forwards to the webhook.
-# stdout: kept enabled for `docker logs deploy-falco-1` debugging.
-grpc:
+# http_output: Falco POSTs each alert to Falcosidekick which handles retries,
+# CUSTOMFIELDS injection, and forwarding to the Orion webhook.
+http_output:
   enabled: true
-  bind_address: "0.0.0.0:5060"
-  threadiness: 8
-
-grpc_output:
-  enabled: true
+  url: http://falcosidekick:2801
+  user_agent: falcosecurity/falco
 
 stdout_output:
   enabled: true
 
-# Disable the file/syslog outputs we don't use — reduces noise + IO.
+# Disable outputs we don't use.
+grpc:
+  enabled: false
+
+grpc_output:
+  enabled: false
+
 file_output:
   enabled: false
 
@@ -43,19 +49,11 @@ syslog_output:
   enabled: false
 
 # ── Other ───────────────────────────────────────────────────────────────────
-# Falco's own metrics endpoint — disabled for now; can enable later for
-# Prometheus scrape if needed.
 metrics:
   enabled: false
 
-# Heartbeat: emit a periodic alert with rule="Heartbeat" so the orion
-# webhook can bump EnvironmentSourceHealth.lastSeenAt and detect silence.
-# This pairs with the isHeartbeat() check in normalize/falco.ts.
 priority: notice
 buffered_outputs: false
 output_timeout: 2000
 
-# Disable the noisy "Watch File Created" / "Detect outbound connections to
-# common miner pool ports" rules for now — they fire too often on a busy
-# homelab and create noise before correlation rules tune them in Phase 2 PR9.
 disable_source: []


### PR DESCRIPTION
## Summary

Five bugs were preventing any real security events from reaching Orion. All found by tracing the live pipelines after the Phase 2 merge.

### Vector → host-agent webhook: 500
`HOST_AGENT_WEBHOOK_SECRET` was in the `vector` service env but missing from `orion`. The handler calls `warnMissingWebhookSecret` which returns `true` in production → 500. Vector has been retrying every batch for hours and dropping them. Fix: add the env var to `orion`.

### Falco crash-loop: `Option 'driver' does not exist`
The previous fix added `command: ["falco", "--driver", "ebpf"]` but `falco-no-driver:0.38.2` has no `--driver` CLI flag — the engine is configured only via `falco.yaml`. Fix: change `engine.kind: modern_ebpf` → `ebpf` in `falco.yaml`.

### Falco → Falcosidekick: silent event drop
`falco.yaml` only had `grpc_output` enabled. Falcosidekick 2.x in its default mode is a **listener** on port 2801 — Falco must POST to it via `http_output`. gRPC subscription is a separate mode that wasn't configured. Fix: add `http_output: url: http://falcosidekick:2801`, disable `grpc` sections.

### Falcosidekick → Orion webhook: 401
`WEBHOOK_CUSTOMHEADERS` sets `X-Orion-Falco-Signature` to the raw secret value. The handler expected `sha256=<hmac_hex>` (HMAC of the body). Falcosidekick has no body-signing capability for generic webhooks. Fix: replace `verifyWebhookHmac` with `constantTimeCompare` (bearer token check).

### Falco SourceHealth: FK constraint crash
`environmentId: 'host'` is a literal string, not a UUID. `EnvironmentSourceHealth.environmentId` is a non-nullable FK to `Environment`. Every Falco event would crash the DB write after insertion. Fix: resolve `'host'` to the real `localhost` environment UUID; skip the upsert if no localhost environment is registered yet.

## Test plan

- [ ] Deploy and confirm `deploy-vector-1` logs show 200 responses (not 500s)
- [ ] Confirm `deploy-falco-1` starts and stays up (no more exit 1)
- [ ] Confirm `deploy-falcosidekick-1` logs show events forwarded to Orion
- [ ] POST a Falco event manually and confirm 200 (not 401)
- [ ] Check Alerts tab shows real Falco events from the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)