### PR TITLE
fix(siem): implement decision-token signer; fix gateway write tool silent failures

### DIFF
--- a/apps/web/src/lib/security/action-service.ts
+++ b/apps/web/src/lib/security/action-service.ts
@@ -10,15 +10,36 @@
  */
 
 import { prisma } from '@/lib/db'
+import { signDecisionToken } from './decision-token'
 import { type ActionRequest, type ActionDecision, actionRequestSchema, actionDecisionSchema } from './types'
 
 // ── Gateway executor ──────────────────────────────────────────────────────────
 
+// Known error prefixes returned by gateway write tools when the upstream
+// source is unavailable or misconfigured. Used to detect soft failures that
+// arrive as HTTP 200 with an error body (the gateway always returns 200 for
+// tool results, using the body to signal failure).
+const GATEWAY_ERROR_PREFIXES = [
+  '{"error"',
+  'environment variable not configured',
+  'decision token rejected',
+  'security write tool requires',
+  'crowdsec error',
+  'wazuh error',
+  'firewall_api',
+]
+
+function isErrorResult(result: string): boolean {
+  const lower = result.toLowerCase()
+  return GATEWAY_ERROR_PREFIXES.some(p => lower.includes(p.toLowerCase()))
+}
+
 /**
  * Execute a security action via the gateway's tool endpoint.
- * Looks up gateway credentials from the connected environment in the DB
- * (same pattern as the flows route) rather than env vars, so it works
- * regardless of which environment the action targets.
+ *
+ * Mints a short-lived HMAC decision token bound to the audit row, action
+ * type, and target — the gateway write tools refuse calls without one.
+ * The auditId is threaded through via payload.__auditId (set by execute()).
  */
 export async function gatewayExecutor(
   action: ActionRequest,
@@ -44,7 +65,9 @@ export async function gatewayExecutor(
       break
     case 'crowdsec_decision_delete':
       toolName = 'crowdsec_decision_delete'
-      toolArgs = { decisionId: target }
+      // Tool body reads args.ip; token check reads args.decisionId.
+      // Send both so the token binding and the LAPI call both work.
+      toolArgs = { ip: target, decisionId: target }
       break
     case 'wazuh_active_response':
       toolName = 'wazuh_active_response'
@@ -55,11 +78,27 @@ export async function gatewayExecutor(
       toolArgs = { cidr: target, reason: payload?.reason ?? 'Blocked via ORION' }
       break
     case 'investigate':
+      // investigate is a read action — no token required, no write tool called
       toolName = 'elk_flow_search'
       toolArgs = { size: payload?.limit ?? 20 }
       break
     default:
       return { success: false, result: `Unknown action type: ${action.actionType}` }
+  }
+
+  // Mint a decision token for write tools. The auditId is passed via payload
+  // by execute() after the ActionAudit row is created.
+  const auditId = typeof payload?.__auditId === 'string' ? payload.__auditId : ''
+  const isWriteTool = action.actionType !== 'investigate'
+  if (isWriteTool && auditId) {
+    try {
+      toolArgs.__decision_token = signDecisionToken({ auditId, actionType: action.actionType, target })
+    } catch (err) {
+      return {
+        success: false,
+        result: `Decision token signing failed: ${err instanceof Error ? err.message : String(err)}`,
+      }
+    }
   }
 
   const res = await fetch(`${env.gatewayUrl}/tools/execute`, {
@@ -73,7 +112,16 @@ export async function gatewayExecutor(
 
   const data = await res.json() as { result?: unknown }
   if (!res.ok) return { success: false, result: JSON.stringify(data) }
-  return { success: true, result: typeof data.result === 'string' ? data.result : JSON.stringify(data.result) }
+
+  const resultStr = typeof data.result === 'string' ? data.result : JSON.stringify(data.result)
+
+  // Gateway write tools return HTTP 200 even on soft failures (token rejected,
+  // upstream unreachable, env var missing). Detect error bodies explicitly.
+  if (isErrorResult(resultStr)) {
+    return { success: false, result: resultStr }
+  }
+
+  return { success: true, result: resultStr }
 }
 
 // ── Tier resolution ───────────────────────────────────────────────────────────
@@ -329,7 +377,9 @@ export async function execute(
   // 2. Auto-tier: execute immediately
   if (parsedDecision.tier === 'auto') {
     try {
-      const { success, result } = await executor(parsed, parsed.target, parsed.payload ?? {})
+      // Thread audit.id into payload so gatewayExecutor can mint the decision token.
+      const execPayload = { ...(parsed.payload ?? {}), __auditId: audit.id }
+      const { success, result } = await executor(parsed, parsed.target, execPayload)
 
       await prisma.actionAudit.update({
         where: { id: audit.id },
@@ -348,7 +398,9 @@ export async function execute(
   // 3. Approve-tier with approvedBy: execute
   if (parsedDecision.tier === 'approve' && parsedDecision.approvedBy) {
     try {
-      const { success, result } = await executor(parsed, parsed.target, parsed.payload ?? {})
+      // Thread audit.id into payload so gatewayExecutor can mint the decision token.
+      const execPayload = { ...(parsed.payload ?? {}), __auditId: audit.id }
+      const { success, result } = await executor(parsed, parsed.target, execPayload)
 
       await prisma.actionAudit.update({
         where: { id: audit.id },

--- a/apps/web/src/lib/security/decision-token.ts
+++ b/apps/web/src/lib/security/decision-token.ts
@@ -1,0 +1,59 @@
+/**
+ * Defense-in-depth signed decision tokens — action-service signer side.
+ *
+ * Gateway write tools (crowdsec_decision_create/delete, wazuh_active_response,
+ * firewall_block) refuse to execute without a valid, fresh, target-bound
+ * `__decision_token` minted here. The token binds the gateway call to a
+ * specific ActionAudit row, action type, and target so it cannot be replayed
+ * across tools, targets, or audit rows.
+ *
+ * Token format: <base64url(payload)>.<base64url(hmac)>
+ *   payload = JSON.stringify({ auditId, actionType, target, exp })
+ *   hmac    = HMAC-SHA256(payloadBytes, ACTION_SERVICE_TOKEN_SECRET)
+ *
+ * MIRROR OF apps/gateway/src/lib/decision-token.ts — the gateway only
+ * verifies (never signs); this module only signs (never verifies).
+ * Keep the format in sync if you change either side.
+ */
+
+import { createHmac } from 'crypto'
+
+const TOKEN_TTL_MS = 5 * 60 * 1000 // 5 minutes — matches gateway replay window
+
+function getSecret(): Buffer {
+  const secret = process.env.ACTION_SERVICE_TOKEN_SECRET
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      'ACTION_SERVICE_TOKEN_SECRET is not set or too short (must be ≥32 chars). ' +
+      'Generate with: openssl rand -hex 32'
+    )
+  }
+  return Buffer.from(secret, 'utf8')
+}
+
+function b64urlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+/**
+ * Mint a decision token for a specific ActionAudit row + gateway call.
+ * The token expires in 5 minutes and is bound to the actionType and target
+ * so the gateway can reject replays across tools or targets.
+ */
+export function signDecisionToken(params: {
+  auditId: string
+  actionType: string
+  target: string
+}): string {
+  const payload = JSON.stringify({
+    auditId: params.auditId,
+    actionType: params.actionType,
+    target: params.target,
+    exp: Date.now() + TOKEN_TTL_MS,
+  })
+
+  const payloadBuf = Buffer.from(payload, 'utf8')
+  const mac = createHmac('sha256', getSecret()).update(payloadBuf).digest()
+
+  return `${b64urlEncode(payloadBuf)}.${b64urlEncode(mac)}`
+}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -55,6 +55,13 @@ DOCKER_GID=
 # Generate: openssl rand -hex 32
 FALCO_WEBHOOK_SECRET=
 
+# ── Action-service → gateway decision token secret ────────────────────────────
+# HMAC secret for signing short-lived tokens that authorize gateway write tools
+# (crowdsec_decision_create, wazuh_active_response, firewall_block, etc.).
+# Must match ACTION_SERVICE_TOKEN_SECRET in the gateway service environment.
+# Generate: openssl rand -hex 32
+ACTION_SERVICE_TOKEN_SECRET=
+
 # ── Executor service token ─────────────────────────────────────────────────────
 # Shared secret between gateway and orion-executor for authenticating tool
 # execution requests. Must be set before starting orion-executor.


### PR DESCRIPTION
## Summary

Fixes the root cause of every security write action silently no-oping while being logged as `succeeded`.

**BLOCKER — Missing web-side decision-token signer**

Gateway write tools (`crowdsec_decision_create`, `crowdsec_decision_delete`, `wazuh_active_response`, `firewall_block`) gate every call on a fresh HMAC-signed `__decision_token`. The gateway verifier (`apps/gateway/src/lib/decision-token.ts`) is complete, but the mirror module it references — `apps/web/src/lib/security/decision-token.ts` — was never created. Every write call returned HTTP 200 with `{ error: 'security write tool requires __decision_token' }` and `gatewayExecutor` treated any HTTP 200 as `success: true`, marking `ActionAudit.status = 'succeeded'` while no ban/block/response ever executed.

**Fix:**
- Created `apps/web/src/lib/security/decision-token.ts` with `signDecisionToken()` — signs `{ auditId, actionType, target, exp }` with `ACTION_SERVICE_TOKEN_SECRET`, base64url-encoded, matching the format the gateway verifier expects
- `gatewayExecutor` now mints a token per call and injects it as `__decision_token` in `toolArgs` for all write tools
- `audit.id` is threaded from `execute()` into the executor via `payload.__auditId` so the token can bind to the specific audit row
- `gatewayExecutor` now detects known error-body patterns in HTTP 200 responses (token rejection, env var missing, upstream errors) and returns `success: false` instead of silently succeeding

**MAJOR — `crowdsec_decision_delete` arg mismatch**

`gatewayExecutor` sent `{ decisionId: target }` but the tool body reads `args.ip`. Now sends `{ ip: target, decisionId: target }` — `decisionId` satisfies the token check, `ip` satisfies the CrowdSec LAPI DELETE call.

**Operational note:** `ACTION_SERVICE_TOKEN_SECRET` must be set in both the web/orion environment and the gateway environment (same value). Added to `deploy/.env.example` with `openssl rand -hex 32` generation instructions.

## Test plan
- [ ] Set `ACTION_SERVICE_TOKEN_SECRET=<same 32+ char secret>` in both web and gateway env
- [ ] POST auto-tier action (e.g. `crowdsec_decision_create`) → ActionAudit `status='succeeded'`, CrowdSec LAPI called
- [ ] POST action with no `ACTION_SERVICE_TOKEN_SECRET` set → `gatewayExecutor` returns `success: false` with token error message, `ActionAudit.status='failed'`
- [ ] POST action to gateway directly without token → HTTP 200 with error body, treated as failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)