### PR TITLE
feat: expose context window token state via API + SSE

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/route.ts
@@ -76,6 +76,8 @@ export async function GET(
     taskId: room.taskId ?? null,
     featureId: room.featureId ?? null,
     epicId: room.epicId ?? null,
+    tokenCount: room.tokenCount,
+    tokenLimit: room.tokenLimit ?? null,
     createdAt: room.createdAt.toISOString(),
     updatedAt: room.updatedAt.toISOString(),
     members, messages,

--- a/apps/web/src/lib/chat-redis.ts
+++ b/apps/web/src/lib/chat-redis.ts
@@ -79,6 +79,32 @@ async function initRedisClient(): Promise<boolean> {
 }
 
 /**
+ * Publish a raw payload to a room's Redis channel for real-time SSE delivery.
+ * Gracefully degrades if Redis is unavailable.
+ */
+export async function publishToRoom(
+  roomId: string,
+  payload: any,
+): Promise<void> {
+  if (!redisAvailable) {
+    const ok = await initRedisClient()
+    if (!ok) return
+  }
+
+  if (!redisPubClient) return
+
+  try {
+    const channel = `chat:room:${roomId}`
+    const payloadStr = JSON.stringify(payload)
+    await redisPubClient.publish(channel, payloadStr)
+  } catch (error) {
+    console.error(`[chat-redis] Failed to publish to ${roomId}:`, error)
+    redisAvailable = false
+    redisPubClient = null
+  }
+}
+
+/**
  * Publish a chat message to Redis for real-time delivery.
  * Called after message is saved to PostgreSQL.
  */
@@ -86,22 +112,7 @@ export async function publishChatMessage(
   roomId: string,
   message: any,
 ): Promise<void> {
-  if (!redisAvailable) {
-    const ok = await initRedisClient()
-    if (!ok) return // Graceful degradation if Redis unavailable
-  }
-
-  if (!redisPubClient) return
-
-  try {
-    const channel = `chat:room:${roomId}`
-    const payload = JSON.stringify(message)
-    await redisPubClient.publish(channel, payload)
-  } catch (error) {
-    console.error(`[chat-redis] Failed to publish message to ${roomId}:`, error)
-    redisAvailable = false
-    redisPubClient = null
-  }
+  await publishToRoom(roomId, message)
 }
 
 /**

--- a/apps/web/src/lib/compaction.ts
+++ b/apps/web/src/lib/compaction.ts
@@ -16,7 +16,7 @@
  */
 
 import { prisma } from './db'
-import { publishChatMessage } from './chat-redis'
+import { publishChatMessage, publishToRoom } from './chat-redis'
 
 // ── Concurrency guard ─────────────────────────────────────────────────────────
 // Prevents two simultaneous compactions for the same room (e.g. two agents both
@@ -245,5 +245,23 @@ export async function publishCompactionWarning(
     attachments: { type: 'compaction-warning', percentage: pct, tokenCount, tokenLimit },
     sender:      { type: 'system', id: null, name: 'System' },
     createdAt:   msg.createdAt instanceof Date ? msg.createdAt.toISOString() : msg.createdAt,
+  })
+}
+
+/**
+ * Publish an ephemeral token update via SSE.
+ * Does NOT write to the database — pure real-time signal for the UI.
+ */
+export async function publishTokenUpdate(
+  roomId: string,
+  tokenCount: number,
+  tokenLimit: number,
+): Promise<void> {
+  const percentage = tokenLimit > 0 ? Math.round((tokenCount / tokenLimit) * 100) : 0
+  await publishToRoom(roomId, {
+    type: 'token-update',
+    tokenCount,
+    tokenLimit,
+    percentage,
   })
 }

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -21,7 +21,7 @@ import { getToolsForContext, executeRegisteredTool } from './tool-registry'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
 import { buildAgentContext, buildAgentLocalContext, buildRoomLocalContext, invalidateSnapshotCache, getModelContextLimit } from './agent-context'
-import { compactRoom, publishCompactionWarning } from './compaction'
+import { compactRoom, publishCompactionWarning, publishTokenUpdate } from './compaction'
 import { getPrompt } from './system-prompts'
 import type { AgentGateway } from './agent-gateway'
 import type { GatewayTool } from './agent-runner/types'
@@ -1017,6 +1017,7 @@ export async function triggerRoomAgentReplies(
               await publishCompactionWarning(roomId, pct, currentTokenCount, effectiveLimit).catch(() => null)
             }
           }
+          await publishTokenUpdate(roomId, currentTokenCount, effectiveLimit)
         }
       }
     } catch (e) {

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -1017,7 +1017,7 @@ export async function triggerRoomAgentReplies(
               await publishCompactionWarning(roomId, pct, currentTokenCount, effectiveLimit).catch(() => null)
             }
           }
-          await publishTokenUpdate(roomId, currentTokenCount, effectiveLimit)
+          await publishTokenUpdate(roomId, currentTokenCount, effectiveLimit).catch(() => null)
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- Extract `publishToRoom()` helper from `publishChatMessage` in `chat-redis.ts`
- Add `publishTokenUpdate()` to `compaction.ts` — ephemeral Redis publish, no DB write
- Call it in `room-agents.ts` after every LLM turn and after compaction resets count to 0
- Add `tokenCount` + `tokenLimit` to GET `/api/chatrooms/[id]` response

## Test plan
- [ ] `curl /api/chatrooms/{id}` includes `tokenCount` (int) and `tokenLimit` (int | null)
- [ ] Send a message in a room; `token-update` SSE event fires after agent responds
- [ ] After compaction, `token-update` fires with `tokenCount: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)