### PR TITLE
fix(siem): fix investigation list crash and incident title blanking

### DIFF
--- a/apps/web/src/app/(app)/security/investigations/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/investigations/[id]/page.tsx
@@ -72,7 +72,9 @@ export default function InvestigationDetailPage() {
 
   const load = useCallback(async () => {
     try {
-      const data = await fetch(`/api/monitoring/security/investigations/${investigationId}`).then(r => r.json())
+      const res = await fetch(`/api/monitoring/security/investigations/${investigationId}`)
+      if (!res.ok) { router.push('/security/investigations'); return }
+      const data = await res.json()
       setInvestigation(data.investigation ?? data)
       setNewStatus(data.investigation?.status ?? data?.status ?? 'open')
     } catch {

--- a/apps/web/src/app/(app)/security/investigations/page.tsx
+++ b/apps/web/src/app/(app)/security/investigations/page.tsx
@@ -13,7 +13,10 @@ interface Investigation {
   tags: string[]
   startedAt: string | null
   resolvedAt: string | null
-  _count: { incidents: number; notes: number; observables: number }
+  // API returns flat counts (not _count) — see investigations/route.ts mapper
+  incidentCount: number
+  noteCount: number
+  observableCount: number
 }
 
 export default function InvestigationsPage() {
@@ -135,11 +138,11 @@ export default function InvestigationsPage() {
                     ))}
                   </div>
                   <div className="text-xs text-text-muted flex items-center gap-2">
-                    <span>{inv._count.incidents} incidents</span>
+                    <span>{inv.incidentCount} incidents</span>
                     <span>&middot;</span>
-                    <span>{inv._count.observables} observables</span>
+                    <span>{inv.observableCount} observables</span>
                     <span>&middot;</span>
-                    <span>{inv._count.notes} notes</span>
+                    <span>{inv.noteCount} notes</span>
                     {inv.startedAt && (
                       <>
                         <span>&middot;</span>

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
@@ -66,6 +66,7 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
       incidents: investigation.incidents.map(i => ({
         id: i.id, status: i.status, severity: i.severity,
         attackerKey: i.attackerKey, hostKey: i.hostKey, openedAt: i.openedAt,
+        rootCauseSummary: i.rootCauseSummary,
       })),
     },
   })


### PR DESCRIPTION
## Summary

Two bugs on the investigations pages, both found by Opus review.

**B1 — List page crashes when any investigation exists**
The API mapper (`investigations/route.ts`) returns flat `incidentCount`/`noteCount`/`observableCount` fields and explicitly sets `_count: undefined`. The list page interface and render code read `inv._count.incidents` → `TypeError: Cannot read properties of undefined`. This crashes the list every time an investigation exists, which is the navigation entry point from "Open Investigation" on incident pages.

Fixed by updating the `Investigation` interface and render to use `incidentCount`/`noteCount`/`observableCount`.

**M1 — Linked incident titles always showed "Untitled"**
The detail GET route's incident mapper included `id`, `status`, `severity`, `attackerKey`, `hostKey`, `openedAt` but not `rootCauseSummary`. The detail page rendered `inc.rootCauseSummary || 'Untitled'` — always "Untitled". Added `rootCauseSummary` to the mapper. The `include` already fetched all Incident columns so no Prisma query change was needed.

**Also:** Added `r.ok` guard to the detail page's `load()` — a 404 previously returned `{ error: '...' }` which was treated as investigation data, crashing on `investigation.incidents.length`.

## Test plan
- [ ] Navigate to `/security/investigations` with at least one investigation → list renders with incident/observable/note counts
- [ ] Click an investigation → detail page loads, linked incidents show their `rootCauseSummary` instead of "Untitled"
- [ ] Navigate to `/security/investigations/nonexistent-id` → redirects to `/security/investigations` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)