### PR TITLE
fix(siem): wire up investigations, alert detail, flows, settings, Falco

### DIFF
--- a/apps/web/src/app/(app)/security/alerts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/alerts/[id]/page.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { ArrowLeft, Shield, Globe, Database, AlertTriangle, CheckCircle2, XCircle, Loader2, ExternalLink } from 'lucide-react'
+import Link from 'next/link'
+
+const sourceIcons: Record<string, React.ElementType> = {
+  crowdsec: Shield,
+  ntopng: Globe,
+  wazuh: Database,
+  elk: Database,
+  falco: Shield,
+}
+
+const sourceColors: Record<string, string> = {
+  crowdsec: 'text-blue-400',
+  ntopng: 'text-green-400',
+  wazuh: 'text-orange-400',
+  elk: 'text-purple-400',
+  falco: 'text-red-400',
+}
+
+interface AlertEvent {
+  id: string
+  type: string
+  source: string
+  severity: number
+  title: string
+  description: string | null
+  rawEvent: unknown
+  acknowledged: boolean
+  acknowledgedAt: string | null
+  dedupKey: string | null
+  firstSeen: string | null
+  lastSeen: string | null
+  createdAt: string
+  incidentId: string | null
+  environmentId: string | null
+}
+
+function SeverityBadge({ severity }: { severity: number }) {
+  if (severity >= 80) return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border bg-red-500/20 text-red-400 border-red-500/30"><XCircle size={10} />{severity} Critical</span>
+  if (severity >= 50) return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border bg-orange-500/20 text-orange-400 border-orange-500/30"><AlertTriangle size={10} />{severity} High</span>
+  if (severity >= 20) return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border bg-yellow-500/20 text-yellow-400 border-yellow-500/30"><AlertTriangle size={10} />{severity} Medium</span>
+  return <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border bg-green-500/20 text-green-400 border-green-500/30"><CheckCircle2 size={10} />{severity} Low</span>
+}
+
+export default function AlertDetailPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const [event, setEvent] = useState<AlertEvent | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [rawExpanded, setRawExpanded] = useState(false)
+  const [acking, setAcking] = useState(false)
+
+  useEffect(() => {
+    fetch(`/api/monitoring/security/alerts/${params.id}`)
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status}`)
+        return r.json()
+      })
+      .then(d => { setEvent(d.event); setLoading(false) })
+      .catch(() => { setLoading(false) })
+  }, [params.id])
+
+  async function acknowledge() {
+    if (!event || event.acknowledged) return
+    setAcking(true)
+    await fetch('/api/monitoring/security/alerts/ack', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [event.id] }),
+    })
+    setEvent(prev => prev ? { ...prev, acknowledged: true, acknowledgedAt: new Date().toISOString() } : prev)
+    setAcking(false)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-accent" />
+      </div>
+    )
+  }
+
+  if (!event) {
+    return (
+      <div className="text-status-error text-sm p-4 border border-status-error/20 bg-status-error/5 rounded-lg">
+        Alert not found.
+      </div>
+    )
+  }
+
+  const Icon = sourceIcons[event.source] || Shield
+
+  return (
+    <div className="p-6 max-w-4xl space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <button onClick={() => router.back()} className="p-1 rounded text-text-muted hover:text-text-primary transition-colors">
+            <ArrowLeft size={16} />
+          </button>
+          <Icon size={18} className={sourceColors[event.source] || 'text-text-muted'} />
+          <h1 className="text-lg font-semibold text-text-primary">{event.title}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          {!event.acknowledged && (
+            <button
+              onClick={acknowledge}
+              disabled={acking}
+              className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-border-subtle text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+            >
+              {acking ? <Loader2 size={12} className="animate-spin" /> : <CheckCircle2 size={12} />}
+              Acknowledge
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Meta */}
+      <div className="bg-bg-surface border border-border-subtle rounded-xl p-4 space-y-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <SeverityBadge severity={event.severity} />
+          <span className="text-xs text-text-muted px-2 py-0.5 rounded bg-bg-raised font-mono">{event.type}</span>
+          <span className="text-xs text-text-muted px-2 py-0.5 rounded bg-bg-raised">{event.source}</span>
+          {event.acknowledged && (
+            <span className="text-xs text-status-success flex items-center gap-1">
+              <CheckCircle2 size={12} /> Acknowledged
+            </span>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
+          <div>
+            <span className="text-text-muted">First seen: </span>
+            <span className="text-text-primary">{event.firstSeen ? new Date(event.firstSeen).toLocaleString() : new Date(event.createdAt).toLocaleString()}</span>
+          </div>
+          <div>
+            <span className="text-text-muted">Last seen: </span>
+            <span className="text-text-primary">{event.lastSeen ? new Date(event.lastSeen).toLocaleString() : '—'}</span>
+          </div>
+          {event.dedupKey && (
+            <div className="col-span-2">
+              <span className="text-text-muted">Dedup key: </span>
+              <code className="text-text-primary font-mono">{event.dedupKey}</code>
+            </div>
+          )}
+        </div>
+
+        {event.incidentId && (
+          <Link
+            href={`/security/incidents/${event.incidentId}`}
+            className="inline-flex items-center gap-1.5 text-xs text-accent hover:underline"
+          >
+            <ExternalLink size={12} />
+            Linked to incident
+          </Link>
+        )}
+      </div>
+
+      {/* Description */}
+      {event.description && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl p-4">
+          <div className="text-xs font-medium text-text-muted mb-2 uppercase tracking-wide">Description</div>
+          <p className="text-sm text-text-primary leading-relaxed">{event.description}</p>
+        </div>
+      )}
+
+      {/* Raw event */}
+      {event.rawEvent && (
+        <div className="bg-bg-surface border border-border-subtle rounded-xl overflow-hidden">
+          <button
+            onClick={() => setRawExpanded(e => !e)}
+            className="w-full px-4 py-3 flex items-center justify-between text-xs font-medium text-text-muted hover:text-text-primary transition-colors border-b border-border-subtle"
+          >
+            <span className="uppercase tracking-wide">Raw Event</span>
+            <span>{rawExpanded ? '▲' : '▼'}</span>
+          </button>
+          {rawExpanded && (
+            <pre className="p-4 text-xs font-mono text-text-secondary overflow-x-auto bg-bg-raised leading-relaxed max-h-96 overflow-y-auto">
+              {JSON.stringify(event.rawEvent as Record<string, unknown>, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/security/incidents/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/incidents/[id]/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { ArrowLeft, AlertTriangle, Shield, Clock, CheckCircle, XCircle, MessageSquare, FileText, Loader2 } from 'lucide-react'
+import { ArrowLeft, AlertTriangle, Shield, Clock, CheckCircle, XCircle, MessageSquare, FileText, Loader2, Search, ExternalLink } from 'lucide-react'
+import Link from 'next/link'
 
 interface ActionAudit {
   id: string
@@ -34,6 +35,7 @@ interface IncidentData {
     hostKey: string | null
     openedAt: string
     closedAt: string | null
+    investigationId: string | null
   }
   events: Array<{
     id: string
@@ -54,13 +56,43 @@ export default function IncidentDetailPage() {
   const [data, setData] = useState<IncidentData | null>(null)
   const [loading, setLoading] = useState(true)
   const [activeTab, setActiveTab] = useState<'events' | 'actions' | 'chat'>('events')
+  const [creatingInvestigation, setCreatingInvestigation] = useState(false)
 
   useEffect(() => {
     fetch(`/api/monitoring/security/incidents/${params.id}`)
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status}`)
+        return r.json()
+      })
       .then(d => { setData(d); setLoading(false) })
       .catch(() => { setLoading(false) })
   }, [params.id])
+
+  async function handleCreateInvestigation() {
+    setCreatingInvestigation(true)
+    try {
+      const r = await fetch(`/api/monitoring/security/incidents/${params.id}/create-investigation`, {
+        method: 'POST',
+      })
+      if (r.status === 409) {
+        // Already linked — navigate to the existing one
+        const d = await r.json()
+        // Refresh incident data to get the investigationId, then navigate
+        const refreshed = await fetch(`/api/monitoring/security/incidents/${params.id}`).then(r2 => r2.json())
+        if (refreshed.incident?.investigationId) {
+          router.push(`/security/investigations/${refreshed.incident.investigationId}`)
+        }
+        return
+      }
+      if (!r.ok) throw new Error(`${r.status}`)
+      const d = await r.json()
+      router.push(`/security/investigations/${d.investigation.id}`)
+    } catch {
+      // non-critical — user can retry
+    } finally {
+      setCreatingInvestigation(false)
+    }
+  }
 
   if (loading) {
     return (
@@ -83,16 +115,38 @@ export default function IncidentDetailPage() {
   return (
     <div className="p-6 max-w-5xl space-y-4">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <button onClick={() => router.back()} className="p-1 rounded text-text-muted hover:text-text-primary transition-colors">
-          <ArrowLeft size={16} />
-        </button>
-        <div className="flex items-center gap-2">
-          <Shield size={18} className="text-accent" />
-          <h1 className="text-lg font-semibold text-text-primary">
-            {incident.rootCauseSummary || 'Untitled Incident'}
-          </h1>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <button onClick={() => router.back()} className="p-1 rounded text-text-muted hover:text-text-primary transition-colors">
+            <ArrowLeft size={16} />
+          </button>
+          <div className="flex items-center gap-2">
+            <Shield size={18} className="text-accent" />
+            <h1 className="text-lg font-semibold text-text-primary">
+              {incident.rootCauseSummary || 'Untitled Incident'}
+            </h1>
+          </div>
         </div>
+
+        {/* Investigation button */}
+        {incident.investigationId ? (
+          <Link
+            href={`/security/investigations/${incident.investigationId}`}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-accent text-accent hover:bg-accent/10 transition-colors"
+          >
+            <ExternalLink size={12} />
+            View Investigation
+          </Link>
+        ) : (
+          <button
+            onClick={handleCreateInvestigation}
+            disabled={creatingInvestigation}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+          >
+            {creatingInvestigation ? <Loader2 size={12} className="animate-spin" /> : <Search size={12} />}
+            Open Investigation
+          </button>
+        )}
       </div>
 
       {/* Incident header */}
@@ -160,7 +214,11 @@ export default function IncidentDetailPage() {
             <div className="px-4 py-8 text-center text-sm text-text-muted">No events linked to this incident.</div>
           ) : (
             events.map(ev => (
-              <div key={ev.id} className="px-4 py-3 flex items-center gap-3">
+              <Link
+                key={ev.id}
+                href={`/security/alerts/${ev.id}`}
+                className="px-4 py-3 flex items-center gap-3 hover:bg-bg-raised transition-colors"
+              >
                 <span className={`text-xs font-bold w-10 shrink-0 text-center ${
                   ev.severity >= 80 ? 'text-status-error' :
                   ev.severity >= 50 ? 'text-status-warning' :
@@ -172,7 +230,8 @@ export default function IncidentDetailPage() {
                     {ev.source} · {ev.type} · {new Date(ev.createdAt).toLocaleString()}
                   </div>
                 </div>
-              </div>
+                <ExternalLink size={12} className="text-text-muted shrink-0" />
+              </Link>
             ))
           )}
         </div>

--- a/apps/web/src/app/api/monitoring/security/alerts/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const event = await prisma.securityEvent.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      type: true,
+      source: true,
+      severity: true,
+      title: true,
+      description: true,
+      rawEvent: true,
+      acknowledged: true,
+      acknowledgedAt: true,
+      dedupKey: true,
+      firstSeen: true,
+      lastSeen: true,
+      createdAt: true,
+      incidentId: true,
+      environmentId: true,
+    },
+  })
+
+  if (!event) {
+    return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ event })
+}

--- a/apps/web/src/app/api/monitoring/security/connections/test/route.ts
+++ b/apps/web/src/app/api/monitoring/security/connections/test/route.ts
@@ -5,12 +5,31 @@ export const dynamic = 'force-dynamic'
 
 // Maps each SecuritySettings key to the cheapest gateway read tool for that source.
 // Tests via gateway so the probe runs from inside the cluster network (correct DNS/auth).
+// Note: elk_flow_search parses its query arg as JSON, so we omit it to get match_all.
 const SOURCE_PROBE: Record<string, { tool: string; args: Record<string, unknown> }> = {
-  CROWDSEC_API:       { tool: 'crowdsec_blocks',    args: { limit: 1 } },
-  NTOPNG_API:         { tool: 'ntopng_threats',     args: { limit: 1 } },
-  ELASTICSEARCH_URL:  { tool: 'elk_flow_search',    args: { query: '*', limit: 1 } },
-  WAZUH_API:          { tool: 'wazuh_alerts',       args: { limit: 1 } },
-  VICTORIA_METRICS_URL: { tool: 'prometheus_query', args: { query: 'up', time: new Date().toISOString() } },
+  CROWDSEC_API:         { tool: 'crowdsec_blocks',    args: { limit: 1 } },
+  NTOPNG_API:           { tool: 'ntopng_threats',     args: { limit: 1 } },
+  ELASTICSEARCH_URL:    { tool: 'elk_flow_search',    args: { size: 1 } },
+  WAZUH_API:            { tool: 'wazuh_alerts',       args: { limit: 1 } },
+  VICTORIA_METRICS_URL: { tool: 'prometheus_query',   args: { query: 'up', time: new Date().toISOString() } },
+}
+
+// Gateway tools return error strings (not HTTP errors) when a source is down.
+// These prefixes/substrings appear in the result string on failure.
+const ERROR_INDICATORS = [
+  'environment variable not configured',
+  'error http',
+  'connection refused',
+  'failed to connect',
+  'econnrefused',
+  'timeout',
+  'unauthorized',
+]
+
+function isErrorResult(result: unknown): boolean {
+  if (typeof result !== 'string') return false
+  const lower = result.toLowerCase()
+  return ERROR_INDICATORS.some(s => lower.includes(s))
 }
 
 export async function GET(request: NextRequest) {
@@ -48,12 +67,21 @@ export async function GET(request: NextRequest) {
       signal: AbortSignal.timeout(8000),
     })
 
-    if (res.ok) {
-      return NextResponse.json({ ok: true })
+    if (!res.ok) {
+      const text = await res.text()
+      return NextResponse.json({ ok: false, error: `Gateway returned ${res.status}: ${text}` })
     }
 
-    const text = await res.text()
-    return NextResponse.json({ ok: false, error: `Gateway returned ${res.status}: ${text}` })
+    // Gateway returns { result: "<tool output string>" } with HTTP 200 even on source errors.
+    // Inspect the result body for known error indicators.
+    const data = await res.json() as { result?: unknown }
+    const result = data?.result
+
+    if (isErrorResult(result)) {
+      return NextResponse.json({ ok: false, error: String(result) })
+    }
+
+    return NextResponse.json({ ok: true })
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     return NextResponse.json({ ok: false, error: msg })

--- a/apps/web/src/app/api/monitoring/security/connections/test/route.ts
+++ b/apps/web/src/app/api/monitoring/security/connections/test/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+// Maps each SecuritySettings key to the cheapest gateway read tool for that source.
+// Tests via gateway so the probe runs from inside the cluster network (correct DNS/auth).
+const SOURCE_PROBE: Record<string, { tool: string; args: Record<string, unknown> }> = {
+  CROWDSEC_API:       { tool: 'crowdsec_blocks',    args: { limit: 1 } },
+  NTOPNG_API:         { tool: 'ntopng_threats',     args: { limit: 1 } },
+  ELASTICSEARCH_URL:  { tool: 'elk_flow_search',    args: { query: '*', limit: 1 } },
+  WAZUH_API:          { tool: 'wazuh_alerts',       args: { limit: 1 } },
+  VICTORIA_METRICS_URL: { tool: 'prometheus_query', args: { query: 'up', time: new Date().toISOString() } },
+}
+
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key')
+
+  if (!key || !SOURCE_PROBE[key]) {
+    return NextResponse.json(
+      { ok: false, error: `Unknown source key: ${key}` },
+      { status: 400 }
+    )
+  }
+
+  const env = await prisma.environment.findFirst({
+    where: { status: 'connected', gatewayUrl: { not: null } },
+    select: { gatewayUrl: true, gatewayToken: true },
+  })
+
+  if (!env?.gatewayUrl) {
+    return NextResponse.json(
+      { ok: false, error: 'No connected gateway — cannot test source connectivity' },
+      { status: 503 }
+    )
+  }
+
+  const { tool, args } = SOURCE_PROBE[key]
+
+  try {
+    const res = await fetch(`${env.gatewayUrl}/tools/execute`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${env.gatewayToken ?? ''}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: tool, arguments: args }),
+      signal: AbortSignal.timeout(8000),
+    })
+
+    if (res.ok) {
+      return NextResponse.json({ ok: true })
+    }
+
+    const text = await res.text()
+    return NextResponse.json({ ok: false, error: `Gateway returned ${res.status}: ${text}` })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ ok: false, error: msg })
+  }
+}

--- a/apps/web/src/app/api/monitoring/security/flows/route.ts
+++ b/apps/web/src/app/api/monitoring/security/flows/route.ts
@@ -16,11 +16,15 @@ interface FlowRow {
 }
 
 function normalizeFlows(raw: unknown): FlowRow[] {
-  // Gateway elk_flow_search returns the raw ES _search response,
-  // sometimes as a JSON string, sometimes already parsed.
+  // Gateway /tools/execute wraps the tool result in { result: <string> }.
+  // elk_flow_search serialises the ES _search response with JSON.stringify,
+  // so we need to unwrap the envelope then parse the inner string.
   let parsed: unknown = raw
-  if (typeof raw === 'string') {
-    try { parsed = JSON.parse(raw) } catch { return [] }
+  if (parsed && typeof parsed === 'object' && 'result' in (parsed as object)) {
+    parsed = (parsed as { result: unknown }).result
+  }
+  if (typeof parsed === 'string') {
+    try { parsed = JSON.parse(parsed) } catch { return [] }
   }
 
   if (!parsed || typeof parsed !== 'object') return []

--- a/apps/web/src/app/api/monitoring/security/flows/route.ts
+++ b/apps/web/src/app/api/monitoring/security/flows/route.ts
@@ -3,20 +3,80 @@ import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
+interface FlowRow {
+  src_ip: string
+  dst_ip: string
+  src_port: number
+  dst_port: number
+  protocol: string
+  bytes: number
+  packets: number
+  duration: number
+  timestamp: string
+}
+
+function normalizeFlows(raw: unknown): FlowRow[] {
+  // Gateway elk_flow_search returns the raw ES _search response,
+  // sometimes as a JSON string, sometimes already parsed.
+  let parsed: unknown = raw
+  if (typeof raw === 'string') {
+    try { parsed = JSON.parse(raw) } catch { return [] }
+  }
+
+  if (!parsed || typeof parsed !== 'object') return []
+
+  // ES _search response shape: { hits: { hits: [{ _source: {...} }] } }
+  const hits = (parsed as any)?.hits?.hits
+  if (Array.isArray(hits)) {
+    return hits.map((h: any) => {
+      const s = h._source ?? h
+      return {
+        src_ip:    String(s.src_ip ?? s.src_addr ?? s['source.ip'] ?? ''),
+        dst_ip:    String(s.dst_ip ?? s.dst_addr ?? s['destination.ip'] ?? ''),
+        src_port:  Number(s.src_port ?? s['source.port'] ?? 0),
+        dst_port:  Number(s.dst_port ?? s['destination.port'] ?? 0),
+        protocol:  String(s.protocol ?? s.transport ?? ''),
+        bytes:     Number(s.bytes ?? s.in_bytes ?? s['network.bytes'] ?? 0),
+        packets:   Number(s.packets ?? s.in_pkts ?? s['network.packets'] ?? 0),
+        duration:  Number(s.duration ?? s.last_switched ?? 0),
+        timestamp: String(s['@timestamp'] ?? s.timestamp ?? s.first_switched ?? new Date().toISOString()),
+      }
+    })
+  }
+
+  // Fallback: if the result is already a flat array of flow objects
+  if (Array.isArray(parsed)) {
+    return (parsed as any[]).map(s => ({
+      src_ip:    String(s.src_ip ?? ''),
+      dst_ip:    String(s.dst_ip ?? ''),
+      src_port:  Number(s.src_port ?? 0),
+      dst_port:  Number(s.dst_port ?? 0),
+      protocol:  String(s.protocol ?? ''),
+      bytes:     Number(s.bytes ?? 0),
+      packets:   Number(s.packets ?? 0),
+      duration:  Number(s.duration ?? 0),
+      timestamp: String(s.timestamp ?? s['@timestamp'] ?? new Date().toISOString()),
+    }))
+  }
+
+  return []
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl
   const query = searchParams.get('q') || '*'
   const limit = searchParams.get('limit') ? parseInt(searchParams.get('limit')!) : 50
 
-  // Gateway credentials live per-environment in the DB, not in env vars.
-  // Use the first connected environment that has a gateway configured.
   const env = await prisma.environment.findFirst({
     where: { status: 'connected', gatewayUrl: { not: null } },
     select: { gatewayUrl: true, gatewayToken: true },
   })
 
   if (!env?.gatewayUrl) {
-    return NextResponse.json({ error: 'No connected environment with a gateway configured' }, { status: 503 })
+    return NextResponse.json(
+      { error: 'No connected environment with a gateway configured', code: 'NO_GATEWAY' },
+      { status: 503 }
+    )
   }
 
   const res = await fetch(`${env.gatewayUrl}/tools/execute`, {
@@ -33,9 +93,10 @@ export async function GET(request: NextRequest) {
 
   if (!res.ok) {
     const text = await res.text()
-    return NextResponse.json({ error: text }, { status: res.status })
+    return NextResponse.json({ error: text, code: 'GATEWAY_ERROR' }, { status: res.status })
   }
 
-  const data = await res.json()
-  return NextResponse.json({ flows: data })
+  const raw = await res.json()
+  const flows = normalizeFlows(raw)
+  return NextResponse.json({ flows })
 }

--- a/apps/web/src/app/api/monitoring/security/incidents/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/incidents/[id]/route.ts
@@ -27,6 +27,7 @@ export async function GET(
       openedAt: true,
       closedAt: true,
       environmentId: true,
+      investigationId: true,
     },
   })
 

--- a/apps/web/src/components/security/AlertFeed.tsx
+++ b/apps/web/src/components/security/AlertFeed.tsx
@@ -1,13 +1,16 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { AlertTriangle, CheckCircle2, XCircle, Loader2, Shield, Globe, Database } from 'lucide-react'
+import Link from 'next/link'
+import { type NotifyMessage } from '@/lib/security/stream-utils'
 
 const sourceIcons: Record<string, React.ElementType> = {
   crowdsec: Shield,
   ntopng: Globe,
   wazuh: Database,
   elk: Database,
+  falco: Shield,
 }
 
 const sourceColors: Record<string, string> = {
@@ -15,6 +18,7 @@ const sourceColors: Record<string, string> = {
   ntopng: 'text-green-400',
   wazuh: 'text-orange-400',
   elk: 'text-purple-400',
+  falco: 'text-red-400',
 }
 
 function SeverityBadge({ severity }: { severity: number }) {
@@ -45,17 +49,34 @@ function SeverityBadge({ severity }: { severity: number }) {
 export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: any[]; compact?: boolean }) {
   const [alerts, setAlerts] = useState(initialAlerts || [])
   const [selected, setSelected] = useState<string[]>([])
+  const mountedRef = useRef(true)
 
   useEffect(() => {
-    const source = new EventSource('/api/monitoring/security/stream')
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
 
-    source.onmessage = (event) => {
-      const parsed = JSON.parse(event.data)
-      if (Array.isArray(parsed)) {
+  useEffect(() => {
+    const source = new EventSource('/api/monitoring/security/stream?channel=events')
+
+    source.onmessage = async (event) => {
+      try {
+        const frame = JSON.parse(event.data) as NotifyMessage
+        if (frame.channel !== 'events' || !frame.payload?.id) return
+
+        // Stream sends id-only frames — fetch the full event
+        const res = await fetch(`/api/monitoring/security/alerts/${frame.payload.id}`)
+        if (!res.ok || !mountedRef.current) return
+        const { event: alertEvent } = await res.json()
+        if (!alertEvent || !mountedRef.current) return
+
         setAlerts(prev => {
-          const all = [...parsed, ...prev]
-          return all.slice(0, 100)
+          // Deduplicate — stream may fire multiple times for the same event
+          if (prev.some((a: any) => a.id === alertEvent.id)) return prev
+          return [alertEvent, ...prev].slice(0, 100)
         })
+      } catch {
+        // Ignore malformed frames
       }
     }
 
@@ -69,7 +90,7 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ids: selected }),
     })
-    setAlerts(prev => prev.map(a => selected.includes(a.id) ? { ...a, acknowledged: true } : a))
+    setAlerts(prev => prev.map((a: any) => selected.includes(a.id) ? { ...a, acknowledged: true } : a))
     setSelected([])
   }
 
@@ -79,6 +100,12 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
         <Loader2 size={20} className="animate-spin mx-auto mb-2 text-accent" />
         Connecting to security stream…
       </div>
+    )
+  }
+
+  if (alerts.length === 0) {
+    return (
+      <div className="p-8 text-center text-text-muted text-sm">No alerts.</div>
     )
   }
 
@@ -94,27 +121,27 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
       )}
 
       <div className="divide-y divide-border-subtle">
-        {alerts.map(alert => {
+        {alerts.map((alert: any) => {
           const Icon = sourceIcons[alert.source] || Shield
           return (
             <div
               key={alert.id}
-              className={`px-4 py-3 flex items-start gap-3 hover:bg-bg-raised transition-colors ${
-                selected.includes(alert.id) ? 'bg-accent/5' : ''
+              className={`px-4 py-3 flex items-start gap-3 transition-colors ${
+                selected.includes(alert.id) ? 'bg-accent/5' : 'hover:bg-bg-raised'
               } ${alert.acknowledged ? 'opacity-50' : ''}`}
             >
               <input
                 type="checkbox"
                 checked={selected.includes(alert.id)}
                 onChange={() => setSelected(prev =>
-                  prev.includes(alert.id) ? prev.filter(id => id !== alert.id) : [...prev, alert.id]
+                  prev.includes(alert.id) ? prev.filter((id: string) => id !== alert.id) : [...prev, alert.id]
                 )}
                 className="mt-1 accent-accent"
               />
               <Icon size={14} className={`flex-shrink-0 mt-0.5 ${sourceColors[alert.source] || 'text-text-muted'}`} />
-              <div className="flex-1 min-w-0">
+              <Link href={`/security/alerts/${alert.id}`} className="flex-1 min-w-0 group">
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-medium text-text-primary truncate">{alert.title}</span>
+                  <span className="text-xs font-medium text-text-primary truncate group-hover:text-accent transition-colors">{alert.title}</span>
                   <SeverityBadge severity={alert.severity} />
                 </div>
                 <div className="flex items-center gap-2 mt-0.5">
@@ -125,7 +152,7 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
                 {!compact && alert.description && (
                   <p className="text-xs text-text-muted mt-1 truncate">{alert.description}</p>
                 )}
-              </div>
+              </Link>
             </div>
           )
         })}

--- a/apps/web/src/components/security/FlowTable.tsx
+++ b/apps/web/src/components/security/FlowTable.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { ChevronUp, ChevronDown, Search, Loader2 } from 'lucide-react'
+import { useState, useEffect, useRef } from 'react'
+import { ChevronUp, ChevronDown, Search, Loader2, Settings } from 'lucide-react'
 
 type FlowRow = {
   src_ip: string
@@ -25,15 +25,29 @@ export default function FlowTable() {
   const [flows, setFlows] = useState<FlowRow[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<string | null>(null)
   const [sortCol, setSortCol] = useState<keyof FlowRow>('timestamp')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [search, setSearch] = useState('')
+  const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
-    fetch('/api/monitoring/security/flows?limit=50')
-      .then(r => r.json())
-      .then(d => { setFlows(d.flows || d || []); setLoading(false) })
-      .catch(e => { setError(e.message); setLoading(false) })
+    abortRef.current = new AbortController()
+
+    fetch('/api/monitoring/security/flows?limit=50', { signal: abortRef.current.signal })
+      .then(r => {
+        if (!r.ok) return r.json().then((d: any) => Promise.reject({ message: d.error || `Error ${r.status}`, code: d.code }))
+        return r.json()
+      })
+      .then(d => { setFlows(d.flows || []); setLoading(false) })
+      .catch((e: any) => {
+        if (e?.name === 'AbortError') return
+        setError(e?.message || 'Failed to load flows')
+        setErrorCode(e?.code ?? null)
+        setLoading(false)
+      })
+
+    return () => abortRef.current?.abort()
   }, [])
 
   if (loading) {
@@ -46,7 +60,21 @@ export default function FlowTable() {
 
   if (error) {
     return (
-      <div className="p-8 text-status-error text-sm">Error loading flows: {error}</div>
+      <div className="p-8 text-center space-y-2">
+        <p className="text-status-error text-sm">{error}</p>
+        {errorCode === 'NO_GATEWAY' && (
+          <p className="text-xs text-text-muted flex items-center justify-center gap-1">
+            <Settings size={12} />
+            ELK not configured — set up sources in the Settings tab
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  if (flows.length === 0) {
+    return (
+      <div className="p-8 text-center text-text-muted text-sm">No flow records available.</div>
     )
   }
 
@@ -111,9 +139,9 @@ export default function FlowTable() {
           <tbody className="divide-y divide-border-subtle">
             {sorted.slice(0, 50).map((flow, i) => (
               <tr key={i} className="hover:bg-bg-raised transition-colors">
-                <td className="px-4 py-2 font-mono text-text-primary">{flow.src_ip}</td>
-                <td className="px-4 py-2 font-mono text-text-primary">{flow.dst_ip}</td>
-                <td className="px-4 py-2 text-text-muted">{flow.protocol}</td>
+                <td className="px-4 py-2 font-mono text-text-primary">{flow.src_ip || '—'}</td>
+                <td className="px-4 py-2 font-mono text-text-primary">{flow.dst_ip || '—'}</td>
+                <td className="px-4 py-2 text-text-muted">{flow.protocol || '—'}</td>
                 <td className="px-4 py-2 text-text-muted">{formatBytes(flow.bytes)}</td>
                 <td className="px-4 py-2 text-text-muted">{flow.packets.toLocaleString()}</td>
                 <td className="px-4 py-2 text-text-muted">{flow.duration}s</td>

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import AlertFeed from './AlertFeed'
 import FlowTable from './FlowTable'
 import SourceHealthPanel from './SourceHealthPanel'
+import SecuritySettings from './SecuritySettings'
 
 function RiskScoreGauge({ score }: { score: number }) {
   const getColor = (s: number) => {
@@ -66,6 +67,7 @@ export default function SecurityDashboard() {
   const loadOverview = useCallback(async () => {
     try {
       const res = await fetch('/api/monitoring/security/overview')
+      if (!res.ok) throw new Error(`${res.status}`)
       const d = await res.json()
       setData(d)
     } catch (e: unknown) {
@@ -284,9 +286,7 @@ export default function SecurityDashboard() {
             <span className="text-sm font-medium text-text-primary">Security Settings</span>
           </div>
           <div className="p-4">
-            <a href="/security/settings" className="text-sm text-accent hover:underline">
-              Configure monitoring sources &rarr;
-            </a>
+            <SecuritySettings />
           </div>
         </div>
       )}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -597,9 +597,10 @@ services:
     restart: unless-stopped
     privileged: true
     pid: host
-    # Use legacy eBPF driver — modern eBPF (default) segfaults (SIGSEGV) on
-    # this kernel build. Legacy eBPF has broader 6.x kernel compatibility.
-    command: ["falco", "--driver", "ebpf"]
+    # engine.kind is set to "ebpf" (legacy) in host-agent/falco/falco.yaml.
+    # modern_ebpf (default) segfaults (SIGSEGV) on this kernel build (6.8).
+    # falco-no-driver uses the config file for engine selection — the --driver
+    # CLI flag does not exist in this image and causes a crash-loop.
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock:ro
       - /dev:/host/dev:ro


### PR DESCRIPTION
## Summary

- **Investigations**: Incident detail page now shows "Open Investigation" button (POSTs to existing `create-investigation` route, auto-navigates to new investigation). Shows "View Investigation" if already linked. Event rows link to alert detail.
- **Alert detail**: New `/security/alerts/[id]` page + GET route — shows source, severity, description, raw event (collapsible), acknowledge in-place.
- **AlertFeed live stream**: Was checking `Array.isArray` on id-only `NotifyMessage` frames (always false — no live updates ever rendered). Now correctly parses stream frames and fetches full event by id. Rows link to alert detail.
- **Flows**: Fixed client-side crash on 503 (no `r.ok` check; error object was passed to `.filter()`). API route now normalises the gateway's `{ result: "<ES JSON>" }` envelope to `FlowRow[]`. Actionable error message when ELK not configured.
- **Settings**: Was a dead link to `/security/settings` (page doesn't exist). Now inlines `SecuritySettings` component directly in the tab. New `connections/test` route proxies through gateway read tools and correctly inspects result bodies (gateway returns errors as strings with HTTP 200, not HTTP error codes).
- **Falco**: Removed invalid `--driver ebpf` CLI flag from `docker-compose.yml` — `falco-no-driver:0.38.2` has no `--driver` option; engine selection is already correct in `falco.yaml` via `engine.kind: ebpf`. This fixes the Falco crash-loop.

Reviewed by Opus before push — two blocker findings were addressed (flows envelope unwrap, connections/test false-positive).

## Test plan

- [ ] Visit an incident → "Open Investigation" button appears; clicking creates investigation and navigates to it
- [ ] Visit same incident again → "View Investigation" button appears instead
- [ ] Click an event row from the incident → navigates to `/security/alerts/[id]` detail page
- [ ] Alerts tab → rows are clickable links to alert detail; raw event section expands
- [ ] Flows tab with no ELK configured → shows "ELK not configured" message instead of crashing
- [ ] Settings tab → `SecuritySettings` renders inline (no navigation); Test buttons show red for unconfigured sources
- [ ] `docker compose up` → Falco starts without crash-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)