### PR TITLE
fix(agents): watcher concurrency lock, tool_call history pollution, lastRun in finally

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -835,7 +835,13 @@ export async function triggerRoomAgentReplies(
 
       // All messages except the very last are history context.
       // The very last message is what this agent is directly responding to.
-      const historyMsgs = recentMessages.slice(0, -1).filter((m: any) => m.senderType !== 'system')
+      // Exclude system and tool_call messages from history. tool_call rows store
+      // the bare tool name for SSE streaming; if they leak into history they appear
+      // as assistant messages containing only a tool name string (e.g. "kubectl_get"),
+      // which confuses the model and triggers the isFakeToolCall rejection path.
+      const historyMsgs = recentMessages.slice(0, -1).filter(
+        (m: any) => m.senderType !== 'system' && m.senderType !== 'tool_call'
+      )
       const lastMsg     = recentMessages[recentMessages.length - 1]
       const lastSender  = lastMsg?.agent?.name ?? lastMsg?.user?.name ?? lastMsg?.user?.username ?? 'User'
       const latestTurn  = lastMsg ? `${lastSender}: ${lastMsg.content}` : triggerContent

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -97,6 +97,10 @@ function buildWikiContext(notes: Array<{ title: string; content: string }>): str
 }
 
 const runningTasks = new Set<string>()
+// Guards against concurrent watcher runs: the 60s poll interval is shorter
+// than many watcher runtimes, so without this a slow watcher would launch
+// multiple parallel copies that each issue duplicate mutating tool calls.
+const runningWatchers = new Set<string>()
 
 const TASK_TIMEOUT_MS = 60 * 60 * 1000 // 60 minutes
 
@@ -609,7 +613,14 @@ async function runWatchers() {
     const watchPrompt = (cfg.watchPrompt as string | undefined)
     if (!watchPrompt?.trim()) continue
 
+    // Skip if this watcher is already running (poll interval < typical run time).
+    if (runningWatchers.has(agent.id)) {
+      log(`Skipping watcher "${agent.name}" — still running from previous cycle`)
+      continue
+    }
+
     log(`Running watcher: "${agent.name}"`)
+    runningWatchers.add(agent.id)
 
     const systemPrompt = (meta.systemPrompt as string | undefined) ?? 'You are a monitoring agent.'
     const modelId = await resolveModelId(cfg.llm)
@@ -685,7 +696,15 @@ async function runWatchers() {
         if (event.type === 'error') throw new Error(event.error)
       }
 
-      // Persist last-run timestamp to DB so it survives restarts
+      if (output.trim()) {
+        await postToFeed(agent.id, `👁 **${agent.name}**:\n\n${output.trim().slice(0, 1500)}`)
+      }
+    } catch (e) {
+      err(`Watcher "${agent.name}" failed: ${e}`)
+      await postToFeed(agent.id, `❌ **${agent.name}** watcher error: ${e}`)
+    } finally {
+      // Always update lastRun (even on error) so a failing watcher respects
+      // its interval instead of retrying every 60s until it succeeds.
       await prisma.agent.update({
         where: { id: agent.id },
         data: {
@@ -694,14 +713,8 @@ async function runWatchers() {
             watcherLastRun: Date.now()
           }
         }
-      })
-
-      if (output.trim()) {
-        await postToFeed(agent.id, `👁 **${agent.name}**:\n\n${output.trim().slice(0, 1500)}`)
-      }
-    } catch (e) {
-      err(`Watcher "${agent.name}" failed: ${e}`)
-      await postToFeed(agent.id, `❌ **${agent.name}** watcher error: ${e}`)
+      }).catch(() => { /* non-critical — next run will re-calculate from old lastRun */ })
+      runningWatchers.delete(agent.id)
     }
   }
 }


### PR DESCRIPTION
## Summary

Three bugs in the agent runner found by Opus review.

**B1 — Watcher loop ran the same agent concurrently**
The 60s `setInterval` for watchers fires faster than many watcher runtimes (Alpha, Veritas can take several minutes doing DB queries + tool calls). Without a lock, a slow watcher launched a second (and third…) copy while still running — each issuing duplicate mutating tool calls (`orion_assign_task`, `orion_create_agent`, etc.). Added `runningWatchers = new Set<string>()` — checks before launch, adds on start, removes in `finally`.

**B2 — `tool_call` messages polluted next conversation history**
`senderType='tool_call'` rows are persisted to the DB for SSE streaming (they store the bare tool name). Previously only `'system'` was filtered from `historyMsgs` — `tool_call` was not, so they re-entered history as assistant messages containing only the tool name string (e.g. `"kubectl_get"`). This triggered the `isFakeToolCall` rejection path and polluted model context. Added `tool_call` to the `senderType` exclusion filter at the history reconstruction line.

**M4 — `watcherLastRun` not written on exception**
The `prisma.agent.update` was inside the `try` block after `runner.run`. If the runner threw, `lastRun` was never updated, so a persistently failing watcher retried every 60s instead of respecting its `watchIntervalMin`. Moved to `finally` so it always runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)