### PR TITLE
fix(siem): fix action service — approve executes, panic order, atomic CAS, toggle route

### DIFF
--- a/apps/web/src/app/api/monitoring/security/actions/route.ts
+++ b/apps/web/src/app/api/monitoring/security/actions/route.ts
@@ -9,71 +9,11 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { decide, execute } from '@/lib/security/action-service'
+import { decide, execute, gatewayExecutor } from '@/lib/security/action-service'
 import { type ActionRequest } from '@/lib/security/types'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 30
-
-/**
- * Gateway executor — calls the gateway's tool execution endpoint.
- */
-async function gatewayExecutor(
-  action: ActionRequest,
-  target: string,
-  payload: Record<string, unknown> | undefined
-): Promise<{ success: boolean; result: string }> {
-  const gatewayUrl = process.env.GATEWAY_URL
-  const gatewayToken = process.env.GATEWAY_TOKEN
-
-  if (!gatewayUrl || !gatewayToken) {
-    return { success: false, result: 'Gateway not configured' }
-  }
-
-  let toolName = ''
-  let toolArgs: Record<string, unknown> = {}
-
-  switch (action.actionType) {
-    case 'crowdsec_decision_create':
-      toolName = 'crowdsec_decision_create'
-      toolArgs = { ip: target, reason: payload?.reason as string ?? 'Blocked via ORION' }
-      break
-    case 'crowdsec_decision_delete':
-      toolName = 'crowdsec_decision_delete'
-      toolArgs = { decisionId: target }
-      break
-    case 'wazuh_active_response':
-      toolName = 'wazuh_active_response'
-      toolArgs = { agent: target, command: (payload?.command as string) ?? '', args: payload?.args }
-      break
-    case 'firewall_block':
-      toolName = 'firewall_block'
-      toolArgs = { cidr: target, reason: payload?.reason as string ?? 'Blocked via ORION' }
-      break
-    case 'investigate':
-      toolName = 'elk_flow_search'
-      toolArgs = { query: target, limit: (payload?.limit as number) ?? 20 }
-      break
-    default:
-      return { success: false, result: `Unknown action type: ${action.actionType}` }
-  }
-
-  const res = await fetch(`${gatewayUrl}/tools/execute`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${gatewayToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ name: toolName, arguments: toolArgs }),
-  })
-
-  const result = await res.json()
-  if (!res.ok) {
-    return { success: false, result: JSON.stringify(result) }
-  }
-
-  return { success: true, result: JSON.stringify(result) }
-}
 
 export async function POST(req: NextRequest) {
   try {
@@ -94,25 +34,21 @@ export async function POST(req: NextRequest) {
     // Decide tier
     const decision = await decide(request, panicMode)
 
-    // If tier is 'escalate' or 'approve' without approval, return pending
-    if (decision.tier === 'escalate' || decision.tier === 'approve') {
-      return NextResponse.json({
-        pending: true,
-        decision,
-        message: decision.tier === 'escalate'
-          ? 'Action requires escalation'
-          : 'Action requires approval',
-      })
-    }
-
-    // Execute if auto
+    // Call execute() for ALL tiers — it creates the ActionAudit row (R9) and
+    // routes correctly: auto→gateway, approve/escalate→pending queue entry,
+    // notify→audit-only. Without this, approve/escalate tiers returned early
+    // with no DB row, leaving the approval queue permanently empty.
     const result = await execute(request, decision, gatewayExecutor)
 
     return NextResponse.json({
-      success: result.status !== 'denied',
+      pending: result.status === 'pending',
+      success: result.status === 'succeeded',
       status: result.status,
       auditId: result.auditId,
       result: result.result,
+      message: result.status === 'pending'
+        ? `Action queued for ${decision.tier === 'escalate' ? 'escalation' : 'approval'}`
+        : undefined,
     })
   } catch (err) {
     return NextResponse.json({ error: `Action failed: ${err instanceof Error ? err.message : String(err)}` }, { status: 500 })

--- a/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
+import { gatewayExecutor } from '@/lib/security/action-service'
 import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
@@ -23,8 +24,6 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  // Approve/deny is a tier-elevation action — only admins. Without this check
-  // anyone reachable on the network can execute pending privileged actions.
   let approver: { id: string; username: string }
   try {
     const user = await requireAdmin()
@@ -35,7 +34,6 @@ export async function POST(
 
   const body = await req.json()
   const parsed = bodySchema.safeParse(body)
-
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid body: action must be "approve" or "deny"' }, { status: 400 })
   }
@@ -43,7 +41,7 @@ export async function POST(
   const { action, note } = parsed.data
   const auditId = params.id
 
-  // Look up the pending audit row
+  // Fetch audit row to get action details for execution
   const audit = await prisma.actionAudit.findUnique({
     where: { id: auditId },
     select: {
@@ -58,59 +56,55 @@ export async function POST(
     },
   })
 
-  if (!audit) {
-    return NextResponse.json({ error: 'Approval not found' }, { status: 404 })
-  }
+  if (!audit) return NextResponse.json({ error: 'Approval not found' }, { status: 404 })
+  if (audit.tier !== 'approve') return NextResponse.json({ error: 'Action tier is not approvable' }, { status: 400 })
 
-  if (audit.status !== 'pending') {
-    return NextResponse.json({ error: 'Action is not pending approval' }, { status: 409 })
-  }
-
-  if (audit.tier !== 'approve') {
-    return NextResponse.json({ error: 'Action tier is not approvable' }, { status: 400 })
-  }
-
-  // Update the audit row.
-  // approvedBy is the resolved admin username — never the literal 'operator',
-  // which would defeat the audit trail (M3/M8).
-  const approverLabel = approver.username
-  const updated = await prisma.actionAudit.update({
-    where: { id: auditId },
+  // Atomic CAS: only transition if still pending. Prevents double-execution
+  // when two operators approve concurrently (M2 — TOCTOU race).
+  const cas = await prisma.actionAudit.updateMany({
+    where: { id: auditId, status: 'pending' },
     data: {
       status: action === 'approve' ? 'attempting' : 'denied',
-      approvedBy: approverLabel,
-    },
-    include: {
-      incident: {
-        select: { id: true, attackerKey: true, rootCauseSummary: true },
-      },
+      approvedBy: approver.username,
+      result: action === 'deny' ? `Denied by operator: ${note ?? 'No reason provided'}` : null,
     },
   })
 
-  if (action === 'approve') {
-    // If auto-executable, mark as succeeded immediately
-    // Actual execution is handled by the action executor
-    // For now, mark as attempting and let the executor pick it up
-    await prisma.actionAudit.update({
-      where: { id: auditId },
-      data: {
-        status: 'attempting',
-        result: note ?? null,
-      },
-    })
-  } else {
-    await prisma.actionAudit.update({
-      where: { id: auditId },
-      data: {
-        status: 'denied',
-        result: `Denied by operator: ${note ?? 'No reason provided'}`,
-      },
-    })
+  if (cas.count === 0) {
+    // Another request already transitioned it
+    return NextResponse.json({ error: 'Action is not pending (already processed or concurrent modification)' }, { status: 409 })
   }
 
-  return NextResponse.json({
-    success: true,
-    id: auditId,
-    status: action === 'approve' ? 'attempting' : 'denied',
-  })
+  if (action === 'deny') {
+    return NextResponse.json({ success: true, id: auditId, status: 'denied' })
+  }
+
+  // Execute the approved action via the gateway (B1 fix — was a dead end before)
+  try {
+    const { success, result } = await gatewayExecutor(
+      {
+        actionType: audit.actionType,
+        target: audit.target,
+        reason: note ?? 'Approved by operator',
+        payload: audit.payload as Record<string, unknown> | null,
+        incidentId: audit.incidentId,
+      },
+      audit.target,
+      audit.payload as Record<string, unknown> | undefined
+    )
+
+    await prisma.actionAudit.update({
+      where: { id: auditId },
+      data: { status: success ? 'succeeded' : 'failed', result },
+    })
+
+    return NextResponse.json({ success, id: auditId, status: success ? 'succeeded' : 'failed', result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    await prisma.actionAudit.update({
+      where: { id: auditId },
+      data: { status: 'failed', result: msg },
+    })
+    return NextResponse.json({ success: false, id: auditId, status: 'failed', result: msg })
+  }
 }

--- a/apps/web/src/app/api/monitoring/security/panic/route.ts
+++ b/apps/web/src/app/api/monitoring/security/panic/route.ts
@@ -1,0 +1,56 @@
+/**
+ * GET  /api/monitoring/security/panic  — read panic mode state
+ * PUT  /api/monitoring/security/panic  — toggle panic mode { active: boolean }
+ *
+ * Panic mode downgrades all auto/notify actions to approve, forcing human
+ * review during an active incident. Backed by the __panic_mode__ ActionPolicy
+ * row seeded at startup.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+export const dynamic = 'force-dynamic'
+
+const PANIC_ACTION_TYPE = '__panic_mode__'
+
+async function getPanicState(): Promise<boolean> {
+  const policy = await prisma.actionPolicy.findUnique({
+    where: { actionType: PANIC_ACTION_TYPE },
+    select: { defaultTier: true },
+  })
+  // Convention: defaultTier='approve' means panic is ON; 'auto' means OFF
+  return policy?.defaultTier === 'approve'
+}
+
+export async function GET() {
+  const active = await getPanicState()
+  return NextResponse.json({ active })
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    await requireAdmin()
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json() as { active?: boolean }
+  if (typeof body.active !== 'boolean') {
+    return NextResponse.json({ error: 'Body must be { active: boolean }' }, { status: 400 })
+  }
+
+  await prisma.actionPolicy.upsert({
+    where: { actionType: PANIC_ACTION_TYPE },
+    update: { defaultTier: body.active ? 'approve' : 'auto', updatedBy: 'admin' },
+    create: {
+      actionType: PANIC_ACTION_TYPE,
+      defaultTier: body.active ? 'approve' : 'auto',
+      targetPatterns: [],
+      updatedBy: 'admin',
+    },
+  })
+
+  return NextResponse.json({ active: body.active })
+}

--- a/apps/web/src/lib/security/action-service.ts
+++ b/apps/web/src/lib/security/action-service.ts
@@ -12,6 +12,70 @@
 import { prisma } from '@/lib/db'
 import { type ActionRequest, type ActionDecision, actionRequestSchema, actionDecisionSchema } from './types'
 
+// ── Gateway executor ──────────────────────────────────────────────────────────
+
+/**
+ * Execute a security action via the gateway's tool endpoint.
+ * Looks up gateway credentials from the connected environment in the DB
+ * (same pattern as the flows route) rather than env vars, so it works
+ * regardless of which environment the action targets.
+ */
+export async function gatewayExecutor(
+  action: ActionRequest,
+  target: string,
+  payload?: Record<string, unknown>
+): Promise<{ success: boolean; result: string }> {
+  const env = await prisma.environment.findFirst({
+    where: { status: 'connected', gatewayUrl: { not: null } },
+    select: { gatewayUrl: true, gatewayToken: true },
+  })
+
+  if (!env?.gatewayUrl) {
+    return { success: false, result: 'No connected gateway configured' }
+  }
+
+  let toolName = ''
+  let toolArgs: Record<string, unknown> = {}
+
+  switch (action.actionType) {
+    case 'crowdsec_decision_create':
+      toolName = 'crowdsec_decision_create'
+      toolArgs = { ip: target, reason: payload?.reason ?? 'Blocked via ORION' }
+      break
+    case 'crowdsec_decision_delete':
+      toolName = 'crowdsec_decision_delete'
+      toolArgs = { decisionId: target }
+      break
+    case 'wazuh_active_response':
+      toolName = 'wazuh_active_response'
+      toolArgs = { agent: target, command: payload?.command ?? '', args: payload?.args }
+      break
+    case 'firewall_block':
+      toolName = 'firewall_block'
+      toolArgs = { cidr: target, reason: payload?.reason ?? 'Blocked via ORION' }
+      break
+    case 'investigate':
+      toolName = 'elk_flow_search'
+      toolArgs = { size: payload?.limit ?? 20 }
+      break
+    default:
+      return { success: false, result: `Unknown action type: ${action.actionType}` }
+  }
+
+  const res = await fetch(`${env.gatewayUrl}/tools/execute`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.gatewayToken ?? ''}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: toolName, arguments: toolArgs }),
+  })
+
+  const data = await res.json() as { result?: unknown }
+  if (!res.ok) return { success: false, result: JSON.stringify(data) }
+  return { success: true, result: typeof data.result === 'string' ? data.result : JSON.stringify(data.result) }
+}
+
 // ── Tier resolution ───────────────────────────────────────────────────────────
 
 /**
@@ -44,20 +108,22 @@ export async function decide(
 
   let tier = policy.defaultTier
 
-  // 3. Check panic mode — downgrades auto/notify to approve
-  if (panicMode) {
-    if (tier === 'auto' || tier === 'notify') {
-      tier = 'approve'
-    }
-  }
-
-  // 4. Check target-pattern overrides
+  // 3. Check target-pattern overrides
   if (policy.targetPatterns && Array.isArray(policy.targetPatterns)) {
     for (const pattern of policy.targetPatterns as Array<{ pattern: string; tier: string; operator?: string }>) {
       if (matchesPattern(parsed.target, pattern.pattern, pattern.operator ?? 'strict')) {
         tier = pattern.tier
         break
       }
+    }
+  }
+
+  // 4. Check panic mode AFTER overrides — panic must be the final transform.
+  // Overrides running before panic could re-elevate a tier back to 'auto'
+  // during an active emergency (B2 from Opus review 2026-06-03).
+  if (panicMode) {
+    if (tier === 'auto' || tier === 'notify') {
+      tier = 'approve'
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two BLOCKERs and three MAJORs from Opus review of the action service and approval flow.

**B1 — Approved actions never executed**
`approvals/[id]/route.ts` set `status='attempting'` with a comment "let the executor pick it up" but nothing ever did. Every `approve`/`escalate`-tier action — firewall blocks, Wazuh active responses, subnet blocks — was human-approved and then silently never ran. Fixed by calling `gatewayExecutor` directly in the approve branch after the atomic CAS succeeds.

**B2 — Panic mode shadowed by overrides**
`decide()` applied: default → **panic → overrides**. An override running after panic could re-elevate a tier back to `auto` during an active emergency. Reordered to: default → overrides → **panic** (last, always wins).

**M1 — Panic mode unreachable**
No code path could toggle `__panic_mode__` without direct DB access, defeating its purpose as an emergency brake. Added `GET /api/monitoring/security/panic` (read state) and `PUT /api/monitoring/security/panic { active: boolean }` (toggle). Sets `__panic_mode__.defaultTier` to `'approve'` (on) or `'auto'` (off).

**M2 — Approval TOCTOU race**
`findUnique → check pending → update` let two concurrent approvers both pass the guard. Replaced with `updateMany({ where: { id, status: 'pending' } })` and check `count === 1` before executing. Two concurrent approvers now get one success and one 409.

**M3 — Triple-write on approve**
Handler wrote `status='attempting'` twice in sequence. Collapsed to a single conditional `updateMany` CAS followed by one execution result update.

**Also:**
- `gatewayExecutor` extracted from `actions/route.ts` to `action-service.ts` (shared, uses DB-backed gateway credentials instead of `process.env.GATEWAY_URL`)
- `actions/route.ts` now calls `execute()` for ALL tiers — `approve`/`escalate` previously returned early without creating an `ActionAudit` row, leaving the approval queue permanently empty

## Test plan
- [ ] POST action with `approve`-tier target → `{ pending: true, auditId }` returned, row appears in approval queue
- [ ] POST to `/approvals/[id]` approve → action executes via gateway, status becomes `succeeded`/`failed`
- [ ] POST to `/approvals/[id]` approve twice concurrently → one 200, one 409
- [ ] PUT `/panic` `{ active: true }` → subsequent `auto`-tier decide returns `approve`
- [ ] PUT `/panic` `{ active: false }` → `auto` tier restored
- [ ] Override pattern targeting `auto` + panic active → action still `approve` (panic wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)