### PR TITLE
fix(siem): harden webhook auth — NaN timestamp, dead loopback, weak dedupKey

### DIFF
--- a/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
@@ -16,7 +16,7 @@ import {
   verifyWebhookHmac,
   isWithinReplayWindow,
   wasAlreadyProcessed,
-  isLoopbackWebhookRequest,
+  shouldAcceptUnauthenticated,
   warnMissingWebhookSecret,
   checkWebhookBodySize,
   WEBHOOK_MAX_BODY_BYTES,
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest) {
         { status: 500 }
       )
     }
-    if (!isLoopbackWebhookRequest(req)) {
+    if (!shouldAcceptUnauthenticated()) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {

--- a/apps/web/src/app/api/monitoring/security/webhooks/falco/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/falco/route.ts
@@ -29,7 +29,7 @@ import { prisma } from '@/lib/db'
 import {
   constantTimeCompare,
   isWithinReplayWindow,
-  isLoopbackWebhookRequest,
+  shouldAcceptUnauthenticated,
   warnMissingWebhookSecret,
   checkWebhookBodySize,
   WEBHOOK_MAX_BODY_BYTES,
@@ -85,10 +85,14 @@ export async function POST(req: NextRequest) {
         { status: 500 }
       )
     }
-    if (!isLoopbackWebhookRequest(req)) {
+    if (!shouldAcceptUnauthenticated()) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {
+    // Falcosidekick sends the raw secret as a bearer token (not HMAC — it cannot
+    // compute HMAC of the body). Timing-safe comparison prevents oracle attacks.
+    // The header is named X-Orion-Falco-Signature for historical reasons but is
+    // semantically a bearer token; do not treat it as a body signature.
     if (!constantTimeCompare(signature ?? '', process.env.FALCO_WEBHOOK_SECRET)) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
     }

--- a/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
@@ -25,7 +25,7 @@ import {
   verifyWebhookHmac,
   isWithinReplayWindow,
   wasAlreadyProcessed,
-  isLoopbackWebhookRequest,
+  shouldAcceptUnauthenticated,
   warnMissingWebhookSecret,
   checkWebhookBodySize,
   WEBHOOK_MAX_BODY_BYTES,
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest) {
         { status: 500 }
       )
     }
-    if (!isLoopbackWebhookRequest(req)) {
+    if (!shouldAcceptUnauthenticated()) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {
@@ -191,7 +191,7 @@ export async function POST(req: NextRequest) {
         dedupKey: c.dedupKey,
         firstSeen: c.firstSeen,
         lastSeen: c.lastSeen,
-        createdAt: c.createdAt,
+        // createdAt intentionally omitted — DB @default(now()) sets ingestion time.
       })),
     })
   }

--- a/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/wazuh/route.ts
@@ -16,7 +16,7 @@ import {
   verifyWebhookHmac,
   isWithinReplayWindow,
   wasAlreadyProcessed,
-  isLoopbackWebhookRequest,
+  shouldAcceptUnauthenticated,
   warnMissingWebhookSecret,
   checkWebhookBodySize,
   WEBHOOK_MAX_BODY_BYTES,
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
         { status: 500 }
       )
     }
-    if (!isLoopbackWebhookRequest(req)) {
+    if (!shouldAcceptUnauthenticated()) {
       return NextResponse.json({ error: 'Webhook secret not configured' }, { status: 403 })
     }
   } else {

--- a/apps/web/src/lib/security/normalize/crowdsec.ts
+++ b/apps/web/src/lib/security/normalize/crowdsec.ts
@@ -5,6 +5,7 @@
  * CrowdSec sends decisions via webhook when new bans occur.
  */
 
+import crypto from 'crypto'
 import { type NormalizedSecurityEvent } from '../types'
 
 export interface CrowdSecAlert {
@@ -116,12 +117,5 @@ export function normalizeCrowdSecDecision(
 }
 
 function createDedupKey(source: string, ...parts: string[]): string {
-  const joined = parts.join(':')
-  let hash = 0
-  for (let i = 0; i < joined.length; i++) {
-    const char = joined.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash &= hash  // Convert to 32-bit int
-  }
-  return `${source}_${Math.abs(hash).toString(16)}`
+  return `${source}_${crypto.createHash('sha256').update(parts.join(':')).digest('hex')}`
 }

--- a/apps/web/src/lib/security/normalize/ntopng.ts
+++ b/apps/web/src/lib/security/normalize/ntopng.ts
@@ -5,6 +5,7 @@
  * ntopng provides both flow data and threat intelligence via its REST API.
  */
 
+import crypto from 'crypto'
 import { type NormalizedSecurityEvent } from '../types'
 
 /**
@@ -259,12 +260,5 @@ function parseTimestamp(ts: string): Date {
 }
 
 function createDedupKey(source: string, ...parts: string[]): string {
-  const joined = parts.join(':')
-  let hash = 0
-  for (let i = 0; i < joined.length; i++) {
-    const char = joined.charCodeAt(i)
-    hash = ((hash << 5) - hash) + char
-    hash &= hash
-  }
-  return `${source}_${Math.abs(hash).toString(16)}`
+  return `${source}_${crypto.createHash('sha256').update(parts.join(':')).digest('hex')}`
 }

--- a/apps/web/src/lib/security/webhook-auth.ts
+++ b/apps/web/src/lib/security/webhook-auth.ts
@@ -138,7 +138,14 @@ export function isWithinReplayWindow(timestampHeader: string | null): boolean {
   } else {
     // Try Unix epoch (seconds or milliseconds)
     const epoch = Number(timestampHeader)
-    if (Number.isNaN(epoch)) return true
+    if (Number.isNaN(epoch)) {
+      // A present-but-unparseable timestamp must be treated the same as
+      // missing: reject in prod, accept-with-warning in dev.
+      if (requireTimestampHeader()) return false
+      // eslint-disable-next-line no-console
+      console.warn('[siem] webhook X-Timestamp header is present but unparseable; allowed because WEBHOOK_REQUIRE_TIMESTAMP is not set')
+      return true
+    }
     timestamp = epoch > 1e12 ? epoch : epoch * 1000 // ms
   }
 
@@ -196,67 +203,60 @@ export async function getWebhookSecret(
   return config?.value ?? null
 }
 
-// ── Client-IP / Loopback Trust ────────────────────────────────────────────────
+// ── Dev-mode unauthenticated acceptance ───────────────────────────────────────
 
 /**
- * Loopback IPv4/IPv6 prefixes. An address that starts with one of these is
- * considered "from this host" and is the only case the webhook fallback
- * (used when a webhook secret is not configured) should treat as trusted.
+ * Whether to accept a webhook request that has no configured secret.
+ *
+ * In production this always returns false — missing secret means misconfigured,
+ * and warnMissingWebhookSecret already returned 500 before this is reached.
+ *
+ * In development this returns true so local testing works without configuring
+ * secrets. Previously this used `isLoopbackWebhookRequest` which read `req.ip`,
+ * but `NextRequest.ip` is undefined in the self-hosted Node runtime (not Vercel),
+ * making the loopback check permanently dead. Replaced with a plain NODE_ENV
+ * check — the dev boundary is the deployment boundary, not the network.
+ *
+ * NOTE ON REPLAY PROTECTION (BLOCK-1):
+ * For CrowdSec and Wazuh, the HMAC is computed by the upstream sender over the
+ * raw body only. We cannot include the X-Timestamp in the signed material without
+ * reconfiguring those senders, so timestamp binding is not feasible for those
+ * sources. The replay window provides best-effort protection; the 24h dedupKey
+ * idempotency (backed by SHA-256 for all sources post this PR) is the primary
+ * replay defence. For host-agent, Vector signs body only by default.
  */
-const LOOPBACK_PREFIXES = ['127.', '::1', '::ffff:127.']
-
-function isLoopbackIp(ip: string): boolean {
-  if (!ip) return false
-  const trimmed = ip.trim()
-  if (!trimmed) return false
-  return LOOPBACK_PREFIXES.some((p) => trimmed.startsWith(p))
+export function shouldAcceptUnauthenticated(): boolean {
+  return process.env.NODE_ENV !== 'production'
 }
 
 /**
- * Determine whether the request originates from loopback for the secret-less
- * dev-mode fallback.
- *
- * Hardening (MAJOR-1 follow-up):
- * - The previous implementation read `X-Forwarded-For` / `X-Real-IP` directly,
- *   which any HTTP client can spoof. With `CROWDSEC_WEBHOOK_SECRET` (or the
- *   Wazuh equivalent) unset, spoofing `X-Forwarded-For: 127.0.0.1` was enough
- *   to inject events.
- * - We now prefer the direct TCP source (`req.ip`, populated by the runtime
- *   from the connection). `X-Forwarded-For` is ONLY consulted when the
- *   direct peer IP is itself an allow-listed reverse proxy
- *   (`WEBHOOK_TRUSTED_PROXY_IPS`, comma-separated). When the peer IP is
- *   missing AND no proxy allow-list is configured, we fall back to refusing
- *   trust — the request must use the signed path.
- *
- * Returns `true` only when we are confident the request is from loopback.
+ * @deprecated req.ip is undefined in Next.js Node runtime — this function
+ * always returns false unless WEBHOOK_TRUSTED_PROXY_IPS is configured.
+ * Use shouldAcceptUnauthenticated() instead for the no-secret dev path.
  */
 export function isLoopbackWebhookRequest(req: {
   headers: Headers
   ip?: string | null
 }): boolean {
   const peerIp = req.ip ?? ''
-  if (isLoopbackIp(peerIp)) return true
+  if (!peerIp) return false
+
+  const LOOPBACK_PREFIXES = ['127.', '::1', '::ffff:127.']
+  if (LOOPBACK_PREFIXES.some((p) => peerIp.startsWith(p))) return true
 
   const allowList = (process.env.WEBHOOK_TRUSTED_PROXY_IPS ?? '')
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean)
 
-  if (allowList.length === 0) {
-    // No proxy allow-list configured. Do not trust XFF — it is spoofable.
-    return false
-  }
+  if (allowList.length === 0) return false
+  if (!allowList.includes(peerIp)) return false
 
-  const peerTrusted = peerIp && allowList.includes(peerIp)
-  if (!peerTrusted) return false
-
-  // Peer is a known reverse proxy; X-Forwarded-For (left-most entry) is
-  // believable. X-Real-IP is single-valued and easier to forge upstream, but
-  // we accept it when the peer is also trusted.
   const xff = req.headers.get('x-forwarded-for') ?? ''
   const realIp = req.headers.get('x-real-ip') ?? ''
   const clientIp = xff.split(',')[0]?.trim() || realIp.trim()
-  return isLoopbackIp(clientIp)
+  const LOOPBACK_PREFIXES2 = ['127.', '::1', '::ffff:127.']
+  return LOOPBACK_PREFIXES2.some((p) => clientIp.startsWith(p))
 }
 
 // ── Body-size guard ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes two BLOCKERs and two MAJORs from Opus security review of the webhook authentication layer.

**MAJOR-6 — Malformed timestamp bypassed replay check**
`Number('abc')` returns `NaN`, and the old code returned `true` (accept) for any NaN timestamp header. A present-but-unparseable `X-Timestamp` now returns `false` in production, matching the behaviour for missing headers.

**BLOCK-2 — Dev loopback path was permanently dead**
`NextRequest.ip` is `undefined` in the self-hosted Next.js Node runtime — `isLoopbackWebhookRequest` always returned `false`, so legitimate localhost requests in dev got 403. Replaced all four route callsites with `shouldAcceptUnauthenticated()` (plain `NODE_ENV !== 'production'` check). The old function is kept `@deprecated` for `WEBHOOK_TRUSTED_PROXY_IPS` users.

**MAJOR-2 — CrowdSec + ntopng used 32-bit djb2 dedupKey**
~2 billion effective values; a collision silently drops a real event as a duplicate. Both normalizers now use SHA-256, matching Falco and host-agent which already did.

**MAJOR-3 (Falco) — Documented bearer-token semantics**
Added inline comment clarifying `X-Orion-Falco-Signature` is a bearer token (Falcosidekick cannot compute HMAC), not a body signature. Timing-safe comparison preserved.

**Bonus: host-agent `createdAt` regression**
The host-agent route was still writing `createdAt: source_timestamp`, re-introducing the B1 correlator window bug fixed in #497. Removed.

**BLOCK-1 note (not fixed — upstream limitation)**
CrowdSec and Wazuh sign body-only; we cannot include `X-Timestamp` in their HMAC without reconfiguring the senders. Documented in `webhook-auth.ts`. SHA-256 dedupKey + 24h idempotency window is the primary replay defence for those sources.

## Test plan
- [ ] POST to CrowdSec webhook with `X-Timestamp: abc` → 410 in prod, accepted in dev
- [ ] POST to any webhook without secret in dev → 200 (no longer 403)
- [ ] POST to any webhook without secret in prod → 500 (unchanged)
- [ ] Two CrowdSec events with same content → second is idempotent (dedupKey match via SHA-256)
- [ ] Verify Falco heartbeat still accepted with correct `FALCO_WEBHOOK_SECRET` token

🤖 Generated with [Claude Code](https://claude.com/claude-code)