### PR TITLE
feat: goal heartbeat — re-trigger agents in stale goal rooms

### DIFF
--- a/apps/web/src/jobs/goal-heartbeat.ts
+++ b/apps/web/src/jobs/goal-heartbeat.ts
@@ -1,0 +1,50 @@
+import { prisma } from '@/lib/db'
+import { triggerRoomAgentReplies } from '@/lib/room-agents'
+
+// A goal room is "stale" if its most recent non-system message is older than this.
+const STALE_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
+
+/**
+ * Periodic sweep: find rooms with an active goal that have gone quiet and
+ * re-trigger their agents. triggerRoomAgentReplies already self-fetches the
+ * active goal and injects it into agent prompts — we only pass a nudge as
+ * the trigger content. We do NOT persist a chat message; doing so would reset
+ * the staleness clock and prevent the heartbeat from ever firing again.
+ */
+export async function runGoalHeartbeat(): Promise<void> {
+  const activeGoals = await prisma.roomGoal.findMany({
+    where: { status: 'active' },
+    select: { roomId: true, text: true },
+  })
+  if (activeGoals.length === 0) return
+
+  const now = Date.now()
+
+  for (const goal of activeGoals) {
+    try {
+      // Exclude system messages from the staleness check — a prior heartbeat
+      // nudge must not mask real inactivity.
+      const lastMsg = await prisma.chatMessage.findFirst({
+        where: { roomId: goal.roomId, senderType: { not: 'system' } },
+        orderBy: { createdAt: 'desc' },
+        select: { createdAt: true },
+      })
+      const lastActivity = lastMsg ? lastMsg.createdAt.getTime() : 0
+      if (now - lastActivity < STALE_THRESHOLD_MS) continue
+
+      // Optimization only (not correctness): skip rooms with no agent members.
+      // triggerRoomAgentReplies returns early for empty rooms anyway.
+      const agentMember = await prisma.chatRoomMember.findFirst({
+        where: { roomId: goal.roomId, agentId: { not: null } },
+        select: { id: true },
+      })
+      if (!agentMember) continue
+
+      const nudge = `[Goal check-in] Still working on: "${goal.text}" — what is the current status and the next concrete step?`
+      await triggerRoomAgentReplies(goal.roomId, nudge)
+    } catch (e) {
+      // Isolate per-room failures so one bad room never aborts the whole sweep.
+      console.error(`[goal-heartbeat] room ${goal.roomId} failed:`, e)
+    }
+  }
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -22,6 +22,7 @@ import { runK8sPollerAll } from './jobs/security-poll-k8s'
 import { runElkPollerAll } from './jobs/security-poll-elk'
 import { runNtopngPollerAll } from './jobs/security-poll-ntopng'
 import { runDailyScan, runEventTriggeredScan } from './jobs/security-scan-vulns'
+import { runGoalHeartbeat } from './jobs/goal-heartbeat'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -891,6 +892,12 @@ async function main() {
       runDailyScan().catch(e => err(`Daily vuln scan failed: ${e}`))
     }
   }, 60 * 60 * 1000)
+
+  // Goal heartbeat — every 5 min, re-trigger agents in rooms whose active goal
+  // has gone stale (no non-system message for 15 min). See jobs/goal-heartbeat.ts.
+  setInterval(() => {
+    runGoalHeartbeat().catch(e => err(`Goal heartbeat failed: ${e}`))
+  }, 5 * 60_000)
 }
 
 main().catch(e => { err(`Fatal: ${e}`); process.exit(1) })


### PR DESCRIPTION
## Summary

Rooms with an active goal (`room_goals.status = 'active'`) stop getting agent activity once the conversation goes quiet. `triggerRoomAgentReplies` only fires when a new message is posted — if no human posts, the goal sits idle forever.

This adds a periodic sweep in the worker process that finds rooms whose active goal has gone stale (no non-system message for 15 minutes) and calls `triggerRoomAgentReplies` to wake agents back up.

## Changes

**New file: `apps/web/src/jobs/goal-heartbeat.ts`**
- `runGoalHeartbeat()` sweeps all active goals, checks staleness (excludes system messages), and nudges agents via `triggerRoomAgentReplies`
- Per-room error isolation — one bad room never aborts the full sweep
- Does NOT persist a `ChatMessage` — that would reset the staleness clock and break the loop

**Modified: `apps/web/src/worker.ts`**
- Added import for `runGoalHeartbeat`
- Registered `setInterval` in `main()` at 5-minute cadence

## Design decisions

- **No message persistence** — the heartbeat nudges agents without writing a chat message, so the staleness clock is never artificially reset
- **No changes to `room-agents.ts`** — `triggerRoomAgentReplies` already self-fetches the active goal and injects it into prompts
- **15-minute staleness, 5-minute sweep** — agents get re-woken within ~15 min of real inactivity

## Files

- `apps/web/src/jobs/goal-heartbeat.ts` — new job
- `apps/web/src/worker.ts` — import + interval registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)