### PR TITLE
Phase 2: Add Orion API endpoint for execution logging

### DIFF
--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const execution = await prisma.toolExecution.findUnique({
+      where: { id: params.id },
+    })
+
+    if (!execution) {
+      return NextResponse.json(
+        { error: 'Execution not found' },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json(execution)
+  } catch (error) {
+    console.error('Error getting execution:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await req.json()
+
+    const {
+      status,
+      riskTier,
+      exitCode,
+      output,
+      durationMs,
+      reviewerId,
+      reviewDecision,
+      reviewedAt,
+      expiresAt,
+      completedAt,
+    } = body
+
+    // Build update object with only provided fields
+    const updateData: any = {}
+    if (status !== undefined) updateData.status = status
+    if (riskTier !== undefined) updateData.riskTier = riskTier
+    if (exitCode !== undefined) updateData.exitCode = exitCode
+    if (output !== undefined) updateData.output = output
+    if (durationMs !== undefined) updateData.durationMs = durationMs
+    if (reviewerId !== undefined) updateData.reviewerId = reviewerId
+    if (reviewDecision !== undefined) updateData.reviewDecision = reviewDecision
+    if (reviewedAt !== undefined) updateData.reviewedAt = reviewedAt
+    if (expiresAt !== undefined) updateData.expiresAt = expiresAt
+    if (completedAt !== undefined) updateData.completedAt = completedAt
+
+    const execution = await prisma.toolExecution.update({
+      where: { id: params.id },
+      data: updateData,
+    })
+
+    return NextResponse.json(execution)
+  } catch (error: any) {
+    if (error?.code === 'P2025') {
+      // Not found
+      return NextResponse.json(
+        { error: 'Execution not found' },
+        { status: 404 }
+      )
+    }
+    console.error('Error updating execution:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/executions/route.ts
+++ b/apps/web/src/app/api/executions/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json()
+
+    const {
+      executionId,
+      environmentId,
+      tool,
+      args,
+      actorId,
+      actorType,
+      riskTier,
+      status,
+    } = body
+
+    // Validate required fields
+    if (!executionId || !tool || !actorId || !actorType || !status) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    // Check if execution already exists (idempotent — same executionId returns existing row)
+    const existing = await prisma.toolExecution.findUnique({
+      where: { executionId },
+    })
+
+    if (existing) {
+      return NextResponse.json(existing, { status: 200 })
+    }
+
+    // Create new execution record
+    const execution = await prisma.toolExecution.create({
+      data: {
+        executionId,
+        environmentId: environmentId || null,
+        tool,
+        args: args || {},
+        actorId,
+        actorType,
+        riskTier: riskTier || 'notify',
+        status,
+      },
+    })
+
+    return NextResponse.json(execution, { status: 201 })
+  } catch (error) {
+    console.error('Error creating execution:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const actorId = searchParams.get('actorId')
+    const status = searchParams.get('status')
+    const limit = Math.min(Number(searchParams.get('limit') || 100), 1000)
+
+    const where: any = {}
+    if (actorId) where.actorId = actorId
+    if (status) where.status = status
+
+    const executions = await prisma.toolExecution.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    })
+
+    return NextResponse.json(executions)
+  } catch (error) {
+    console.error('Error listing executions:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -227,6 +227,18 @@ export async function middleware(req: NextRequest) {
     return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
   }
 
+  // Executor service calls — x-executor-token header is the auth.
+  // Executor logs execution records and reads them for status polling.
+  // Use constant-time comparison to prevent timing attacks (SOC2 #166)
+  const executorToken = process.env.ORION_EXECUTOR_TOKEN
+  if (
+    pathname.startsWith('/api/executions') &&
+    executorToken &&
+    timingSafeCompare(req.headers.get('x-executor-token') ?? '', executorToken)
+  ) {
+    return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
+  }
+
   // Service token (gateway) calls — accept Bearer token instead of session.
   // Gateway tools need to read/write notes, list agent-groups, etc.
   // Use constant-time comparison to prevent timing attacks (SOC2 #166)


### PR DESCRIPTION
## Summary
- Add executor token auth bypass in middleware for /api/executions
- Implement POST /api/executions for creating/upserting execution records
- Implement GET /api/executions for listing with actor/status filters
- Implement GET /api/executions/[id] for status polling
- Implement PATCH /api/executions/[id] for updating status, output, results
- Support idempotent creation (duplicate executionId returns existing record)

## Scope
This PR implements Phase 2c of the Executor plan: the Orion API endpoint for executor to log execution intents and update results with full audit trail.

## Test Plan
- [x] POST creates new execution or returns existing with same executionId
- [x] GET lists executions with optional actorId/status filters
- [x] GET [id] returns specific execution for polling
- [x] PATCH updates any fields on execution record
- [x] All endpoints validate executor token in middleware

🤖 Generated with Claude Code