### PR TITLE
docs: update README with SIEM, security stack, and current structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Operations & Resource Infrastructure Orchestration Node**
 
-ORION is a self-hosted management platform that lives *outside* the infrastructure it controls. It bootstraps, manages, and automates Kubernetes clusters and Docker hosts through an AI-driven GitOps pipeline — so when your cluster goes down, your management plane stays up.
+ORION is a self-hosted management platform that lives *outside* the infrastructure it controls. It bootstraps, manages, and automates Kubernetes clusters and Docker hosts through an AI-driven GitOps pipeline — and monitors them in real time through a built-in SIEM. When your cluster goes down, your management plane stays up.
 
 ---
 
@@ -16,14 +16,14 @@ ORION is a self-hosted management platform that lives *outside* the infrastructu
 | **Infrastructure — nodes & pods** | **GitOps — PR tracking & environments** |
 | ![Ingress](docs/screenshots/ingress.png) | ![Chat](docs/screenshots/chat.png) |
 | **Ingress Manager** | **Claude Chat** |
-| ![Tasks](docs/screenshots/tasks.png) | ![Environments](docs/screenshots/environments.png) |
-| **Tasks — kanban board** | **Admin — environment tools** |
+| ![Tasks](docs/screenshots/tasks.png) | ![Security](docs/screenshots/security.png) |
+| **Tasks — kanban board** | **Security Dashboard** |
 
 ---
 
 ## How It Works
 
-ORION runs on a dedicated management node (a Raspberry Pi 4 8GB works great). On first boot it spins up its own dependencies, then you register environments through the UI. From that point on, every infrastructure change flows through Git.
+ORION runs on a dedicated management node (a Raspberry Pi 4 8GB works great). On first boot it spins up its own dependencies, then you register environments through the UI. From that point on, every infrastructure change flows through Git and every security event flows into the SIEM.
 
 ```
 GitHub
@@ -39,13 +39,15 @@ GitHub
                     │                    │
              Kubernetes             Docker Host
               Cluster                   │
-                    │              ORION Gateway
-             ArgoCD + ORION        (Docker type)
-              Gateway              + Gitea Actions
-           (cluster type)
-                    │
-              GitOps sync
-           manifests → cluster
+                    │              ORION Gateway        Falco
+             ArgoCD + ORION        (Docker type)    (host syscalls)
+              Gateway              + Gitea Actions       │
+           (cluster type)               │           Falcosidekick
+                    │                   │                │
+              GitOps sync           Vector ─────────────┘
+           manifests → cluster    (journald, Docker                 │
+                                   events, Vault audit)    ORION Security API
+                                                           (normalise → DB → UI)
 ```
 
 **The AI GitOps loop:**
@@ -57,6 +59,15 @@ GitHub
 5. Review operations wait for human approval in Gitea → then ArgoCD syncs
 6. ORION Gateway (MCP server inside the cluster) reports sync status back to ORION
 7. Full audit trail — every cluster change is a Gitea commit with AI reasoning attached
+
+**The security event pipeline:**
+
+1. Falco captures syscall-level events on the management node (shells in containers, file reads, network anomalies)
+2. Falcosidekick forwards each alert to the ORION webhook with retries and environment attribution
+3. Vector ships journald auth events, Docker lifecycle events, and Vault audit logs in batches
+4. K8s events poller pulls audit events from each registered cluster environment
+5. All sources are normalised into `SecurityEvent` rows; the correlator groups them into `Incident`s
+6. The security dashboard shows live incidents, alerts, source health, and Warden-generated action approvals
 
 ---
 
@@ -71,6 +82,9 @@ GitHub
 - **Internal DNS** — CoreDNS on the management node is authoritative for your internal domain; configured via the first-run wizard
 - **Cluster bootstrap** — register a cluster and ORION automatically deploys ArgoCD, ESO, and the ORION Gateway
 - **MCP gateway** — ORION Gateway exposes kubectl/Docker tools to AI agents via the Model Context Protocol
+- **Built-in SIEM** — Falco, CrowdSec, Wazuh, and Vector ship events to a normalised pipeline; incidents are correlated automatically and surfaced in the security dashboard
+- **Vulnerability scanning** — Trivy scans container images on pull and on a daily schedule; CVE findings are enriched and linked to environments
+- **Warden agent** — AI security operator that reviews incidents, proposes remediations, and queues actions for human approval
 
 ---
 
@@ -78,13 +92,18 @@ GitHub
 
 | Component | Role |
 |---|---|
-| **ORION Web** | Next.js 14 dashboard + API + AI agent orchestrator |
+| **ORION Web** | Next.js 15 dashboard + API + AI agent orchestrator |
 | **ORION Gateway** | MCP server deployed inside each managed environment |
 | **Gitea** | Self-hosted Git — one repo per registered environment |
 | **Vault** | Secrets store with per-environment isolation |
-| **PostgreSQL 16** | ORION database |
+| **PostgreSQL 16** | ORION database (pgvector enabled) |
 | **Traefik** | Reverse proxy for management node services |
 | **CoreDNS** | Authoritative DNS for your internal domain |
+| **Falco** | Syscall-level runtime security on the management host |
+| **Falcosidekick** | Forwards Falco alerts to ORION with HMAC auth and retries |
+| **Vector** | Ships journald, Docker events, and Vault audit logs to ORION |
+| **Redis Sentinel** | HA Redis cluster for distributed rate limiting |
+| **MinIO** | S3-compatible audit log archival |
 
 ---
 
@@ -154,14 +173,24 @@ In the ORION UI, go to **Environments → Add Environment** and select:
 ```
 orion-web/
 ├── apps/
-│   ├── web/          # ORION dashboard (Next.js 14 + Prisma + TypeScript)
-│   └── gateway/      # ORION Gateway MCP server (Express + TypeScript)
+│   ├── web/                    # ORION dashboard (Next.js 15 + Prisma + TypeScript)
+│   │   └── src/
+│   │       ├── app/            # Next.js app router (API routes + pages)
+│   │       ├── components/     # UI components (security dashboard, infrastructure, etc.)
+│   │       ├── jobs/           # Background pollers (K8s events, ELK, ntopng, vuln scan)
+│   │       ├── lib/            # Shared libraries
+│   │       │   └── security/   # SIEM pipeline: normalizers, correlator, rule engine
+│   │       └── workers/        # Security correlator worker
+│   └── gateway/                # ORION Gateway MCP server (Express + TypeScript)
 ├── deploy/
-│   ├── docker-compose.yml   # Full management node stack
-│   ├── bootstrap.sh         # First-run setup script
-│   ├── .env.example         # Environment variable template
-│   └── coredns/             # CoreDNS config + zone files
-└── .github/workflows/       # Multi-arch builds (amd64 + arm64) → ghcr.io
+│   ├── docker-compose.yml      # Full management node stack
+│   ├── bootstrap.sh            # First-run setup script
+│   ├── .env.example            # Environment variable template
+│   ├── coredns/                # CoreDNS config + zone files
+│   └── host-agent/
+│       ├── falco/falco.yaml    # Falco runtime security config
+│       └── vector.toml         # Vector telemetry shipper config
+└── .github/workflows/          # Multi-arch builds (amd64 + arm64) → ghcr.io
 ```
 
 ---
@@ -188,8 +217,15 @@ Pushing to `main` triggers GitHub Actions that build multi-arch Docker images (`
 | `POSTGRES_PASSWORD` | PostgreSQL password | — |
 | `NEXTAUTH_SECRET` | NextAuth secret (generate with `openssl rand -base64 32`) | — |
 | `ORION_VERSION` | Image tag to deploy | `latest` |
+| `FALCO_WEBHOOK_SECRET` | Shared token — Falcosidekick → ORION Falco webhook | — |
+| `HOST_AGENT_WEBHOOK_SECRET` | HMAC secret — Vector → ORION host-agent webhook | — |
+| `CROWDSEC_WEBHOOK_SECRET` | HMAC secret — CrowdSec → ORION webhook | — |
+| `WAZUH_WEBHOOK_SECRET` | HMAC secret — Wazuh → ORION webhook | — |
+| `ELK_URL` | ELK/Elasticsearch base URL for the ELK poller | — |
+| `NTOPNG_URL` | ntopng API base URL for the ntopng poller | — |
 
 > Domains are bootstrap defaults only — the first-run wizard lets you configure your actual internal and public domains interactively.
+> Security webhook secrets are generated by `bootstrap.sh` and written to `.env` automatically.
 
 See `deploy/.env.example` for the full list.
 
@@ -201,6 +237,7 @@ See `deploy/.env.example` for the full list.
 - **ORION's source of truth is GitHub** — Gitea manages cluster repos; ORION's own code lives here to avoid a circular dependency
 - **One Vault, N environments** — secret paths and auth methods are scoped per environment; cross-environment access is impossible by policy
 - **CoreDNS is authoritative** — ORION configures CoreDNS for your internal domain during setup; cluster CoreDNS instances forward to it; internal DNS survives cluster outages
+- **SIEM is pull and push** — push-based sources (Falco, CrowdSec, Wazuh, Vector) POST events to ORION webhooks; pull-based sources (K8s events, ELK, ntopng) are polled on configurable intervals from the worker process
 - **Portable** — no hardcoded domains, IP ranges, or cloud provider assumptions; works on any network with any internal domain
 
 ---


### PR DESCRIPTION
## Summary

- Adds SIEM to the headline and project description
- Extends the architecture diagram to show the security event pipeline (Falco → Falcosidekick → Vector → ORION)
- Adds Built-in SIEM, Trivy vulnerability scanning, and Warden agent to the features list
- Adds Falco, Falcosidekick, Vector, Redis Sentinel, and MinIO to the stack table
- Updates repository structure to show `jobs/`, `workers/`, and `lib/security/` subdirectories
- Adds security webhook env vars (`FALCO_WEBHOOK_SECRET`, `HOST_AGENT_WEBHOOK_SECRET`, `ELK_URL`, `NTOPNG_URL`) to the env vars table
- Updates architecture notes with pull/push SIEM model
- Fixes the screenshots table (Tasks → Security Dashboard)
- Bumps Next.js version 14 → 15 in stack table

🤖 Generated with [Claude Code](https://claude.com/claude-code)