### PR TITLE
Phase 1a: Add ToolExecution schema for executor tool tracking

### DIFF
--- a/apps/web/prisma/migrations/19_add_tool_execution/migration.sql
+++ b/apps/web/prisma/migrations/19_add_tool_execution/migration.sql
@@ -1,0 +1,32 @@
+-- Add ToolExecution table for tracking executor tool calls
+-- Tracks shell_exec, file_read, and system_info execution with Warden approval gating
+
+CREATE TABLE "ToolExecution" (
+  "id" TEXT NOT NULL,
+  "executionId" TEXT NOT NULL,
+  "environmentId" TEXT,
+  "tool" TEXT NOT NULL,
+  "args" JSONB NOT NULL,
+  "actorId" TEXT NOT NULL,
+  "actorType" TEXT NOT NULL,
+  "riskTier" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "exitCode" INTEGER,
+  "output" TEXT,
+  "durationMs" INTEGER,
+  "reviewerId" TEXT,
+  "reviewDecision" TEXT,
+  "reviewedAt" TIMESTAMPTZ(3),
+  "expiresAt" TIMESTAMPTZ(3),
+  "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "completedAt" TIMESTAMPTZ(3),
+
+  CONSTRAINT "ToolExecution_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ToolExecution_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX "ToolExecution_executionId_key" ON "ToolExecution"("executionId");
+CREATE INDEX "ToolExecution_actorId_createdAt" ON "ToolExecution"("actorId", "createdAt");
+CREATE INDEX "ToolExecution_status_createdAt" ON "ToolExecution"("status", "createdAt");
+CREATE INDEX "ToolExecution_tool_createdAt" ON "ToolExecution"("tool", "createdAt");
+CREATE INDEX "ToolExecution_expiresAt" ON "ToolExecution"("expiresAt");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -133,6 +133,7 @@ model Environment {
   environmentSourceHealths EnvironmentSourceHealth[]
   vulnerabilityFindings    VulnerabilityFinding[]
   suppressions             Suppression[]
+  toolExecutions           ToolExecution[]
 }
 
 /// Tracks every PR opened by the GitOps loop — open, auto-merged, or awaiting review.
@@ -1585,4 +1586,38 @@ model InvestigationAudit {
   timestamp       DateTime      @default(now())
 
   @@index([investigationId, timestamp])
+}
+
+// ── Executor: Tool Execution Tracking ──────────────────────────────────────────
+// Tracks every execution intent and result for shell_exec, file_read, system_info.
+// Single row per execution that mutates through its lifecycle: pending → running →
+// completed/failed/denied. Server-attested actor identity, risk classification,
+// and Warden approval gating.
+
+model ToolExecution {
+  id              String    @id @default(cuid())
+  executionId     String    @unique  // client UUID — duplicate POST returns existing row, never re-executes
+  environmentId   String?           // null = localhost/management-host
+  tool            String            // "shell_exec" | "file_read" | "system_info"
+  args            Json              // redacted before storage — no secrets in DB
+  actorId         String            // agentId or userId (server-attested by gateway, not client-asserted)
+  actorType       String            // "agent" | "human"
+  riskTier        String            // "auto" | "notify" | "approve" | "escalate"
+  status          String            // "pending" | "running" | "completed" | "failed" | "denied"
+  exitCode        Int?
+  output          String?           // stdout+stderr, truncated to 10k, secrets redacted
+  durationMs      Int?
+  reviewerId      String?
+  reviewDecision  String?           // "approved" | "denied"
+  reviewedAt      DateTime?
+  expiresAt       DateTime?         // set for approve/escalate — auto-deny when reached
+  createdAt       DateTime  @default(now())
+  completedAt     DateTime?
+
+  environment     Environment?      @relation(fields: [environmentId], references: [id])
+
+  @@index([actorId, createdAt])
+  @@index([status, createdAt])
+  @@index([tool, createdAt])
+  @@index([expiresAt])              // for expiry sweep job
 }


### PR DESCRIPTION
## Summary
- Add ToolExecution Prisma model with full schema for tracking tool execution lifecycle
- Add database migration to create ToolExecution table with proper indexes and relationships
- Add relation to Environment model for environmentId foreign key

## Scope
This PR implements Phase 1a of the Executor plan: the database schema for tracking shell_exec, file_read, and system_info tool calls with audit trail, actor identity, risk classification, and Warden approval gating.

## Test Plan
- [x] Schema validation passes
- [x] Migration file created with correct SQL structure
- [x] All indexes present per plan specification

🤖 Generated with Claude Code