### PR TITLE
Phase 3a-3b: Add Warden execution room and approval tools

### DIFF
--- a/apps/web/src/lib/seed-system-epic.ts
+++ b/apps/web/src/lib/seed-system-epic.ts
@@ -11,12 +11,14 @@
  *     Feature: "Operations"  → ChatRoom for Alpha/Veritas cycle summaries
  *     Feature: "Maintenance" → ChatRoom for scheduled upkeep, upgrades, patches
  *     Feature: "Security"    → ChatRoom for Warden incident triage + action proposals
+ *     Feature: "Execution"   → ChatRoom for tool execution approval gating
  *
  * After seeding, room IDs are stored in SystemSetting:
  *   system.room.health      → ChatRoom ID for the Health feature
  *   system.room.operations  → ChatRoom ID for the Operations feature
  *   system.room.maintenance → ChatRoom ID for the Maintenance feature
  *   system.room.security    → ChatRoom ID for the Security feature
+ *   system.room.execution   → ChatRoom ID for the Execution feature
  *
  * The worker reads these settings and injects them into each watcher's
  * enriched prompt so agents always know where to post.
@@ -54,6 +56,12 @@ const SYSTEM_FEATURES: SystemFeatureDef[] = [
     title:       'Security',
     description: 'SIEM incident management. Warden posts incident triage summaries and proposed actions here.',
     settingKey:  'system.room.security',
+    agents:      ['Warden'],
+  },
+  {
+    title:       'Execution',
+    description: 'Tool execution approval and gating. Warden approves/denies risky tool calls from agents and system services.',
+    settingKey:  'system.room.execution',
     agents:      ['Warden'],
   },
 ]

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -37,6 +37,7 @@ export type ToolCategory =
   | 'knowledge'    // knowledge base: search, write, graph
   | 'environment'  // cluster environments: health, config, bootstrap
   | 'secrets'      // secret management
+  | 'execution'    // tool execution approval gating
   | 'tools'        // meta: tool discovery, tool requests, nova lookup
 
 export interface ToolDefinition {
@@ -2859,5 +2860,123 @@ registerTool({
       `  2. If a new tool is genuinely needed, call propose_tool with a name, description, and inputSchema.`,
       `  3. If this should be a Nova (a custom reusable tool bundle), inform a human to create one.`,
     ].join('\n')
+  },
+})
+
+// ── Execution: Tool Execution Approval Gating ─────────────────────────────────
+
+registerTool({
+  name: 'approve_execution',
+  description: 'Approve a pending tool execution that is waiting for review. Only use this after reviewing the tool, args, and actor. The execution will proceed immediately after approval.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      executionId: {
+        type: 'string',
+        description: 'The ORION execution id (from the notification in system.room.execution)',
+      },
+      reason: {
+        type: 'string',
+        description: 'Why this execution is approved (logged to audit trail)',
+      },
+    },
+    required: ['executionId', 'reason'],
+  },
+  tier: 'write',
+  parallelSafe: false,
+  availableIn: 'chat',
+  category: 'execution',
+  handler: async (args, ctx) => {
+    try {
+      const { executionId, reason } = parseArgs(args) as { executionId?: string; reason?: string }
+      if (!executionId) return 'Error: executionId is required'
+      if (!reason) return 'Error: reason is required'
+
+      // Call executor service to approve
+      const executorUrl = process.env.ORION_EXECUTOR_URL || 'http://orion-executor:3200'
+      const executorToken = process.env.ORION_EXECUTOR_TOKEN
+
+      if (!executorToken) {
+        return 'Error: executor service token not configured'
+      }
+
+      const response = await fetch(`${executorUrl}/executions/${executionId}/review`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-executor-token': executorToken,
+        },
+        body: JSON.stringify({
+          decision: 'approved',
+          reason,
+        }),
+      })
+
+      if (!response.ok) {
+        return `Error: executor service returned ${response.status}`
+      }
+
+      return `Execution ${executionId} approved. Reason: ${reason}`
+    } catch (e) {
+      return `Error: ${e instanceof Error ? e.message : String(e)}`
+    }
+  },
+})
+
+registerTool({
+  name: 'deny_execution',
+  description: 'Deny a pending tool execution. The calling agent will receive an error. Use when the command looks suspicious, out of scope, or unsafe.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      executionId: {
+        type: 'string',
+        description: 'The ORION execution id',
+      },
+      reason: {
+        type: 'string',
+        description: 'Why this execution is denied (sent back to the calling agent)',
+      },
+    },
+    required: ['executionId', 'reason'],
+  },
+  tier: 'write',
+  parallelSafe: false,
+  availableIn: 'chat',
+  category: 'execution',
+  handler: async (args, ctx) => {
+    try {
+      const { executionId, reason } = parseArgs(args) as { executionId?: string; reason?: string }
+      if (!executionId) return 'Error: executionId is required'
+      if (!reason) return 'Error: reason is required'
+
+      // Call executor service to deny
+      const executorUrl = process.env.ORION_EXECUTOR_URL || 'http://orion-executor:3200'
+      const executorToken = process.env.ORION_EXECUTOR_TOKEN
+
+      if (!executorToken) {
+        return 'Error: executor service token not configured'
+      }
+
+      const response = await fetch(`${executorUrl}/executions/${executionId}/review`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-executor-token': executorToken,
+        },
+        body: JSON.stringify({
+          decision: 'denied',
+          reason,
+        }),
+      })
+
+      if (!response.ok) {
+        return `Error: executor service returned ${response.status}`
+      }
+
+      return `Execution ${executionId} denied. Reason: ${reason}`
+    } catch (e) {
+      return `Error: ${e instanceof Error ? e.message : String(e)}`
+    }
   },
 })


### PR DESCRIPTION
## Summary
- Seed system.room.execution ChatRoom for tool execution approval gating
- Add Execution feature to System epic with Warden as sole member
- Register approve_execution tool for Warden to approve pending executions
- Register deny_execution tool for Warden to deny suspicious commands
- Tools make HTTP POST calls to executor service /executions/[id]/review endpoint

## Scope
This PR implements Phase 3a-3b of the Executor plan: seeding the execution room where Warden approves/denies tool calls and registering the approval tools.

## Test Plan
- [x] system.room.execution is created and stored in SystemSetting
- [x] Warden agent is added as member to execution room
- [x] approve_execution tool calls executor with 'approved' decision
- [x] deny_execution tool calls executor with 'denied' decision
- [x] Both tools validate required fields (executionId, reason)

🤖 Generated with Claude Code