### PR TITLE
feat: context window utilization bar UI in RoomChat

### DIFF
--- a/apps/web/src/components/messages/ContextWindowBar.tsx
+++ b/apps/web/src/components/messages/ContextWindowBar.tsx
@@ -17,7 +17,16 @@ function fmt(n: number): string {
 export default function ContextWindowBar({ tokenCount, tokenLimit, onCompact }: Props) {
   const [expanded, setExpanded] = useState(false)
 
-  if (!tokenLimit) return null
+  if (!tokenLimit) {
+    if (!tokenCount) return null
+    return (
+      <div className="px-4 py-1.5 border-b border-border-subtle flex-shrink-0">
+        <span className="text-[10px] text-text-muted tabular-nums">
+          {fmt(tokenCount)} tokens used
+        </span>
+      </div>
+    )
+  }
 
   const pct = Math.min(100, Math.round((tokenCount / tokenLimit) * 100))
   const remaining = tokenLimit - tokenCount

--- a/apps/web/src/components/messages/ContextWindowBar.tsx
+++ b/apps/web/src/components/messages/ContextWindowBar.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  tokenCount: number
+  tokenLimit: number | null
+  onCompact?: () => void
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export default function ContextWindowBar({ tokenCount, tokenLimit, onCompact }: Props) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!tokenLimit) return null
+
+  const pct = Math.min(100, Math.round((tokenCount / tokenLimit) * 100))
+  const remaining = tokenLimit - tokenCount
+  const autoCompactAt = Math.round(tokenLimit * 0.9)
+
+  const barColor =
+    pct >= 90 ? 'bg-status-error' :
+    pct >= 70 ? 'bg-status-warning' :
+    'bg-status-healthy'
+
+  return (
+    <div className="px-4 py-1.5 border-b border-border-subtle flex-shrink-0">
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="w-full text-left"
+        aria-label={`Context window: ${pct}% used`}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex-1 h-1.5 rounded-full bg-bg-raised overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="text-[10px] text-text-muted tabular-nums whitespace-nowrap">
+            {fmt(tokenCount)} / {fmt(tokenLimit)} · {pct}%
+          </span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="mt-2 text-[11px] text-text-muted space-y-1 pb-1">
+          <div className="flex justify-between">
+            <span>Used</span>
+            <span className="tabular-nums">{fmt(tokenCount)} tokens</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Remaining</span>
+            <span className="tabular-nums">{fmt(remaining)} tokens</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Limit</span>
+            <span className="tabular-nums">{fmt(tokenLimit)} tokens</span>
+          </div>
+          <div className="flex justify-between opacity-60">
+            <span>Auto-compacts at 90%</span>
+            <span className="tabular-nums">{fmt(autoCompactAt)}</span>
+          </div>
+          {pct >= 60 && onCompact && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onCompact() }}
+              className="mt-1 w-full text-center py-1 rounded bg-bg-raised hover:bg-bg-sidebar text-text-muted text-[11px] transition-colors"
+            >
+              Compact Now
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -201,7 +201,6 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
             return
           }
 
-          // Handle token update events
           if (message.type === 'token-update') {
             setTokenState({ count: message.tokenCount, limit: message.tokenLimit })
             return
@@ -432,6 +431,13 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
     } catch { /* ignore */ }
   }, [room, roomId, loadRoom])
 
+  const handleCompact = useCallback(async () => {
+    try {
+      await fetch(`/api/chatrooms/${roomId}/compact`, { method: 'POST' })
+      await loadRoom()
+    } catch { /* ignore */ }
+  }, [roomId, loadRoom])
+
   // Filter invite list by search
   const filteredUsers = inviteUsers.filter(u =>
     !inviteSearch || (u.name || u.username || '').toLowerCase().includes(inviteSearch.toLowerCase())
@@ -570,6 +576,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
       <ContextWindowBar
         tokenCount={tokenState.count}
         tokenLimit={tokenState.limit}
+        onCompact={handleCompact}
       />
 
       {/* Messages */}

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect, useCallback, useRef } from 'react'
+import ContextWindowBar from '@/components/messages/ContextWindowBar'
 import {
   Users, Bot, User as UserIcon,
   Hash, Send, X, Loader2, Plus, LogOut, AtSign, BookmarkCheck, Terminal, Layers,
@@ -108,6 +109,10 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   const [showCompleteGoal, setShowCompleteGoal] = useState(false)
   const [goalSummaryInput, setGoalSummaryInput] = useState('')
   const [completingGoal, setCompletingGoal] = useState(false)
+  const [tokenState, setTokenState] = useState<{ count: number; limit: number | null }>({
+    count: 0,
+    limit: null,
+  })
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
@@ -154,6 +159,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
       const res = await fetch(`/api/chatrooms/${roomId}?messages=${limit ?? messageLimit}`)
       const detail = await res.json()
       setRoom(detail)
+      setTokenState({ count: detail.tokenCount ?? 0, limit: detail.tokenLimit ?? null })
     } catch { /* ignore */ }
     setLoading(false)
   }, [roomId, messageLimit])
@@ -192,6 +198,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           // Skip the initial "connected" message
           if (message.type === 'connected') {
             console.log('[RoomChat] SSE connected for room', roomId)
+            return
+          }
+
+          // Handle token update events
+          if (message.type === 'token-update') {
+            setTokenState({ count: message.tokenCount, limit: message.tokenLimit })
             return
           }
 
@@ -553,6 +565,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           )}
         </div>
       )}
+
+      {/* Context window bar */}
+      <ContextWindowBar
+        tokenCount={tokenState.count}
+        tokenLimit={tokenState.limit}
+      />
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 space-y-3">

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -987,7 +987,12 @@ export async function triggerRoomAgentReplies(
         const effectiveLimit = roomTokenLimit ?? (discoveredContextLimit > 0 ? discoveredContextLimit : 0)
         await prisma.chatRoom.update({
           where: { id: roomId },
-          data: { tokenCount: currentTokenCount, updatedAt: new Date() },
+          data: {
+            tokenCount: currentTokenCount,
+            updatedAt: new Date(),
+            // Cache auto-discovered limit so GET route can return it without re-querying the model
+            ...(room.tokenLimit === null && effectiveLimit > 0 ? { tokenLimit: effectiveLimit } : {}),
+          },
         })
         if (effectiveLimit > 0) {
           const pct = currentTokenCount / effectiveLimit


### PR DESCRIPTION
## Summary

- New `ContextWindowBar.tsx` component: persistent bar below room header showing real-time token utilization
- `RoomChat.tsx`: initialise token state from API response, handle `token-update` SSE events, render bar
- Green → amber (≥70%) → red (≥90%) color thresholds with click-to-expand detail card
- Compact Now button wired to POST `/api/chatrooms/[id]/compact`
- Persists auto-discovered `effectiveLimit` to `tokenLimit` in DB on first agent turn so subsequent page loads show the full progress bar
- Degraded state (`X tokens used`) shown when limit is not yet known but token count exists

## Depends on
#463 (merged) — backend SSE `token-update` events + `tokenCount`/`tokenLimit` in GET response

## Test plan
- [ ] Load a room with prior history → bar shows `N tokens used` (degraded state)
- [ ] Send a message → after agent responds, bar updates to full progress bar with percentage
- [ ] Click bar → detail card shows used / remaining / limit / auto-compact threshold
- [ ] At ≥70% usage → bar turns amber; at ≥90% → red
- [ ] Compact Now button fires compact API → bar resets to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)