### PR TITLE
fix: Claude OAuth submit button does nothing — three bugs

### DIFF
--- a/apps/web/src/app/(app)/admin/claude/page.tsx
+++ b/apps/web/src/app/(app)/admin/claude/page.tsx
@@ -86,6 +86,9 @@ export default function ClaudeOAuthPage() {
       if (res?.ok) {
         const data: PollData = await res.json()
         setPoll(data)
+        if (typeof data.output === 'string' && /invalid code/i.test(data.output)) {
+          setCodeErr('Invalid code. Make sure you copied the full authorization code.')
+        }
       }
     }, 1500)
     return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }
@@ -111,18 +114,21 @@ export default function ClaudeOAuthPage() {
   const submitCode = async () => {
     if (!code.trim()) return
     setSending(true)
+    setCodeErr(null)
     const res = await fetch('/api/admin/claude/oauth?action=code', {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify({ code: code.trim() }),
     }).catch(() => null)
     const data = await res?.json().catch(() => null)
-    if (res?.ok && data) {
-      setCodeErr(null)
+    if (res?.ok && data && !data.error) {
+      setCode('')
+      if (typeof data.output === 'string' && /invalid code/i.test(data.output)) {
+        setCodeErr('Invalid code. Make sure you copied the full authorization code.')
+      }
       setPoll(prev => prev ? { ...prev, ...data } : data)
     } else {
-      const msg = data?.error ?? 'Failed to submit code — service may be unreachable'
-      setCodeErr(msg)
+      setCodeErr(data?.error ?? 'Failed to submit code — service may be unreachable')
     }
     setSending(false)
   }
@@ -326,8 +332,21 @@ export default function ClaudeOAuthPage() {
             </div>
           )}
 
-          {/* Code input — shown once we have the URL */}
-          {poll?.authUrl && poll.status !== 'done' && poll.status !== 'error' && (
+          {/* Verifying indicator */}
+          {poll?.status === 'completing' && !codeErr && (
+            <div className="flex items-center gap-2 text-sm text-text-secondary">
+              <RefreshCw size={13} className="animate-spin" />
+              Verifying code…
+            </div>
+          )}
+
+          {codeErr && (
+            <p className="text-sm text-status-error">{codeErr}</p>
+          )}
+
+          {/* Code input — hidden while verifying unless there's an error to re-try */}
+          {poll?.authUrl && poll.status !== 'done' && poll.status !== 'error' &&
+            (poll.status !== 'completing' || !!codeErr) && (
             <div className="flex gap-2">
               <input
                 value={code}


### PR DESCRIPTION
## Root cause (diagnosed with Opus)

Three bugs working together made Submit appear to do nothing:

1. **No visible feedback** — sidecar flips to `status: 'completing'` while verifying the code, but the input stayed on screen unchanged. The click took effect but the UI never changed.

2. **Race condition** — the 1.5s background poll calls `setPoll()` as a full replace. `submitCode()` merged state but the next tick (≤1.5s later) clobbered it before the user saw anything.

3. **Invalid code swallowed silently** — the sidecar re-prompts with `"Invalid code"` in output text, but `res.ok` is true and the body is valid JSON, so no error path triggered.

## Changes

- `submitCode()`: clear input on successful POST (immediate feedback); detect `"Invalid code"` in sidecar output and surface as inline error
- Poll loop: also detect `"Invalid code"` re-prompt so the racing poll tick still shows the error
- Render: show `"Verifying code…"` spinner while `status === 'completing'`; hide code input during verification unless there's an error to re-try
- Restore in-progress login on mount so URL + input survive page refresh

## Test plan

- [ ] Submit a valid code → input clears, spinner shows, completes successfully
- [ ] Submit an invalid/expired code → error message appears, input re-shown for retry
- [ ] Refresh the page mid-flow → URL and input reappear automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)