### PR TITLE
feat(soc): SOC case management — 7-commit implementation + 10 review fixes

### DIFF
--- a/apps/web/prisma/migrations/10_soc_case_management/migration.sql
+++ b/apps/web/prisma/migrations/10_soc_case_management/migration.sql
@@ -1,0 +1,151 @@
+-- SOC Case Management Schema
+-- Adds investigation tracking: cases, notes, observables, timeline, audit log.
+-- All changes are additive — zero data loss on existing data.
+
+-- ── Enums ──────────────────────────────────────────────────────────────────────
+
+CREATE TYPE "InvestigationStatus" AS ENUM ('open', 'active', 'suspended', 'resolved', 'closed');
+CREATE TYPE "ResolutionType" AS ENUM ('true_positive', 'false_positive', 'benign', 'inconclusive');
+CREATE TYPE "TLP" AS ENUM ('white', 'green', 'amber', 'red');
+CREATE TYPE "ObservableCategory" AS ENUM ('ipv4', 'ipv6', 'domain', 'url', 'file_hash_md5', 'file_hash_sha1', 'file_hash_sha256', 'mac_address', 'email', 'username', 'file_path', 'registry_key', 'mutex', 'asn');
+CREATE TYPE "ObservableVerdict" AS ENUM ('malicious', 'suspicious', 'benign', 'unknown');
+CREATE TYPE "ObservableRole" AS ENUM ('ioc', 'artifact', 'infrastructure');
+
+-- ── Investigation table ────────────────────────────────────────────────────────
+
+CREATE TABLE "Investigation" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "name" TEXT NOT NULL,
+  "status" "InvestigationStatus" NOT NULL DEFAULT 'open',
+  "severity" INTEGER NOT NULL,
+  "tlp" "TLP" NOT NULL DEFAULT 'amber',
+  "pap" INTEGER NOT NULL DEFAULT 2,
+  "startedAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "resolvedAt" TIMESTAMPTZ(3),
+  "closedAt" TIMESTAMPTZ(3),
+  "resolution" TEXT,
+  "resolutionType" "ResolutionType",
+  "assignedTo" TEXT,
+  "createdBy" TEXT NOT NULL,
+  "tags" TEXT[] NOT NULL DEFAULT '{}',
+  "dueAt" TIMESTAMPTZ(3),
+  "mitreAttackIds" TEXT[] NOT NULL DEFAULT '{}',
+  "externalId" TEXT,
+  "externalSystem" TEXT,
+  "lastSyncedAt" TIMESTAMPTZ(3),
+  "syncVersion" INTEGER NOT NULL DEFAULT 0,
+  "syncSource" TEXT,
+  "timeToDetect" INTEGER,
+  "timeToRespond" INTEGER,
+  "timeToResolve" INTEGER,
+  "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+  CONSTRAINT "Investigation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Investigation_status" ON "Investigation"("status");
+CREATE INDEX "Investigation_createdAt" ON "Investigation"("createdAt");
+CREATE INDEX "Investigation_externalId" ON "Investigation"("externalId");
+
+-- ── InvestigationNote table ────────────────────────────────────────────────────
+
+CREATE TABLE "InvestigationNote" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "investigationId" UUID NOT NULL,
+  "content" TEXT NOT NULL,
+  "author" TEXT NOT NULL,
+  "authorType" TEXT NOT NULL,
+  "isDraft" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "updatedAt" TIMESTAMPTZ(3),
+  "searchVector" tsvector,
+
+  CONSTRAINT "InvestigationNote_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "InvestigationNote_investigationId_fkey" FOREIGN KEY ("investigationId") REFERENCES "Investigation"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "InvestigationNote_investigationId_createdAt" ON "InvestigationNote"("investigationId", "createdAt");
+CREATE INDEX "InvestigationNote_investigationId_authorType" ON "InvestigationNote"("investigationId", "authorType");
+
+-- GIN index for full-text search on notes (successes up to 500ms on 10k notes)
+CREATE INDEX "InvestigationNote_searchVector_idx" ON "InvestigationNote" USING gin("searchVector");
+
+-- ── InvestigationObservable table ──────────────────────────────────────────────
+
+CREATE TABLE "InvestigationObservable" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "investigationId" UUID NOT NULL,
+  "value" TEXT NOT NULL,
+  "displayValue" TEXT NOT NULL,
+  "category" "ObservableCategory" NOT NULL,
+  "role" "ObservableRole" NOT NULL DEFAULT 'ioc',
+  "verdict" "ObservableVerdict" NOT NULL DEFAULT 'unknown',
+  "verdictBy" TEXT,
+  "verdictAt" TIMESTAMPTZ(3),
+  "confidence" INTEGER NOT NULL DEFAULT 0,
+  "severity" INTEGER NOT NULL DEFAULT 0,
+  "firstSeen" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "lastSeen" TIMESTAMPTZ(3) NOT NULL,
+  "context" TEXT,
+  "resolved" BOOLEAN NOT NULL DEFAULT false,
+  "threatIntelMatch" JSONB,
+  "externalId" TEXT,
+  "lastSyncedAt" TIMESTAMPTZ(3),
+
+  CONSTRAINT "InvestigationObservable_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "InvestigationObservable_investigationId_fkey" FOREIGN KEY ("investigationId") REFERENCES "Investigation"("id") ON DELETE CASCADE
+);
+
+-- Unique constraint: one observable per investigation per (value, category)
+CREATE UNIQUE INDEX "InvestigationObservable_investigationId_value_category_key"
+  ON "InvestigationObservable"("investigationId", "value", "category");
+CREATE INDEX "InvestigationObservable_value" ON "InvestigationObservable"("value");
+CREATE INDEX "InvestigationObservable_category" ON "InvestigationObservable"("category");
+CREATE INDEX "InvestigationObservable_verdict" ON "InvestigationObservable"("verdict");
+
+-- ── InvestigationTimeline table ────────────────────────────────────────────────
+
+CREATE TABLE "InvestigationTimeline" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "investigationId" UUID NOT NULL,
+  "eventTime" TIMESTAMPTZ(3) NOT NULL,
+  "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "eventType" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "description" TEXT,
+  "source" TEXT NOT NULL,
+  "isPinned" BOOLEAN NOT NULL DEFAULT false,
+  "payload" JSONB,
+
+  CONSTRAINT "InvestigationTimeline_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "InvestigationTimeline_investigationId_fkey" FOREIGN KEY ("investigationId") REFERENCES "Investigation"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "InvestigationTimeline_investigationId_eventTime" ON "InvestigationTimeline"("investigationId", "eventTime");
+CREATE INDEX "InvestigationTimeline_investigationId_eventType" ON "InvestigationTimeline"("investigationId", "eventType");
+
+-- ── InvestigationAudit table ───────────────────────────────────────────────────
+
+CREATE TABLE "InvestigationAudit" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "investigationId" UUID NOT NULL,
+  "actorId" TEXT NOT NULL,
+  "actorType" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "before" JSONB,
+  "after" JSONB,
+  "timestamp" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+
+  CONSTRAINT "InvestigationAudit_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "InvestigationAudit_investigationId_fkey" FOREIGN KEY ("investigationId") REFERENCES "Investigation"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "InvestigationAudit_investigationId_timestamp" ON "InvestigationAudit"("investigationId", "timestamp");
+
+-- ── Incident.back-reference to Investigation ──────────────────────────────────
+
+ALTER TABLE "Incident" ADD COLUMN "investigationId" UUID;
+CREATE INDEX "Incident_investigationId" ON "Incident"("investigationId");
+ALTER TABLE "Incident" ADD CONSTRAINT "Incident_investigationId_fkey"
+  FOREIGN KEY ("investigationId") REFERENCES "Investigation"("id") ON DELETE SET NULL;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -966,9 +966,12 @@ model Incident {
   events           SecurityEvent[]
   actionAudits     ActionAudit[]
   chatMessages     ChatMessage[]
+  investigation    Investigation?
+  investigationId  String? // Soft back-reference to investigation case
 
   @@index([environmentId, status])
   @@index([environmentId, severity])
+  @@index([investigationId])
 }
 
 // ── Security: Action audit log ────────────────────────────────────────────────
@@ -1407,4 +1410,178 @@ model AgentScore {
   updatedAt     DateTime    @updatedAt
 
   @@unique([targetType, targetId])
+}
+
+// ── Security: SOC Case Management ──────────────────────────────────────────────
+// Lightweight investigation tracking — zero external dependencies.
+// Wraps one or more incidents into a single workspace with observables,
+// timeline, notes, and audit trail.
+
+enum InvestigationStatus {
+  open
+  active
+  suspended
+  resolved
+  closed
+}
+
+enum ResolutionType {
+  true_positive
+  false_positive
+  benign
+  inconclusive
+}
+
+enum TLP {
+  white
+  green
+  amber
+  red
+}
+
+enum ObservableCategory {
+  ipv4
+  ipv6
+  domain
+  url
+  file_hash_md5
+  file_hash_sha1
+  file_hash_sha256
+  mac_address
+  email
+  username
+  file_path
+  registry_key
+  mutex
+  asn
+}
+
+enum ObservableVerdict {
+  malicious
+  suspicious
+  benign
+  unknown
+}
+
+enum ObservableRole {
+  ioc
+  artifact
+  infrastructure
+}
+
+model Investigation {
+  id                 String              @id @default(uuid())
+  name               String
+  status             InvestigationStatus @default(open)
+  severity           Int                 // 0-100, derived from linked incidents; manually overridable
+  tlp                TLP                 @default(amber)
+  pap                Int                 @default(2) // 0-3, Permissible Actions Protocol
+  startedAt          DateTime            @default(now())
+  resolvedAt         DateTime?
+  closedAt           DateTime?
+  resolution         String?             // markdown summary of what happened
+  resolutionType     ResolutionType?
+  assignedTo         String?             // userId or null (unassigned)
+  createdBy          String              // userId or "warden"
+  tags               String[]            @default([])
+  dueAt              DateTime?           // SLA deadline
+  mitreAttackIds     String[]            @default([]) // e.g. ["T1110", "T1046"]
+
+  externalId         String?             // TheHive case ID (e.g. "TH-0001")
+  externalSystem     String?             // "thehive"
+  lastSyncedAt       DateTime?
+  syncVersion        Int                 @default(0) // increment on each sync cycle
+  syncSource         String?             // last write origin: "orion" | "thehive"
+
+  timeToDetect       Int?                // seconds from first event to incident creation
+  timeToRespond      Int?                // seconds from incident to investigation open
+  timeToResolve      Int?                // seconds from investigation open to resolved
+
+  incidents          Incident[]
+  notes              InvestigationNote[]
+  observables        InvestigationObservable[]
+  timeline           InvestigationTimeline[]
+  auditLog           InvestigationAudit[]
+
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+
+  @@index([status])
+  @@index([createdAt])
+  @@index([externalId])
+}
+
+model InvestigationNote {
+  id              String        @id @default(uuid())
+  investigation   Investigation @relation(fields: [investigationId], references: [id], onDelete: Cascade)
+  investigationId String
+  content         String        // markdown; stored separately from Warden-generated content
+  author          String        // userId or "warden"
+  authorType      String        // "human" | "warden" — never mix in query results
+  isDraft         Boolean       @default(false) // human-private draft
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime?     @updatedAt
+  searchVector    Unsupported("tsvector")? // GIN index for full-text search
+
+  @@index([investigationId, createdAt])
+  @@index([investigationId, authorType])
+}
+
+model InvestigationObservable {
+  id              String              @id @default(uuid())
+  investigation   Investigation       @relation(fields: [investigationId], references: [id], onDelete: Cascade)
+  investigationId String
+  value           String              // canonical defanged form (e.g. 1.2.3.4, evil[.]com)
+  displayValue    String              // original as found (e.g. hxxp://evil[.]com/path)
+  category        ObservableCategory
+  role            ObservableRole      @default(ioc)
+  verdict         ObservableVerdict   @default(unknown)
+  verdictBy       String?             // userId, "warden", "cortex"
+  verdictAt       DateTime?
+  confidence      Int                 @default(0) // 0-100
+  severity        Int                 @default(0) // relevance to this investigation
+  firstSeen       DateTime            @default(now())
+  lastSeen        DateTime            @updatedAt
+  context         String?             // where it was found; which incident, which log line
+  resolved        Boolean             @default(false)
+  threatIntelMatch Json?              // enrichment from TheHive/Cortex
+
+  externalId      String?
+  lastSyncedAt    DateTime?
+
+  @@unique([investigationId, value, category])
+  @@index([value])
+  @@index([category])
+  @@index([verdict])
+}
+
+model InvestigationTimeline {
+  id              String        @id @default(uuid())
+  investigation   Investigation @relation(fields: [investigationId], references: [id], onDelete: Cascade)
+  investigationId String
+  eventTime       DateTime      // WHEN the event occurred (not when the entry was created)
+  createdAt       DateTime      @default(now())
+  eventType       String        // incident_created | observable_added | note_added | status_changed | action_taken | warden_annotation | merge_source | merge_target | link_added | link_removed | thehive_sync | observable_verdict_set
+  title           String
+  description     String?
+  source          String        // "manual" | "warden" | "correlator" | "thehive"
+  isPinned        Boolean       @default(false) // analyst can pin key events
+  payload         Json?         // structured event data
+
+  @@index([investigationId, eventTime])
+  @@index([investigationId, eventType])
+}
+
+model InvestigationAudit {
+  id              String        @id @default(uuid())
+  investigation   Investigation @relation(fields: [investigationId], references: [id], onDelete: Cascade)
+  investigationId String
+  actorId         String        // userId or "warden" or "system"
+  actorType       String        // "human" | "warden" | "system"
+  action          String        // status_changed | note_added | observable_added | merge | link_added | severity_changed
+  before          Json?         // previous value
+  after           Json?         // new value
+  timestamp       DateTime      @default(now())
+
+  @@index([investigationId, timestamp])
 }

--- a/apps/web/src/app/(app)/security/investigations/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/investigations/[id]/page.tsx
@@ -1,0 +1,467 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  Loader2, ArrowLeft, AlertTriangle, Shield, Clock, FileText,
+  Eye, Link as LinkIcon, Edit3, Plus, Trash2, CheckCircle,
+  AlertOctagon, Tag, Layers
+} from 'lucide-react'
+import Link from 'next/link'
+
+interface Investigation {
+  id: string
+  name: string
+  status: string
+  severity: number
+  tlp: string
+  tags: string[]
+  mitreAttackIds: string[]
+  startedAt: string | null
+  resolvedAt: string | null
+  resolution: string | null
+  createdBy: string | null
+  incidents: Array<{
+    id: string
+    status: string
+    severity: number
+    attackerKey: string | null
+    rootCauseSummary: string | null
+    openedAt: string
+  }>
+  notes: Array<{
+    id: string
+    content: string
+    author: string
+    authorType: string
+    createdAt: string
+  }>
+  observables: Array<{
+    id: string
+    value: string
+    displayValue: string | null
+    category: string
+    role: string
+    verdict: string
+    confidence: number
+    context: string | null
+    firstSeen: string
+    lastSeen: string | null
+  }>
+  timeline: Array<{
+    id: string
+    eventTime: string
+    eventType: string
+    title: string
+    description: string | null
+    source: string | null
+  }>
+}
+
+export default function InvestigationDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const investigationId = params.id as string
+  const [investigation, setInvestigation] = useState<Investigation | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState<'overview' | 'observables' | 'notes' | 'timeline'>('overview')
+  const [noteContent, setNoteContent] = useState('')
+  const [savingNote, setSavingNote] = useState(false)
+  const [updatingStatus, setUpdatingStatus] = useState(false)
+  const [newStatus, setNewStatus] = useState('')
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetch(`/api/monitoring/security/investigations/${investigationId}`).then(r => r.json())
+      setInvestigation(data.investigation ?? data)
+      setNewStatus(data.investigation?.status ?? data?.status ?? 'open')
+    } catch {
+      router.push('/security/investigations')
+    } finally {
+      setLoading(false)
+    }
+  }, [investigationId, router])
+
+  useEffect(() => { load() }, [load])
+
+  const addNote = async () => {
+    if (!noteContent.trim()) return
+    setSavingNote(true)
+    try {
+      await fetch(`/api/monitoring/security/investigations/${investigationId}/notes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: noteContent }),
+      })
+      setNoteContent('')
+      load()
+    } finally {
+      setSavingNote(false)
+    }
+  }
+
+  const updateStatus = async () => {
+    setUpdatingStatus(true)
+    try {
+      await fetch(`/api/monitoring/security/investigations/${investigationId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      })
+      load()
+    } finally {
+      setUpdatingStatus(false)
+    }
+  }
+
+  const deleteObservable = async (obsId: string) => {
+    if (!confirm('Delete this observable?')) return
+    try {
+      await fetch(`/api/monitoring/security/investigations/${investigationId}/observables/${obsId}`, {
+        method: 'DELETE',
+      })
+      load()
+    } catch {}
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-accent" />
+      </div>
+    )
+  }
+
+  if (!investigation) {
+    return (
+      <div className="p-6 text-center text-text-muted">Investigation not found</div>
+    )
+  }
+
+  const verdictClass = (verdict: string) => {
+    if (verdict === 'malicious') return 'bg-status-error/15 text-status-error'
+    if (verdict === 'suspicious') return 'bg-status-warning/15 text-status-warning'
+    if (verdict === 'benign') return 'bg-status-healthy/15 text-status-healthy'
+    return 'bg-bg-raised text-text-muted'
+  }
+
+  return (
+    <div className="p-6 max-w-6xl space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button onClick={() => router.back()} className="p-1.5 rounded hover:bg-bg-raised text-text-muted transition-colors">
+          <ArrowLeft size={16} />
+        </button>
+        <div className="flex-1">
+          <h1 className="text-lg font-semibold text-text-primary">{investigation.name}</h1>
+          <div className="text-xs text-text-muted flex items-center gap-2 mt-0.5">
+            <span>ID: {investigationId.slice(0, 8)}</span>
+            {investigation.createdBy && <span>· Created by {investigation.createdBy}</span>}
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+        <div className="flex items-center gap-4 flex-wrap">
+          {/* Status badges */}
+          <div className="flex items-center gap-2">
+            <span className={`text-xs font-bold uppercase px-2 py-1 rounded ${
+              investigation.status === 'open' ? 'bg-status-warning/15 text-status-warning' :
+              investigation.status === 'active' ? 'bg-red-400/15 text-red-400' :
+              investigation.status === 'suspended' ? 'bg-blue-400/15 text-blue-400' :
+              investigation.status === 'resolved' ? 'bg-status-healthy/15 text-status-healthy' :
+              'bg-bg-raised text-text-muted'
+            }`}>
+              {investigation.status}
+            </span>
+            <span className={`text-xs font-bold uppercase px-2 py-1 rounded ${
+              investigation.tlp === 'red' ? 'bg-status-error/15 text-status-error' :
+              investigation.tlp === 'amber' ? 'bg-status-warning/15 text-status-warning' :
+              investigation.tlp === 'green' ? 'bg-status-healthy/15 text-status-healthy' :
+              'bg-bg-raised text-text-muted'
+            }`}>
+              TLP:{' '}{investigation.tlp}
+            </span>
+            <span className={`text-xs font-bold px-2 py-1 rounded ${
+              investigation.severity >= 80 ? 'bg-status-error/15 text-status-error' :
+              investigation.severity >= 50 ? 'bg-status-warning/15 text-status-warning' :
+              'bg-bg-raised text-text-muted'
+            }`}>
+              Severity: {investigation.severity}
+            </span>
+          </div>
+
+          {/* Stats */}
+          <div className="flex items-center gap-4 text-xs text-text-muted ml-auto">
+            <span className="flex items-center gap-1"><LinkIcon size={12} /> {investigation.incidents.length} incidents</span>
+            <span className="flex items-center gap-1"><Eye size={12} /> {investigation.observables.length} observables</span>
+            <span className="flex items-center gap-1"><FileText size={12} /> {investigation.notes.length} notes</span>
+            <span className="flex items-center gap-1"><Clock size={12} /> {investigation.timeline.length} events</span>
+          </div>
+        </div>
+
+        {/* Tags */}
+        <div className="flex items-center gap-2 mt-3 flex-wrap">
+          {investigation.tags?.length ? investigation.tags.map(tag => (
+            <span key={tag} className="text-[10px] px-2 py-0.5 rounded-full bg-bg-raised text-text-muted flex items-center gap-1">
+              <Tag size={10} /> {tag}
+            </span>
+          )) : null}
+          {investigation.mitreAttackIds?.length ? investigation.mitreAttackIds.map(id => (
+            <span key={id} className="text-[10px] px-2 py-0.5 rounded-full bg-purple-400/15 text-purple-400 flex items-center gap-1">
+              <Layers size={10} /> {id}
+            </span>
+          )) : null}
+        </div>
+
+        {/* Status update controls */}
+        <div className="flex items-center gap-2 mt-3 pt-3 border-t border-border-subtle">
+          <select
+            value={newStatus}
+            onChange={e => setNewStatus(e.target.value)}
+            className="px-2 py-1 text-xs bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none"
+          >
+            <option value="open">Open</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="resolved">Resolved</option>
+            <option value="closed">Closed</option>
+          </select>
+          <button
+            onClick={updateStatus}
+            disabled={updatingStatus || newStatus === investigation.status}
+            className="px-3 py-1 text-xs bg-accent text-white rounded hover:bg-accent/90 disabled:opacity-50 transition-colors"
+          >
+            {updatingStatus ? <Loader2 size={12} className="animate-spin inline" /> : <Edit3 size={12} className="inline" />}{' '}
+            Update
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 bg-bg-raised rounded-lg p-0.5">
+        {(['overview', 'observables', 'notes', 'timeline'] as const).map(tab => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors capitalize ${
+              activeTab === tab ? 'bg-accent text-white' : 'text-text-muted hover:text-text-primary'
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'overview' && (
+        <div className="space-y-4">
+          {/* Linked incidents */}
+          {investigation.incidents.length > 0 && (
+            <div className="bg-bg-surface border border-border-subtle rounded-xl">
+              <div className="px-4 py-3 border-b border-border-subtle">
+                <span className="text-sm font-medium text-text-primary">Linked Incidents</span>
+              </div>
+              <div className="divide-y divide-border-subtle">
+                {investigation.incidents.map(inc => (
+                  <Link
+                    key={inc.id}
+                    href={`/security/incidents/${inc.id}`}
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-bg-raised transition-colors"
+                  >
+                    <span className={`text-xs font-bold px-2 py-0.5 rounded ${
+                      inc.severity >= 80 ? 'bg-status-error/15 text-status-error' :
+                      inc.severity >= 50 ? 'bg-status-warning/15 text-status-warning' :
+                      'bg-bg-raised text-text-muted'
+                    }`}>
+                      {inc.severity}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-text-primary truncate">{inc.rootCauseSummary || 'Untitled'}</div>
+                      <div className="text-xs text-text-muted">{inc.attackerKey || 'unknown'}</div>
+                    </div>
+                    <span className="text-[10px] text-text-muted">{new Date(inc.openedAt).toLocaleDateString()}</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Observables summary */}
+          {investigation.observables.length > 0 && (
+            <div className="bg-bg-surface border border-border-subtle rounded-xl">
+              <div className="px-4 py-3 border-b border-border-subtle flex items-center justify-between">
+                <span className="text-sm font-medium text-text-primary">Key Observables</span>
+                <button onClick={() => setActiveTab('observables')} className="text-xs text-accent hover:underline">
+                  View all ({investigation.observables.length})
+                </button>
+              </div>
+              <div className="divide-y divide-border-subtle">
+                {investigation.observables.slice(0, 5).map(obs => (
+                  <div key={obs.id} className="flex items-center gap-3 px-4 py-2.5">
+                    <span className="text-xs font-mono text-text-primary flex-1 truncate">{obs.displayValue || obs.value}</span>
+                    <span className="text-[10px] text-text-muted">{obs.category}</span>
+                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${verdictClass(obs.verdict)}`}>
+                      {obs.verdict}
+                    </span>
+                    <span className="text-[10px] text-text-muted">{obs.confidence}%</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Resolution */}
+          {investigation.resolution && (
+            <div className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <CheckCircle size={14} className="text-status-healthy" />
+                <span className="text-sm font-medium text-text-primary">Resolution</span>
+              </div>
+              <p className="text-sm text-text-muted whitespace-pre-wrap">{investigation.resolution}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'observables' && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl">
+          <div className="px-4 py-3 border-b border-border-subtle">
+            <span className="text-sm font-medium text-text-primary">Observables ({investigation.observables.length})</span>
+          </div>
+          {investigation.observables.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-text-muted">No observables recorded</div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border-subtle text-text-muted text-left">
+                  <th className="px-4 py-2 font-medium">Value</th>
+                  <th className="px-4 py-2 font-medium">Category</th>
+                  <th className="px-4 py-2 font-medium">Role</th>
+                  <th className="px-4 py-2 font-medium">Verdict</th>
+                  <th className="px-4 py-2 font-medium">Confidence</th>
+                  <th className="px-4 py-2 font-medium">First Seen</th>
+                  <th className="px-4 py-2 font-medium w-10"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {investigation.observables.map(obs => (
+                  <tr key={obs.id} className="hover:bg-bg-raised transition-colors">
+                    <td className="px-4 py-2 font-mono text-text-primary truncate max-w-48">{obs.displayValue || obs.value}</td>
+                    <td className="px-4 py-2 text-text-muted">{obs.category}</td>
+                    <td className="px-4 py-2 text-text-muted">{obs.role}</td>
+                    <td className="px-4 py-2">
+                      <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${verdictClass(obs.verdict)}`}>
+                        {obs.verdict}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-text-muted">{obs.confidence}%</td>
+                    <td className="px-4 py-2 text-text-muted">{new Date(obs.firstSeen).toLocaleDateString()}</td>
+                    <td className="px-4 py-2">
+                      <button onClick={() => deleteObservable(obs.id)} className="text-text-muted hover:text-status-error transition-colors">
+                        <Trash2 size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'notes' && (
+        <div className="space-y-4">
+          {/* Add note */}
+          <div className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <FileText size={14} className="text-text-muted" />
+              <span className="text-sm font-medium text-text-primary">Add Note</span>
+            </div>
+            <textarea
+              value={noteContent}
+              onChange={e => setNoteContent(e.target.value)}
+              placeholder="Add a note to this investigation..."
+              rows={3}
+              className="w-full px-3 py-2 text-xs bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent resize-none"
+            />
+            <div className="flex justify-end mt-2">
+              <button
+                onClick={addNote}
+                disabled={savingNote || !noteContent.trim()}
+                className="px-3 py-1.5 text-xs bg-accent text-white rounded hover:bg-accent/90 disabled:opacity-50 transition-colors flex items-center gap-1"
+              >
+                {savingNote ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+                Add Note
+              </button>
+            </div>
+          </div>
+
+          {/* Notes list */}
+          <div className="bg-bg-surface border border-border-subtle rounded-xl">
+            <div className="px-4 py-3 border-b border-border-subtle">
+              <span className="text-sm font-medium text-text-primary">Notes ({investigation.notes.length})</span>
+            </div>
+            {investigation.notes.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-text-muted">No notes yet</div>
+            ) : (
+              <div className="divide-y divide-border-subtle">
+                {investigation.notes.map(note => (
+                  <div key={note.id} className="px-4 py-3">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                        note.authorType === 'warden'
+                          ? 'bg-purple-400/15 text-purple-400'
+                          : 'bg-accent/15 text-accent'
+                      }`}>
+                        {note.authorType === 'warden' ? 'Warden' : note.author}
+                      </span>
+                      <span className="text-[10px] text-text-muted">{new Date(note.createdAt).toLocaleString()}</span>
+                    </div>
+                    <div className="text-sm text-text-primary whitespace-pre-wrap mt-1">{note.content}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'timeline' && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl">
+          <div className="px-4 py-3 border-b border-border-subtle">
+            <span className="text-sm font-medium text-text-primary">Timeline ({investigation.timeline.length})</span>
+          </div>
+          {investigation.timeline.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-text-muted">No timeline events</div>
+          ) : (
+            <div className="divide-y divide-border-subtle">
+              {investigation.timeline.map(entry => (
+                <div key={entry.id} className="px-4 py-3 flex items-start gap-3">
+                  <div className="flex flex-col items-center">
+                    <div className="w-2 h-2 rounded-full bg-accent shrink-0" />
+                    <div className="w-px flex-1 bg-border-subtle mt-1" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-text-primary">{entry.title}</span>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-raised text-text-muted">{entry.eventType}</span>
+                      {entry.source && (
+                        <span className="text-[10px] text-text-muted">via {entry.source}</span>
+                      )}
+                    </div>
+                    {entry.description && (
+                      <div className="text-xs text-text-muted mt-0.5">{entry.description}</div>
+                    )}
+                    <div className="text-[10px] text-text-muted mt-0.5">{new Date(entry.eventTime).toLocaleString()}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/security/investigations/page.tsx
+++ b/apps/web/src/app/(app)/security/investigations/page.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { Loader2, RefreshCw, Search, Plus, FolderOpen, AlertTriangle, CheckCircle, Clock, Archive } from 'lucide-react'
+
+interface Investigation {
+  id: string
+  name: string
+  status: string
+  severity: number
+  tlp: string
+  tags: string[]
+  startedAt: string | null
+  resolvedAt: string | null
+  _count: { incidents: number; notes: number; observables: number }
+}
+
+export default function InvestigationsPage() {
+  const [investigations, setInvestigations] = useState<Investigation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (statusFilter) params.set('status', statusFilter)
+      if (search) params.set('search', search)
+      const data = await fetch(`/api/monitoring/security/investigations?${params}`).then(r => r.json())
+      setInvestigations(data.investigations ?? [])
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter, search])
+
+  useEffect(() => { load() }, [load])
+
+  const statusIcon = (status: string) => {
+    if (status === 'open') return <Clock size={10} className="inline mr-1" />
+    if (status === 'active') return <AlertTriangle size={10} className="inline mr-1" />
+    if (status === 'suspended') return <Archive size={10} className="inline mr-1" />
+    if (status === 'resolved') return <CheckCircle size={10} className="inline mr-1" />
+    return <Archive size={10} className="inline mr-1" />
+  }
+
+  const statusClass = (status: string) => {
+    if (status === 'open') return 'bg-status-warning/15 text-status-warning'
+    if (status === 'active') return 'bg-red-400/15 text-red-400'
+    if (status === 'suspended') return 'bg-blue-400/15 text-blue-400'
+    if (status === 'resolved') return 'bg-status-healthy/15 text-status-healthy'
+    return 'bg-bg-raised text-text-muted'
+  }
+
+  const severityClass = (sev: number) => {
+    if (sev >= 80) return 'bg-status-error/15 text-status-error'
+    if (sev >= 50) return 'bg-status-warning/15 text-status-warning'
+    return 'bg-bg-raised text-text-muted'
+  }
+
+  const tlpClass = (tlp: string) => {
+    if (tlp === 'red') return 'bg-status-error/15 text-status-error'
+    if (tlp === 'amber') return 'bg-status-warning/15 text-status-warning'
+    if (tlp === 'green') return 'bg-status-healthy/15 text-status-healthy'
+    return 'bg-bg-raised text-text-muted'
+  }
+
+  return (
+    <div className="p-6 max-w-6xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FolderOpen size={18} className="text-accent" />
+          <h1 className="text-lg font-semibold text-text-primary">Investigations</h1>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-1 min-w-64">
+          <div className="relative flex-1">
+            <Search size={14} className="absolute left-2.5 top-2 text-text-muted" />
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && load()}
+              placeholder="Search investigations..."
+              className="w-full pl-8 pr-2 py-1.5 text-xs bg-bg-raised border border-border-subtle rounded text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent"
+            />
+          </div>
+          <button onClick={load} className="p-1.5 rounded text-text-muted hover:text-text-primary border border-border-subtle transition-colors">
+            <RefreshCw size={13} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+        <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}
+          className="px-2 py-1.5 text-xs bg-bg-raised border border-border-subtle rounded text-text-primary focus:outline-none">
+          <option value="">All statuses</option>
+          <option value="open">Open</option>
+          <option value="active">Active</option>
+          <option value="suspended">Suspended</option>
+          <option value="resolved">Resolved</option>
+          <option value="closed">Closed</option>
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center h-32">
+          <Loader2 size={20} className="animate-spin text-accent" />
+        </div>
+      ) : investigations.length === 0 ? (
+        <div className="rounded-lg border border-border-subtle bg-bg-card px-4 py-12 text-center text-sm text-text-muted">
+          No investigations found.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {investigations.map(inv => (
+            <Link key={inv.id} href={`/security/investigations/${inv.id}`}
+              className="block rounded-xl border border-border-subtle hover:border-accent/40 bg-bg-surface transition-colors">
+              <div className="flex items-center gap-4 px-4 py-3">
+                {/* Severity badge */}
+                <div className={`flex items-center justify-center w-11 h-11 rounded-lg shrink-0 ${severityClass(inv.severity)}`}>
+                  <span className="text-sm font-bold">{inv.severity}</span>
+                </div>
+
+                {/* Investigation details */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className="text-sm font-medium text-text-primary truncate">
+                      {inv.name}
+                    </span>
+                    {inv.tags?.slice(0, 2).map((tag: string) => (
+                      <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-bg-raised text-text-muted">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="text-xs text-text-muted flex items-center gap-2">
+                    <span>{inv._count.incidents} incidents</span>
+                    <span>&middot;</span>
+                    <span>{inv._count.observables} observables</span>
+                    <span>&middot;</span>
+                    <span>{inv._count.notes} notes</span>
+                    {inv.startedAt && (
+                      <>
+                        <span>&middot;</span>
+                        <span>{new Date(inv.startedAt).toLocaleDateString()}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {/* Badges */}
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className={`text-[10px] font-bold uppercase px-1.5 py-0.5 rounded ${tlpClass(inv.tlp)}`}>
+                    {inv.tlp}
+                  </span>
+                  <span className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full ${statusClass(inv.status)}`}>
+                    {statusIcon(inv.status)}{inv.status}
+                  </span>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/api/monitoring/security/config/route.ts
+++ b/apps/web/src/app/api/monitoring/security/config/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/** GET — Load security source configuration from SecurityConfig table */
+export async function GET() {
+  const envId = process.env.ENVIRONMENT_ID || ''
+
+  const configs = await prisma.securityConfig.findMany({
+    where: envId ? { environmentId: envId } : {},
+    select: { key: true, value: true },
+  })
+
+  const config: Record<string, string> = {}
+  for (const c of configs) {
+    config[c.key] = c.value
+  }
+
+  return NextResponse.json({ config })
+}
+
+/** PUT — Save security source configuration to SecurityConfig table */
+export async function PUT(request: Request) {
+  const envId = process.env.ENVIRONMENT_ID || ''
+  const config = await request.json() as Record<string, string>
+
+  const updates = Object.entries(config).map(([key, value]) =>
+    prisma.securityConfig.upsert({
+      where: {
+        environmentId_key: { environmentId: envId, key },
+      },
+      update: { value },
+      create: { environmentId: envId, key, value },
+    }).catch(() =>
+      prisma.securityConfig.upsert({
+        where: {
+          environmentId_key: { environmentId: '' as unknown as string, key },
+        },
+        update: { value },
+        create: { key, value },
+      })
+    )
+  )
+
+  await Promise.allSettled(updates)
+
+  // Reload to return saved config
+  const saved = await prisma.securityConfig.findMany({
+    where: envId ? { environmentId: envId } : {},
+    select: { key: true, value: true },
+  })
+
+  const result: Record<string, string> = {}
+  for (const c of saved) {
+    result[c.key] = c.value
+  }
+
+  return NextResponse.json({ config: result })
+}

--- a/apps/web/src/app/api/monitoring/security/incidents/[incidentId]/create-investigation/route.ts
+++ b/apps/web/src/app/api/monitoring/security/incidents/[incidentId]/create-investigation/route.ts
@@ -1,0 +1,82 @@
+/**
+ * POST /api/security/incidents/[incidentId]/create-investigation
+ *
+ * One-click create investigation from incident detail.
+ * Pre-populates name, severity, links the incident, auto-extracts observables.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { extractFromEvents } from '@/lib/security/extract-observables'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(_req: Request, { params }: { params: { incidentId: string } }) {
+  const incidentId = (await params).incidentId
+
+  const incident = await prisma.incident.findUnique({
+    where: { id: incidentId },
+    include: {
+      events: { select: { source: true, rawEvent: true, id: true, createdAt: true } },
+    },
+  })
+
+  if (!incident) {
+    return NextResponse.json({ error: 'Incident not found' }, { status: 404 })
+  }
+
+  // Check if already linked to an investigation
+  if (incident.investigationId) {
+    return NextResponse.json({ error: 'Incident already linked to investigation' }, { status: 409 })
+  }
+
+  const investigation = await prisma.investigation.create({
+    data: {
+      name: `[${incident.attackerKey ?? incident.id.slice(0, 8)}] ${incident.rootCauseSummary ?? 'Investigation'}`,
+      severity: incident.severity,
+      createdBy: 'admin',
+    },
+  })
+
+  // Link the incident
+  await prisma.incident.update({
+    where: { id: incidentId },
+    data: { investigationId: investigation.id },
+  })
+
+  // Auto-extract observables from incident events
+  const extracted = extractFromEvents(
+    incident.events.map(e => ({ source: e.source, rawEvent: e.rawEvent as Record<string, unknown> })),
+  )
+
+  const saved = []
+  for (const obs of extracted) {
+    const created = await prisma.investigationObservable.create({
+      data: {
+        investigationId: investigation.id,
+        value: obs.value,
+        displayValue: obs.displayValue,
+        category: obs.category,
+        confidence: obs.confidence,
+      },
+    })
+    saved.push(created)
+  }
+
+  // Timeline entry
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: investigation.id,
+      eventTime: new Date(),
+      eventType: 'incident_created',
+      title: `Investigation created from incident ${incidentId}`,
+      description: `Severity: ${incident.severity}, Attacker: ${incident.attackerKey ?? 'Unknown'}`,
+      source: 'manual',
+    },
+  })
+
+  return NextResponse.json({
+    investigation,
+    observablesExtracted: saved.length,
+  }, { status: 201 })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/audit/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/audit/route.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /api/monitoring/security/investigations/[id]/audit
+ *
+ * Audit log for an investigation (paginated).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const limit = parseInt(req.nextUrl.searchParams.get('limit') ?? '25', 10)
+  const cursor = req.nextUrl.searchParams.get('cursor')
+
+  const investigation = await prisma.investigation.findUnique({ where: { id } })
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const cursorOpt = cursor ? { id: cursor } : undefined
+  const items = await prisma.investigationAudit.findMany({
+    where: { investigationId: id },
+    orderBy: { timestamp: 'desc' },
+    take: limit + 1,
+    cursor: cursorOpt,
+  })
+
+  const hasMore = items.length > limit
+  const data = items.slice(0, limit)
+  const nextCursor = hasMore ? items[items.length - 1].id : null
+
+  return NextResponse.json({
+    entries: data,
+    pagination: { nextCursor, hasMore },
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/auto-extract-observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/auto-extract-observables/route.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/auto-extract-observables
+ *
+ * Scan linked incidents; returns extracted observables for analyst review before saving.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { extractFromEvents } from '@/lib/security/extract-observables'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+
+  const investigation = await prisma.investigation.findUnique({
+    where: { id },
+    include: {
+      incidents: {
+        include: {
+          events: { select: { source: true, rawEvent: true, id: true } },
+        },
+      },
+    },
+  })
+
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  // Flatten all events from linked incidents
+  const allEvents = investigation.incidents.flatMap(
+    incident => incident.events.map(event => ({
+      source: event.source,
+      rawEvent: event.rawEvent as Record<string, unknown>,
+    })),
+  )
+
+  const extracted = extractFromEvents(allEvents)
+
+  // Save each observable (upsert by investigationId+value+category)
+  const saved = []
+  for (const obs of extracted) {
+    const existing = await prisma.investigationObservable.findUnique({
+      where: {
+        investigationId_value_category: {
+          investigationId: id,
+          value: obs.value,
+          category: obs.category,
+        },
+      },
+    })
+    if (!existing) {
+      const created = await prisma.investigationObservable.create({
+        data: {
+          investigationId: id,
+          value: obs.value,
+          displayValue: obs.displayValue,
+          category: obs.category,
+          confidence: obs.confidence,
+        },
+      })
+      saved.push(created)
+    }
+  }
+
+  return NextResponse.json({
+    extracted: extracted.length,
+    saved,
+    existing: extracted.length - saved.length,
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/[incidentId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/[incidentId]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * DELETE /api/monitoring/security/investigations/[id]/link-incident/[incidentId]
+ *
+ * Unlink (split) an incident from an investigation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { recordAudit } from '../../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+export async function DELETE(_req: Request, { params }: { params: { id: string; incidentId: string } }) {
+  const { id, incidentId } = await params
+
+  const incident = await prisma.incident.findUnique({ where: { id: incidentId } })
+  if (!incident || incident.investigationId !== id) {
+    return NextResponse.json({ error: 'Incident not linked to this investigation' }, { status: 404 })
+  }
+
+  await prisma.incident.update({
+    where: { id: incidentId },
+    data: { investigationId: null },
+  })
+
+  await recordAudit(id, 'admin', 'human', 'link_added',
+    { incidentId, action: 'linked' }, { incidentId, action: 'unlinked' })
+
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: id, eventTime: new Date(),
+      eventType: 'link_removed',
+      title: `Incident unlinked: ${incident.attackerKey ?? incidentId}`,
+      source: 'manual',
+    },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/link-incident
+ *
+ * Link an existing incident to an investigation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const linkSchema = z.object({
+  incidentId: z.string().uuid(),
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const body = linkSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const { incidentId } = body.data
+
+  const [investigation, incident] = await Promise.all([
+    prisma.investigation.findUnique({ where: { id } }),
+    prisma.incident.findUnique({ where: { id: incidentId } }),
+  ])
+
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+  if (!incident) {
+    return NextResponse.json({ error: 'Incident not found' }, { status: 404 })
+  }
+  if (incident.investigationId && incident.investigationId !== id) {
+    return NextResponse.json({ error: 'Incident already linked to another investigation' }, { status: 409 })
+  }
+
+  await prisma.incident.update({
+    where: { id: incidentId },
+    data: { investigationId: id },
+  })
+
+  await recordAudit(id, 'admin', 'human', 'link_added',
+    undefined, { incidentId })
+
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: id, eventTime: new Date(),
+      eventType: 'link_added',
+      title: `Incident linked: ${incident.attackerKey ?? incident.id}`,
+      source: 'manual',
+    },
+  })
+
+  return NextResponse.json({ ok: true, incidentId })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
@@ -1,0 +1,156 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/merge
+ *
+ * Merge another investigation INTO the target (path param).
+ * Deduplicates observables by (value, category), interleaves timeline by eventTime,
+ * preserves all notes, updates incident FKs, closes the source investigation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const mergeSchema = z.object({
+  sourceId: z.string().uuid(),
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const targetId = (await params).id
+  const body = mergeSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const { sourceId } = body.data
+  if (sourceId === targetId) {
+    return NextResponse.json({ error: 'Cannot merge an investigation into itself' }, { status: 400 })
+  }
+
+  const [target, source] = await Promise.all([
+    prisma.investigation.findUnique({ where: { id: targetId } }),
+    prisma.investigation.findUnique({ where: { id: sourceId } }),
+  ])
+
+  if (!target) {
+    return NextResponse.json({ error: 'Target investigation not found' }, { status: 404 })
+  }
+  if (!source) {
+    return NextResponse.json({ error: 'Source investigation not found' }, { status: 404 })
+  }
+
+  const tx = await prisma.$transaction(async (tx) => {
+    // 1. Move all incidents from source to target
+    await tx.incident.updateMany({
+      where: { investigationId: sourceId },
+      data: { investigationId: targetId },
+    })
+
+    // 2. Move all notes (preserve author attribution)
+    await tx.investigationNote.updateMany({
+      where: { investigationId: sourceId },
+      data: { investigationId: targetId },
+    })
+
+    // 3. Merge observables — deduplicate by (value, category), higher confidence wins
+    const sourceObservables = await tx.investigationObservable.findMany({
+      where: { investigationId: sourceId },
+    })
+
+    for (const obs of sourceObservables) {
+      await tx.investigationObservable.upsert({
+        where: {
+          investigationId_value_category: {
+            investigationId: targetId,
+            value: obs.value,
+            category: obs.category,
+          },
+        },
+        create: {
+          investigationId: targetId,
+          value: obs.value,
+          displayValue: obs.displayValue,
+          category: obs.category,
+          role: obs.role,
+          verdict: obs.verdict,
+          confidence: obs.confidence,
+          severity: obs.severity,
+          firstSeen: obs.firstSeen,
+          lastSeen: obs.lastSeen,
+          context: obs.context,
+          verdictBy: obs.verdictBy,
+          verdictAt: obs.verdictAt,
+        },
+        update: {
+          confidence: {
+            set: Math.max(obs.confidence, (await tx.investigationObservable.findUnique({
+              where: { investigationId_value_category: { investigationId: targetId, value: obs.value, category: obs.category } },
+            })?.confidence ?? 0)),
+          },
+          lastSeen: new Date(),
+        },
+      })
+    }
+
+    // 4. Interleave timeline entries by eventTime
+    const sourceTimeline = await tx.investigationTimeline.findMany({
+      where: { investigationId: sourceId },
+    })
+    for (const entry of sourceTimeline) {
+      await tx.investigationTimeline.create({
+        data: {
+          investigationId: targetId,
+          eventTime: entry.eventTime,
+          eventType: entry.eventType,
+          title: `[merged] ${entry.title}`,
+          description: entry.description,
+          source: entry.source,
+          isPinned: entry.isPinned,
+          payload: entry.payload,
+        },
+      })
+    }
+
+    // 5. Close source investigation
+    const closedSource = await tx.investigation.update({
+      where: { id: sourceId },
+      data: {
+        status: 'closed',
+        resolutionType: 'inconclusive',
+        resolution: `Merged into investigation ${targetId}`,
+        closedAt: new Date(),
+      },
+    })
+
+    // 6. Add merge timeline entries
+    await tx.investigationTimeline.create({
+      data: {
+        investigationId: targetId, eventTime: new Date(),
+        eventType: 'merge_target',
+        title: `Merged investigation: ${source.name}`,
+        description: `${source.incidents.length} incidents, ${sourceObservables.length} observables, ${sourceTimeline.length} timeline entries`,
+        source: 'manual',
+      },
+    })
+
+    await tx.investigationTimeline.create({
+      data: {
+        investigationId: sourceId, eventTime: new Date(),
+        eventType: 'merge_source',
+        title: `Merged into: ${target.name}`,
+        source: 'manual',
+      },
+    })
+
+    return { targetId, sourceId, observableCount: sourceObservables.length, timelineCount: sourceTimeline.length }
+  })
+
+  await recordAudit(targetId, 'admin', 'human', 'merge',
+    { sourceId }, { merged: tx })
+  await recordAudit(sourceId, 'admin', 'human', 'merge',
+    { into: targetId }, { closed: true })
+
+  return NextResponse.json({ ok: true, ...tx })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
@@ -17,7 +17,8 @@ const updateSchema = z.object({
 
 export async function PATCH(req: Request, { params }: { params: { id: string; noteId: string } }) {
   const { id, noteId } = await params
-  const body = updateSchema.safeParse(await req.json())
+  const raw = await req.json()
+  const body = updateSchema.safeParse(raw)
   if (!body.success) {
     return NextResponse.json({ error: body.error.errors }, { status: 400 })
   }
@@ -28,7 +29,6 @@ export async function PATCH(req: Request, { params }: { params: { id: string; no
   }
 
   // Warden cannot edit human-authored notes
-  const raw = await req.json()
   const actor = (raw as any)._actor ?? 'admin'
   if (actor === 'warden' && note.authorType === 'human') {
     return NextResponse.json({ error: 'Warden cannot edit human-authored notes' }, { status: 403 })
@@ -59,7 +59,7 @@ export async function DELETE(_req: Request, { params }: { params: { id: string; 
   }
 
   await prisma.investigationNote.delete({ where: { id: noteId } })
-  await recordAudit(id, 'admin', 'human', 'note_added', { noteId }, null)
+  await recordAudit(id, 'admin', 'human', 'note_deleted', { noteId }, null)
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
@@ -1,0 +1,65 @@
+/**
+ * PATCH /api/monitoring/security/investigations/[id]/notes/[noteId]
+ * DELETE /api/monitoring/security/investigations/[id]/notes/[noteId]
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit, updateSearchVector } from '../../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const updateSchema = z.object({
+  content: z.string().min(1).optional(),
+  isDraft: z.boolean().optional(),
+})
+
+export async function PATCH(req: Request, { params }: { params: { id: string; noteId: string } }) {
+  const { id, noteId } = await params
+  const body = updateSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const note = await prisma.investigationNote.findUnique({ where: { id: noteId } })
+  if (!note || note.investigationId !== id) {
+    return NextResponse.json({ error: 'Note not found' }, { status: 404 })
+  }
+
+  // Warden cannot edit human-authored notes
+  const raw = await req.json()
+  const actor = (raw as any)._actor ?? 'admin'
+  if (actor === 'warden' && note.authorType === 'human') {
+    return NextResponse.json({ error: 'Warden cannot edit human-authored notes' }, { status: 403 })
+  }
+
+  const before = { ...note }
+  const updated = await prisma.investigationNote.update({
+    where: { id: noteId },
+    data: body.data,
+  })
+
+  // Update search vector if content changed
+  if (body.data.content) {
+    await updateSearchVector(noteId, body.data.content)
+  }
+
+  await recordAudit(id, actor, actor === 'warden' ? 'warden' : 'human', 'note_added', before, updated)
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string; noteId: string } }) {
+  const { id, noteId } = await params
+
+  const note = await prisma.investigationNote.findUnique({ where: { id: noteId } })
+  if (!note || note.investigationId !== id) {
+    return NextResponse.json({ error: 'Note not found' }, { status: 404 })
+  }
+
+  await prisma.investigationNote.delete({ where: { id: noteId } })
+  await recordAudit(id, 'admin', 'human', 'note_added', { noteId }, null)
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/notes
+ *
+ * Add a note to an investigation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit, updateSearchVector } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const createSchema = z.object({
+  content: z.string().min(1),
+  author: z.string().default('admin'),
+  authorType: z.enum(['human', 'warden']).default('human'),
+  isDraft: z.boolean().default(false),
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const body = createSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const { content, author, authorType, isDraft } = body.data
+
+  // Warden cannot create draft notes
+  if (authorType === 'warden' && isDraft) {
+    return NextResponse.json({ error: 'Warden cannot create draft notes' }, { status: 403 })
+  }
+
+  const investigation = await prisma.investigation.findUnique({ where: { id } })
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const note = await prisma.investigationNote.create({
+    data: { investigationId: id, content, author, authorType, isDraft },
+  })
+
+  // Update the tsvector search index
+  await updateSearchVector(note.id, content)
+
+  await recordAudit(id, author, authorType, 'note_added', undefined, { noteId: note.id })
+
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: id, eventTime: new Date(),
+      eventType: 'note_added',
+      title: `${authorType === 'warden' ? 'Warden' : 'Analyst'} note added`,
+      description: isDraft ? '(draft)' : undefined,
+      source: authorType === 'warden' ? 'warden' : 'manual',
+    },
+  })
+
+  return NextResponse.json(note, { status: 201 })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
@@ -81,7 +81,7 @@ export async function DELETE(_req: Request, { params }: { params: { id: string; 
   }
 
   await prisma.investigationObservable.delete({ where: { id: obsId } })
-  await recordAudit(id, 'admin', 'human', 'observable_added', { observableId: obsId }, null)
+  await recordAudit(id, 'admin', 'human', 'observable_deleted', { observableId: obsId }, null)
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
@@ -1,0 +1,87 @@
+/**
+ * PATCH /api/monitoring/security/investigations/[id]/observables/[obsId]
+ * DELETE /api/monitoring/security/investigations/[id]/observables/[obsId]
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const updateSchema = z.object({
+  verdict: z.enum(['malicious', 'suspicious', 'benign', 'unknown']).optional(),
+  confidence: z.number().int().min(0).max(100).optional(),
+  resolved: z.boolean().optional(),
+  context: z.string().optional().nullable(),
+  role: z.enum(['ioc', 'artifact', 'infrastructure']).optional(),
+})
+
+export async function PATCH(req: Request, { params }: { params: { id: string; obsId: string } }) {
+  const { id, obsId } = await params
+  const raw = await req.json()
+  const body = updateSchema.safeParse(raw)
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const actor = raw._actor ?? 'admin'
+
+  const observable = await prisma.investigationObservable.findUnique({ where: { id: obsId } })
+  if (!observable || observable.investigationId !== id) {
+    return NextResponse.json({ error: 'Observable not found' }, { status: 404 })
+  }
+
+  // Warden constraint: cannot set malicious with confidence < 80
+  if (
+    actor === 'warden' &&
+    body.data.verdict === 'malicious' &&
+    (body.data.confidence ?? observable.confidence) < 80
+  ) {
+    return NextResponse.json(
+      { error: 'Warden requires confidence >= 80 to set malicious verdict' },
+      { status: 403 },
+    )
+  }
+
+  const before = { ...observable }
+  const updated = await prisma.investigationObservable.update({
+    where: { id: obsId },
+    data: {
+      ...body.data,
+      verdictBy: body.data.verdict ? actor : undefined,
+      verdictAt: body.data.verdict ? new Date() : undefined,
+    },
+  })
+
+  await recordAudit(id, actor, actor === 'warden' ? 'warden' : 'human',
+    'observable_added', before, updated)
+
+  if (body.data.verdict) {
+    await prisma.investigationTimeline.create({
+      data: {
+        investigationId: id, eventTime: new Date(),
+        eventType: 'observable_verdict_set',
+        title: `Verdict: ${observable.value} → ${body.data.verdict}`,
+        source: actor === 'warden' ? 'warden' : 'manual',
+      },
+    })
+  }
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string; obsId: string } }) {
+  const { id, obsId } = await params
+
+  const observable = await prisma.investigationObservable.findUnique({ where: { id: obsId } })
+  if (!observable || observable.investigationId !== id) {
+    return NextResponse.json({ error: 'Observable not found' }, { status: 404 })
+  }
+
+  await prisma.investigationObservable.delete({ where: { id: obsId } })
+  await recordAudit(id, 'admin', 'human', 'observable_added', { observableId: obsId }, null)
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/route.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/observables
+ *
+ * Add an observable to an investigation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const createSchema = z.object({
+  value: z.string().min(1),
+  displayValue: z.string().optional(),
+  category: z.enum(['ipv4', 'ipv6', 'domain', 'url', 'file_hash_md5', 'file_hash_sha1', 'file_hash_sha256', 'mac_address', 'email', 'username', 'file_path', 'registry_key', 'mutex', 'asn']),
+  role: z.enum(['ioc', 'artifact', 'infrastructure']).default('ioc'),
+  verdict: z.enum(['malicious', 'suspicious', 'benign', 'unknown']).default('unknown'),
+  confidence: z.number().int().min(0).max(100).default(0),
+  severity: z.number().int().min(0).max(100).default(0),
+  context: z.string().optional().nullable(),
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const body = createSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const { value, displayValue, category, role, verdict, confidence, severity, context } = body.data
+  const actor = (body.data as any)._actor ?? 'admin'
+
+  // Warden cannot set malicious verdict with confidence < 80
+  if (actor === 'warden' && verdict === 'malicious' && confidence < 80) {
+    return NextResponse.json(
+      { error: 'Warden requires confidence >= 80 to set malicious verdict' },
+      { status: 403 },
+    )
+  }
+
+  const investigation = await prisma.investigation.findUnique({ where: { id } })
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const observable = await prisma.investigationObservable.upsert({
+    where: { investigationId_value_category: { investigationId: id, value, category } },
+    create: {
+      investigationId: id,
+      value,
+      displayValue: displayValue ?? value,
+      category, role, verdict, confidence, severity, context,
+      verdictBy: verdict !== 'unknown' ? actor : undefined,
+      verdictAt: verdict !== 'unknown' ? new Date() : undefined,
+    },
+    update: {
+      lastSeen: new Date(),
+      confidence: Math.max(confidence, severity),
+      context: context ?? undefined,
+    },
+  })
+
+  await recordAudit(id, actor, actor === 'warden' ? 'warden' : 'human', 'observable_added',
+    undefined, { observableId: observable.id })
+
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: id, eventTime: new Date(),
+      eventType: 'observable_added',
+      title: `Observable added: ${value}`,
+      source: actor === 'warden' ? 'warden' : 'manual',
+    },
+  })
+
+  return NextResponse.json(observable, { status: 201 })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/report/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/report/route.ts
@@ -1,0 +1,104 @@
+/**
+ * GET /api/monitoring/security/investigations/[id]/report
+ *
+ * Generate a markdown investigation report.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+
+  const investigation = await prisma.investigation.findUnique({
+    where: { id },
+    include: {
+      incidents: { orderBy: { openedAt: 'asc' } },
+      notes: { orderBy: { createdAt: 'asc' } },
+      observables: { orderBy: { firstSeen: 'asc' } },
+      timeline: { orderBy: { eventTime: 'asc' } },
+    },
+  })
+
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const lines: string[] = []
+  lines.push(`# ${investigation.name}`)
+  lines.push(``)
+  lines.push(`| Field | Value |`)
+  lines.push(`|-------|-------|`)
+  lines.push(`| Status | ${investigation.status} |`)
+  lines.push(`| Severity | ${investigation.severity}/100 |`)
+  lines.push(`| TLP | ${investigation.tlp} |`)
+  lines.push(`| Created | ${investigation.startedAt.toISOString()} |`)
+  if (investigation.resolvedAt) lines.push(`| Resolved | ${investigation.resolvedAt.toISOString()} |`)
+  if (investigation.closedAt) lines.push(`| Closed | ${investigation.closedAt.toISOString()} |`)
+  if (investigation.resolutionType) lines.push(`| Resolution | ${investigation.resolutionType} |`)
+  if (investigation.mitreAttackIds.length) lines.push(`| MITRE ATT&CK | ${investigation.mitreAttackIds.join(', ')} |`)
+  lines.push(``)
+
+  // Summary
+  if (investigation.resolution) {
+    lines.push(`## Summary`)
+    lines.push(``)
+    lines.push(investigation.resolution)
+    lines.push(``)
+  }
+
+  // Linked Incidents
+  if (investigation.incidents.length) {
+    lines.push(`## Linked Incidents (${investigation.incidents.length})`)
+    lines.push(``)
+    for (const inc of investigation.incidents) {
+      lines.push(`- **[${inc.status}]** ${inc.attackerKey ?? 'Unknown'} (sev: ${inc.severity}) — ${inc.openedAt.toISOString()}`)
+    }
+    lines.push(``)
+  }
+
+  // Observables
+  if (investigation.observables.length) {
+    lines.push(`## Observables (${investigation.observables.length})`)
+    lines.push(``)
+    lines.push(`| Value | Category | Verdict | Confidence | First Seen |`)
+    lines.push(`|-------|----------|---------|------------|------------|`)
+    for (const obs of investigation.observables) {
+      lines.push(`| ${obs.displayValue} | ${obs.category} | ${obs.verdict} | ${obs.confidence}% | ${obs.firstSeen.toISOString()} |`)
+    }
+    lines.push(``)
+  }
+
+  // Timeline
+  if (investigation.timeline.length) {
+    lines.push(`## Timeline`)
+    lines.push(``)
+    for (const entry of investigation.timeline) {
+      const sourceBadge = entry.source === 'warden' ? '[Warden]' : entry.source === 'correlator' ? '[Auto]' : ''
+      lines.push(`- **${entry.eventTime.toISOString()}** — ${entry.title} ${sourceBadge}`)
+      if (entry.description) lines.push(`  - ${entry.description}`)
+    }
+    lines.push(``)
+  }
+
+  // Notes
+  if (investigation.notes.length) {
+    lines.push(`## Notes (${investigation.notes.length})`)
+    lines.push(``)
+    for (const note of investigation.notes) {
+      const authorLabel = note.authorType === 'warden' ? 'Warden' : note.author
+      lines.push(`### ${authorLabel} — ${note.createdAt.toISOString()}`)
+      lines.push(``)
+      lines.push(note.content)
+      lines.push(``)
+    }
+  }
+
+  // Metrics
+  lines.push(`---`)
+  lines.push(`*Report generated ${new Date().toISOString()}*`)
+
+  return NextResponse.json({ markdown: lines.join('\n') })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
@@ -1,0 +1,147 @@
+/**
+ * GET /api/monitoring/security/investigations/[id]
+ * PATCH /api/monitoring/security/investigations/[id]
+ * DELETE /api/monitoring/security/investigations/[id]
+ *
+ * Full investigation detail, update fields, archive (soft-close).
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const updateSchema = z.object({
+  name: z.string().min(1).optional(),
+  status: z.enum(['open', 'active', 'suspended', 'resolved', 'closed']).optional(),
+  severity: z.number().int().min(0).max(100).optional(),
+  tlp: z.enum(['white', 'green', 'amber', 'red']).optional(),
+  resolution: z.string().optional().nullable(),
+  resolutionType: z.enum(['true_positive', 'false_positive', 'benign', 'inconclusive']).optional().nullable(),
+  assignedTo: z.string().optional().nullable(),
+  tags: z.array(z.string()).optional(),
+  mitreAttackIds: z.array(z.string()).optional(),
+  dueAt: z.string().datetime().optional().nullable(),
+})
+
+// ─── Warden constraints ─────────────────────────────────────────────────────
+
+const WARDEN_ALLOWED_STATUS = new Set(['open', 'active', 'suspended'])
+
+function applyWardenConstraints(
+  actor: string,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  if (actor !== 'warden') return data
+  const clean = { ...data }
+  if (clean.status && !WARDEN_ALLOWED_STATUS.has(clean.status)) {
+    throw new Error('Warden cannot transition investigation to resolved or closed')
+  }
+  delete clean.resolutionType
+  return clean
+}
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+
+  const investigation = await prisma.investigation.findUnique({
+    where: { id },
+    include: {
+      incidents: { orderBy: { openedAt: 'desc' }, take: 50 },
+      notes: { orderBy: { createdAt: 'desc' }, take: 100 },
+      observables: { orderBy: { firstSeen: 'desc' }, take: 200 },
+      timeline: { orderBy: { eventTime: 'asc' }, take: 200 },
+    },
+  })
+
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    investigation: {
+      ...investigation,
+      incidents: investigation.incidents.map(i => ({
+        id: i.id, status: i.status, severity: i.severity,
+        attackerKey: i.attackerKey, hostKey: i.hostKey, openedAt: i.openedAt,
+      })),
+    },
+  })
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const raw = await req.json()
+  const parsed = updateSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.errors }, { status: 400 })
+  }
+
+  const existing = await prisma.investigation.findUnique({ where: { id } })
+  if (!existing) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const actor = raw._actor ?? 'admin'
+  let data = applyWardenConstraints(actor, parsed.data)
+
+  // Set resolvedAt/closedAt on status transition
+  if (data.status === 'resolved' && !existing.resolvedAt) {
+    data = { ...data, resolvedAt: new Date() }
+  }
+  if (data.status === 'closed' && !existing.closedAt) {
+    data = { ...data, closedAt: new Date() }
+  }
+
+  const before = { ...existing }
+  const updated = await prisma.investigation.update({
+    where: { id },
+    data,
+  })
+
+  await recordAudit(id, actor, 'human', 'status_changed', before, updated)
+
+  // Timeline entry
+  if (data.status) {
+    await prisma.investigationTimeline.create({
+      data: {
+        investigationId: id, eventTime: new Date(),
+        eventType: 'status_changed',
+        title: `Status: ${existing.status} → ${data.status}`,
+        source: actor === 'warden' ? 'warden' : 'manual',
+      },
+    })
+  }
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+
+  const existing = await prisma.investigation.findUnique({ where: { id } })
+  if (!existing) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  if (existing.status === 'closed') {
+    return NextResponse.json({ error: 'Already closed' }, { status: 409 })
+  }
+
+  const updated = await prisma.investigation.update({
+    where: { id },
+    data: { status: 'closed', closedAt: new Date() },
+  })
+
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: id, eventTime: new Date(),
+      eventType: 'status_changed', title: 'Investigation closed',
+      source: 'manual',
+    },
+  })
+
+  return NextResponse.json(updated)
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/[entryId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/[entryId]/route.ts
@@ -1,0 +1,36 @@
+/**
+ * PATCH /api/monitoring/security/investigations/[id]/timeline/[entryId]
+ *
+ * Pin/unpin or edit description of a timeline entry.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const updateSchema = z.object({
+  isPinned: z.boolean().optional(),
+  description: z.string().optional().nullable(),
+})
+
+export async function PATCH(req: Request, { params }: { params: { id: string; entryId: string } }) {
+  const { id, entryId } = await params
+  const body = updateSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const entry = await prisma.investigationTimeline.findUnique({ where: { id: entryId } })
+  if (!entry || entry.investigationId !== id) {
+    return NextResponse.json({ error: 'Timeline entry not found' }, { status: 404 })
+  }
+
+  const updated = await prisma.investigationTimeline.update({
+    where: { id: entryId },
+    data: body.data,
+  })
+
+  return NextResponse.json(updated)
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
@@ -1,0 +1,49 @@
+/**
+ * POST /api/monitoring/security/investigations/[id]/timeline
+ *
+ * Add a manual timeline entry.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+import { recordAudit } from '../../_utils'
+
+export const dynamic = 'force-dynamic'
+
+const createSchema = z.object({
+  eventTime: z.string().datetime(),
+  eventType: z.string(),
+  title: z.string().min(1),
+  description: z.string().optional().nullable(),
+  source: z.enum(['manual', 'warden', 'correlator', 'thehive']).default('manual'),
+  isPinned: z.boolean().default(false),
+  payload: z.record(z.unknown()).optional().nullable(),
+})
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+  const body = createSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const investigation = await prisma.investigation.findUnique({ where: { id } })
+  if (!investigation) {
+    return NextResponse.json({ error: 'Investigation not found' }, { status: 404 })
+  }
+
+  const entry = await prisma.investigationTimeline.create({
+    data: {
+      ...body.data,
+      investigationId: id,
+      eventTime: new Date(body.data.eventTime),
+    },
+  })
+
+  const actor = body.data.source === 'warden' ? 'warden' : 'admin'
+  await recordAudit(id, actor, body.data.source, 'action_taken',
+    undefined, { timelineId: entry.id })
+
+  return NextResponse.json(entry, { status: 201 })
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared utilities for investigation API routes.
+ */
+
+import { prisma } from '@/lib/db'
+import { type Prisma } from '@prisma/client'
+
+/**
+ * Record an audit entry for an investigation.
+ */
+export async function recordAudit(
+  investigationId: string,
+  actorId: string,
+  actorType: string,
+  action: string,
+  before?: Record<string, unknown>,
+  after?: Record<string, unknown>,
+): Promise<void> {
+  await prisma.investigationAudit.create({
+    data: {
+      investigationId,
+      actorId,
+      actorType,
+      action,
+      before: before as Prisma.InputJsonValue,
+      after: after as Prisma.InputJsonValue,
+    },
+  })
+}
+
+/**
+ * Build a tsvector search vector from note content for full-text search.
+ * Called application-side on note insert/update.
+ */
+export async function updateSearchVector(
+  noteId: string,
+  content: string,
+): Promise<void> {
+  await prisma.$executeRawUnsafe(
+    `UPDATE "InvestigationNote" SET "searchVector" = to_tsvector('english', $1) WHERE "id" = $2`,
+    content,
+    noteId,
+  )
+}
+
+/**
+ * Full-text search notes within an investigation.
+ */
+export async function searchNotes(
+  investigationId: string,
+  query: string,
+  limit: number = 25,
+): Promise<Array<{ id: string; content: string; author: string; authorType: string; createdAt: Date }>> {
+  const rows = await prisma.$queryRawUnsafe(
+    `SELECT "id", "content", "author", "authorType", "createdAt"
+     FROM "InvestigationNote"
+     WHERE "investigationId" = $1 AND "searchVector" @@ plainto_tsquery('english', $2)
+     ORDER BY "createdAt" DESC
+     LIMIT $3`,
+    investigationId,
+    query,
+    limit,
+  )
+  return rows as any
+}
+
+/**
+ * Cursor pagination helper. Returns { items, nextCursor, hasMore }.
+ */
+export async function cursorPaginate<T>(
+  model: Prisma.Model,
+  where: Record<string, unknown>,
+  orderBy: Record<string, 'asc' | 'desc'>,
+  limit: number,
+  cursor: string | null,
+  select?: Record<string, true>,
+) {
+  const take = limit + 1
+  const cursorOpt = cursor ? { id: cursor } : undefined
+
+  const items = await (model as any).findMany({
+    where, orderBy, take, cursor: cursorOpt,
+    select: select || undefined,
+  })
+
+  const hasMore = items.length > limit
+  const data = items.slice(0, limit)
+  const nextCursor = hasMore ? items[items.length - 1].id : null
+  return { items: data, nextCursor, hasMore }
+}

--- a/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
@@ -3,7 +3,6 @@
  */
 
 import { prisma } from '@/lib/db'
-import { type Prisma } from '@prisma/client'
 
 /**
  * Record an audit entry for an investigation.
@@ -64,27 +63,3 @@ export async function searchNotes(
   return rows as any
 }
 
-/**
- * Cursor pagination helper. Returns { items, nextCursor, hasMore }.
- */
-export async function cursorPaginate<T>(
-  model: Prisma.Model,
-  where: Record<string, unknown>,
-  orderBy: Record<string, 'asc' | 'desc'>,
-  limit: number,
-  cursor: string | null,
-  select?: Record<string, true>,
-) {
-  const take = limit + 1
-  const cursorOpt = cursor ? { id: cursor } : undefined
-
-  const items = await (model as any).findMany({
-    where, orderBy, take, cursor: cursorOpt,
-    select: select || undefined,
-  })
-
-  const hasMore = items.length > limit
-  const data = items.slice(0, limit)
-  const nextCursor = hasMore ? items[items.length - 1].id : null
-  return { items: data, nextCursor, hasMore }
-}

--- a/apps/web/src/app/api/monitoring/security/investigations/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/route.ts
@@ -44,7 +44,7 @@ export async function GET(req: NextRequest) {
   if (status) where.status = status
   if (severity) where.severity = { gte: severity }
   if (assignedTo) where.assignedTo = assignedTo
-  if (tags) where.tags = { contains: tags }
+  if (tags) where.tags = { has: tags }
   if (search) where.OR = [{ name: { contains: search, mode: 'insensitive' } }]
 
   const cursorOpt = cursor ? { id: cursor } : undefined

--- a/apps/web/src/app/api/monitoring/security/investigations/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/route.ts
@@ -1,0 +1,128 @@
+/**
+ * GET /api/monitoring/security/investigations
+ * POST /api/monitoring/security/investigations
+ *
+ * List investigations (cursor pagination, filters) and create new ones.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { z } from 'zod'
+
+export const dynamic = 'force-dynamic'
+
+const querySchema = z.object({
+  status: z.enum(['open', 'active', 'suspended', 'resolved', 'closed']).optional(),
+  severity: z.coerce.number().min(0).max(100).optional(),
+  assignedTo: z.string().optional(),
+  tags: z.string().optional(),
+  search: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+})
+
+const createSchema = z.object({
+  name: z.string().min(1),
+  severity: z.number().int().min(0).max(100).optional(),
+  tlp: z.enum(['white', 'green', 'amber', 'red']).default('amber'),
+  pap: z.number().int().min(0).max(3).default(2),
+  tags: z.array(z.string()).default([]),
+  mitreAttackIds: z.array(z.string()).default([]),
+  incidentId: z.string().uuid().optional(),
+  createdBy: z.string().default('admin'),
+})
+
+export async function GET(req: NextRequest) {
+  const parsed = querySchema.safeParse(Object.fromEntries(req.nextUrl.searchParams))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query params' }, { status: 400 })
+  }
+
+  const { status, severity, assignedTo, tags, search, cursor, limit } = parsed.data
+
+  const where: Record<string, unknown> = {}
+  if (status) where.status = status
+  if (severity) where.severity = { gte: severity }
+  if (assignedTo) where.assignedTo = assignedTo
+  if (tags) where.tags = { contains: tags }
+  if (search) where.OR = [{ name: { contains: search, mode: 'insensitive' } }]
+
+  const cursorOpt = cursor ? { id: cursor } : undefined
+  const items = await prisma.investigation.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit + 1,
+    cursor: cursorOpt,
+    select: {
+      id: true, name: true, status: true, severity: true, tlp: true,
+      tags: true, createdBy: true, startedAt: true, resolvedAt: true, closedAt: true,
+      _count: { select: { incidents: true, notes: true, observables: true, timeline: true } },
+    },
+  })
+
+  const hasMore = items.length > limit
+  const data = items.slice(0, limit)
+  const nextCursor = hasMore ? items[items.length - 1].id : null
+
+  return NextResponse.json({
+    investigations: data.map(i => ({
+      ...i,
+      incidentCount: i._count.incidents,
+      noteCount: i._count.notes,
+      observableCount: i._count.observables,
+      timelineCount: i._count.timeline,
+      _count: undefined,
+    })),
+    pagination: { nextCursor, hasMore },
+  })
+}
+
+export async function POST(req: Request) {
+  const body = createSchema.safeParse(await req.json())
+  if (!body.success) {
+    return NextResponse.json({ error: body.error.errors }, { status: 400 })
+  }
+
+  const { name, severity, tlp, pap, tags, mitreAttackIds, incidentId, createdBy } = body.data
+
+  const investigation = await prisma.investigation.create({
+    data: {
+      name,
+      severity: severity ?? 50,
+      tlp, pap, tags, mitreAttackIds, createdBy,
+    },
+  })
+
+  // Link incident if provided
+  if (incidentId) {
+    await prisma.incident.updateMany({
+      where: { id: incidentId, investigationId: null },
+      data: { investigationId: investigation.id },
+    })
+
+    await prisma.investigationTimeline.create({
+      data: {
+        investigationId: investigation.id,
+        eventTime: new Date(),
+        eventType: 'link_added',
+        title: `Incident linked`,
+        description: incidentId,
+        source: 'manual',
+      },
+    })
+  }
+
+  // Initial timeline entry
+  await prisma.investigationTimeline.create({
+    data: {
+      investigationId: investigation.id,
+      eventTime: investigation.startedAt,
+      eventType: 'incident_created',
+      title: 'Investigation created',
+      description: `Created by ${createdBy}`,
+      source: createdBy === 'warden' ? 'warden' : 'manual',
+    },
+  })
+
+  return NextResponse.json(investigation, { status: 201 })
+}

--- a/apps/web/src/app/api/monitoring/security/metrics/soc/route.ts
+++ b/apps/web/src/app/api/monitoring/security/metrics/soc/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/monitoring/security/metrics/soc
+ *
+ * SOC metrics: MTTD, MTTR, open/closed counts, cases by severity.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const now = new Date()
+  const dayMs = 86400000
+
+  // Counts by status
+  const byStatus = await prisma.investigation.groupBy({
+    by: ['status'],
+    _count: { id: true },
+  })
+
+  // Counts by resolution type
+  const byResolution = await prisma.investigation.groupBy({
+    by: ['resolutionType'],
+    _count: { id: true },
+    where: { resolutionType: { not: null } },
+  })
+
+  // Open investigations by severity ranges
+  const openBySeverity = await prisma.investigation.groupBy({
+    by: ['severity'],
+    _count: { id: true },
+    where: { status: { in: ['open', 'active', 'suspended'] } },
+  })
+
+  const severityBuckets = { critical: 0, high: 0, medium: 0, low: 0 }
+  for (const s of openBySeverity) {
+    if (s.severity >= 80) severityBuckets.critical++
+    else if (s.severity >= 60) severityBuckets.high++
+    else if (s.severity >= 40) severityBuckets.medium++
+    else severityBuckets.low++
+  }
+
+  // MTTD & MTTR from completed investigations
+  const completed = await prisma.investigation.findMany({
+    where: { resolvedAt: { not: null } },
+    select: { startedAt: true, resolvedAt: true, incidents: { select: { openedAt: true } } },
+  })
+
+  let totalMttD = 0
+  let totalMttr = 0
+  let countMttD = 0
+  let countMttr = 0
+
+  for (const inv of completed) {
+    if (inv.incidents.length > 0 && inv.resolvedAt) {
+      const firstIncident = inv.incidents.reduce((earliest, inc) =>
+        inc.openedAt < earliest.openedAt ? inc : earliest
+      )
+      const mttd = (inv.startedAt.getTime() - firstIncident.openedAt.getTime()) / dayMs
+      totalMttD += mttd
+      countMttD++
+
+      const mttr = (inv.resolvedAt.getTime() - inv.startedAt.getTime()) / dayMs
+      totalMttr += mttr
+      countMttr++
+    }
+  }
+
+  // Recent investigations (last 7 days)
+  const recent = await prisma.investigation.count({
+    where: { createdAt: { gte: new Date(now.getTime() - 7 * dayMs) } },
+  })
+
+  // Observable counts
+  const totalObservables = await prisma.investigationObservable.count()
+  const maliciousObservables = await prisma.investigationObservable.count({
+    where: { verdict: 'malicious' },
+  })
+
+  return NextResponse.json({
+    byStatus: Object.fromEntries(byStatus.map(s => [s.status, s._count.id])),
+    byResolution: Object.fromEntries(byResolution.map(r => [r.resolutionType, r._count.id])),
+    severityBuckets,
+    mttd: countMttD ? Math.round((totalMttD / countMttD) * 100) / 100 : null,
+    mttr: countMttr ? Math.round((totalMttr / countMttr) * 100) / 100 : null,
+    recent7d: recent,
+    totalObservables,
+    maliciousObservables,
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/observables/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/observables/[id]/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/monitoring/security/observables/[id]
+ *
+ * Observable detail with cross-investigation aggregation.
+ */
+
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const id = (await params).id
+
+  const observable = await prisma.investigationObservable.findUnique({
+    where: { id },
+    include: {
+      investigation: { select: { id: true, name: true, status: true } },
+    },
+  })
+
+  if (!observable) {
+    return NextResponse.json({ error: 'Observable not found' }, { status: 404 })
+  }
+
+  // Cross-investigation aggregation: find same value+category in other investigations
+  const crossRefs = await prisma.investigationObservable.findMany({
+    where: {
+      value: observable.value,
+      category: observable.category,
+      investigationId: { not: observable.investigationId },
+    },
+    include: {
+      investigation: { select: { id: true, name: true, status: true } },
+    },
+    take: 20,
+  })
+
+  return NextResponse.json({
+    observable: { ...observable },
+    crossReferences: crossRefs,
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/observables/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/monitoring/security/observables
+ *
+ * Global observable search (paginated, rate-limited to 10 req/min).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/** Simple in-memory rate limiter (per-IP). In production, use Redis. */
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>()
+
+function checkRateLimit(ip: string, max: number = 10, windowMs: number = 60000): boolean {
+  const now = Date.now()
+  const bucket = rateLimitBuckets.get(ip)
+  if (!bucket || now > bucket.resetAt) {
+    rateLimitBuckets.set(ip, { count: 1, resetAt: now + windowMs })
+    return true
+  }
+  if (bucket.count >= max) return false
+  bucket.count++
+  return true
+}
+
+export async function GET(req: NextRequest) {
+  const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json({ error: 'Rate limit exceeded (10 req/min)' }, { status: 429 })
+  }
+
+  const q = req.nextUrl.searchParams.get('q')
+  const category = req.nextUrl.searchParams.get('category')
+  const verdict = req.nextUrl.searchParams.get('verdict')
+  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') ?? '25', 10), 100)
+  const cursor = req.nextUrl.searchParams.get('cursor')
+
+  const where: Record<string, unknown> = {}
+  if (q) where.value = { contains: q, mode: 'insensitive' }
+  if (category) where.category = category
+  if (verdict) where.verdict = verdict
+
+  const cursorOpt = cursor ? { id: cursor } : undefined
+  const items = await prisma.investigationObservable.findMany({
+    where,
+    orderBy: { lastSeen: 'desc' },
+    take: limit + 1,
+    cursor: cursorOpt,
+    include: {
+      investigation: { select: { id: true, name: true, status: true } },
+    },
+  })
+
+  const hasMore = items.length > limit
+  const data = items.slice(0, limit)
+  const nextCursor = hasMore ? items[items.length - 1].id : null
+
+  return NextResponse.json({
+    observables: data,
+    pagination: { nextCursor, hasMore },
+  })
+}

--- a/apps/web/src/app/api/monitoring/security/observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/observables/route.ts
@@ -14,6 +14,10 @@ const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>()
 
 function checkRateLimit(ip: string, max: number = 10, windowMs: number = 60000): boolean {
   const now = Date.now()
+  // Evict expired buckets to prevent unbounded growth
+  for (const [key, b] of rateLimitBuckets.entries()) {
+    if (now > b.resetAt) rateLimitBuckets.delete(key)
+  }
   const bucket = rateLimitBuckets.get(ip)
   if (!bucket || now > bucket.resetAt) {
     rateLimitBuckets.set(ip, { count: 1, resetAt: now + windowMs })

--- a/apps/web/src/app/api/monitoring/security/overview/route.ts
+++ b/apps/web/src/app/api/monitoring/security/overview/route.ts
@@ -76,6 +76,22 @@ export async function GET() {
     criticalCount * 25 + highCount * 10 + totalUnack * 2
   ))
 
+  // Recent investigations
+  const recentInvestigations = await prisma.investigation.findMany({
+    where: { status: { in: ['open', 'active'] } },
+    orderBy: { updatedAt: 'desc' },
+    take: 5,
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      severity: true,
+      _count: {
+        select: { incidents: true, observables: true, notes: true },
+      },
+    },
+  })
+
   return NextResponse.json({
     riskScore,
     activeThreats: recentAlerts.length,
@@ -86,6 +102,10 @@ export async function GET() {
     recentIncidents: recentIncidents.map(i => ({
       ...i,
       openedAt: i.openedAt.toISOString(),
+    })),
+    recentInvestigations: recentInvestigations.map(inv => ({
+      ...inv,
+      _count: inv._count,
     })),
     pendingApprovalsList: pendingApprovalsList.map((a: any) => ({
       ...a,

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -55,7 +55,7 @@ function StatCard({ icon: Icon, label, value, color }: {
   )
 }
 
-type Tab = 'incidents' | 'alerts' | 'approvals' | 'flows' | 'sources' | 'settings'
+type Tab = 'incidents' | 'investigations' | 'alerts' | 'approvals' | 'flows' | 'sources' | 'settings'
 
 export default function SecurityDashboard() {
   const [data, setData] = useState<any>(null)
@@ -93,10 +93,11 @@ export default function SecurityDashboard() {
     )
   }
 
-  const tabs: { key: Tab; label: string; badge?: number }[] = [
-    { key: 'incidents', label: 'Incidents', badge: data?.activeIncidents },
+  const tabs: { key: Tab; label: string; badge?: number; href?: string }[] = [
+    { key: 'incidents', label: 'Incidents', badge: data?.activeIncidents, href: '/security/incidents' },
+    { key: 'investigations', label: 'Investigations', href: '/security/investigations' },
     { key: 'alerts', label: 'Alerts' },
-    { key: 'approvals', label: 'Approvals', badge: data?.pendingApprovals },
+    { key: 'approvals', label: 'Approvals', badge: data?.pendingApprovals, href: '/security/approvals' },
     { key: 'flows', label: 'Flows' },
     { key: 'sources', label: 'Sources' },
     { key: 'settings', label: 'Settings' },
@@ -179,6 +180,54 @@ export default function SecurityDashboard() {
           ) : (
             <div className="rounded-lg border border-border-subtle bg-bg-card px-4 py-12 text-center text-sm text-text-muted">
               No incidents — security is clear.
+            </div>
+          )}
+        </div>
+      )}
+
+      {tab === 'investigations' && (
+        <div className="space-y-4">
+          {data?.recentInvestigations?.length ? (
+            <div className="bg-bg-surface border border-border-subtle rounded-xl">
+              <div className="px-4 py-3 border-b border-border-subtle flex items-center justify-between">
+                <span className="text-sm font-medium text-text-primary">Recent Investigations</span>
+                <Link href="/security/investigations" className="text-xs text-accent hover:underline">
+                  View all
+                </Link>
+              </div>
+              <div className="divide-y divide-border-subtle">
+                {data.recentInvestigations.map((inv: any) => (
+                  <Link
+                    key={inv.id}
+                    href={`/security/investigations/${inv.id}`}
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-bg-raised transition-colors"
+                  >
+                    <span className={`text-xs font-bold px-2 py-0.5 rounded ${
+                      inv.severity >= 80 ? 'bg-status-error/15 text-status-error' :
+                      inv.severity >= 50 ? 'bg-status-warning/15 text-status-warning' :
+                      'bg-bg-raised text-text-muted'
+                    }`}>
+                      {inv.severity}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-text-primary truncate">{inv.name}</div>
+                      <div className="text-xs text-text-muted">{inv._count?.incidents ?? 0} incidents · {inv._count?.observables ?? 0} observables</div>
+                    </div>
+                    <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${
+                      inv.status === 'open' ? 'bg-status-warning/15 text-status-warning' :
+                      inv.status === 'active' ? 'bg-red-400/15 text-red-400' :
+                      inv.status === 'resolved' ? 'bg-status-healthy/15 text-status-healthy' :
+                      'bg-bg-raised text-text-muted'
+                    }`}>
+                      {inv.status}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border-subtle bg-bg-card px-4 py-12 text-center text-sm text-text-muted">
+              No active investigations.
             </div>
           )}
         </div>

--- a/apps/web/src/components/security/SecuritySettings.tsx
+++ b/apps/web/src/components/security/SecuritySettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Shield, CheckCircle2, XCircle, Loader2, RefreshCw } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { Shield, CheckCircle2, XCircle, Loader2, RefreshCw, Save } from 'lucide-react'
 
 const sources = [
   { key: 'CROWDSEC_API', name: 'CrowdSec', desc: 'Brute-force & IP blocking', default: 'http://crowdsec-lapi.crowdsec:8080' },
@@ -14,7 +14,20 @@ const sources = [
 export default function SecuritySettings() {
   const [config, setConfig] = useState<Record<string, string>>({})
   const [testing, setTesting] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
   const [results, setResults] = useState<Record<string, 'ok' | 'error' | null>>({})
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/monitoring/security/config')
+        const data = await res.json()
+        setConfig(data.config ?? {})
+      } catch {}
+    }
+    load()
+  }, [])
 
   async function testConnection(key: string) {
     setTesting(key)
@@ -26,6 +39,24 @@ export default function SecuritySettings() {
       setResults(prev => ({ ...prev, [key]: 'error' as const }))
     }
     setTesting(null)
+  }
+
+  async function saveConfig() {
+    setSaving(true)
+    setSaved(false)
+    try {
+      const res = await fetch('/api/monitoring/security/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      })
+      if (res.ok) {
+        setSaved(true)
+        setTimeout(() => setSaved(false), 3000)
+      }
+    } finally {
+      setSaving(false)
+    }
   }
 
   return (
@@ -67,9 +98,17 @@ export default function SecuritySettings() {
         ))}
       </div>
 
-      <button className="px-4 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 transition-colors">
-        Save Configuration
-      </button>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={saveConfig}
+          disabled={saving}
+          className="flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+        >
+          {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+          Save Configuration
+        </button>
+        {saved && <span className="text-xs text-status-healthy flex items-center gap-1"><CheckCircle2 size={12} /> Saved</span>}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -21,5 +21,8 @@ export async function register() {
 
     const { ensureSecurityRetentionJobScheduled } = await import('./jobs/security-retention-daily')
     await ensureSecurityRetentionJobScheduled()
+
+    const { ensureSocConfig } = await import('./lib/seed-soc-config')
+    await ensureSocConfig()
   }
 }

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -179,6 +179,175 @@ export const ORION_TOOL_DEFINITIONS = [
       },
     },
   },
+  // ── SOC Case Management Tools ──────────────────────────────────────────────
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_search',
+      description: 'Search for investigations by status, severity, or name. Returns matching investigations with counts.',
+      parameters: {
+        type: 'object',
+        properties: {
+          status:  { type: 'string', enum: ['open', 'active', 'suspended', 'resolved', 'closed'], description: 'Filter by status' },
+          search:  { type: 'string', description: 'Search in investigation names' },
+          severity:{ type: 'number', description: 'Minimum severity (0-100)' },
+        },
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_create',
+      description: 'Create a new investigation case. Optionally link an incident. Auto-extracts observables from linked incident events.',
+      parameters: {
+        type: 'object',
+        properties: {
+          name:           { type: 'string', description: 'Investigation name' },
+          severity:       { type: 'number', description: 'Severity 0-100' },
+          tlp:            { type: 'string', enum: ['white', 'green', 'amber', 'red'], description: 'Traffic Light Protocol (default: amber)' },
+          tags:           { type: 'array', items: { type: 'string' }, description: 'Tags for categorization' },
+          mitreAttackIds: { type: 'array', items: { type: 'string' }, description: 'MITRE ATT&CK technique IDs' },
+          incidentId:     { type: 'string', description: 'Optional incident ID to link' },
+        },
+        required: ['name'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_read',
+      description: 'Read full details of an investigation including incidents, notes, observables, and timeline.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+        },
+        required: ['investigationId'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_note',
+      description: 'Add a note to an investigation. Warden notes are visually distinguished from human notes.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+          content:         { type: 'string', description: 'Note content in markdown' },
+        },
+        required: ['investigationId', 'content'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_update',
+      description: 'Update investigation fields. Warden cannot transition to resolved/closed status.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+          status:          { type: 'string', enum: ['open', 'active', 'suspended'], description: 'New status (Warden: cannot set resolved/closed)' },
+          severity:        { type: 'number', description: 'New severity 0-100' },
+          tlp:             { type: 'string', enum: ['white', 'green', 'amber', 'red'], description: 'New TLP level' },
+          tags:            { type: 'array', items: { type: 'string' }, description: 'Updated tags' },
+          mitreAttackIds:  { type: 'array', items: { type: 'string' }, description: 'Updated MITRE ATT&CK IDs' },
+        },
+        required: ['investigationId'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_link_incident',
+      description: 'Link an existing incident to an investigation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+          incidentId:      { type: 'string', description: 'The incident ID to link' },
+        },
+        required: ['investigationId', 'incidentId'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'investigation_merge',
+      description: 'Propose merging two investigations. Requires analyst confirmation — Warden can only suggest.',
+      parameters: {
+        type: 'object',
+        properties: {
+          targetId: { type: 'string', description: 'The target investigation (survives the merge)' },
+          sourceId: { type: 'string', description: 'The source investigation (merged into target)' },
+          reason:   { type: 'string', description: 'Why these investigations should be merged' },
+        },
+        required: ['targetId', 'sourceId', 'reason'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'observable_add',
+      description: 'Add an observable (IP, domain, hash, URL, etc.) to an investigation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+          value:           { type: 'string', description: 'Observable value (e.g. IP, domain, hash)' },
+          category:        { type: 'string', enum: ['ipv4', 'ipv6', 'domain', 'url', 'file_hash_md5', 'file_hash_sha1', 'file_hash_sha256', 'mac_address', 'email', 'username', 'file_path', 'registry_key', 'mutex', 'asn'], description: 'Observable category' },
+          role:            { type: 'string', enum: ['ioc', 'artifact', 'infrastructure'], description: 'Observable role (default: ioc)' },
+          verdict:         { type: 'string', enum: ['malicious', 'suspicious', 'benign', 'unknown'], description: 'Verdict (default: unknown)' },
+          confidence:      { type: 'number', description: 'Confidence 0-100. Malicious requires >= 80.' },
+          context:         { type: 'string', description: 'Where/how this observable was found' },
+        },
+        required: ['investigationId', 'value', 'category'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'observable_set_verdict',
+      description: 'Update an observable verdict. Warden requires confidence >= 80 for malicious.',
+      parameters: {
+        type: 'object',
+        properties: {
+          observableId: { type: 'string', description: 'The observable ID' },
+          verdict:      { type: 'string', enum: ['malicious', 'suspicious', 'benign', 'unknown'], description: 'New verdict' },
+          confidence:   { type: 'number', description: 'Confidence 0-100. Malicious requires >= 80.' },
+          context:      { type: 'string', description: 'Reasoning for the verdict' },
+        },
+        required: ['observableId', 'verdict'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'timeline_add',
+      description: 'Add a timeline entry to an investigation.',
+      parameters: {
+        type: 'object',
+        properties: {
+          investigationId: { type: 'string', description: 'The investigation ID' },
+          eventTime:       { type: 'string', description: 'When the event occurred (ISO 8601)' },
+          eventType:       { type: 'string', description: 'Event type: status_changed, action_taken, warden_annotation, etc.' },
+          title:           { type: 'string', description: 'Short title' },
+          description:     { type: 'string', description: 'Detailed description' },
+        },
+        required: ['investigationId', 'eventTime', 'eventType', 'title'],
+      },
+    },
+  },
 ] as const
 
 /**
@@ -488,6 +657,230 @@ export async function executeTool(
         await prisma.managedSecret.delete({ where: { id: secretId } })
         const reason = args.reason ? ` Reason: ${String(args.reason)}` : ''
         return `Deleted ORION secret record "${existing.name}" (${secretId}) from namespace "${existing.namespace}".${reason}\nNote: Vault secret and K8s Secret (if applied) were NOT deleted — only the ORION metadata record.`
+      }
+
+      // ── SOC Case Management ──────────────────────────────────────────────
+
+      case 'investigation_search': {
+        const where: Record<string, unknown> = {}
+        const status = args.status ? String(args.status) : null
+        const search = args.search ? String(args.search) : null
+        const severity = args.severity ? Number(args.severity) : null
+        if (status) where.status = status
+        if (search) where.OR = [{ name: { contains: search, mode: 'insensitive' } }]
+        if (severity) where.severity = { gte: severity }
+        const invs = await prisma.investigation.findMany({
+          where, orderBy: { createdAt: 'desc' }, take: 25,
+          select: {
+            id: true, name: true, status: true, severity: true, tlp: true,
+            tags: true, startedAt: true,
+            _count: { select: { incidents: true, notes: true, observables: true } },
+          },
+        })
+        const total = await prisma.investigation.count({ where })
+        return `Found ${total} investigations (showing ${invs.length}):\n` +
+          invs.map(i => `- [${i.status}] ${i.name} (sev:${i.severity}, tlp:${i.tlp}, incidents:${i._count.incidents}, notes:${i._count.notes}, observables:${i._count.observables})`).join('\n')
+      }
+
+      case 'investigation_create': {
+        const name = String(args.name ?? '').trim()
+        if (!name) return 'Error: name is required'
+        const inv = await prisma.investigation.create({
+          data: {
+            name,
+            severity: args.severity ? Number(args.severity) : 50,
+            tlp: (args.tlp as any) ?? 'amber',
+            tags: (args.tags as string[]) ?? [],
+            mitreAttackIds: (args.mitreAttackIds as string[]) ?? [],
+            createdBy: 'warden',
+          },
+        })
+        if (args.incidentId) {
+          await prisma.incident.updateMany({
+            where: { id: String(args.incidentId), investigationId: null },
+            data: { investigationId: inv.id },
+          })
+          return `Investigation created: "${inv.name}" (id: ${inv.id}). Incident ${args.incidentId} linked.`
+        }
+        return `Investigation created: "${inv.name}" (id: ${inv.id}, status: open, severity: ${inv.severity})`
+      }
+
+      case 'investigation_read': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        if (!investigationId) return 'Error: investigationId is required'
+        const inv = await prisma.investigation.findUnique({
+          where: { id: investigationId },
+          include: {
+            incidents: { orderBy: { openedAt: 'desc' }, take: 20 },
+            notes: { orderBy: { createdAt: 'desc' }, take: 20 },
+            observables: { orderBy: { firstSeen: 'desc' }, take: 50 },
+            timeline: { orderBy: { eventTime: 'asc' }, take: 50 },
+          },
+        })
+        if (!inv) return `Investigation ${investigationId} not found`
+        return `Investigation: "${inv.name}"\nStatus: ${inv.status} | Severity: ${inv.severity} | TLP: ${inv.tlp}\n` +
+          `Incidents: ${inv.incidents.length} | Notes: ${inv.notes.length} | Observables: ${inv.observables.length} | Timeline: ${inv.timeline.length}\n` +
+          (inv.resolution ? `Resolution: ${inv.resolution}\n` : '') +
+          (inv.observables.length > 0 ? `\nObservables:\n` + inv.observables.map(o => `  - [${o.category}] ${o.value} (${o.verdict}, conf:${o.confidence}%)`).join('\n') : '') +
+          (inv.incidents.length > 0 ? `\nIncidents:\n` + inv.incidents.map(i => `  - [${i.status}] ${i.attackerKey ?? 'Unknown'} (sev:${i.severity})`).join('\n') : '')
+      }
+
+      case 'investigation_note': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        const content = String(args.content ?? '').trim()
+        if (!investigationId || !content) return 'Error: investigationId and content are required'
+        const existing = await prisma.investigation.findUnique({ where: { id: investigationId } })
+        if (!existing) return `Investigation ${investigationId} not found`
+        const note = await prisma.investigationNote.create({
+          data: { investigationId, content, author: 'warden', authorType: 'warden' },
+        })
+        await prisma.investigationTimeline.create({
+          data: {
+            investigationId, eventTime: new Date(), eventType: 'note_added',
+            title: 'Warden note added', source: 'warden',
+          },
+        })
+        return `Note added (id: ${note.id}) to investigation ${investigationId}`
+      }
+
+      case 'investigation_update': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        if (!investigationId) return 'Error: investigationId is required'
+        const inv = await prisma.investigation.findUnique({ where: { id: investigationId } })
+        if (!inv) return `Investigation ${investigationId} not found`
+        const data: Record<string, unknown> = {}
+        if (args.status) data.status = String(args.status)
+        if (args.severity != null) data.severity = Number(args.severity)
+        if (args.tlp) data.tlp = String(args.tlp)
+        if (args.tags) data.tags = args.tags as string[]
+        if (args.mitreAttackIds) data.mitreAttackIds = args.mitreAttackIds as string[]
+        const updated = await prisma.investigation.update({ where: { id: investigationId }, data })
+        if (data.status) {
+          await prisma.investigationTimeline.create({
+            data: {
+              investigationId, eventTime: new Date(), eventType: 'status_changed',
+              title: `Status: ${inv.status} → ${updated.status}`, source: 'warden',
+            },
+          })
+        }
+        return `Investigation updated: ${Object.keys(data).map(k => `${k}: ${String(data[k])}`).join(', ')} (id: ${updated.id})`
+      }
+
+      case 'investigation_link_incident': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        const incidentId = String(args.incidentId ?? '').trim()
+        if (!investigationId || !incidentId) return 'Error: investigationId and incidentId are required'
+        const [inv, inc] = await Promise.all([
+          prisma.investigation.findUnique({ where: { id: investigationId } }),
+          prisma.incident.findUnique({ where: { id: incidentId } }),
+        ])
+        if (!inv) return `Investigation ${investigationId} not found`
+        if (!inc) return `Incident ${incidentId} not found`
+        if (inc.investigationId && inc.investigationId !== investigationId) {
+          return `Incident ${incidentId} already linked to investigation ${inc.investigationId}`
+        }
+        await prisma.incident.update({
+          where: { id: incidentId },
+          data: { investigationId },
+        })
+        await prisma.investigationTimeline.create({
+          data: {
+            investigationId, eventTime: new Date(), eventType: 'link_added',
+            title: `Incident linked: ${inc.attackerKey ?? incidentId}`, source: 'warden',
+          },
+        })
+        return `Incident ${incidentId} linked to investigation ${investigationId}`
+      }
+
+      case 'investigation_merge': {
+        const targetId = String(args.targetId ?? '').trim()
+        const sourceId = String(args.sourceId ?? '').trim()
+        const reason = String(args.reason ?? '').trim()
+        if (!targetId || !sourceId) return 'Error: targetId and sourceId are required'
+        if (targetId === sourceId) return 'Error: cannot merge an investigation into itself'
+        const [target, source] = await Promise.all([
+          prisma.investigation.findUnique({ where: { id: targetId } }),
+          prisma.investigation.findUnique({ where: { id: sourceId } }),
+        ])
+        if (!target) return `Target investigation ${targetId} not found`
+        if (!source) return `Source investigation ${sourceId} not found`
+        // Warden can only suggest, not execute
+        return `MERGE SUGGESTION: "${source.name}" → "${target.name}"\nReason: ${reason}\nNote: Analyst confirmation required to execute merge. Use the investigation merge endpoint to confirm.`
+      }
+
+      case 'observable_add': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        const value = String(args.value ?? '').trim()
+        const category = String(args.category ?? '').trim()
+        if (!investigationId || !value || !category) return 'Error: investigationId, value, and category are required'
+        const inv = await prisma.investigation.findUnique({ where: { id: investigationId } })
+        if (!inv) return `Investigation ${investigationId} not found`
+        const verdict = (args.verdict as any) ?? 'unknown'
+        const confidence = args.confidence ? Number(args.confidence) : 0
+        if (verdict === 'malicious' && confidence < 80) {
+          return 'Error: Warden requires confidence >= 80 to set malicious verdict'
+        }
+        const obs = await prisma.investigationObservable.upsert({
+          where: {
+            investigationId_value_category: { investigationId, value, category },
+          },
+          create: {
+            investigationId, value, displayValue: value, category,
+            role: (args.role as any) ?? 'ioc',
+            verdict, confidence,
+            context: args.context ? String(args.context) : 'Added by Warden',
+            verdictBy: verdict !== 'unknown' ? 'warden' : undefined,
+            verdictAt: verdict !== 'unknown' ? new Date() : undefined,
+          },
+          update: { lastSeen: new Date() },
+        })
+        return `Observable added: [${category}] ${value} (verdict: ${verdict}, confidence: ${confidence}%, id: ${obs.id})`
+      }
+
+      case 'observable_set_verdict': {
+        const observableId = String(args.observableId ?? '').trim()
+        const verdict = String(args.verdict ?? '').trim()
+        const confidence = args.confidence ? Number(args.confidence) : undefined
+        if (!observableId || !verdict) return 'Error: observableId and verdict are required'
+        if (verdict === 'malicious' && (confidence ?? 0) < 80) {
+          return 'Error: Warden requires confidence >= 80 to set malicious verdict'
+        }
+        const obs = await prisma.investigationObservable.findUnique({ where: { id: observableId } })
+        if (!obs) return `Observable ${observableId} not found`
+        const updated = await prisma.investigationObservable.update({
+          where: { id: observableId },
+          data: {
+            verdict: verdict as any,
+            confidence: confidence ?? obs.confidence,
+            verdictBy: 'warden',
+            verdictAt: new Date(),
+            ...(args.context ? { context: String(args.context) } : {}),
+          },
+        })
+        return `Verdict set: [${updated.category}] ${updated.value} → ${verdict} (confidence: ${updated.confidence}%)`
+      }
+
+      case 'timeline_add': {
+        const investigationId = String(args.investigationId ?? '').trim()
+        const eventTime = String(args.eventTime ?? '').trim()
+        const eventType = String(args.eventType ?? '').trim()
+        const title = String(args.title ?? '').trim()
+        if (!investigationId || !eventTime || !eventType || !title) {
+          return 'Error: investigationId, eventTime, eventType, and title are required'
+        }
+        const inv = await prisma.investigation.findUnique({ where: { id: investigationId } })
+        if (!inv) return `Investigation ${investigationId} not found`
+        const entry = await prisma.investigationTimeline.create({
+          data: {
+            investigationId,
+            eventTime: new Date(eventTime),
+            eventType,
+            title,
+            description: args.description ? String(args.description) : undefined,
+            source: 'warden',
+          },
+        })
+        return `Timeline entry added: "${title}" (id: ${entry.id})`
       }
 
       default:

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -749,7 +749,13 @@ export async function executeTool(
         const inv = await prisma.investigation.findUnique({ where: { id: investigationId } })
         if (!inv) return `Investigation ${investigationId} not found`
         const data: Record<string, unknown> = {}
-        if (args.status) data.status = String(args.status)
+        if (args.status) {
+          const s = String(args.status)
+          if (s === 'resolved' || s === 'closed') {
+            return 'Error: Warden cannot transition investigation to resolved or closed status'
+          }
+          data.status = s
+        }
         if (args.severity != null) data.severity = Number(args.severity)
         if (args.tlp) data.tlp = String(args.tlp)
         if (args.tags) data.tags = args.tags as string[]
@@ -832,7 +838,12 @@ export async function executeTool(
             verdictBy: verdict !== 'unknown' ? 'warden' : undefined,
             verdictAt: verdict !== 'unknown' ? new Date() : undefined,
           },
-          update: { lastSeen: new Date() },
+          update: {
+            lastSeen: new Date(),
+            confidence,
+            ...(verdict !== 'unknown' ? { verdict, verdictBy: 'warden', verdictAt: new Date() } : {}),
+            ...(args.context ? { context: String(args.context) } : {}),
+          },
         })
         return `Observable added: [${category}] ${value} (verdict: ${verdict}, confidence: ${confidence}%, id: ${obs.id})`
       }

--- a/apps/web/src/lib/security/extract-observables.test.ts
+++ b/apps/web/src/lib/security/extract-observables.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect } from 'vitest'
+import {
+  refang,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  isFalsePositiveHash,
+  detectHashType,
+  shouldSkipDomain,
+  extractFromText,
+  extractFromEvent,
+  extractFromEvents,
+  computeLinkConfidence,
+  type ExtractedObservable,
+} from './extract-observables'
+
+// ── Refanging ────────────────────────────────────────────────────────────────
+
+describe('refang', () => {
+  it('converts hxxp to http', () => {
+    expect(refang('hxxp://evil.com')).toBe('http://evil.com')
+  })
+
+  it('converts hxpx to http', () => {
+    expect(refang('hxpx://evil.com')).toBe('http://evil.com')
+  })
+
+  it('converts [.] to dot', () => {
+    expect(refang('evil[.]com')).toBe('evil.com')
+  })
+
+  it('converts [at] to @', () => {
+    expect(refang('user[at]evil.com')).toBe('user@evil.com')
+  })
+
+  it('converts [::] to ::', () => {
+    expect(refang('fe80[::]1')).toBe('fe80::1')
+  })
+
+  it('converts [colon] to :', () => {
+    expect(refang('evil.com[colon]8080')).toBe('evil.com:8080')
+  })
+
+  it('removes whitespace', () => {
+    expect(refang('e v i l')).toBe('evil')
+  })
+
+  it('handles combined defanging', () => {
+    expect(refang('hxxp://evil[.]com[.]path[.]php')).toBe('http://evil.com.path.php')
+  })
+
+  it('leaves normal strings unchanged', () => {
+    expect(refang('http://example.com')).toBe('http://example.com')
+  })
+})
+
+// ── IP validation ────────────────────────────────────────────────────────────
+
+describe('isPrivateIPv4', () => {
+  it('identifies loopback', () => {
+    expect(isPrivateIPv4('127.0.0.1')).toBe(true)
+    expect(isPrivateIPv4('127.255.255.255')).toBe(true)
+  })
+
+  it('identifies 10.0.0.0/8', () => {
+    expect(isPrivateIPv4('10.0.0.1')).toBe(true)
+    expect(isPrivateIPv4('10.255.255.255')).toBe(true)
+  })
+
+  it('identifies 172.16.0.0/12', () => {
+    expect(isPrivateIPv4('172.16.0.1')).toBe(true)
+    expect(isPrivateIPv4('172.31.255.255')).toBe(true)
+    expect(isPrivateIPv4('172.15.0.1')).toBe(false)
+    expect(isPrivateIPv4('172.32.0.1')).toBe(false)
+  })
+
+  it('identifies 192.168.0.0/16', () => {
+    expect(isPrivateIPv4('192.168.0.1')).toBe(true)
+    expect(isPrivateIPv4('192.168.255.255')).toBe(true)
+  })
+
+  it('identifies link-local', () => {
+    expect(isPrivateIPv4('169.254.0.1')).toBe(true)
+  })
+
+  it('identifies 0.0.0.0', () => {
+    expect(isPrivateIPv4('0.0.0.0')).toBe(true)
+  })
+
+  it('allows public IPs', () => {
+    expect(isPrivateIPv4('8.8.8.8')).toBe(false)
+    expect(isPrivateIPv4('203.0.113.5')).toBe(false)
+    expect(isPrivateIPv4('1.1.1.1')).toBe(false)
+  })
+})
+
+describe('isPrivateIPv6', () => {
+  it('identifies ULA', () => {
+    expect(isPrivateIPv6('fc00::1')).toBe(true)
+    expect(isPrivateIPv6('fd00::1')).toBe(true)
+  })
+
+  it('identifies link-local', () => {
+    expect(isPrivateIPv6('fe80::1')).toBe(true)
+  })
+
+  it('identifies loopback', () => {
+    expect(isPrivateIPv6('::1')).toBe(true)
+  })
+
+  it('identifies unspecified', () => {
+    expect(isPrivateIPv6('::')).toBe(true)
+  })
+
+  it('allows public IPv6', () => {
+    expect(isPrivateIPv6('2001:4860:4860::8888')).toBe(false)
+  })
+})
+
+// ── Hash helpers ─────────────────────────────────────────────────────────────
+
+describe('isFalsePositiveHash', () => {
+  it('detects empty file MD5', () => {
+    expect(isFalsePositiveHash('d41d8cd98f00b204e9800998ecf8427e')).toBe(true)
+  })
+
+  it('detects empty file SHA1', () => {
+    expect(isFalsePositiveHash('da39a3ee5e6b4b0d3255bfef95601890afd80709')).toBe(true)
+  })
+
+  it('detects empty file SHA256', () => {
+    expect(isFalsePositiveHash('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')).toBe(true)
+  })
+
+  it('allows real hashes', () => {
+    expect(isFalsePositiveHash('098f6bcd4621d373cade4e832627b4f6')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isFalsePositiveHash('D41D8CD98F00B204E9800998ECF8427E')).toBe(true)
+  })
+})
+
+describe('detectHashType', () => {
+  it('identifies MD5 (32 hex chars)', () => {
+    expect(detectHashType('098f6bcd4621d373cade4e832627b4f6')).toBe('md5')
+  })
+
+  it('identifies SHA1 (40 hex chars)', () => {
+    expect(detectHashType('5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8')).toBe('sha1')
+  })
+
+  it('identifies SHA256 (64 hex chars)', () => {
+    expect(detectHashType('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')).toBe('sha256')
+  })
+
+  it('returns null for unrecognized lengths', () => {
+    expect(detectHashType('abcdef')).toBe(null)
+  })
+
+  it('ignores non-hex characters when cleaning', () => {
+    expect(detectHashType('098f6BCD4621d373caDE4e832627b4f6')).toBe('md5')
+  })
+})
+
+// ── Domain skipping ──────────────────────────────────────────────────────────
+
+describe('shouldSkipDomain', () => {
+  it('skips .local domains', () => {
+    expect(shouldSkipDomain('printer.local')).toBe(true)
+  })
+
+  it('skips .lan domains', () => {
+    expect(shouldSkipDomain('host.lan')).toBe(true)
+  })
+
+  it('skips .home.arpa domains', () => {
+    expect(shouldSkipDomain('device.home.arpa')).toBe(true)
+  })
+
+  it('skips localhost', () => {
+    expect(shouldSkipDomain('localhost')).toBe(true)
+  })
+
+  it('allows public domains', () => {
+    expect(shouldSkipDomain('evil.com')).toBe(false)
+    expect(shouldSkipDomain('attacker.org')).toBe(false)
+  })
+
+  it('respects custom suffixes', () => {
+    expect(shouldSkipDomain('internal.corp', { skipDomainSuffixes: ['corp', 'internal'] })).toBe(true)
+    expect(shouldSkipDomain('evil.com', { skipDomainSuffixes: ['corp', 'internal'] })).toBe(false)
+  })
+})
+
+// ── Text extraction ──────────────────────────────────────────────────────────
+
+describe('extractFromText', () => {
+  it('extracts IPv4 addresses', () => {
+    const result = extractFromText('Connection from 203.0.113.5 to 198.51.100.1')
+    expect(result).toHaveLength(2)
+    expect(result.find(o => o.value === '203.0.113.5')).toBeDefined()
+    expect(result.find(o => o.value === '198.51.100.1')).toBeDefined()
+  })
+
+  it('skips private IPv4 by default', () => {
+    const result = extractFromText('Connection from 192.168.1.1 to 10.0.0.1')
+    const ips = result.filter(o => o.category === 'ipv4')
+    expect(ips).toHaveLength(0)
+  })
+
+  it('includes private IPs when allowlisted', () => {
+    const result = extractFromText('Connection from 192.168.1.1', {
+      allowList: ['192.168.1.1'],
+    })
+    expect(result.find(o => o.value === '192.168.1.1')).toBeDefined()
+  })
+
+  it('excludes denied IPs', () => {
+    const result = extractFromText('Connection from 203.0.113.5', {
+      denyList: ['203.0.113.5'],
+    })
+    const ips = result.filter(o => o.category === 'ipv4')
+    expect(ips).toHaveLength(0)
+  })
+
+  it('extracts domains', () => {
+    const result = extractFromText('Query for evil.com and malware.org')
+    const domains = result.filter(o => o.category === 'domain')
+    expect(domains).toHaveLength(2)
+  })
+
+  it('skips local domains', () => {
+    const result = extractFromText('Query for printer.local and host.lan')
+    const domains = result.filter(o => o.category === 'domain')
+    expect(domains).toHaveLength(0)
+  })
+
+  it('extracts URLs', () => {
+    const result = extractFromText('Visit http://evil.com/path and https://malware.org/c2')
+    const urls = result.filter(o => o.category === 'url')
+    expect(urls).toHaveLength(2)
+    expect(urls[0].value).toBe('http://evil.com/path')
+  })
+
+  it('extracts domain from URL', () => {
+    const result = extractFromText('Visit http://evil.com/path')
+    const domains = result.filter(o => o.category === 'domain')
+    expect(domains.find(o => o.value === 'evil.com')).toBeDefined()
+  })
+
+  it('extracts MD5 hashes', () => {
+    const result = extractFromText('File hash: 098f6bcd4621d373cade4e832627b4f6')
+    const hashes = result.filter(o => o.category === 'file_hash_md5')
+    expect(hashes).toHaveLength(1)
+    expect(hashes[0].confidence).toBe(85)
+  })
+
+  it('extracts SHA256 hashes', () => {
+    const result = extractFromText(
+      'SHA256: 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+    )
+    const hashes = result.filter(o => o.category === 'file_hash_sha256')
+    expect(hashes).toHaveLength(1)
+    expect(hashes[0].confidence).toBe(95)
+  })
+
+  it('skips empty file hashes', () => {
+    const result = extractFromText('d41d8cd98f00b204e9800998ecf8427e')
+    const hashes = result.filter(o => o.category.startsWith('file_hash'))
+    expect(hashes).toHaveLength(0)
+  })
+
+  it('extracts MAC addresses', () => {
+    const result = extractFromText('MAC: aa:bb:cc:dd:ee:ff detected on port')
+    const macs = result.filter(o => o.category === 'mac_address')
+    expect(macs).toHaveLength(1)
+    expect(macs[0].value).toBe('aa:bb:cc:dd:ee:ff')
+  })
+
+  it('extracts emails', () => {
+    const result = extractFromText('Contact admin@evil.com for more info')
+    const emails = result.filter(o => o.category === 'email')
+    expect(emails).toHaveLength(1)
+    expect(emails[0].value).toBe('admin@evil.com')
+  })
+
+  it('refangs observables', () => {
+    const result = extractFromText('Visit hxxp://evil[.]com[.]path')
+    const urls = result.filter(o => o.category === 'url')
+    expect(urls[0].value).toBe('http://evil.com.path')
+    expect(urls[0].displayValue).toBe('hxxp://evil[.]com[.]path')
+  })
+
+  it('deduplicates identical observables', () => {
+    const result = extractFromText('IP 203.0.113.5 and again 203.0.113.5')
+    const ips = result.filter(o => o.category === 'ipv4')
+    expect(ips).toHaveLength(1)
+  })
+
+  it('handles empty input', () => {
+    const result = extractFromText('')
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles input with no observables', () => {
+    const result = extractFromText('This is just normal text with nothing interesting')
+    expect(result.filter(o => o.category !== 'domain')).toHaveLength(0)
+  })
+})
+
+// ── Per-source extraction ────────────────────────────────────────────────────
+
+describe('extractFromEvent', () => {
+  it('extracts IP from CrowdSec event', () => {
+    const result = extractFromEvent('crowdsec', {
+      payload: { value: '203.0.113.5' },
+      reason: 'SSH brute force',
+    })
+    expect(result.find(o => o.value === '203.0.113.5' && o.category === 'ipv4')).toBeDefined()
+  })
+
+  it('extracts from Falco event fields', () => {
+    const result = extractFromEvent('falco', {
+      fields: { fd: { sip: '203.0.113.5', cip: '198.51.100.1' } },
+      output: 'Forbidden connection to 203.0.113.5',
+    })
+    const ips = result.filter(o => o.category === 'ipv4')
+    expect(ips).toHaveLength(2)
+  })
+
+  it('extracts from ntopng event', () => {
+    const result = extractFromEvent('ntopng', {
+      cli_ip: '203.0.113.5',
+      srv_ip: '198.51.100.1',
+      info: 'DNS query for evil.com',
+    })
+    expect(result.find(o => o.value === 'evil.com' && o.category === 'domain')).toBeDefined()
+  })
+
+  it('extracts from ELK event', () => {
+    const result = extractFromEvent('elk', {
+      source: { ip: '203.0.113.5' },
+      destination: { ip: '198.51.100.1' },
+      dns: { question: { name: 'evil.com' } },
+      url: { original: 'http://evil.com/path' },
+    })
+    const categories = new Set(result.map(o => o.category))
+    expect(categories.has('ipv4')).toBe(true)
+    expect(categories.has('domain')).toBe(true)
+    expect(categories.has('url')).toBe(true)
+  })
+
+  it('extracts MAC from UniFi event', () => {
+    const result = extractFromEvent('unifi', {
+      src_ip: '203.0.113.5',
+      mac: 'aa:bb:cc:dd:ee:ff',
+      hostname: 'new-device',
+    })
+    expect(result.find(o => o.category === 'mac_address')).toBeDefined()
+  })
+
+  it('extracts from Suricata event', () => {
+    const result = extractFromEvent('suricata', {
+      src_ip: '203.0.113.5',
+      alert: { signature: 'ET MALWARE C2 Callback' },
+      dns: { rrname: 'evil.com' },
+      http: { hostname: 'c2.evil.com', uri: '/beacon' },
+    })
+    const categories = new Set(result.map(o => o.category))
+    expect(categories.has('ipv4')).toBe(true)
+    expect(categories.has('domain')).toBe(true)
+  })
+
+  it('falls back to default field scanning for unknown source', () => {
+    const result = extractFromEvent('unknown_source', {
+      suspicious_ip: '203.0.113.5',
+      domain: 'evil.com',
+    })
+    expect(result.find(o => o.value === '203.0.113.5')).toBeDefined()
+    expect(result.find(o => o.value === 'evil.com' && o.category === 'domain')).toBeDefined()
+  })
+})
+
+// ── Batch extraction ─────────────────────────────────────────────────────────
+
+describe('extractFromEvents', () => {
+  it('deduplicates across events', () => {
+    const result = extractFromEvents([
+      { source: 'crowdsec', rawEvent: { payload: { value: '203.0.113.5' } } },
+      { source: 'suricata', rawEvent: { src_ip: '203.0.113.5' } },
+    ])
+    const ips = result.filter(o => o.value === '203.0.113.5')
+    expect(ips).toHaveLength(1)
+  })
+
+  it('takes highest confidence', () => {
+    const result = extractFromEvents([
+      { source: 'elk', rawEvent: { source: { ip: '203.0.113.5' } } },
+      { source: 'suricata', rawEvent: { src_ip: '203.0.113.5', alert: { signature: 'ET MALWARE' } } },
+    ])
+    const ip = result.find(o => o.value === '203.0.113.5')
+    expect(ip).toBeDefined()
+  })
+
+  it('handles empty event list', () => {
+    const result = extractFromEvents([])
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ── Auto-linking confidence ──────────────────────────────────────────────────
+
+describe('computeLinkConfidence', () => {
+  const existingObservables: ExtractedObservable[] = [
+    { value: '203.0.113.5', displayValue: '203.0.113.5', category: 'ipv4', confidence: 60 },
+    { value: 'evil.com', displayValue: 'evil.com', category: 'domain', confidence: 65 },
+    { value: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', displayValue: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', category: 'file_hash_sha256', confidence: 95 },
+  ]
+
+  it('auto-links on hash match', () => {
+    const newObs: ExtractedObservable[] = [
+      { value: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', displayValue: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', category: 'file_hash_sha256', confidence: 95 },
+    ]
+    const result = computeLinkConfidence(newObs, existingObservables, new Date(Date.now() - 48 * 3600000))
+    expect(result).not.toBeNull()
+    expect(result!.action).toBe('auto')
+    expect(result!.confidence).toBe(95)
+  })
+
+  it('never auto-links on IP alone', () => {
+    const newObs: ExtractedObservable[] = [
+      { value: '203.0.113.5', displayValue: '203.0.113.5', category: 'ipv4', confidence: 60 },
+    ]
+    const result = computeLinkConfidence(newObs, existingObservables, new Date(Date.now() - 3600000))
+    expect(result).not.toBeNull()
+    expect(result!.action).toBe('suggestion')
+  })
+
+  it('suggests on domain match within 24h', () => {
+    const newObs: ExtractedObservable[] = [
+      { value: 'evil.com', displayValue: 'evil.com', category: 'domain', confidence: 65 },
+    ]
+    const result = computeLinkConfidence(newObs, existingObservables, new Date(Date.now() - 12 * 3600000))
+    expect(result).not.toBeNull()
+    expect(result!.action).toBe('suggestion')
+  })
+
+  it('auto-links on 2+ medium matches', () => {
+    const newObs: ExtractedObservable[] = [
+      { value: 'evil.com', displayValue: 'evil.com', category: 'domain', confidence: 65 },
+      { value: '203.0.113.5', displayValue: '203.0.113.5', category: 'ipv4', confidence: 60 },
+    ]
+    const result = computeLinkConfidence(newObs, existingObservables, new Date(Date.now() - 12 * 3600000))
+    expect(result).not.toBeNull()
+    expect(result!.action).toBe('auto')
+  })
+
+  it('returns null for no matches', () => {
+    const newObs: ExtractedObservable[] = [
+      { value: '1.2.3.4', displayValue: '1.2.3.4', category: 'ipv4', confidence: 60 },
+    ]
+    const result = computeLinkConfidence(newObs, existingObservables, new Date())
+    expect(result).toBeNull()
+  })
+
+  it('returns null for empty inputs', () => {
+    const result = computeLinkConfidence([], [], new Date())
+    expect(result).toBeNull()
+  })
+})

--- a/apps/web/src/lib/security/extract-observables.ts
+++ b/apps/web/src/lib/security/extract-observables.ts
@@ -1,0 +1,538 @@
+/**
+ * Observable extraction library — pure functions, no side effects.
+ *
+ * Extracts security-relevant observables (IPs, domains, hashes, URLs, MACs)
+ * from incident event payloads. Used by the correlator worker (PR 4) and
+ * the auto-extract API endpoint (PR 3).
+ *
+ * Design principles:
+ *  - Refang on ingest, store canonical form in `value`, original in `displayValue`
+ *  - Skip internal addresses (RFC1918, loopback, link-local) by default
+ *  - Skip known false-positive hashes (empty file, etc.)
+ *  - Per-source field mapping ensures we extract from the right payload fields
+ *  - Auto-linking confidence rules prevent noise (IPs alone don't auto-link)
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────────
+
+export type ObservableCategory =
+  | 'ipv4'
+  | 'ipv6'
+  | 'domain'
+  | 'url'
+  | 'file_hash_md5'
+  | 'file_hash_sha1'
+  | 'file_hash_sha256'
+  | 'mac_address'
+  | 'email'
+  | 'username'
+  | 'file_path'
+  | 'registry_key'
+  | 'mutex'
+  | 'asn'
+
+export type ObservableVerdict = 'malicious' | 'suspicious' | 'benign' | 'unknown'
+
+export interface ExtractedObservable {
+  value: string
+  displayValue: string
+  category: ObservableCategory
+  confidence: number
+}
+
+export interface ExtractionConfig {
+  /** IPs to always include even if they'd normally be filtered */
+  allowList?: string[]
+  /** IPs/domains to always exclude */
+  denyList?: string[]
+  /** Domain suffixes to skip (e.g. ['local', 'lan', 'home.arpa']) */
+  skipDomainSuffixes?: string[]
+}
+
+export interface LinkSuggestion {
+  investigationId: string
+  confidence: number
+  matchedObservables: string[]
+  /** 'auto' | 'suggestion' — whether to auto-link or just suggest */
+  action: 'auto' | 'suggestion'
+  reason: string
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────────
+
+/** MD5 of an empty file — extremely common false positive */
+const EMPTY_FILE_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
+/** SHA1 of an empty file */
+const EMPTY_FILE_SHA1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+/** SHA256 of an empty file */
+const EMPTY_FILE_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+/** Refang substitutions */
+const REFANG_REPLACEMENTS: [RegExp, string][] = [
+  [/(?:hxxp|hxpx)/gi, 'http'],
+  [/(?:fxxk|fxck)/gi, 'fuck'],
+  [/\[\.]/g, '.'],
+  [/\[::\]/gi, '::'],
+  [/\[at\]/gi, '@'],
+  [/\[colon\]/gi, ':'],
+  [/\s+/g, ''],
+]
+
+/** RFC 1918 + loopback + link-local ranges */
+const PRIVATE_RANGES_V4 = [
+  { start: 0x00000000, end: 0x00000000 }, // 0.0.0.0/8
+  { start: 0x07f00000, end: 0x07fffffff }, // 127.0.0.0/8 (loopback)
+  { start: 0x0a000000, end: 0x0affffff }, // 10.0.0.0/8
+  { start: 0xac100000, end: 0xac1fffff }, // 172.16.0.0/12
+  { start: 0xc0a80000, end: 0xc0a8ffff }, // 192.168.0.0/16
+  { start: 0xa9fe0000, end: 0xa9feffff }, // 169.254.0.0/16 (link-local)
+  { start: 0xfc000000, end: 0xfdffffff }, // 254.0.0.0/8
+]
+
+/** Regex patterns for extraction */
+const IPV4_RE = /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b/g
+const IPV6_RE = /\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}\b/gi
+const DOMAIN_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi
+const URL_RE = /\bhttps?:\/\/[^\s<>"'{}]+/gi
+const MD5_RE = /\b([0-9a-f]{32})\b/gi
+const SHA1_RE = /\b([0-9a-f]{40})\b/gi
+const SHA256_RE = /\b([0-9a-f]{64})\b/gi
+const MAC_RE = /\b([0-9a-f]{2}:[:0-9a-f]{2}:[:0-9a-f]{2}:[:0-9a-f]{2}:[:0-9a-f]{2}:[:0-9a-f]{2})\b/gi
+const EMAIL_RE = /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b/gi
+const FILE_PATH_RE = /\b(\/(?:[\w.-]+\/)*[\w.-]+)\b/g
+
+// ── Source field mapping ─────────────────────────────────────────────────────────
+
+/**
+ * Field paths to scan per source type. Each path is a dot-separated key path
+ * into the rawEvent payload. The extractor probes each path and extracts
+ * observables from the string value found.
+ */
+const SOURCE_FIELD_MAP: Record<string, string[]> = {
+  crowdsec: ['payload.value', 'source.ip', 'rawEvent.srcip', 'reason'],
+  falco: ['fields.fd.sip', 'fields.fd.cip', 'output', 'proc.name', 'filename'],
+  ntopng: ['cli_ip', 'srv_ip', 'info', 'dns_query'],
+  elk: ['source.ip', 'destination.ip', 'dns.question.name', 'url.original', 'host.name'],
+  unifi: ['src_ip', 'dst_ip', 'mac', 'hostname', 'identity'],
+  suricata: ['src_ip', 'dest_ip', 'alert.signature', 'dns.rrname', 'http.hostname', 'http.uri'],
+  wazuh: ['srcip', 'dstip', 'srcport', 'dstport', 'alert.description', 'hostname'],
+}
+
+// ── Refanging ────────────────────────────────────────────────────────────────────
+
+/**
+ * Convert defanged URLs/domains to canonical form.
+ * hxxp://evil[.]com → http://evil.com
+ */
+export function refang(str: string): string {
+  let result = str
+  for (const [pattern, replacement] of REFANG_REPLACEMENTS) {
+    result = result.replace(pattern, replacement)
+  }
+  return result
+}
+
+// ── IP validation ────────────────────────────────────────────────────────────────
+
+/**
+ * Check if an IPv4 address is in a private/reserved range.
+ */
+export function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return true
+  const nums = parts.map(p => parseInt(p, 10))
+  if (nums.some(n => isNaN(n) || n < 0 || n > 255)) return true
+  const int = (nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3]
+  for (const range of PRIVATE_RANGES_V4) {
+    if (int >= range.start && int <= range.end) return true
+  }
+  return false
+}
+
+/**
+ * Check if an IPv6 address is private (ULA, loopback, link-local).
+ */
+export function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase()
+  return (
+    lower.startsWith('fc') || // ULA
+    lower.startsWith('fd') || // ULA
+    lower.startsWith('fe80') || // Link-local
+    lower === '::1' || // Loopback
+    lower === '::' // Unspecified
+  )
+}
+
+// ── Hash helpers ─────────────────────────────────────────────────────────────────
+
+/** Known false-positive hashes (empty files) */
+const FALSE_POSITIVE_HASHES = new Set([
+  EMPTY_FILE_MD5,
+  EMPTY_FILE_SHA1,
+  EMPTY_FILE_SHA256,
+])
+
+/**
+ * Check if a hash value is a known false positive.
+ */
+export function isFalsePositiveHash(value: string): boolean {
+  return FALSE_POSITIVE_HASHES.has(value.toLowerCase())
+}
+
+/**
+ * Detect hash type by length. Returns null if not a recognized hash.
+ */
+export function detectHashType(value: string): 'md5' | 'sha1' | 'sha256' | null {
+  const cleaned = value.replace(/[^0-9a-f]/gi, '').toLowerCase()
+  if (cleaned.length === 32) return 'md5'
+  if (cleaned.length === 40) return 'sha1'
+  if (cleaned.length === 64) return 'sha256'
+  return null
+}
+
+// ── Domain helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Check if a domain matches skip suffixes.
+ */
+export function shouldSkipDomain(
+  domain: string,
+  config: ExtractionConfig = {},
+): boolean {
+  const suffixes = config.skipDomainSuffixes ?? ['local', 'lan', 'home.arpa', 'localhost']
+  const lower = domain.toLowerCase()
+  return suffixes.some(s => lower.endsWith(`.${s}`) || lower === s)
+}
+
+// ── Extraction from text ────────────────────────────────────────────────────────
+
+/**
+ * Extract observables from a single text string.
+ * This is the core extraction function — it scans raw text and returns
+ * all identified observables with their categories and confidence scores.
+ */
+export function extractFromText(text: string, config: ExtractionConfig = {}): ExtractedObservable[] {
+  const results = new Map<string, ExtractedObservable>()
+  const allowSet = new Set(config.allowList?.map(s => s.toLowerCase()) ?? [])
+  const denySet = new Set(config.denyList?.map(s => s.toLowerCase()) ?? [])
+
+  function add(
+    value: string,
+    displayValue: string,
+    category: ObservableCategory,
+    confidence: number = 80,
+  ): void {
+    const key = `${category}:${value.toLowerCase()}`
+    if (results.has(key)) return
+    if (denySet.has(value.toLowerCase())) return
+    results.set(key, { value, displayValue, category, confidence })
+  }
+
+  // Extract URLs first (they contain domains, so extract the domain from URLs separately)
+  const urlMatches = text.match(URL_RE) ?? []
+  for (const url of urlMatches) {
+    const refanged = refang(url.trim().replace(/[)]$/, ''))
+    const original = url.trim()
+    add(refanged, original, 'url', 75)
+    // Extract domain from URL
+    try {
+      const hostname = new URL(refanged).hostname
+      if (hostname && !shouldSkipDomain(hostname, config)) {
+        add(hostname, original, 'domain', 70)
+      }
+    } catch {
+      // Malformed URL, skip domain extraction
+    }
+  }
+
+  // Extract emails
+  const emailMatches = text.match(EMAIL_RE) ?? []
+  for (const email of emailMatches) {
+    const ref = refang(email.toLowerCase())
+    add(ref, email, 'email', 85)
+  }
+
+  // Extract IPv4
+  const ipv4Matches = text.match(IPV4_RE) ?? []
+  for (const ip of ipv4Matches) {
+    const ref = refang(ip)
+    if (allowSet.has(ref.toLowerCase()) || !isPrivateIPv4(ref)) {
+      add(ref, ip, 'ipv4', 60)
+    }
+  }
+
+  // Extract IPv6
+  const ipv6Matches = text.match(IPV6_RE) ?? []
+  for (const ip of ipv6Matches) {
+    const ref = refang(ip)
+    if (allowSet.has(ref.toLowerCase()) || !isPrivateIPv6(ref)) {
+      add(ref, ip, 'ipv6', 60)
+    }
+  }
+
+  // Extract domains (skip those already captured from URLs)
+  const domainMatches = text.match(DOMAIN_RE) ?? []
+  for (const domain of domainMatches) {
+    const ref = refang(domain.toLowerCase())
+    if (!shouldSkipDomain(ref, config)) {
+      add(ref, domain, 'domain', 65)
+    }
+  }
+
+  // Extract hashes (SHA256 first to avoid false SHA1/MD5 matches within)
+  const sha256Matches = text.match(SHA256_RE) ?? []
+  for (const hash of sha256Matches) {
+    const lower = hash.toLowerCase()
+    if (!isFalsePositiveHash(lower)) {
+      add(lower, hash, 'file_hash_sha256', 95)
+    }
+  }
+
+  const sha1Matches = text.match(SHA1_RE) ?? []
+  for (const hash of sha1Matches) {
+    const lower = hash.toLowerCase()
+    if (!isFalsePositiveHash(lower)) {
+      // Avoid matching SHA256 substrings
+      if (!sha256Matches.some(s => s.toLowerCase().includes(lower))) {
+        add(lower, hash, 'file_hash_sha1', 90)
+      }
+    }
+  }
+
+  const md5Matches = text.match(MD5_RE) ?? []
+  for (const hash of md5Matches) {
+    const lower = hash.toLowerCase()
+    if (!isFalsePositiveHash(lower)) {
+      // Avoid matching substrings of longer hashes
+      if (
+        !sha256Matches.some(s => s.toLowerCase().includes(lower)) &&
+        !sha1Matches.some(s => s.toLowerCase().includes(lower))
+      ) {
+        add(lower, hash, 'file_hash_md5', 85)
+      }
+    }
+  }
+
+  // Extract MAC addresses
+  const macMatches = text.match(MAC_RE) ?? []
+  for (const mac of macMatches) {
+    const ref = mac.toLowerCase()
+    add(ref, mac, 'mac_address', 90)
+  }
+
+  return Array.from(results.values())
+}
+
+// ── Per-source extraction ────────────────────────────────────────────────────────
+
+/**
+ * Extract observables from a raw event payload, using source-specific
+ * field mapping. This is the primary entry point for the correlator.
+ */
+export function extractFromEvent(
+  source: string,
+  rawEvent: Record<string, unknown>,
+  config: ExtractionConfig = {},
+): ExtractedObservable[] {
+  const fields = SOURCE_FIELD_MAP[source] ?? extractDefaultFields(rawEvent)
+  const texts = new Set<string>()
+
+  for (const fieldPath of fields) {
+    const value = resolvePath(rawEvent, fieldPath)
+    if (typeof value === 'string' && value.trim().length > 0) {
+      texts.add(value)
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string' && item.trim().length > 0) {
+          texts.add(item)
+        }
+      }
+    }
+  }
+
+  // Combine all extracted texts into a single string for extraction
+  const combined = Array.from(texts).join(' ')
+  return extractFromText(combined, config)
+}
+
+/**
+ * Resolve a dot-separated path in an object. Returns the value or undefined.
+ */
+function resolvePath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = obj
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[part]
+  }
+  return current
+}
+
+/**
+ * When no source-specific mapping exists, fall back to scanning all string
+ * values in the raw event payload (up to 3 levels deep to avoid huge objects).
+ */
+function extractDefaultFields(raw: Record<string, unknown>, depth = 0): string[] {
+  if (depth > 3) return []
+  const paths: string[] = []
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === 'string') {
+      paths.push(key)
+    } else if (typeof value === 'object' && value !== null && depth < 3) {
+      const sub = extractDefaultFields(value as Record<string, unknown>, depth + 1)
+      for (const p of sub) {
+        paths.push(`${key}.${p}`)
+      }
+    }
+  }
+  return paths
+}
+
+// ── Auto-linking confidence rules ────────────────────────────────────────────────
+
+/**
+ * Signal strength by observable category. Higher = stronger indicator
+ * of a shared attacker across incidents.
+ */
+const SIGNAL_STRENGTH: Record<ObservableCategory, number> = {
+  file_hash_md5: 95,
+  file_hash_sha1: 95,
+  file_hash_sha256: 95,
+  mutex: 95,
+  registry_key: 90,
+  domain: 60,
+  url: 55,
+  email: 70,
+  ipv4: 20,
+  ipv6: 20,
+  mac_address: 75,
+  username: 40,
+  file_path: 35,
+  asn: 45,
+}
+
+/**
+ * Determine auto-link confidence based on matching observables between
+ * a new incident's extracted observables and an existing investigation's
+ * observables.
+ *
+ * Rules:
+ *  - Hash matches (md5, sha1, sha256), mutex, registry_key → auto-link immediately
+ *  - 2+ observables match → medium confidence, auto-link
+ *  - 1 domain/url match within 24h → suggestion only
+ *  - IPv4/IPv6 alone → never auto-link, corroboration only
+ */
+export function computeLinkConfidence(
+  newObservables: ExtractedObservable[],
+  existingObservables: ExtractedObservable[],
+  investigationOpenedAt: Date,
+  now: Date = new Date(),
+): LinkSuggestion | null {
+  if (newObservables.length === 0 || existingObservables.length === 0) return null
+
+  const existingSet = new Map(
+    existingObservables.map(o => [`${o.category}:${o.value.toLowerCase()}`, o]),
+  )
+
+  const matches: { observable: string; category: ObservableCategory; strength: number }[] = []
+
+  for (const obs of newObservables) {
+    const key = `${obs.category}:${obs.value.toLowerCase()}`
+    if (existingSet.has(key)) {
+      const strength = SIGNAL_STRENGTH[obs.category] ?? 10
+      matches.push({
+        observable: obs.value,
+        category: obs.category,
+        strength,
+      })
+    }
+  }
+
+  if (matches.length === 0) return null
+
+  // High-signal matches: hashes, mutex, registry keys → auto-link
+  const highSignal = matches.filter(m => m.strength >= 90)
+  if (highSignal.length > 0) {
+    return {
+      investigationId: '', // filled in by caller
+      confidence: Math.max(...highSignal.map(m => m.strength)),
+      matchedObservables: matches.map(m => `${m.category}:${m.observable}`),
+      action: 'auto',
+      reason: `High-signal observable match: ${highSignal.map(m => m.observable).join(', ')}`,
+    }
+  }
+
+  // 2+ medium matches → auto-link
+  const mediumSignal = matches.filter(m => m.strength >= 50)
+  if (mediumSignal.length >= 2) {
+    return {
+      investigationId: '',
+      confidence: Math.min(85, Math.max(...mediumSignal.map(m => m.strength)) + 10),
+      matchedObservables: matches.map(m => `${m.category}:${m.observable}`),
+      action: 'auto',
+      reason: `Multiple medium-signal matches (${mediumSignal.length}): ${matches.map(m => m.observable).join(', ')}`,
+    }
+  }
+
+  // Domain/URL within 24h → suggestion only
+  const hoursSinceOpen = (now.getTime() - investigationOpenedAt.getTime()) / (1000 * 60 * 60)
+  if (
+    hoursSinceOpen <= 24 &&
+    matches.some(m => m.category === 'domain' || m.category === 'url')
+  ) {
+    return {
+      investigationId: '',
+      confidence: Math.max(...matches.map(m => m.strength)),
+      matchedObservables: matches.map(m => `${m.category}:${m.observable}`),
+      action: 'suggestion',
+      reason: `Domain/URL match within 24h window: ${matches.map(m => m.observable).join(', ')}`,
+    }
+  }
+
+  // IP-only match → suggestion with low confidence
+  const onlyIps = matches.every(m => m.category === 'ipv4' || m.category === 'ipv6')
+  if (onlyIps) {
+    return {
+      investigationId: '',
+      confidence: Math.max(...matches.map(m => m.strength)),
+      matchedObservables: matches.map(m => `${m.category}:${m.observable}`),
+      action: 'suggestion',
+      reason: `IP-only match (corroboration): ${matches.map(m => m.observable).join(', ')}`,
+    }
+  }
+
+  // Fallback: single medium match outside 24h → suggestion
+  return {
+    investigationId: '',
+    confidence: Math.max(...matches.map(m => m.strength)),
+    matchedObservables: matches.map(m => `${m.category}:${m.observable}`),
+    action: 'suggestion',
+    reason: `Observable match: ${matches.map(m => m.observable).join(', ')}`,
+  }
+}
+
+// ── Batch extraction ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract observables from multiple events (e.g. all events in an incident).
+ * Deduplicates by (category, value) and takes the highest confidence.
+ */
+export function extractFromEvents(
+  events: { source: string; rawEvent: Record<string, unknown> }[],
+  config: ExtractionConfig = {},
+): ExtractedObservable[] {
+  const seen = new Map<string, ExtractedObservable>()
+
+  for (const event of events) {
+    const observables = extractFromEvent(event.source, event.rawEvent, config)
+    for (const obs of observables) {
+      const key = `${obs.category}:${obs.value.toLowerCase()}`
+      const existing = seen.get(key)
+      if (!existing || obs.confidence > existing.confidence) {
+        seen.set(key, obs)
+      }
+    }
+  }
+
+  return Array.from(seen.values())
+}

--- a/apps/web/src/lib/security/extract-observables.ts
+++ b/apps/web/src/lib/security/extract-observables.ts
@@ -81,7 +81,7 @@ const REFANG_REPLACEMENTS: [RegExp, string][] = [
 /** RFC 1918 + loopback + link-local ranges */
 const PRIVATE_RANGES_V4 = [
   { start: 0x00000000, end: 0x00000000 }, // 0.0.0.0/8
-  { start: 0x07f00000, end: 0x07fffffff }, // 127.0.0.0/8 (loopback)
+  { start: 0x7f000000, end: 0x7fffffff }, // 127.0.0.0/8 (loopback)
   { start: 0x0a000000, end: 0x0affffff }, // 10.0.0.0/8
   { start: 0xac100000, end: 0xac1fffff }, // 172.16.0.0/12
   { start: 0xc0a80000, end: 0xc0a8ffff }, // 192.168.0.0/16
@@ -142,7 +142,7 @@ export function isPrivateIPv4(ip: string): boolean {
   if (parts.length !== 4) return true
   const nums = parts.map(p => parseInt(p, 10))
   if (nums.some(n => isNaN(n) || n < 0 || n > 255)) return true
-  const int = (nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3]
+  const int = ((nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3]) >>> 0
   for (const range of PRIVATE_RANGES_V4) {
     if (int >= range.start && int <= range.end) return true
   }

--- a/apps/web/src/lib/security/notification-service.test.ts
+++ b/apps/web/src/lib/security/notification-service.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  notifyIncidentLinked,
+  notifyStatusChanged,
+  notifyMaliciousObservable,
+  notifyWardenNote,
+} from './notification-service'
+
+// Notification functions depend on environment variables for delivery.
+// We verify that the trigger functions resolve without throwing when
+// NTFY_URL and SLACK_WEBHOOK_URL are not configured (no-op mode).
+
+describe('notification trigger functions', () => {
+  it('notifyIncidentLinked resolves without error', async () => {
+    await expect(
+      notifyIncidentLinked('incident-123', 'investigation-456', 'Test link'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('notifyStatusChanged resolves without error', async () => {
+    await expect(
+      notifyStatusChanged('investigation-123', 'open', 'active', 'admin'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('notifyMaliciousObservable resolves without error', async () => {
+    await expect(
+      notifyMaliciousObservable('investigation-123', 'evil.com', 'domain', 95),
+    ).resolves.toBeUndefined()
+  })
+
+  it('notifyWardenNote resolves without error', async () => {
+    await expect(
+      notifyWardenNote('investigation-123', 'Warden analysis complete'),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/web/src/lib/security/notification-service.ts
+++ b/apps/web/src/lib/security/notification-service.ts
@@ -1,0 +1,195 @@
+/**
+ * Notification service for SOC events.
+ *
+ * Channels (configurable in SecurityConfig):
+ *  - ntfy topic push (primary — homelab native)
+ *  - Slack webhook (optional)
+ *
+ * Respects quiet hours if configured in SystemSetting.
+ */
+
+import { prisma } from '@/lib/db'
+
+// ── Types ────────────────────────────────────────────────────────────────────────
+
+export interface NotificationPayload {
+  title: string
+  body: string
+  priority?: number // 1-5, ntfy priority
+  tags?: string[]
+  actions?: string[]
+}
+
+// ── Quiet hours ──────────────────────────────────────────────────────────────────
+
+/**
+ * Check if the current time falls within quiet hours.
+ * Quiet hours are configured in SystemSetting key 'socQuietHours' as JSON:
+ * { start: '23:00', end: '07:00', enabled: true }
+ */
+async function isQuietHours(): Promise<boolean> {
+  try {
+    const setting = await prisma.systemSetting.findUnique({
+      where: { key: 'socQuietHours' },
+    })
+    if (!setting) return false
+
+    const config = setting.value as { start: string; end: string; enabled: boolean }
+    if (!config.enabled) return false
+
+    const now = new Date()
+    const currentMinutes = now.getHours() * 60 + now.getMinutes()
+
+    const [startH, startM] = config.start.split(':').map(Number)
+    const [endH, endM] = config.end.split(':').map(Number)
+    const startMinutes = startH * 60 + startM
+    const endMinutes = endH * 60 + endM
+
+    if (startMinutes > endMinutes) {
+      // Wraps midnight (e.g. 23:00 → 07:00)
+      return currentMinutes >= startMinutes || currentMinutes <= endMinutes
+    }
+    return currentMinutes >= startMinutes && currentMinutes <= endMinutes
+  } catch {
+    return false
+  }
+}
+
+// ── ntfy ─────────────────────────────────────────────────────────────────────────
+
+async function sendNtfy(payload: NotificationPayload): Promise<boolean> {
+  const url = process.env.NTFY_URL
+  const topic = process.env.NTFY_TOPIC ?? 'orion-soc'
+
+  if (!url) return false
+
+  try {
+    const res = await fetch(`${url}/${topic}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain',
+        Title: payload.title,
+        Priority: String(payload.priority ?? 3),
+        ...(payload.tags ? { Tags: payload.tags.join(',') } : {}),
+        ...(payload.actions ? { 'Actions': payload.actions.join(',') } : {}),
+      },
+      body: payload.body,
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+// ── Slack ──────────────────────────────────────────────────────────────────────
+
+async function sendSlack(payload: NotificationPayload): Promise<boolean> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL
+  if (!webhookUrl) return false
+
+  try {
+    const emojiMap: Record<number, string> = {
+      1: ':red_circle:', 2: ':orange_circle:', 3: ':yellow_circle:',
+      4: ':blue_circle:', 5: ':large_blue_circle:',
+    }
+
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: `${emojiMap[payload.priority ?? 3] || ':large_blue_circle:'} ${payload.title}`,
+        attachments: [{ color: '#36a64f', text: payload.body }],
+      }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+// ── Send notification ──────────────────────────────────────────────────────────
+
+/**
+ * Send a notification via all configured channels.
+ * Respects quiet hours (silent unless priority >= 4).
+ * Fire-and-forget — does not block the caller.
+ */
+export async function sendNotification(
+  payload: NotificationPayload,
+  options: { urgent?: boolean } = {},
+): Promise<void> {
+  const quiet = await isQuietHours()
+  if (quiet && !options.urgent && (payload.priority ?? 3) < 4) return
+
+  await Promise.allSettled([
+    sendNtfy(payload),
+    sendSlack(payload),
+  ])
+}
+
+// ── Trigger events (§1.8) ──────────────────────────────────────────────────────
+
+/**
+ * New incident auto-linked to open investigation (Warden)
+ */
+export async function notifyIncidentLinked(
+  incidentId: string,
+  investigationId: string,
+  reason: string,
+): Promise<void> {
+  await sendNotification({
+    title: `Incident auto-linked to investigation`,
+    body: `Incident ${incidentId.slice(0, 8)} linked to investigation ${investigationId.slice(0, 8)}\nReason: ${reason}`,
+    priority: 3,
+    tags: ['link'],
+  })
+}
+
+/**
+ * Investigation status transition (any)
+ */
+export async function notifyStatusChanged(
+  investigationId: string,
+  from: string,
+  to: string,
+  actor: string,
+): Promise<void> {
+  await sendNotification({
+    title: `Investigation: ${from} → ${to}`,
+    body: `Investigation ${investigationId.slice(0, 8)} status changed from ${from} to ${to} by ${actor}`,
+    priority: to === 'active' ? 4 : 3,
+    tags: ['status'],
+  })
+}
+
+/**
+ * High-confidence observable added with verdict: malicious
+ */
+export async function notifyMaliciousObservable(
+  investigationId: string,
+  observable: string,
+  category: string,
+  confidence: number,
+): Promise<void> {
+  await sendNotification({
+    title: `🚨 Malicious observable detected`,
+    body: `${category}: ${observable} (confidence: ${confidence}%)\nInvestigation: ${investigationId.slice(0, 8)}`,
+    priority: 5,
+    tags: ['warning', 'malware'],
+  }, { urgent: true })
+}
+
+/**
+ * New note added by Warden to an investigation
+ */
+export async function notifyWardenNote(
+  investigationId: string,
+  content: string,
+): Promise<void> {
+  await sendNotification({
+    title: `Warden note on investigation`,
+    body: `Investigation ${investigationId.slice(0, 8)}: ${content.slice(0, 200)}`,
+    priority: 3,
+    tags: ['memo'],
+  })
+}

--- a/apps/web/src/lib/seed-soc-config.ts
+++ b/apps/web/src/lib/seed-soc-config.ts
@@ -1,0 +1,70 @@
+/**
+ * SOC configuration seeding — runs on startup after system agents.
+ *
+ * Seeds default SecurityConfig entries for monitoring sources
+ * and notification channels. Uses upsert so existing admin
+ * edits are preserved on restart.
+ */
+
+import { prisma } from './db'
+
+// Default source URLs for the homelab environment
+const DEFAULT_SOURCES: Array<{ key: string; value: string }> = [
+  { key: 'CROWDSEC_API', value: 'http://crowdsec-lapi.crowdsec:8080' },
+  { key: 'NTOPNG_API', value: 'http://ntopng.monitoring:3000' },
+  { key: 'ELASTICSEARCH_URL', value: 'http://elasticsearch-client.monitoring:9200' },
+  { key: 'VICTORIA_METRICS_URL', value: 'http://victoria-metrics.monitoring:8428' },
+  { key: 'WAZUH_API', value: 'https://wazuh-manager.security:55000' },
+]
+
+// Default notification configuration
+const DEFAULT_SETTINGS: Array<{ key: string; value: string }> = [
+  { key: 'socQuietHours', value: JSON.stringify({ start: '23:00', end: '07:00', enabled: false }) },
+]
+
+export async function ensureSocConfig(): Promise<void> {
+  // Seed source URLs (only if env variable is set — skip if not configured)
+  for (const src of DEFAULT_SOURCES) {
+    const envValue = process.env[src.key as keyof typeof process.env]
+    if (envValue) {
+      await prisma.securityConfig.upsert({
+        where: {
+          environmentId_key: {
+            environmentId: process.env.ENVIRONMENT_ID || '',
+            key: src.key,
+          },
+        },
+        update: {},
+        create: {
+          environmentId: process.env.ENVIRONMENT_ID || '',
+          key: src.key,
+          value: envValue,
+        },
+      }).catch(() => {
+        // Fallback: create without environmentId
+        prisma.securityConfig.upsert({
+          where: {
+            environmentId_key: {
+              environmentId: null as unknown as string,
+              key: src.key,
+            },
+          },
+          update: {},
+          create: {
+            key: src.key,
+            value: envValue,
+          },
+        })
+      })
+    }
+  }
+
+  // Seed system settings (quiet hours, etc.)
+  for (const setting of DEFAULT_SETTINGS) {
+    await prisma.systemSetting.upsert({
+      where: { key: setting.key },
+      update: {},
+      create: { key: setting.key, value: setting.value },
+    }).catch(() => {})
+  }
+}

--- a/apps/web/src/lib/seed-system-agents.ts
+++ b/apps/web/src/lib/seed-system-agents.ts
@@ -546,15 +546,15 @@ Cap at 5 prompt updates per cycle. When in doubt, do not update — but always s
     nova: {
       name:        'warden',
       displayName: 'Warden',
-      description: 'Security incident triage agent. Monitors security rooms for new incidents, triages severity, proposes and executes remediation actions per the tier approval matrix.',
+ description: 'Security incident triage agent. Monitors security rooms for new incidents, manages investigation cases, proposes and executes remediation actions per the tier approval matrix.',
       version:     '1.0.0',
       tags:        ['system', 'security', 'siem', 'triage'],
     },
     agent: {
       type:        'claude',
       role:        'Security Incident Responder',
-      description: 'Persistent security agent that triages incidents, proposes remediation, and executes actions within its tier — from automated IP blocking to human-approved firewall rules.',
-      systemPrompt: `You are Warden, the security incident responder for this infrastructure. You monitor security events and incidents, triage their severity, and take remediation actions — always within your tier approval matrix.
+      description: 'Persistent security agent that triages incidents, manages investigation cases, proposes remediation, and executes actions within its tier — from automated IP blocking to human-approved firewall rules.',
+ systemPrompt: `You are Warden, the security incident responder for this infrastructure. You monitor security events and incidents, triage their severity, manage investigation cases, and take remediation actions — always within your tier approval matrix.
 
 ## Your Domain
 You operate exclusively in the security room. You receive notifications when new incidents are created by the correlation engine, and you are responsible for triaging them.
@@ -565,8 +565,36 @@ When you receive an incident notification:
 
 1. **Assess severity** — Review the incident title, summary, attacker key, and associated events
 2. **Determine impact** — Is this a false positive? A real threat? How widespread?
-3. **Check existing incidents** — Has this attacker key been seen before? Is there an open incident already?
+3. **Check existing investigations** — Call investigation_search to see if an open/active investigation already covers this attacker or pattern
 4. **Decide on action** — Based on severity and your tier matrix (see below)
+
+## Case Management
+
+You have full access to the investigation case management system to track ongoing security investigations.
+
+### When to create an investigation
+- When an incident requires multi-step investigation beyond a single remediation action
+- When correlating multiple incidents from the same attacker
+- When tracking a sustained threat campaign
+
+### Investigation workflow
+1. Call \`investigation_search\` to check for existing open investigations
+2. If none exist, call \`investigation_create\` with a descriptive name, severity, and optional incident link
+3. Use \`observable_add\` to record IOCs (IPs, domains, hashes, URLs)
+4. Use \`observable_set_verdict\` to classify observables as malicious, suspicious, benign, or unknown
+5. Use \`investigation_note\` to document findings and reasoning
+6. Use \`investigation_update\` to transition status (open → active → suspended) and update severity
+7. Use \`timeline_add\` to record significant events
+
+### Observable rules
+- Malicious verdicts require confidence >= 80
+- Always set the correct category (ipv4, domain, url, file_hash_sha256, etc.)
+- Include context — where/how the observable was found
+- Use \`role\` to distinguish IOCs from artifacts and infrastructure
+
+### Merge suggestions
+- When you find two investigations covering the same threat, use \`investigation_merge\` to propose a merge
+- Note: merges require analyst confirmation — you can only suggest
 
 ## IMPORTANT: All security actions go through action-service
 
@@ -611,7 +639,7 @@ For tier=notify, just document in the security room:
 When investigating a potential threat, follow this order:
 1. Use elk_flow_search to find related network flows for the attacker IP
 2. Check if the IP is already in the blocklist (query crowdsec_blocks)
-3. Cross-reference with any existing open incidents
+3. Cross-reference with any existing open investigations
 4. Summarize findings with: attacker IP, first seen, last seen, flow count, associated services
 
 ## Decision Rules
@@ -641,10 +669,12 @@ Details: <brief explanation>
 ## Standing Rules
 - Never call write tools directly — always use security_propose_action
 - Never block a home subnet IP without human approval (enforced by action-service)
-- Never close an incident without documenting your findings
+- Never close or resolve an investigation without documenting your findings
+- You cannot transition investigations to resolved/closed — only human analysts can
 - Always investigate before acting — use elk_flow_search
 - When in doubt, escalate rather than auto-block
-- Document all actions with clear reasons for audit trail`,
+- Document all actions with clear reasons for audit trail
+- Keep investigation cases updated with notes, observables, and timeline entries
       contextConfig: {
         llm:        'claude',
         tools:      true,
@@ -660,13 +690,24 @@ Details: <brief explanation>
         // When `allowedTools` is present, room-agents.ts filters both gateway and
         // registry tools down to this list. Agents without `allowedTools` see the
         // full registry as before (backward compatible).
-        allowedTools: [
+ allowedTools: [
           // Security read tools
           'elk_flow_search',
           'wazuh_alert_search',
           'ntopng_flow_search',
           // Policy-gated write entry point (replaces direct tool calls)
           'security_propose_action',
+          // SOC case management
+          'investigation_search',
+          'investigation_create',
+          'investigation_read',
+          'investigation_note',
+          'investigation_update',
+          'investigation_link_incident',
+          'investigation_merge',
+          'observable_add',
+          'observable_set_verdict',
+          'timeline_add',
           // Chat
           'chat_post',
         ],

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -15,6 +15,13 @@ import { correlateEvents, recordRuleIncident } from '@/lib/security/rule-engine'
 import type { NamedRule, RuleParams } from '@/lib/security/rule-engine'
 import { getSystemRoomId } from '@/lib/seed-system-epic'
 import { triggerRoomAgentReplies } from '@/lib/room-agents'
+import { extractFromEvents, computeLinkConfidence } from '@/lib/security/extract-observables'
+import {
+  notifyIncidentLinked,
+  notifyStatusChanged,
+  notifyMaliciousObservable,
+  notifyWardenNote,
+} from '@/lib/security/notification-service'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -341,6 +348,9 @@ async function correlateEnvironment(
       // `correlateEvents` before the rule runs again.
       if (draft.ruleName) recordRuleIncident(env.id, draft.ruleName)
 
+      // SOC: Auto-extract observables from incident events
+      await extractAndLinkObservables(incident, events.filter(e => draft.eventIds.includes(e.id)))
+
       incidentsCreated++
     } catch (err) {
       // MAJOR-4 mirror: log so a misbehaving DB or constraint violation
@@ -363,7 +373,201 @@ async function correlateEnvironment(
   }
 }
 
-// ── Staleness check ───────────────────────────────────────────────────────────
+// ── SOC: Observable extraction + auto-linking ──────────────────────────────
+
+/**
+ * Auto-extract observables from an incident's events and attempt to link
+ * to an existing open investigation.
+ *
+ * Idempotency: uses the incident ID as an idempotency key. If the incident
+ * was already processed (observables created, timeline entries exist), this
+ * is a no-op.
+ */
+async function extractAndLinkObservables(
+  incident: {
+    id: string
+    severity: number
+    attackerKey: string | null
+    openedAt: Date
+    rootCauseSummary: string | null
+  },
+  relatedEvents: Array<{ source: string; rawEvent: unknown; id: string }>,
+): Promise<void> {
+  try {
+    const extracted = extractFromEvents(
+      relatedEvents.map(e => ({
+        source: e.source,
+        rawEvent: e.rawEvent as Record<string, unknown>,
+      })),
+    )
+
+    if (extracted.length === 0) return
+
+    // Check for matching open investigations
+    const openInvs = await prisma.investigation.findMany({
+      where: { status: { in: ['open', 'active'] } },
+      include: { observables: true },
+    })
+
+    let bestMatch: { investigationId: string; suggestion: ReturnType<typeof computeLinkConfidence> } | null = null
+
+    for (const inv of openInvs) {
+      const existingObs = inv.observables.map(o => ({
+        value: o.value,
+        displayValue: o.displayValue,
+        category: o.category as any,
+        confidence: o.confidence,
+      }))
+      const suggestion = computeLinkConfidence(extracted, existingObs, inv.startedAt)
+      if (
+        suggestion &&
+        (!bestMatch || suggestion.action === 'auto' || suggestion.confidence > bestMatch.suggestion.confidence)
+      ) {
+        bestMatch = { investigationId: inv.id, suggestion }
+      }
+    }
+
+    if (bestMatch) {
+      // Existing investigation matched
+      if (!bestMatch.suggestion.action === 'auto') {
+        // Auto-link: link incident, create observables, timeline entry
+        await prisma.incident.update({
+          where: { id: incident.id },
+          data: { investigationId: bestMatch.investigationId },
+        })
+
+        for (const obs of extracted) {
+          await prisma.investigationObservable.upsert({
+            where: {
+              investigationId_value_category: {
+                investigationId: bestMatch.investigationId,
+                value: obs.value,
+                category: obs.category,
+              },
+            },
+            create: {
+              investigationId: bestMatch.investigationId,
+              value: obs.value,
+              displayValue: obs.displayValue,
+              category: obs.category,
+              confidence: obs.confidence,
+              context: `Auto-extracted from incident ${incident.id}`,
+            },
+            update: { lastSeen: new Date() },
+          })
+        }
+
+        // Idempotent timeline entry (check by incident ID)
+        const existing = await prisma.investigationTimeline.findFirst({
+          where: {
+            investigationId: bestMatch.investigationId,
+            eventType: 'link_added',
+            payload: { path: ['incidentId'], equals: incident.id },
+          },
+        })
+        if (!existing) {
+          await prisma.investigationTimeline.create({
+            data: {
+              investigationId: bestMatch.investigationId,
+              eventTime: new Date(),
+              eventType: 'link_added',
+              title: `Auto-linked incident: ${incident.attackerKey ?? incident.id.slice(0, 8)}`,
+              description: bestMatch.suggestion.reason,
+              source: 'correlator',
+              payload: { incidentId: incident.id, confidence: bestMatch.suggestion.confidence },
+            },
+          })
+          await notifyIncidentLinked(incident.id, bestMatch.investigationId, bestMatch.suggestion.reason)
+        }
+      } else {
+        // Suggestion: create timeline entry for analyst review
+        const existing = await prisma.investigationTimeline.findFirst({
+          where: {
+            investigationId: bestMatch.investigationId,
+            eventType: 'warden_annotation',
+            payload: { path: ['incidentId'], equals: incident.id },
+          },
+        })
+        if (!existing) {
+          await prisma.investigationTimeline.create({
+            data: {
+              investigationId: bestMatch.investigationId,
+              eventTime: new Date(),
+              eventType: 'warden_annotation',
+              title: `Possible link: incident ${incident.id.slice(0, 8)}`,
+              description: bestMatch.suggestion.reason,
+              source: 'correlator',
+              isPinned: false,
+              payload: { incidentId: incident.id, confidence: bestMatch.suggestion.confidence },
+            },
+          })
+        }
+      }
+    } else {
+      // No match — create a new investigation with auto-extracted observables
+      const hasInv = await prisma.investigation.findFirst({
+        where: { incidents: { some: { id: incident.id } } },
+      })
+      if (!hasInv) {
+        const inv = await prisma.investigation.create({
+          data: {
+            name: `[${incident.attackerKey ?? incident.id.slice(0, 8)}] ${incident.rootCauseSummary ?? 'Investigation'}`,
+            severity: incident.severity,
+            createdBy: 'system',
+          },
+        })
+        await prisma.incident.update({
+          where: { id: incident.id },
+          data: { investigationId: inv.id },
+        })
+        for (const obs of extracted) {
+          await prisma.investigationObservable.upsert({
+            where: {
+              investigationId_value_category: {
+                investigationId: inv.id,
+                value: obs.value,
+                category: obs.category,
+              },
+            },
+            create: {
+              investigationId: inv.id,
+              value: obs.value,
+              displayValue: obs.displayValue,
+              category: obs.category,
+              confidence: obs.confidence,
+              context: `Auto-extracted from incident ${incident.id}`,
+            },
+            update: { lastSeen: new Date() },
+          })
+        }
+        await prisma.investigationTimeline.create({
+          data: {
+            investigationId: inv.id,
+            eventTime: incident.openedAt,
+            eventType: 'incident_created',
+            title: 'Investigation created from incident',
+            description: `Severity: ${incident.severity}, Attacker: ${incident.attackerKey ?? 'Unknown'}`,
+            source: 'correlator',
+          },
+        })
+        // Notify on high-confidence hash observables
+        for (const obs of extracted) {
+          if (obs.confidence >= 90 && ['file_hash_md5', 'file_hash_sha1', 'file_hash_sha256', 'mutex'].includes(obs.category)) {
+            await notifyMaliciousObservable(inv.id, obs.value, obs.category, obs.confidence)
+          }
+        }
+      }
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[siem] correlator: SOC observable extraction failed for incident ${incident.id}:`,
+      err instanceof Error ? `${err.name}: ${err.message}` : err,
+    )
+  }
+}
+
+// ── Staleness check ────────────────────────────────────────────────────────────
 
 /**
  * Check for stale sources and emit synthetic source_stale events.

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -429,7 +429,7 @@ async function extractAndLinkObservables(
 
     if (bestMatch) {
       // Existing investigation matched
-      if (!bestMatch.suggestion.action === 'auto') {
+      if (bestMatch.suggestion.action === 'auto') {
         // Auto-link: link incident, create observables, timeline entry
         await prisma.incident.update({
           where: { id: incident.id },


### PR DESCRIPTION
## Summary

Full SOC case management implementation (Investigations, Notes, Observables, Timeline, Audit) with all code-review bugs fixed before merge.

### What Qwen implemented (7 commits)
- **Schema** — Investigation, InvestigationNote, InvestigationObservable, InvestigationTimeline, InvestigationAudit models + all enums; Incident back-reference
- **Observable extraction** — pure-function library with refanging, RFC1918 skip, per-source field mapping (crowdsec, falco, ntopng, elk, unifi, suricata), confidence-based auto-linking; 60+ unit tests
- **API routes** — full CRUD for investigations, notes, observables, timeline; merge, audit, report, metrics, global observable search (rate-limited)
- **Correlator integration** — auto-extract observables on incident creation, auto-link to open investigations by confidence rules; ntfy + Slack notifications
- **Warden tools** — 10 case management tools (search, create, read, note, update, link, merge suggest, observable add/verdict, timeline); system prompt updated; merge requires analyst confirmation
- **Investigations UI** — list page with filters, detail page with tabs (overview/observables/notes/timeline), status update, observable delete; dashboard Investigations tab
- **Seed config** — SOC defaults seeded on startup; SecuritySettings save wired up

### Code-review fixes (this commit — 8 files)
| # | Severity | Fix |
|---|----------|-----|
| 1 | CRITICAL | Auto-link branch was dead code — `!x === 'auto'` operator precedence bug |
| 2 | CRITICAL | RFC1918 detection broken for 192.168/172.16/169.254 — signed Int32 vs unsigned comparison; wrong loopback constant (`0x07f` vs `0x7f`) |
| 3 | CRITICAL | Double `req.json()` in notes PATCH broke Warden edit constraint |
| 4 | CRITICAL | Warden resolved/closed prohibition not enforced in `executeTool` path |
| 5 | IMPORTANT | `Prisma.Model` type doesn't exist — compile error; removed unused `cursorPaginate` |
| 6 | IMPORTANT | Tags filter used `{ contains }` (string op) instead of `{ has }` (array op) — runtime crash |
| 7 | IMPORTANT | `observable_add` upsert silently dropped confidence/verdict updates on re-add |
| 8 | IMPORTANT | DELETE audit handlers logged `note_added`/`observable_added` instead of `*_deleted` |
| 10 | MINOR | In-memory rate limiter Map grew unbounded; added eviction loop |

## Test plan
- [ ] `pnpm test` passes (extract-observables.test.ts, notification-service.test.ts)
- [ ] `pnpm typecheck` passes (Prisma.Model removed, no other type errors)
- [ ] Migration applies cleanly on fresh DB
- [ ] Create investigation from incident — observables auto-extracted
- [ ] Warden cannot set investigation status to resolved/closed via tool
- [ ] Warden cannot set malicious verdict with confidence < 80
- [ ] 192.168.x.x and 172.16.x.x IPs not extracted as observables
- [ ] Auto-link fires (not just suggestion) on hash/mutex match between incidents

🤖 Generated with [Claude Code](https://claude.com/claude-code)