### PR TITLE
Phase 1c: Route localhost tools through executor service

### DIFF
--- a/apps/gateway/src/builtin-tools/localhost.ts
+++ b/apps/gateway/src/builtin-tools/localhost.ts
@@ -1,57 +1,20 @@
-import { execFile } from 'child_process'
-import { promisify } from 'util'
-import { readFileSync, statSync } from 'fs'
+import { randomUUID } from 'crypto'
+import { executorClient } from '../executor-client.js'
 
 /**
- * Dangerous command patterns that should never be allowed in shell_exec.
- * SOC2: [H-005] Defense-in-depth for the localhost shell_exec tool.
- * Since shell_exec takes a full command string (not interpolated args),
- * we can't use quote(). Instead we block dangerous patterns.
+ * File read allowlist — paths permitted via file_read.
+ * Gateway enforces this as a defense-in-depth control;
+ * executor also validates against its own allowlist.
  */
-const DANGEROUS_PATTERNS = [
-  /;\s*(rm|dd|chmod|chown|mkfs|fdisk|wipe|mke2fs|cfdisk|parted|sgdisk|hdparm|blkdiscard)\b/i,
-  /&&\s*(rm|dd|chmod|chown|mkfs|fdisk|wipe|mke2fs|cfdisk|parted|sgdisk|hdparm|blkdiscard)\b/i,
-  /\|\s*(rm|dd|chmod|chown|mkfs|fdisk|wipe|mke2fs|cfdisk|parted|sgdisk|hdparm|blkdiscard)\b/i,
-  /\|\|\s*(rm|dd|chmod|chown|mkfs|fdisk|wipe|mke2fs|cfdisk|parted|sgdisk|hdparm|blkdiscard)\b/i,
-  /&&\s*(curl|wget)\b/i,
-  /;\s*(curl|wget)\b/i,
-  />>\s*(\/etc\/|\/root\/|\/\.ssh\/)/i,
-  />\s*\/etc\/(passwd|shadow|sudoers|crontab)/i,
-  />\s*\/root\/\.ssh\/(authorized_keys|id_|known_hosts)/i,
-  /\|\s*(nc|ncat|socat|netcat)\b/i,
-  /\/proc\/(self|fs|sys)/i,
-  /\/dev\/(sda|sdb|vda|vdb|nbd|loop|xvd)/i,
-  /eval\b/,
-  /source\b.*\/etc\//i,
-  /base64\s+-[di]/i,
-] as const
+const FILE_READ_ALLOWLIST = [
+  '/var/log',
+  '/etc/hosts',
+  '/proc/cpuinfo',
+  '/proc/meminfo',
+]
 
-/**
- * Blocklist of shell metacharacters that could enable injection.
- * SOC2: [H-005] Comprehensive blocklist for shell_exec command input.
- * Note: The command IS shell syntax, so we can't quote it.
- * We block characters that enable subcommand injection.
- */
-const SHELL_META_RE = /[;&|`$<>\\!{}()\[\]]/
-
-/**
- * Check if a command string contains dangerous patterns.
- * Returns null if safe, or the reason it's blocked.
- */
-function checkDangerous(cmd: string): string | null {
-  for (const pattern of DANGEROUS_PATTERNS) {
-    if (pattern.test(cmd)) {
-      return `Blocked: command matches dangerous pattern '${pattern.source}'`
-    }
-  }
-  return null
-}
-
-const exec = promisify(execFile)
-
-async function sh(cmd: string, args: string[], timeoutMs = 30_000): Promise<string> {
-  const { stdout, stderr } = await exec(cmd, args, { timeout: timeoutMs })
-  return stdout || stderr
+function isFileReadAllowed(path: string): boolean {
+  return FILE_READ_ALLOWLIST.some(allowed => path.startsWith(allowed))
 }
 
 export const localhostTools = ([
@@ -72,26 +35,26 @@ export const localhostTools = ([
       },
       required: ['command'],
     },
-    async execute(args: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
       const command = String(args.command ?? '').trim()
       if (!command) return 'Error: command is required'
 
-      // SOC2: [H-005] Check for shell metacharacters that could enable injection
-      if (SHELL_META_RE.test(command)) {
-        return 'Error: command contains disallowed shell metacharacters'
-      }
-
-      // SOC2: [H-005] Check for dangerous command patterns
-      const dangerReason = checkDangerous(command)
-      if (dangerReason) {
-        return `Error: ${dangerReason}`
-      }
-
-      const timeoutMs = Math.min((Number(args.timeout_secs ?? 30)) * 1000, 120_000)
-
       console.log(`[localhost] shell_exec: ${command}`)
-      const { stdout, stderr } = await exec('sh', ['-c', command], { timeout: timeoutMs })
-      return (stdout + stderr).trim() || '(no output)'
+
+      const executionId = randomUUID()
+      const result = await executorClient.execute({
+        tool: 'shell_exec',
+        args: { command },
+        actorId: (ctx?.agentId as string) || (ctx?.userId as string) || 'unknown',
+        actorType: ctx?.agentId ? 'agent' : 'human',
+        executionId,
+      })
+
+      if (result.error) {
+        return `Error: ${result.error}`
+      }
+
+      return result.output?.trim() || '(no output)'
     },
   },
 
@@ -106,20 +69,31 @@ export const localhostTools = ([
       },
       required: ['path'],
     },
-    async execute(args: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
       const filePath = String(args.path ?? '').trim()
       if (!filePath) return 'Error: path is required'
-      const maxBytes = Math.min(Number(args.max_bytes ?? 65536), 1_048_576) // cap at 1MB
 
-      try {
-        const stat = statSync(filePath)
-        const content = readFileSync(filePath)
-        const slice = content.slice(0, maxBytes)
-        const truncated = content.length > maxBytes
-        return `[${filePath}] (${stat.size} bytes${truncated ? `, showing first ${maxBytes}` : ''})\n\n${slice.toString('utf8')}`
-      } catch (err) {
-        return `Error: ${err instanceof Error ? err.message : String(err)}`
+      // Validate path against allowlist
+      if (!isFileReadAllowed(filePath)) {
+        return `Error: path '${filePath}' is not in the allowlist`
       }
+
+      console.log(`[localhost] file_read: ${filePath}`)
+
+      const executionId = randomUUID()
+      const result = await executorClient.execute({
+        tool: 'file_read',
+        args: { path: filePath, max_bytes: Number(args.max_bytes ?? 65536) },
+        actorId: (ctx?.agentId as string) || (ctx?.userId as string) || 'unknown',
+        actorType: ctx?.agentId ? 'agent' : 'human',
+        executionId,
+      })
+
+      if (result.error) {
+        return `Error: ${result.error}`
+      }
+
+      return result.output || '(no output)'
     },
   },
 
@@ -130,25 +104,23 @@ export const localhostTools = ([
       type: 'object',
       properties: {},
     },
-    async execute() {
-      const [uptime, memory, disk] = await Promise.allSettled([
-        sh('uptime', []),
-        sh('free', ['-h']),
-        sh('df', ['-h', '--output=target,size,used,avail,pcent', '-x', 'tmpfs', '-x', 'devtmpfs']),
-      ])
+    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+      console.log(`[localhost] system_info`)
 
-      const lines: string[] = ['=== System Info ===']
-      lines.push('')
-      lines.push('-- Uptime --')
-      lines.push(uptime.status === 'fulfilled' ? uptime.value.trim() : `Error: ${uptime.reason}`)
-      lines.push('')
-      lines.push('-- Memory --')
-      lines.push(memory.status === 'fulfilled' ? memory.value.trim() : `Error: ${memory.reason}`)
-      lines.push('')
-      lines.push('-- Disk --')
-      lines.push(disk.status === 'fulfilled' ? disk.value.trim() : `Error: ${disk.reason}`)
+      const executionId = randomUUID()
+      const result = await executorClient.execute({
+        tool: 'system_info',
+        args: {},
+        actorId: (ctx?.agentId as string) || (ctx?.userId as string) || 'unknown',
+        actorType: ctx?.agentId ? 'agent' : 'human',
+        executionId,
+      })
 
-      return lines.join('\n')
+      if (result.error) {
+        return `Error: ${result.error}`
+      }
+
+      return result.output || '(no output)'
     },
   },
 ] as const).map(t => ({ ...t, category: 'localhost' as const }))

--- a/apps/gateway/src/executor-client.ts
+++ b/apps/gateway/src/executor-client.ts
@@ -1,0 +1,118 @@
+import axios, { AxiosInstance } from 'axios'
+
+const EXECUTOR_URL = process.env.ORION_EXECUTOR_URL || 'http://orion-executor:3200'
+const EXECUTOR_TOKEN = process.env.ORION_EXECUTOR_TOKEN || ''
+
+interface ExecutionRequest {
+  tool: 'shell_exec' | 'file_read' | 'system_info'
+  args: Record<string, unknown>
+  actorId: string
+  actorType: 'agent' | 'human'
+  executionId: string
+}
+
+interface ExecutionResponse {
+  executionId: string
+  status: string
+  output?: string
+  message?: string
+  error?: string
+}
+
+interface ToolExecution {
+  id: string
+  executionId: string
+  status: string
+  output?: string
+  exitCode?: number
+  durationMs?: number
+  reviewDecision?: string
+}
+
+class ExecutorClient {
+  private client: AxiosInstance
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: EXECUTOR_URL,
+      headers: {
+        'x-executor-token': EXECUTOR_TOKEN,
+      },
+      timeout: 120000,
+    })
+  }
+
+  async execute(request: ExecutionRequest): Promise<ExecutionResponse> {
+    try {
+      const response = await this.client.post('/execute', request)
+      const result = response.data as ExecutionResponse
+
+      // If status is pending (awaiting approval), poll until complete
+      if (result.status === 'pending' && result.executionId) {
+        return await this.pollUntilComplete(result.executionId)
+      }
+
+      return result
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        throw new Error(`Executor error: ${error.message}`)
+      }
+      throw error
+    }
+  }
+
+  private async pollUntilComplete(executionId: string): Promise<ExecutionResponse> {
+    const maxAttempts = 200 // 200 * 500ms = 100s timeout
+    let attempts = 0
+
+    while (attempts < maxAttempts) {
+      try {
+        const response = await this.client.get(`/executions/${executionId}`)
+        const execution = response.data as ToolExecution
+
+        if (execution.status === 'completed') {
+          return {
+            executionId,
+            status: 'completed',
+            output: execution.output,
+          }
+        }
+
+        if (execution.status === 'failed' || execution.status === 'denied') {
+          return {
+            executionId,
+            status: execution.status,
+            error: execution.output || `Execution ${execution.status}`,
+          }
+        }
+
+        // Still pending, wait before next poll
+        await new Promise(resolve => setTimeout(resolve, 500))
+        attempts++
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          throw new Error(`Execution not found: ${executionId}`)
+        }
+        throw error
+      }
+    }
+
+    throw new Error(`Execution polling timeout for ${executionId}`)
+  }
+
+  async approve(executionId: string, reason: string): Promise<void> {
+    await this.client.post(`/executions/${executionId}/review`, {
+      decision: 'approved',
+      reason,
+    })
+  }
+
+  async deny(executionId: string, reason: string): Promise<void> {
+    await this.client.post(`/executions/${executionId}/review`, {
+      decision: 'denied',
+      reason,
+    })
+  }
+}
+
+export const executorClient = new ExecutorClient()


### PR DESCRIPTION
## Summary
- Create executor-client.ts for HTTP communication with orion-executor service
- Add polling logic to wait for approval/escalate tier execution completion
- Update shell_exec, file_read, system_info tools to route through executor
- Add file_read path allowlist validation at gateway (defense-in-depth)
- Remove gateway-side pattern checks (executor's risk classifier handles this)
- Capture actorId and actorType from request context and pass to executor

## Scope
This PR implements Phase 1c of the Executor plan: modifying the gateway to route tool execution to the executor service instead of executing locally.

## Test Plan
- [x] executor-client.ts implements polling for completion
- [x] All three tools route through executor service
- [x] file_read validates paths against allowlist before forwarding
- [x] actorId/actorType are captured and passed to executor

🤖 Generated with Claude Code