### PR TITLE
feat: move context window bar inline to room header

### DIFF
--- a/apps/web/src/components/messages/ContextWindowBar.tsx
+++ b/apps/web/src/components/messages/ContextWindowBar.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useState } from 'react'
-
 interface Props {
   tokenCount: number
   tokenLimit: number | null
@@ -15,22 +13,17 @@ function fmt(n: number): string {
 }
 
 export default function ContextWindowBar({ tokenCount, tokenLimit, onCompact }: Props) {
-  const [expanded, setExpanded] = useState(false)
-
   if (!tokenLimit) {
     if (!tokenCount) return null
     return (
-      <div className="px-4 py-1.5 border-b border-border-subtle flex-shrink-0">
-        <span className="text-[10px] text-text-muted tabular-nums">
-          {fmt(tokenCount)} tokens used
-        </span>
-      </div>
+      <span className="text-[10px] text-text-muted tabular-nums flex-shrink-0">
+        {fmt(tokenCount)} tokens
+      </span>
     )
   }
 
   const pct = Math.min(100, Math.round((tokenCount / tokenLimit) * 100))
   const remaining = tokenLimit - tokenCount
-  const autoCompactAt = Math.round(tokenLimit * 0.9)
 
   const barColor =
     pct >= 90 ? 'bg-status-error' :
@@ -38,52 +31,27 @@ export default function ContextWindowBar({ tokenCount, tokenLimit, onCompact }: 
     'bg-status-healthy'
 
   return (
-    <div className="px-4 py-1.5 border-b border-border-subtle flex-shrink-0">
-      <button
-        onClick={() => setExpanded(v => !v)}
-        className="w-full text-left"
-        aria-label={`Context window: ${pct}% used`}
-      >
-        <div className="flex items-center gap-2">
-          <div className="flex-1 h-1.5 rounded-full bg-bg-raised overflow-hidden">
-            <div
-              className={`h-full rounded-full transition-all duration-500 ${barColor}`}
-              style={{ width: `${pct}%` }}
-            />
-          </div>
-          <span className="text-[10px] text-text-muted tabular-nums whitespace-nowrap">
-            {fmt(tokenCount)} / {fmt(tokenLimit)} · {pct}%
-          </span>
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="mt-2 text-[11px] text-text-muted space-y-1 pb-1">
-          <div className="flex justify-between">
-            <span>Used</span>
-            <span className="tabular-nums">{fmt(tokenCount)} tokens</span>
-          </div>
-          <div className="flex justify-between">
-            <span>Remaining</span>
-            <span className="tabular-nums">{fmt(remaining)} tokens</span>
-          </div>
-          <div className="flex justify-between">
-            <span>Limit</span>
-            <span className="tabular-nums">{fmt(tokenLimit)} tokens</span>
-          </div>
-          <div className="flex justify-between opacity-60">
-            <span>Auto-compacts at 90%</span>
-            <span className="tabular-nums">{fmt(autoCompactAt)}</span>
-          </div>
-          {pct >= 60 && onCompact && (
-            <button
-              onClick={(e) => { e.stopPropagation(); onCompact() }}
-              className="mt-1 w-full text-center py-1 rounded bg-bg-raised hover:bg-bg-sidebar text-text-muted text-[11px] transition-colors"
-            >
-              Compact Now
-            </button>
-          )}
-        </div>
+    <div
+      className="flex items-center gap-1.5 flex-shrink-0"
+      title={`${fmt(tokenCount)} / ${fmt(tokenLimit)} tokens (${pct}%)\nRemaining: ${fmt(remaining)}\nAuto-compacts at 90%`}
+    >
+      <div className="w-16 h-1.5 rounded-full bg-bg-raised overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[10px] text-text-muted tabular-nums whitespace-nowrap">
+        {fmt(tokenCount)} · {pct}%
+      </span>
+      {onCompact && (
+        <button
+          onClick={onCompact}
+          className="text-[10px] px-1.5 py-0.5 rounded bg-bg-raised text-text-muted hover:text-text-primary hover:bg-bg-sidebar transition-colors flex-shrink-0"
+          title="Compact conversation history"
+        >
+          Compact
+        </button>
       )}
     </div>
   )

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -454,6 +454,11 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
         <Hash size={14} className="text-text-muted flex-shrink-0" />
         <span className="text-sm font-semibold text-text-primary truncate">{room?.name}</span>
         {room && <span className={`px-1.5 py-0.5 rounded text-[9px] flex-shrink-0 ${TYPE_COLORS[room.type] || TYPE_COLORS.general}`}>{room.type}</span>}
+        <ContextWindowBar
+          tokenCount={tokenState.count}
+          tokenLimit={tokenState.limit}
+          onCompact={handleCompact}
+        />
         <div className="flex items-center gap-1 ml-auto flex-shrink-0">
           {/* Invite button */}
           <button
@@ -571,13 +576,6 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
           )}
         </div>
       )}
-
-      {/* Context window bar */}
-      <ContextWindowBar
-        tokenCount={tokenState.count}
-        tokenLimit={tokenState.limit}
-        onCompact={handleCompact}
-      />
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-4 space-y-3">

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -991,7 +991,7 @@ export async function triggerRoomAgentReplies(
             tokenCount: currentTokenCount,
             updatedAt: new Date(),
             // Cache auto-discovered limit so GET route can return it without re-querying the model
-            ...(room.tokenLimit === null && effectiveLimit > 0 ? { tokenLimit: effectiveLimit } : {}),
+            ...(room?.tokenLimit === null && effectiveLimit > 0 ? { tokenLimit: effectiveLimit } : {}),
           },
         })
         if (effectiveLimit > 0) {


### PR DESCRIPTION
## Summary

Moves the context window indicator from a full-width bordered row below the header into the header bar itself, sitting between the room type tag and the action buttons.

**Before:** Separate `border-b` row between goal banner and messages  
**After:** Inline in the header — `# RoomName [general] [▓░░░░] 26.5K · 21% [Compact] [+] [⚑] [→]`

Changes:
- `ContextWindowBar.tsx` — rewritten as an inline flex component (no wrapper border/padding); renders mini 64px progress bar + `N · pct%` text + Compact button; degraded state shows `N tokens` text only; hover `title` exposes full breakdown (used / remaining / limit / auto-compact threshold)
- `RoomChat.tsx` — bar placed in header row after type tag, before `ml-auto` action buttons; old standalone placement removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)