### PR TITLE
fix: tighten Claude sidecar reliability (probe cache, binary check, error mapping)

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -76,6 +76,14 @@ export function parseMentions(content: string): string[] {
 
 const CLAUDE_URL = process.env.ORION_CLAUDE_URL ?? 'http://orion-claude:3100'
 
+function mapClaudeError(raw: string): string {
+  const lower = raw.toLowerCase()
+  if (lower.includes('auth') || lower.includes('token') || lower.includes('401') || lower.includes('invalid api')) return 'authentication issue'
+  if (lower.includes('credit') || lower.includes('quota') || lower.includes('usage limit')) return 'out of credits'
+  if (lower.includes('enoent') || lower.includes('not found') || lower.includes('command failed')) return 'claude binary not installed'
+  return 'service error'
+}
+
 // ── LLM call helpers ──────────────────────────────────────────────────────────
 
 type HistoryEntry = { name: string; content: string; isSelf: boolean }
@@ -201,7 +209,7 @@ async function callClaude(
   agentId?: string,
   roomId?: string,
   activeGoal?: string,
-): Promise<string | null> {
+): Promise<{ text: string | null; error?: string }> {
   // Always enable MCP when in a room context — Claude should have the same tool access
   // as OpenAI-compatible agents. maxTurns controls depth; hasTools controls prompt framing.
   const useMcp = !!agentId && !!roomId
@@ -226,16 +234,20 @@ async function callClaude(
     // MCP tool calls can take longer — allow 5 min for tool-using sessions
     signal: AbortSignal.timeout(useMcp ? 300_000 : 120_000),
   }).catch((e: Error) => { console.error(`[room-agents] orion-claude fetch failed: ${e.message}`); return null })
-  if (!res?.ok) {
-    const errBody = await res?.text().catch(() => '')
-    console.error(`[room-agents] orion-claude /run/collect HTTP ${res?.status}: ${errBody?.slice(0, 400)}`)
-    return null
+  if (!res) return { text: null, error: 'service unreachable' }
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => '')
+    console.error(`[room-agents] orion-claude /run/collect HTTP ${res.status}: ${errBody?.slice(0, 400)}`)
+    return { text: null, error: mapClaudeError(errBody || `HTTP ${res.status}`) }
   }
   const data = await res.json() as { text?: string; error?: string }
   if (data.error) {
-    console.error(`[room-agents] orion-claude /run/collect returned error: ${data.error.slice(0, 400)}`)
+    console.error(`[room-agents] orion-claude error: ${data.error.slice(0, 400)}`)
+    return { text: null, error: mapClaudeError(data.error) }
   }
-  return data.text?.trim() || null
+  const text = data.text?.trim() || null
+  if (!text) console.warn('[room-agents] orion-claude returned empty text')
+  return { text }
 }
 
 /** Ollama native /api/chat endpoint */
@@ -873,11 +885,13 @@ export async function triggerRoomAgentReplies(
           // When tools are enabled, the sidecar writes a per-request .mcp.json so Claude
           // calls ORION tools natively via MCP (ORION is the harness, Claude is the brain).
           const claudeModel = llm.startsWith('claude:') ? llm.slice('claude:'.length) : undefined
-          reply = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext, agent.id, roomId, activeGoal)
+          const claudeResult = await callClaude(agent.name, agentBasePrompt, otherParticipants, history, latestTurn, claudeModel, !!toolContext, agent.id, roomId, activeGoal)
+          reply = claudeResult.text
           if (reply === null) {
-            // Claude is unavailable — post a message on the agent's behalf rather than silently skipping
+            // Claude is unavailable — post a notice on the agent's behalf
             console.warn(`[room-agents] ${agent.name}: Claude unavailable, posting unavailability notice`)
-            const notice = `I'm currently unavailable — the Claude service is unreachable or out of credits. Please try again shortly.`
+            const hint = claudeResult.error ? ` (${claudeResult.error})` : ''
+            const notice = `I'm currently unavailable${hint}. Please try again shortly or contact an admin if the issue persists.`
             const msg = await prisma.chatMessage.create({
               data: { roomId, agentId: agent.id, senderType: 'agent', content: notice },
               include: {

--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -154,16 +154,21 @@ function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 12000
 
 // ── Auth helpers ──────────────────────────────────────────────────────────────
 
-/** Cached binary check — only runs once per process lifetime. */
 let _binaryAvailable = null
+let _binaryCheckedAt = 0
+const BINARY_RECHECK_NEG_MS = 2 * 60 * 1000  // re-check negatives every 2 min
+
 function isBinaryAvailable() {
-  if (_binaryAvailable !== null) return _binaryAvailable
+  const now = Date.now()
+  if (_binaryAvailable === true) return true  // permanent positive cache
+  if (_binaryAvailable === false && (now - _binaryCheckedAt) < BINARY_RECHECK_NEG_MS) return false
   try {
-    execFileSync('claude', ['--version'], { timeout: 5000, stdio: 'pipe' })
+    execFileSync('claude', ['--version'], { timeout: 1500, stdio: 'pipe' })
     _binaryAvailable = true
   } catch {
     _binaryAvailable = false
   }
+  _binaryCheckedAt = now
   return _binaryAvailable
 }
 
@@ -171,21 +176,29 @@ function isBinaryAvailable() {
 let _probeCache = null  // { ok: boolean, error?: string, checkedAt: number }
 const PROBE_TTL_MS = 5 * 60 * 1000
 
+let _probeInFlight = null  // single-flight: deduplicate concurrent probe calls
+
 async function runLiveProbe() {
   const now = Date.now()
   if (_probeCache && (now - _probeCache.checkedAt) < PROBE_TTL_MS) return _probeCache
-  try {
-    const stdout = await runClaude('Reply with exactly: OK', { maxTurns: 1, timeout: 30000 })
-    let text = stdout.trim()
-    try { const p = JSON.parse(stdout); text = p?.result ?? p?.text ?? text } catch {}
-    _probeCache = { ok: !!text, checkedAt: now }
-    console.log('[orion-claude] live probe: OK')
-  } catch (err) {
-    const errMsg = (err instanceof Error ? err.message : String(err)).slice(0, 300)
-    _probeCache = { ok: false, error: errMsg, checkedAt: now }
-    console.warn('[orion-claude] live probe failed:', errMsg)
-  }
-  return _probeCache
+  if (_probeInFlight) return _probeInFlight
+  _probeInFlight = (async () => {
+    try {
+      const stdout = await runClaude('Reply with exactly: OK', { maxTurns: 1, timeout: 30000 })
+      let text = stdout.trim()
+      try { const p = JSON.parse(stdout); text = p?.result ?? p?.text ?? text } catch {}
+      _probeCache = { ok: !!text, checkedAt: Date.now() }
+      console.log('[orion-claude] live probe: OK')
+    } catch (err) {
+      const errMsg = (err instanceof Error ? err.message : String(err)).slice(0, 300)
+      _probeCache = { ok: false, error: errMsg, checkedAt: Date.now() }
+      console.warn('[orion-claude] live probe failed:', errMsg)
+    } finally {
+      _probeInFlight = null
+    }
+    return _probeCache
+  })()
+  return _probeInFlight
 }
 
 function getCredStatus() {
@@ -295,6 +308,7 @@ const server = http.createServer(async (req, res) => {
           } catch (e) {
             console.log('[orion-claude] Could not copy to shared volume:', e.message)
           }
+          _probeCache = null  // force fresh probe after successful login
         } else if (loginStatus !== 'done') {
           loginStatus = 'error'
         }
@@ -384,6 +398,7 @@ const server = http.createServer(async (req, res) => {
       }
       fs.mkdirSync(CLAUDE_HOME, { recursive: true })
       fs.writeFileSync(CREDS_PATH, JSON.stringify(credentials, null, 2), 'utf8')
+      _probeCache = null  // force fresh probe after credential change
       console.log('[orion-claude] Credentials stored via paste')
       return json(res, 200, { ok: true })
     }


### PR DESCRIPTION
## Summary
Implements four bug fixes to Claude sidecar reliability:

1. **Binary availability check**: Permanent positive cache with 2-minute TTL on failures, prevents cache-lock after first install failure
2. **Probe single-flight**: Deduplicates concurrent probe calls so only one real turn is spawned, reducing credit usage and avoiding duplicate status checks
3. **Probe cache invalidation**: Clears cached probe state when credentials are stored (paste or OAuth login) to force fresh validation
4. **Error threading & mapping**: Routes real errors through all failure paths (fetch timeout, HTTP error, service error) and maps them to user-safe strings so raw CLI text (tokens, paths) doesn't leak into chat messages

## Affected code
- `deploy/orion-claude/server.js`: Binary check, probe logic, credential handlers
- `apps/web/src/lib/room-agents.ts`: Error handling in Claude callsite

## Test plan
- Claude sidecar starts with no credentials → binary check returns false, retries after 2 min
- Paste credentials → probe cache invalidates, next status call runs fresh probe
- OAuth login completes → probe cache invalidates, next status call runs fresh probe
- Multiple concurrent probes → only one actual turn spawned, results shared
- Service error responses → user sees mapped reason (e.g. "out of credits") not raw stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)