### PR TITLE
fix(soc): resolve TypeScript errors in SOC case management routes

### DIFF
--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
@@ -43,6 +43,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   const tx = await prisma.$transaction(async (tx) => {
     // 1. Move all incidents from source to target
+    const sourceIncidentCount = await tx.incident.count({ where: { investigationId: sourceId } })
     await tx.incident.updateMany({
       where: { investigationId: sourceId },
       data: { investigationId: targetId },
@@ -60,6 +61,10 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     })
 
     for (const obs of sourceObservables) {
+      const existing = await tx.investigationObservable.findUnique({
+        where: { investigationId_value_category: { investigationId: targetId, value: obs.value, category: obs.category } },
+        select: { confidence: true },
+      })
       await tx.investigationObservable.upsert({
         where: {
           investigationId_value_category: {
@@ -84,11 +89,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
           verdictAt: obs.verdictAt,
         },
         update: {
-          confidence: {
-            set: Math.max(obs.confidence, (await tx.investigationObservable.findUnique({
-              where: { investigationId_value_category: { investigationId: targetId, value: obs.value, category: obs.category } },
-            })?.confidence ?? 0)),
-          },
+          confidence: { set: Math.max(obs.confidence, existing?.confidence ?? 0) },
           lastSeen: new Date(),
         },
       })
@@ -108,7 +109,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
           description: entry.description,
           source: entry.source,
           isPinned: entry.isPinned,
-          payload: entry.payload,
+          payload: entry.payload ?? undefined,
         },
       })
     }
@@ -130,7 +131,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
         investigationId: targetId, eventTime: new Date(),
         eventType: 'merge_target',
         title: `Merged investigation: ${source.name}`,
-        description: `${source.incidents.length} incidents, ${sourceObservables.length} observables, ${sourceTimeline.length} timeline entries`,
+        description: `${sourceIncidentCount} incidents, ${sourceObservables.length} observables, ${sourceTimeline.length} timeline entries`,
         source: 'manual',
       },
     })

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
@@ -59,7 +59,7 @@ export async function DELETE(_req: Request, { params }: { params: { id: string; 
   }
 
   await prisma.investigationNote.delete({ where: { id: noteId } })
-  await recordAudit(id, 'admin', 'human', 'note_deleted', { noteId }, null)
+  await recordAudit(id, 'admin', 'human', 'note_deleted', { noteId }, undefined)
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
@@ -81,7 +81,7 @@ export async function DELETE(_req: Request, { params }: { params: { id: string; 
   }
 
   await prisma.investigationObservable.delete({ where: { id: obsId } })
-  await recordAudit(id, 'admin', 'human', 'observable_deleted', { observableId: obsId }, null)
+  await recordAudit(id, 'admin', 'human', 'observable_deleted', { observableId: obsId }, undefined)
 
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
@@ -36,7 +36,7 @@ function applyWardenConstraints(
 ): Record<string, unknown> {
   if (actor !== 'warden') return data
   const clean = { ...data }
-  if (clean.status && !WARDEN_ALLOWED_STATUS.has(clean.status)) {
+  if (clean.status && !WARDEN_ALLOWED_STATUS.has(clean.status as string)) {
     throw new Error('Warden cannot transition investigation to resolved or closed')
   }
   delete clean.resolutionType

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       ...body.data,
       investigationId: id,
       eventTime: new Date(body.data.eventTime),
+      payload: (body.data.payload ?? undefined) as import('@prisma/client').Prisma.InputJsonValue | undefined,
     },
   })
 

--- a/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/_utils.ts
@@ -2,6 +2,7 @@
  * Shared utilities for investigation API routes.
  */
 
+import { type Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 
 /**

--- a/apps/web/src/lib/agent-tools.ts
+++ b/apps/web/src/lib/agent-tools.ts
@@ -817,7 +817,7 @@ export async function executeTool(
       case 'observable_add': {
         const investigationId = String(args.investigationId ?? '').trim()
         const value = String(args.value ?? '').trim()
-        const category = String(args.category ?? '').trim()
+        const category = String(args.category ?? '').trim() as import('@prisma/client').ObservableCategory
         if (!investigationId || !value || !category) return 'Error: investigationId, value, and category are required'
         const inv = await prisma.investigation.findUnique({ where: { id: investigationId } })
         if (!inv) return `Investigation ${investigationId} not found`

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -409,7 +409,7 @@ async function extractAndLinkObservables(
       include: { observables: true },
     })
 
-    let bestMatch: { investigationId: string; suggestion: ReturnType<typeof computeLinkConfidence> } | null = null
+    let bestMatch: { investigationId: string; suggestion: NonNullable<ReturnType<typeof computeLinkConfidence>> } | null = null
 
     for (const inv of openInvs) {
       const existingObs = inv.observables.map(o => ({


### PR DESCRIPTION
## Summary
Fixes all TypeScript errors that blocked the production build after the SOC case management code landed on main.

- **`_utils.ts`**: restore `Prisma` namespace import removed in an earlier fix (needed for `InputJsonValue` cast in `recordAudit`)
- **`merge/route.ts`**: count incidents via `tx.incident.count()` before the `updateMany` (can't read `.incidents` directly on an `Investigation`); extract `findUnique` before `upsert` so `await` resolves before `.confidence` is accessed; use `payload ?? undefined` to avoid `null` JSON type mismatch
- **`notes/[noteId]/route.ts`** & **`observables/[obsId]/route.ts`**: pass `undefined` instead of `null` to `recordAudit` `after` parameter
- **`route.ts`**: cast `clean.status` to `string` for `Set.has()` (value is `unknown`)
- **`timeline/route.ts`**: cast zod `payload` to `Prisma.InputJsonValue` to satisfy Prisma's JSON input type
- **`agent-tools.ts`**: cast `category` string to `ObservableCategory` enum
- **`security-correlator.ts`**: type `bestMatch.suggestion` as `NonNullable<ReturnType<typeof computeLinkConfidence>>` — the null is already excluded by the truthiness guard but TS couldn't see it

## Test plan
- [ ] `npx tsc --noEmit` passes locally (verified ✓)
- [ ] `npm run build` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)