### PR TITLE
fix: restore in-progress OAuth login state after page refresh

### DIFF
--- a/apps/web/src/app/(app)/admin/claude/page.tsx
+++ b/apps/web/src/app/(app)/admin/claude/page.tsx
@@ -54,7 +54,18 @@ export default function ClaudeOAuthPage() {
     setProbing(false)
   }
 
-  useEffect(() => { loadStatus() }, [])
+  // On mount: load status AND resume any in-progress login (survives page refresh)
+  useEffect(() => {
+    loadStatus()
+    fetch('/api/admin/claude/oauth?action=poll')
+      .then(r => r.ok ? r.json() : null)
+      .then((data: PollData | null) => {
+        if (data && data.status !== 'idle' && data.status !== 'done' && data.status !== 'error') {
+          setPoll(data)
+        }
+      })
+      .catch(() => null)
+  }, [])
 
   // Auto-scroll logs
   useEffect(() => {


### PR DESCRIPTION
## Problem

The Submit button and code input only render when `poll.authUrl` is set. On page refresh, React state is lost — the sidecar can be mid-login waiting for a code, but the UI shows nothing: no URL, no input, no Submit button. The user sees a blank OAuth tab and can't complete the flow.

## Fix

Poll `/auth/poll` on mount and restore any in-progress login state automatically, so the URL and code input reappear after a refresh.

## Test plan

- [ ] Start OAuth flow, copy the URL, refresh the page → URL and code input reappear automatically
- [ ] Complete the flow after refresh → authentication succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)