### PR TITLE
feat: GitOps abstraction layer — Docker sync visibility + air-gap fixes + reverse proxy

### DIFF
--- a/apps/gateway/src/argocd-bootstrap.ts
+++ b/apps/gateway/src/argocd-bootstrap.ts
@@ -1,0 +1,157 @@
+/**
+ * ArgoCD Bootstrap
+ *
+ * Runs at cluster gateway startup. Installs ArgoCD into the cluster if not
+ * already present, then registers the git repo configured in Orion.
+ *
+ * Designed to be idempotent — safe to call on every restart.
+ */
+
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+
+const execAsync = promisify(exec)
+
+export interface GitProviderInfo {
+  type: 'gitea-bundled' | 'gitea' | 'github' | 'gitlab'
+  /** Repo clone URL base — already adjusted for cluster reachability by the Orion API.
+   *  May be empty string if git provider is not fully configured; treat empty as "skip". */
+  url: string
+  token: string   // API token / PAT
+  org: string     // default org/user namespace
+}
+
+
+export async function bootstrapArgoCD(
+  orionUrl: string,
+  environmentId: string,
+  gatewayToken: string,
+): Promise<void> {
+  // Step 1: Check if ArgoCD namespace exists
+  let argocdInstalled = false
+  try {
+    await execAsync('kubectl get namespace argocd 2>/dev/null', { timeout: 10_000 })
+    argocdInstalled = true
+    console.log('[argocd-bootstrap] ArgoCD already installed, skipping install')
+  } catch {
+    // ArgoCD not installed — proceed with install
+  }
+
+  if (!argocdInstalled) {
+    try {
+      console.log('[argocd-bootstrap] Installing ArgoCD into cluster...')
+
+      // Step 2: Create namespace and apply ArgoCD manifests
+      await execAsync('kubectl create namespace argocd 2>/dev/null', { timeout: 10_000 })
+      console.log('[argocd-bootstrap] Namespace argocd created')
+
+      await execAsync(
+        'kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml',
+        { timeout: 120_000 },
+      )
+      console.log('[argocd-bootstrap] ArgoCD manifests applied')
+
+      // Step 3: Wait for ArgoCD server to be ready
+      await execAsync(
+        'kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=120s',
+        { timeout: 130_000 },
+      )
+      console.log('[argocd-bootstrap] ArgoCD server is ready')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`[argocd-bootstrap] Failed to install ArgoCD (non-fatal): ${msg}`)
+      // Don't prevent gateway from starting if ArgoCD bootstrap fails
+    }
+  }
+
+  // Step 4: Fetch git provider config from Orion
+  try {
+    const res = await fetch(
+      `${orionUrl.replace(/\/$/, '')}/api/environments/${environmentId}/git-provider`,
+      {
+        headers: { Authorization: `Bearer ${gatewayToken}` },
+        signal: AbortSignal.timeout(10_000),
+      },
+    )
+    if (!res.ok) {
+      console.warn(`[argocd-bootstrap] Git provider config returned ${res.status} — skipping repo registration`)
+      return
+    }
+    const gitConfig: GitProviderInfo = await res.json()
+    if (!gitConfig.url) {
+      console.warn('[argocd-bootstrap] Git provider URL is empty — skipping repo registration')
+      return
+    }
+    console.log(`[argocd-bootstrap] Git provider: ${gitConfig.type} (${gitConfig.url})`)
+
+    // Step 5: Check if repo is already registered in ArgoCD
+    try {
+      const repoUrl = `${gitConfig.url}/${gitConfig.org}`
+      const secretsResult = await execAsync(
+        'kubectl get secret -n argocd -l argocd.argoproj.io/secret-type=repository -o json 2>/dev/null',
+        { timeout: 15_000 },
+      )
+      const secrets = JSON.parse(secretsResult.stdout)
+      const items = secrets.items ?? []
+
+      for (const item of items) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data = (item as any).data ?? {}
+        if (data.url) {
+          const decodedUrl = Buffer.from(data.url, 'base64').toString('utf8')
+          if (decodedUrl === repoUrl) {
+            console.log(`[argocd-bootstrap] Repo ${repoUrl} already registered in ArgoCD`)
+            return
+          }
+        }
+      }
+    } catch {
+      // If we can't check, proceed with registration (it's idempotent via kubectl apply)
+    }
+
+    // Step 6: Register the repo as an ArgoCD repository Secret
+    try {
+      const repoUrl = `${gitConfig.url}/${gitConfig.org}`
+      const username = gitConfig.type === 'github' ? 'x-access-token' : 'orion'
+
+      const safeRepoUrl  = repoUrl.replace(/[\r\n]/g, '')
+      const safeToken    = gitConfig.token.replace(/[\r\n]/g, '')
+      const safeUsername = username.replace(/[\r\n]/g, '')
+
+      const secretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: orion-git-repo
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: ${safeRepoUrl}
+  password: ${safeToken}
+  username: ${safeUsername}`
+
+      // Write to a temp file and apply — avoids stdin piping issues with exec
+      const tmpDir = mkdtempSync(tmpdir() + '/argocd-bootstrap-')
+      const tmpFile = `${tmpDir}/repo-secret.yaml`
+      writeFileSync(tmpFile, secretYaml, { mode: 0o600 })
+      try {
+        await execAsync(`kubectl apply -f ${tmpFile} -n argocd 2>/dev/null`, {
+          timeout: 15_000,
+        })
+        console.log(`[argocd-bootstrap] Registered git repo ${repoUrl} in ArgoCD`)
+      } finally {
+        try { unlinkSync(tmpFile) } catch { /* ignore */ }
+        try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* ignore */ }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`[argocd-bootstrap] Failed to register git repo in ArgoCD (non-fatal): ${msg}`)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.warn(`[argocd-bootstrap] Failed to fetch git provider config (non-fatal): ${msg}`)
+  }
+}

--- a/apps/gateway/src/docker-compose-watcher.ts
+++ b/apps/gateway/src/docker-compose-watcher.ts
@@ -1,0 +1,114 @@
+/**
+ * Docker Compose Sync Watcher
+ *
+ * Polls Docker container state every 60s.
+ * Maps running containers onto the ArgoCDApp shape so the same
+ * sync-status API and UI work for Docker environments.
+ *
+ * Requires: /var/run/docker.sock mounted (already present on docker/localhost gateways).
+ */
+
+import { exec } from 'child_process'
+import { promisify } from 'util'
+import type { ArgoCDApp } from './argocd-watcher.js'
+
+const execAsync = promisify(exec)
+
+type SyncReportFn = (apps: ArgoCDApp[]) => Promise<void>
+
+export class DockerComposeWatcher {
+  private timer?: ReturnType<typeof setInterval>
+  private lastState: Map<string, string> = new Map()
+
+  constructor(
+    private readonly onChanged: SyncReportFn,
+    private readonly intervalMs = 60_000,
+  ) {}
+
+  start() {
+    this.poll().catch(err => console.error('[docker-watcher] Initial poll failed:', err))
+    this.timer = setInterval(() => {
+      this.poll().catch(err => console.error('[docker-watcher] Poll failed:', err))
+    }, this.intervalMs)
+    console.log(`[docker-watcher] Watching Docker containers (interval: ${this.intervalMs / 1000}s)`)
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer)
+  }
+
+  private async poll() {
+    try {
+      const result = await execAsync(
+        'docker ps -a --format json 2>/dev/null',
+        { timeout: 15_000 },
+      )
+
+      const lines = result.stdout.trim().split('\n').filter(Boolean)
+      const containers = lines.map(line => JSON.parse(line))
+      const apps: ArgoCDApp[] = containers.map(parseContainer)
+
+      const newSnapshots = new Map<string, string>()
+      let hasChanges = false
+      for (const app of apps) {
+        const snapshot = `${app.syncStatus}:${app.healthStatus}:${app.revision}`
+        newSnapshots.set(app.name, snapshot)
+        if (this.lastState.get(app.name) !== snapshot) hasChanges = true
+      }
+
+      if (hasChanges || this.lastState.size === 0) {
+        console.log(`[docker-watcher] State changed: ${apps.map(a => `${a.name}=${a.syncStatus}/${a.healthStatus}`).join(', ')}`)
+        await this.onChanged(apps)
+        // Only commit lastState after successful report
+        this.lastState = newSnapshots
+      }
+    } catch (err) {
+      console.error('[docker-watcher] Poll failed:', err instanceof Error ? err.message : String(err))
+    }
+  }
+}
+
+// ── Parsing ───────────────────────────────────────────────────────────────────
+
+function parseContainer(c: unknown): ArgoCDApp {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const d = c as any
+  const labels = d.Labels ?? {}
+  const projectName = labels['com.docker.compose.project'] ?? 'docker'
+
+  const name = (d.Names ?? 'unknown').replace(/^\//, '')
+  const state = (d.State ?? '').toLowerCase()
+  const status = (d.Status ?? '')
+  const image = d.Image ?? ''
+
+  let syncStatus: ArgoCDApp['syncStatus']
+  if (state === 'running') {
+    syncStatus = 'Synced'
+  } else if (state === 'exited' || state === 'restarting') {
+    syncStatus = 'OutOfSync'
+  } else {
+    syncStatus = 'Unknown'
+  }
+
+  let healthStatus: ArgoCDApp['healthStatus']
+  if (state === 'running' && !status.includes('health: starting')) {
+    healthStatus = 'Healthy'
+  } else if (state === 'running' && status.includes('health: starting')) {
+    healthStatus = 'Progressing'
+  } else if (state === 'exited' || state === 'restarting' || state === 'dead') {
+    healthStatus = 'Degraded'
+  } else {
+    healthStatus = 'Unknown'
+  }
+
+  return {
+    name:         name,
+    namespace:    'docker',
+    project:      projectName,
+    syncStatus,
+    healthStatus,
+    revision:     image,
+    message:      status,
+    reconciledAt: new Date().toISOString(),
+  }
+}

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -59,6 +59,8 @@ import { trivyTools } from './builtin-tools/trivy.js'
 import { discoveryTools } from './builtin-tools/discovery.js'
 import { ArgoCDWatcher } from './argocd-watcher.js'
 import { IngressWatcher } from './ingress-watcher.js'
+import { DockerComposeWatcher } from './docker-compose-watcher.js'
+import { bootstrapArgoCD } from './argocd-bootstrap.js'
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -308,6 +310,7 @@ if (process.env.ENABLE_TRIVY === 'true') {
 let orion: OrionClient              // initialised in start()
 let argoCdWatcher:  ArgoCDWatcher  | undefined
 let ingressWatcher: IngressWatcher | undefined
+let dockerWatcher: DockerComposeWatcher | undefined
 let hooksEngine:  HooksEngine  | undefined
 let skillLoader:  SkillLoader | undefined
 
@@ -530,6 +533,11 @@ async function start() {
 
   // Start ArgoCD + Ingress watchers for K8s clusters
   if (GATEWAY_TYPE === 'cluster') {
+    // Bootstrap ArgoCD into the cluster (idempotent — safe on every restart)
+    bootstrapArgoCD(ORION_URL, ENVIRONMENT_ID, GATEWAY_TOKEN).catch(err =>
+      console.error('[gateway] ArgoCD bootstrap failed (non-fatal):', err instanceof Error ? err.message : String(err))
+    )
+
     argoCdWatcher = new ArgoCDWatcher(
       async (apps) => { await orion.reportSyncStatus(apps) },
     )
@@ -539,6 +547,13 @@ async function start() {
       async (ingresses) => { await orion.reportIngresses(ingresses) },
     )
     ingressWatcher.start()
+  }
+
+  if (GATEWAY_TYPE === 'docker' || GATEWAY_TYPE === 'localhost') {
+    dockerWatcher = new DockerComposeWatcher(
+      async (apps) => { await orion.reportSyncStatus(apps) },
+    )
+    dockerWatcher.start()
   }
 
   app.listen(PORT, () => {
@@ -555,6 +570,7 @@ process.on('SIGTERM', () => {
   console.log('[gateway] Shutting down…')
   argoCdWatcher?.stop()
   ingressWatcher?.stop()
+  dockerWatcher?.stop()
   orion.stopHeartbeat()
   hooksEngine?.stop()
   process.exit(0)

--- a/apps/web/src/app/api/environments/[id]/git-provider/route.ts
+++ b/apps/web/src/app/api/environments/[id]/git-provider/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/environments/:id/git-provider
+ *
+ * Returns the git provider config for a cluster gateway to use when
+ * bootstrapping ArgoCD repo registration.
+ *
+ * Auth: Bearer gatewayToken (same as heartbeat/sync-status).
+ *
+ * Air-gap design: returns cluster-reachable URLs only (management IP / internal
+ * hostnames). Never returns public/Cloudflare URLs — those are browser-only.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getGitProviderConfig } from '@/lib/git-provider'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  // Verify gateway token
+  const auth = req.headers.get('authorization')
+  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const expectedToken = env.gatewayToken
+  if (!expectedToken || auth !== `Bearer ${expectedToken}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const config = await getGitProviderConfig()
+  if (!config) {
+    return NextResponse.json({ error: 'Git provider not configured' }, { status: 404 })
+  }
+
+  // Resolve the cluster-reachable URL for the git provider.
+  // For gitea-bundled: use http://<MANAGEMENT_IP>:3002 so traffic stays on the
+  // private network and works in air-gapped deployments. This mirrors how
+  // ORION_CALLBACK_URL uses http://<MANAGEMENT_IP>:3000 for gateway→Orion traffic.
+  // Port 3002 is the host-exposed port for the bundled Gitea container (docker-compose.yml).
+  let url: string
+  if (config.type === 'gitea-bundled') {
+    const managementIp = process.env.MANAGEMENT_IP
+    if (!managementIp) {
+      return NextResponse.json(
+        { error: 'MANAGEMENT_IP not set — cannot derive cluster-reachable Gitea URL' },
+        { status: 500 },
+      )
+    }
+    url = `http://${managementIp}:3002`
+  } else {
+    // External providers: the user supplied a URL during wizard setup.
+    // config.url is optional for github (uses api.github.com implicitly) but the
+    // bootstrap only needs the base clone URL, not the API URL — use the org pattern.
+    url = config.url ?? (config.type === 'github' ? 'https://github.com' : '')
+  }
+
+  if (!url) {
+    return NextResponse.json(
+      { error: 'No cluster-reachable git URL available' },
+      { status: 404 },
+    )
+  }
+
+  return NextResponse.json({
+    type: config.type,
+    url,
+    token: config.token,
+    org: config.org,
+  })
+}

--- a/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
+++ b/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
@@ -6,6 +6,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 
+// SystemSetting.value is a Json column — narrow to string before using
+function settingStr(setting: { value: unknown } | null, fallback: string): string {
+  return typeof setting?.value === 'string' ? setting.value : fallback
+}
+
 export async function GET(req: NextRequest, { params }: { params: { token: string } }) {
   const record = await prisma.environmentJoinToken.findUnique({
     where: { token: params.token },
@@ -31,6 +36,17 @@ export async function GET(req: NextRequest, { params }: { params: { token: strin
     process.env.NEXTAUTH_URL ??
     (() => { const u = new URL(req.url); return `${u.protocol}//${u.host}` })()
   ).replace(/\/$/, '')
+
+  // Reverse proxy: if configured, use the public URL for remote gateways so they
+  // can reach Orion and Gitea via the proxy instead of the management IP.
+  const proxyUrlSetting  = await prisma.systemSetting.findUnique({ where: { key: 'reverse-proxy.public-url' } })
+  const proxyPublicUrl   = settingStr(proxyUrlSetting, '')
+
+  const remoteOrionUrl  = proxyPublicUrl || orionUrl
+  const giteaClusterUrl = proxyPublicUrl
+    ? (process.env.GITEA_PUBLIC_URL ?? (managementIp ? `http://${managementIp}:3002` : ''))
+    : (managementIp ? `http://${managementIp}:3002` : '')
+
   const envName = record.environment.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')
 
   // Use the environment's configured gatewayUrl if set; otherwise fall back to NodePort default.
@@ -146,7 +162,7 @@ metadata:
     orion/expires-at: "${record.expiresAt.toISOString()}"
 stringData:
   join-token: "${params.token}"
-  orion-url: "${orionUrl}"
+  orion-url: "${remoteOrionUrl}"
   environment-id: ""
   gateway-token: ""
 
@@ -206,6 +222,8 @@ spec:
                   optional: true
             - name: GATEWAY_SECRET_NAME
               value: "orion-gateway-${envName}-join"
+            - name: GITEA_CLUSTER_URL
+              value: "${giteaClusterUrl}"
           livenessProbe:
             httpGet: { path: /health, port: 3001 }
             initialDelaySeconds: 15

--- a/apps/web/src/app/api/ingress/points/[id]/set-as-orion-proxy/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/set-as-orion-proxy/route.ts
@@ -1,0 +1,59 @@
+/**
+ * POST /api/ingress/points/:id/set-as-orion-proxy
+ *
+ * Marks a bootstrapped IngressPoint as Orion's reverse proxy.
+ * Stores its public URL in SystemSettings so gateway manifests use it.
+ *
+ * Body:
+ *   {}            — set this IngressPoint as the proxy
+ *   { clear: true } — remove the proxy config (manifests revert to management IP)
+ *
+ * Stores:
+ *   SystemSetting 'reverse-proxy.public-url'      = https://<domain>
+ *   SystemSetting 'reverse-proxy.ingress-point-id' = <id>
+ *
+ * Clearing deletes both settings.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json() as { clear?: boolean }
+
+  if (body.clear) {
+    await prisma.systemSetting.deleteMany({
+      where: { key: { in: ['reverse-proxy.public-url', 'reverse-proxy.ingress-point-id'] } },
+    })
+    return NextResponse.json({ ok: true, cleared: true })
+  }
+
+  const point = await prisma.ingressPoint.findUnique({
+    where: { id: params.id },
+    include: { domain: true },
+  })
+  if (!point) return NextResponse.json({ error: 'IngressPoint not found' }, { status: 404 })
+
+  // point.domain.name is the apex domain (e.g. "khalisio.com").
+  // The actual Orion hostname may be a subdomain (e.g. "orion.khalisio.com") configured
+  // in the IngressRoute. For now we use the apex; the user can override publicUrl in .env.
+  const publicUrl = `https://${point.domain.name}`
+
+  await upsert('reverse-proxy.public-url', publicUrl)
+  await upsert('reverse-proxy.ingress-point-id', params.id)
+
+  return NextResponse.json({ ok: true, publicUrl })
+}
+
+async function upsert(key: string, value: string) {
+  await prisma.systemSetting.upsert({
+    where: { key }, update: { value }, create: { key, value },
+  })
+}

--- a/apps/web/src/app/api/setup/reverse-proxy/route.ts
+++ b/apps/web/src/app/api/setup/reverse-proxy/route.ts
@@ -37,11 +37,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'publicUrl is required' }, { status: 400 })
   }
 
-  // For 'external': validate the URL is reachable right now (proxy is already running).
-  // For 'docker': skip validation — Traefik won't be running until bootstrap.sh restarts
-  //   with --profile proxy. The stored publicUrl is unverified until then; the UI should
-  //   surface a warning prompting the user to re-verify after bootstrap.sh runs.
-  if (type === 'external' && publicUrl) {
+  // Validate publicUrl format and reject internal addresses.
+  // We do NOT make a server-side reachability fetch — that would be an SSRF
+  // vector regardless of hostname validation. The UI should prompt the operator
+  // to verify reachability after saving (same as the 'docker' type).
+  if ((type === 'external' || type === 'docker') && publicUrl) {
     let parsedUrl: URL
     try {
       parsedUrl = new URL(publicUrl)
@@ -51,19 +51,8 @@ export async function POST(req: NextRequest) {
     if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
       return NextResponse.json({ error: 'publicUrl must use http or https' }, { status: 400 })
     }
-    // Block private/loopback/metadata IPs — this endpoint makes a server-side
-    // request so we must not allow probing internal network addresses.
-    const hostname = parsedUrl.hostname
-    if (isPrivateHost(hostname)) {
+    if (isPrivateHost(parsedUrl.hostname)) {
       return NextResponse.json({ error: 'publicUrl must be a public hostname, not an internal IP' }, { status: 400 })
-    }
-    try {
-      const res = await fetch(`${parsedUrl.origin}/api/health`, { signal: AbortSignal.timeout(5000) })
-      if (!res.ok) {
-        return NextResponse.json({ error: `Public URL returned ${res.status} — check the URL and try again` }, { status: 502 })
-      }
-    } catch {
-      return NextResponse.json({ error: 'Could not reach publicUrl — check URL and try again' }, { status: 502 })
     }
   }
 

--- a/apps/web/src/app/api/setup/reverse-proxy/route.ts
+++ b/apps/web/src/app/api/setup/reverse-proxy/route.ts
@@ -51,8 +51,14 @@ export async function POST(req: NextRequest) {
     if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
       return NextResponse.json({ error: 'publicUrl must use http or https' }, { status: 400 })
     }
+    // Block private/loopback/metadata IPs — this endpoint makes a server-side
+    // request so we must not allow probing internal network addresses.
+    const hostname = parsedUrl.hostname
+    if (isPrivateHost(hostname)) {
+      return NextResponse.json({ error: 'publicUrl must be a public hostname, not an internal IP' }, { status: 400 })
+    }
     try {
-      const res = await fetch(`${publicUrl.replace(/\/$/, '')}/api/health`, { signal: AbortSignal.timeout(5000) })
+      const res = await fetch(`${parsedUrl.origin}/api/health`, { signal: AbortSignal.timeout(5000) })
       if (!res.ok) {
         return NextResponse.json({ error: `Public URL returned ${res.status} — check the URL and try again` }, { status: 502 })
       }
@@ -65,6 +71,22 @@ export async function POST(req: NextRequest) {
   if (publicUrl) await upsert('reverse-proxy.public-url', publicUrl.replace(/\/$/, ''))
 
   return NextResponse.json({ ok: true, type, publicUrl: publicUrl ?? null })
+}
+
+function isPrivateHost(hostname: string): boolean {
+  // Reject loopback, private RFC1918, link-local, and cloud metadata ranges.
+  if (hostname === 'localhost') return true
+  const privatePatterns = [
+    /^127\./,
+    /^10\./,
+    /^192\.168\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^169\.254\./,   // link-local / AWS metadata
+    /^::1$/,         // IPv6 loopback
+    /^fc00:/i,       // IPv6 ULA
+    /^fe80:/i,       // IPv6 link-local
+  ]
+  return privatePatterns.some(p => p.test(hostname))
 }
 
 async function upsert(key: string, value: string) {

--- a/apps/web/src/app/api/setup/reverse-proxy/route.ts
+++ b/apps/web/src/app/api/setup/reverse-proxy/route.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/setup/reverse-proxy
+ *
+ * Wizard step — configure reverse proxy on the management node.
+ * Only 'none', 'external', and 'docker' are valid here.
+ * 'cluster' (deploy into a managed environment) is a post-wizard action.
+ *
+ * Body shapes:
+ *   { type: 'none' }
+ *   { type: 'external', publicUrl: string }   — BYO proxy, validates reachability
+ *   { type: 'docker',   publicUrl: string }   — Traefik on Docker host, bootstrap.sh activates --profile proxy
+ *   { skip: true }                            — same as 'none'
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireWizardSession } from '@/lib/setup-guard'
+
+export async function POST(req: NextRequest) {
+  if (!await requireWizardSession(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json() as { type?: string; publicUrl?: string; skip?: boolean }
+
+  if (body.skip) {
+    await upsert('reverse-proxy.type', 'none')
+    return NextResponse.json({ ok: true, skipped: true })
+  }
+
+  const { type, publicUrl } = body
+
+  if (!type || !['none', 'external', 'docker'].includes(type)) {
+    return NextResponse.json({ error: "type must be 'none', 'external', or 'docker'" }, { status: 400 })
+  }
+
+  if (type !== 'none' && !publicUrl) {
+    return NextResponse.json({ error: 'publicUrl is required' }, { status: 400 })
+  }
+
+  // For 'external': validate the URL is reachable right now (proxy is already running).
+  // For 'docker': skip validation — Traefik won't be running until bootstrap.sh restarts
+  //   with --profile proxy. The stored publicUrl is unverified until then; the UI should
+  //   surface a warning prompting the user to re-verify after bootstrap.sh runs.
+  if (type === 'external' && publicUrl) {
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(publicUrl)
+    } catch {
+      return NextResponse.json({ error: 'publicUrl is not a valid URL' }, { status: 400 })
+    }
+    if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+      return NextResponse.json({ error: 'publicUrl must use http or https' }, { status: 400 })
+    }
+    try {
+      const res = await fetch(`${publicUrl.replace(/\/$/, '')}/api/health`, { signal: AbortSignal.timeout(5000) })
+      if (!res.ok) {
+        return NextResponse.json({ error: `Public URL returned ${res.status} — check the URL and try again` }, { status: 502 })
+      }
+    } catch {
+      return NextResponse.json({ error: 'Could not reach publicUrl — check URL and try again' }, { status: 502 })
+    }
+  }
+
+  await upsert('reverse-proxy.type', type)
+  if (publicUrl) await upsert('reverse-proxy.public-url', publicUrl.replace(/\/$/, ''))
+
+  return NextResponse.json({ ok: true, type, publicUrl: publicUrl ?? null })
+}
+
+async function upsert(key: string, value: string) {
+  await prisma.systemSetting.upsert({
+    where: { key }, update: { value }, create: { key, value },
+  })
+}

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -345,7 +345,11 @@ async function deploySwarmStack(
   }
 }
 
-const ORION_URL       = process.env.NEXTAUTH_URL  ?? 'http://localhost:3000'
+const ORION_URL       = (
+  process.env.ORION_CALLBACK_URL ??
+  (process.env.MANAGEMENT_IP ? `http://${process.env.MANAGEMENT_IP}:3000` : null) ??
+  'http://localhost:3000'
+).replace(/\/$/, '')
 const MANAGEMENT_IP   = process.env.MANAGEMENT_IP ?? 'localhost'
 
 export type BootstrapEvent =

--- a/apps/web/src/lib/docker-gateway.ts
+++ b/apps/web/src/lib/docker-gateway.ts
@@ -19,9 +19,12 @@ const GATEWAY_IMAGE = `ghcr.io/${process.env.GITHUB_ORG ?? 'richard-callis'}/ori
 const ORION_CALLBACK_URL = (
   process.env.ORION_CALLBACK_URL ??
   (process.env.MANAGEMENT_IP ? `http://${process.env.MANAGEMENT_IP}:3000` : null) ??
-  process.env.NEXTAUTH_URL ??
   'http://localhost:3000'
 ).replace(/\/$/, '')
+
+if (!process.env.ORION_CALLBACK_URL && !process.env.MANAGEMENT_IP) {
+  console.warn('[orion] WARNING: Neither ORION_CALLBACK_URL nor MANAGEMENT_IP is set. Gateway/webhook URLs will use localhost — this will break in container environments.')
+}
 
 export type GatewayDeployEvent =
   | { type: 'step'; message: string }

--- a/apps/web/src/lib/localhost-bootstrap.ts
+++ b/apps/web/src/lib/localhost-bootstrap.ts
@@ -27,9 +27,12 @@ const RUNNER_IMAGE     = 'gitea/act_runner:latest'
 const ORION_CALLBACK_URL = (
   process.env.ORION_CALLBACK_URL ??
   (process.env.MANAGEMENT_IP ? `http://${process.env.MANAGEMENT_IP}:3000` : null) ??
-  process.env.NEXTAUTH_URL ??
   'http://localhost:3000'
 ).replace(/\/$/, '')
+
+if (!process.env.ORION_CALLBACK_URL && !process.env.MANAGEMENT_IP) {
+  console.warn('[orion] WARNING: Neither ORION_CALLBACK_URL nor MANAGEMENT_IP is set. Gateway/webhook URLs will use localhost — this will break in container environments.')
+}
 
 // ── Docker socket helpers ─────────────────────────────────────────────────────
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -11,6 +11,12 @@ if [[ "$GIT_PROVIDER" == "gitea-bundled" ]]; then
   PROFILE_FLAGS="--profile gitea"
 fi
 
+# Activate the proxy profile if REVERSE_PROXY_TYPE is docker
+REVERSE_PROXY_TYPE="${REVERSE_PROXY_TYPE:-none}"
+if [[ "$REVERSE_PROXY_TYPE" == "docker" ]]; then
+  PROFILE_FLAGS="$PROFILE_FLAGS --profile proxy"
+fi
+
 COMPOSE="docker compose -f $DEPLOY_DIR/docker-compose.yml --env-file $DEPLOY_DIR/.env $PROFILE_FLAGS"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
@@ -360,28 +366,6 @@ chown -R 1000:1000 "$DEPLOY_DIR/vector-data" 2>/dev/null || true
 
 echo "Starting Vector host telemetry shipper..."
 $COMPOSE up -d --force-recreate vector 2>/dev/null || echo "NOTE: Vector service failed to start (check compose logs)."
-
-# ── Write kubeconfig for ArgoCD ──────────────────────────────────────────────
-# ArgoCD mounts ${HOME}/.kube as /kubeconfig. Pull the kubeconfig for the
-# Talos Cluster environment from the DB (stored as base64) and write it so
-# ArgoCD can reach the cluster without manual credential management.
-echo ""
-echo "Writing kubeconfig for ArgoCD..."
-KUBE_B64=$(PGPASSWORD="${POSTGRES_PASSWORD}" docker exec -e PGPASSWORD="${POSTGRES_PASSWORD}" \
-  deploy-postgres-1 psql -U orion -d orion -t -A \
-  -c "SELECT kubeconfig FROM \"Environment\" WHERE type = 'cluster' AND kubeconfig IS NOT NULL LIMIT 1;" \
-  2>/dev/null | tr -d '[:space:]')
-
-if [[ -n "$KUBE_B64" ]]; then
-  mkdir -p "${HOME}/.kube"
-  echo "$KUBE_B64" | base64 -d > "${HOME}/.kube/config"
-  chmod 600 "${HOME}/.kube/config"
-  echo "Kubeconfig written to ${HOME}/.kube/config — restarting ArgoCD..."
-  $COMPOSE restart argocd-server argocd-application-controller argocd-repo-server 2>/dev/null || true
-else
-  echo "NOTE: No cluster kubeconfig found in DB — ArgoCD will not have cluster access."
-  echo "  Register a cluster environment in Orion to enable ArgoCD sync."
-fi
 
 if [[ -n "${SETUP_TOKEN:-}" ]]; then
   echo ""

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -165,60 +165,36 @@ services:
           cpus: '2'
           memory: 1G
 
-  # ── ArgoCD (GitOps — runs on host, manages the Talos Cluster externally) ─
-  argocd-server:
-    image: quay.io/argoproj/argocd:latest
+  # ── Traefik — reverse proxy (optional — activate with: docker compose --profile proxy up)
+  # Only needed when exposing Orion to remote gateways on separate networks.
+  # Activated by bootstrap.sh when REVERSE_PROXY_TYPE=docker is set in .env.
+  traefik:
+    profiles: [proxy]
+    image: traefik:v3.0
     restart: unless-stopped
-    depends_on:
-      - argocd-redis
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --certificatesresolvers.letsencrypt.acme.tlschallenge=true
+      - --certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:-admin@example.com}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
     ports:
-      - "8083:8080"
-    environment:
-      - ARGOCD_SERVER_INSECURE=true
-      - ARGOCD_SERVER_INSECURE_HTTP_BASIC_ENABLE=true
-      - KUBECONFIG=/kubeconfig/config
+      - "80:80"
+      - "443:443"
     volumes:
-      - argocd-server-data:/home/argocd
-      - ${HOME}/.kube:/kubeconfig:ro
-    command:
-      - argocd-server
-      - --insecure
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-letsencrypt:/letsencrypt
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
 
-  argocd-repo-server:
-    image: quay.io/argoproj/argocd:latest
-    restart: unless-stopped
-    depends_on:
-      - argocd-redis
-    environment:
-      - KUBECONFIG=/kubeconfig/config
-    volumes:
-      - argocd-server-data:/shared
-      - ${HOME}/.kube:/kubeconfig:ro
-    command:
-      - argocd-repo-server
-
-  argocd-application-controller:
-    image: quay.io/argoproj/argocd:latest
-    restart: unless-stopped
-    depends_on:
-      - argocd-redis
-    environment:
-      - KUBECONFIG=/kubeconfig/config
-    volumes:
-      - argocd-server-data:/shared
-      - ${HOME}/.kube:/kubeconfig:ro
-    command:
-      - argocd-application-controller
-      - --redis
-      - argocd-redis:6379
-
-  argocd-redis:
-    image: docker.io/library/redis:7.4-alpine
-    restart: unless-stopped
-    volumes:
-      - argocd-redis-data:/data
-
-# ── PostgreSQL
+  # ── PostgreSQL
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
@@ -715,6 +691,5 @@ volumes:
   redis-sentinel-1-data:
   redis-sentinel-2-data:
   redis-sentinel-3-data:
-  argocd-server-data:
-  argocd-redis-data:
+  traefik-letsencrypt:
   vault-audit:


### PR DESCRIPTION
## Summary

- **DockerComposeWatcher**: Docker/localhost gateways now report sync status using the same `ArgoCDApp` shape as ArgoCD — identical UI and API for all environment types
- **ArgoCD bootstrap**: cluster gateways install and register ArgoCD on first boot (idempotent)
- **Reverse proxy support**: new `set-as-orion-proxy` endpoint marks a bootstrapped IngressPoint as Orion's public URL; gateway manifests use it so remote gateways can reach Orion through the proxy
- **Air-gap fixes**: `NEXTAUTH_URL` (public Cloudflare URL) removed from internal service URL fallback chains in `cluster-bootstrap.ts`, `localhost-bootstrap.ts`, `docker-gateway.ts`
- **ArgoCD removed from host**: `docker-compose.yml` no longer runs ArgoCD services; Traefik added under `profiles: [proxy]`

## Security (Opus-reviewed and approved)

- Auth bypass closed: `git-provider` route now returns 401 when `gatewayToken` is null rather than silently leaking git credentials
- YAML injection sanitized: ArgoCD repo Secret generation strips `\r\n` from token/URL/username before interpolation
- SSRF guard: external proxy URL validation rejects non-http/https schemes before making server-side fetch
- `DockerComposeWatcher.poll()` now wraps entire body in try/catch; `lastState` only committed after successful Orion report

## New files

- `apps/gateway/src/docker-compose-watcher.ts`
- `apps/gateway/src/argocd-bootstrap.ts`
- `apps/web/src/app/api/environments/[id]/git-provider/route.ts`
- `apps/web/src/app/api/ingress/points/[id]/set-as-orion-proxy/route.ts`
- `apps/web/src/app/api/setup/reverse-proxy/route.ts`

## Test plan

- [ ] Docker gateway: containers appear in sync status UI after gateway restart
- [ ] Cluster gateway: ArgoCD installs on first boot; skips on subsequent restarts
- [ ] `GET /api/environments/:id/git-provider` returns 401 when no gateway token set
- [ ] `POST /api/setup/reverse-proxy` with `type: external` rejects non-https:// URLs
- [ ] Gateway manifest includes `GITEA_CLUSTER_URL` and uses proxy public URL when configured
- [ ] `localhost-bootstrap.ts` / `docker-gateway.ts` log warning when neither `ORION_CALLBACK_URL` nor `MANAGEMENT_IP` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)