### PR TITLE
fix: optional chain room?.tokenLimit to satisfy TS null check

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -991,7 +991,7 @@ export async function triggerRoomAgentReplies(
             tokenCount: currentTokenCount,
             updatedAt: new Date(),
             // Cache auto-discovered limit so GET route can return it without re-querying the model
-            ...(room.tokenLimit === null && effectiveLimit > 0 ? { tokenLimit: effectiveLimit } : {}),
+            ...(room?.tokenLimit === null && effectiveLimit > 0 ? { tokenLimit: effectiveLimit } : {}),
           },
         })
         if (effectiveLimit > 0) {


### PR DESCRIPTION
## Summary

Build failure after merging #465 — TypeScript strict null check rejected `room.tokenLimit` because `room` is typed as possibly `null` at that point in `room-agents.ts`.

One-character fix: `room.tokenLimit` → `room?.tokenLimit`. Optional chaining returns `undefined` when room is null, which correctly falls through to the falsy branch and skips the tokenLimit cache write.

## Test plan
- [ ] `npm run build:web` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)