### PR TITLE
fix(schema): add @relation to Incident.investigation — unbreaks build

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -966,7 +966,7 @@ model Incident {
   events           SecurityEvent[]
   actionAudits     ActionAudit[]
   chatMessages     ChatMessage[]
-  investigation    Investigation?
+  investigation    Investigation?  @relation(fields: [investigationId], references: [id], onDelete: SetNull)
   investigationId  String? // Soft back-reference to investigation case
 
   @@index([environmentId, status])


### PR DESCRIPTION
## Summary

- `prisma generate` was failing with P1012 after #457 merged
- `Incident.investigation` relation field was missing the required `fields` and `references` arguments
- Fix: `@relation(fields: [investigationId], references: [id], onDelete: SetNull)`

Cherry-picked from `feat-soc-warden` onto clean main — no conflicts.

## Test plan
- [ ] Build ORION Web passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)