### PR TITLE
fix: fall back to GITEA_RUNNER_TOKEN when registration-token API returns 404

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -281,6 +281,12 @@ if [[ "${GIT_PROVIDER:-gitea-bundled}" == "gitea-bundled" ]]; then
       -H "Authorization: token ${GITEA_ADMIN_TOKEN:-}" \
       2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null || echo "")
 
+    # Gitea v1.26+ removed the registration-token API endpoint; fall back to the
+    # static token stored during initial setup.
+    if [[ -z "$REG_TOKEN" ]]; then
+      REG_TOKEN="${GITEA_RUNNER_TOKEN:-}"
+    fi
+
     if [[ -n "$REG_TOKEN" ]]; then
       (cd /opt/orion-runner && /usr/local/bin/act_runner register \
         --no-interactive \


### PR DESCRIPTION
## Summary
- Gitea v1.26+ removed the `/api/v1/admin/runners/registration-token` endpoint that bootstrap used to fetch a fresh registration token
- When the API returned 404, `REG_TOKEN` was empty and bootstrap silently skipped runner re-registration with a warning — no error surfaced to the operator
- This left the runner advertising stale labels (missing `ubuntu-latest`), causing all talos-cluster GitOps pipeline runs to queue indefinitely

## Fix
Fall back to `GITEA_RUNNER_TOKEN` from `.env` when the API call returns nothing. The static token is set during initial Gitea setup and remains valid.

## Test plan
- [ ] Run `bootstrap.sh` on a fresh instance and confirm runner registers with `ubuntu-latest` label
- [ ] Run `bootstrap.sh` again — confirm idempotent (skips re-registration since label is present)
- [ ] Confirm queued Gitea Actions runs are picked up after bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)