### PR TITLE
fix(executor): multi-stage Dockerfile to compile TypeScript during build

### DIFF
--- a/apps/executor/Dockerfile
+++ b/apps/executor/Dockerfile
@@ -1,3 +1,14 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
 FROM node:20-alpine
 
 WORKDIR /app
@@ -5,7 +16,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 
-COPY dist ./dist
+COPY --from=builder /app/dist ./dist
 COPY config ./config
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Root cause

PR #473 introduced `apps/executor/Dockerfile` with `COPY dist ./dist`, expecting a pre-built TypeScript output to exist on the host. But `dist/` is gitignored and never present during CI/CD deploys — causing every deploy to fail at bootstrap with:

```
#9 ERROR: failed to calculate checksum of ref ...: "/dist": not found
```

This has been breaking deploys since #473 merged (confirmed in runs 26667569331 and 26670062306).

## Fix

Replace the single-stage Dockerfile with a two-stage build:

1. **Builder stage** — installs all deps (including devDependencies) and runs `tsc` to compile `src/` → `dist/`
2. **Production stage** — fresh image, production deps only, copies compiled `dist/` from the builder

No changes to `bootstrap.sh` or `docker-compose.yml` needed.

## Test plan
- [ ] Deploy pipeline runs bootstrap without `/dist: not found` error
- [ ] `orion-executor` container starts and passes its healthcheck at `:3200/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)