### PR TITLE
fix(soc): rename [incidentId] route segment to [id]

### DIFF
--- a/apps/web/src/app/api/monitoring/security/incidents/[id]/create-investigation/route.ts
+++ b/apps/web/src/app/api/monitoring/security/incidents/[id]/create-investigation/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/security/incidents/[incidentId]/create-investigation
+ * POST /api/security/incidents/[id]/create-investigation
  *
  * One-click create investigation from incident detail.
  * Pre-populates name, severity, links the incident, auto-extracts observables.
@@ -11,8 +11,8 @@ import { extractFromEvents } from '@/lib/security/extract-observables'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request, { params }: { params: { incidentId: string } }) {
-  const incidentId = (await params).incidentId
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  const incidentId = (await params).id
 
   const incident = await prisma.incident.findUnique({
     where: { id: incidentId },


### PR DESCRIPTION
## Summary
- Renames `incidents/[incidentId]/create-investigation/` → `incidents/[id]/create-investigation/`
- Next.js requires all dynamic segments at the same directory level to use the same slug name; mixing `[incidentId]` and `[id]` caused a build failure
- The handler logic is unchanged — only `params.incidentId` → `params.id`

## Test plan
- [ ] `npm run build` passes with no slug conflict errors
- [ ] `POST /api/monitoring/security/incidents/:id/create-investigation` returns 201 and creates investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)