### PR TITLE
fix(vault): wrong token key breaks all writes; secrets not admin-gated; mTLS fail-open

### DIFF
--- a/apps/web/src/app/api/environments/[id]/secrets/[secretId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/secrets/[secretId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCurrentUser } from '@/lib/auth'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { writeVaultSecret } from '@/lib/vault'
 
@@ -17,8 +17,10 @@ type Params = { params: Promise<{ id: string; secretId: string }> }
  *     — written directly to Vault, NEVER stored in the database
  */
 export async function PATCH(req: NextRequest, { params }: Params) {
-  const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  let user: Awaited<ReturnType<typeof requireAdmin>>
+  try { user = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   const { secretId } = await params
   const body = await req.json().catch(() => ({})) as Record<string, unknown>
@@ -110,8 +112,10 @@ export async function PATCH(req: NextRequest, { params }: Params) {
  * Delete a managed secret record.
  */
 export async function DELETE(_: NextRequest, { params }: Params) {
-  const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  let user: Awaited<ReturnType<typeof requireAdmin>>
+  try { user = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   const { secretId } = await params
 

--- a/apps/web/src/app/api/environments/[id]/secrets/route.ts
+++ b/apps/web/src/app/api/environments/[id]/secrets/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getCurrentUser } from '@/lib/auth'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { writeVaultSecret } from '@/lib/vault'
 
@@ -12,8 +12,10 @@ type Params = { params: Promise<{ id: string }> }
  * Returns all managed secrets for this environment (metadata only — no values).
  */
 export async function GET(_: NextRequest, { params }: Params) {
-  const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  let user: Awaited<ReturnType<typeof requireAdmin>>
+  try { user = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   const { id: environmentId } = await params
 
@@ -44,8 +46,10 @@ export async function GET(_: NextRequest, { params }: Params) {
  *   3. Store metadata-only ManagedSecret record (dataKeys = key names, no values)
  */
 export async function POST(req: NextRequest, { params }: Params) {
-  const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  let user: Awaited<ReturnType<typeof requireAdmin>>
+  try { user = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   const { id: environmentId } = await params
   const body = await req.json().catch(() => ({})) as Record<string, unknown>

--- a/apps/web/src/lib/vault.ts
+++ b/apps/web/src/lib/vault.ts
@@ -22,12 +22,25 @@ function getVaultAgent(): https.Agent | undefined {
   const caPath   = process.env.VAULT_CACERT
   const certPath = process.env.VAULT_CLIENT_CERT
   const keyPath  = process.env.VAULT_CLIENT_KEY
-  if (!caPath && !certPath) { _agent = undefined; return undefined }
+  if (!caPath && !certPath) {
+    // No cert configuration — only allow if VAULT_ADDR is HTTP (dev/local).
+    // In production, VAULT_ADDR should be HTTPS and certs must be configured.
+    const addr = process.env.VAULT_ADDR ?? ''
+    if (addr.startsWith('https://') && process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'Vault mTLS not configured: VAULT_CACERT must be set when VAULT_ADDR uses HTTPS in production. ' +
+        'Refusing to connect without cert verification.'
+      )
+    }
+    _agent = undefined
+    return undefined
+  }
   _agent = new https.Agent({
     ca:   caPath   ? fs.readFileSync(caPath)   : undefined,
     cert: certPath ? fs.readFileSync(certPath) : undefined,
     key:  keyPath  ? fs.readFileSync(keyPath)  : undefined,
-    rejectUnauthorized: !!caPath,
+    // Always verify the server cert — never silently downgrade.
+    rejectUnauthorized: true,
   })
   return _agent
 }
@@ -90,8 +103,11 @@ export async function writeVaultSecret(
   kvPath: string,
   data: Record<string, string>,
 ): Promise<void> {
-  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.rootToken' } })
-  if (!setting?.value) throw new Error('Vault root token not configured — has the Vault setup wizard been completed?')
+  // Setup wizard writes 'vault.adminToken', never 'vault.rootToken' (root is
+  // generated once and immediately revoked). Reading 'vault.rootToken' would
+  // always return null, silently breaking every secret write.
+  const setting = await prisma.systemSetting.findUnique({ where: { key: 'vault.adminToken' } })
+  if (!setting?.value) throw new Error('Vault admin token not configured — has the Vault setup wizard been completed?')
   const token = decrypt(String(setting.value))
 
   // Normalise: strip "secret/data/" prefix if the caller included it


### PR DESCRIPTION
## Summary

Three critical bugs found by Opus security review of Vault integration.

**CRITICAL (functional) — All Vault secret writes were failing**
`vault.ts:93` read from key `'vault.rootToken'`. The setup wizard only ever writes `'vault.adminToken'` (the root token is generated once and immediately revoked per Vault best practice). So `setting?.value` was always null → `writeVaultSecret` always threw `'Vault root token not configured'`. Every secret write in the system was silently broken. Fixed: changed to `'vault.adminToken'`.

**BLOCKER (security) — Secrets routes not admin-gated**
Both `environments/[id]/secrets/route.ts` and `[secretId]/route.ts` used `getCurrentUser()` — any authenticated user including SSO auto-provisioned `'user'` role accounts could write arbitrary data to any Vault path using the privileged admin token. Changed both to `requireAdmin()`.

**BLOCKER (security) — mTLS failed open**
`vault.ts:30` set `rejectUnauthorized: !!caPath`. If `VAULT_CACERT` was unset with HTTPS Vault in production, TLS connected but skipped server cert verification (MITM vector). Fixed: always `rejectUnauthorized: true` when certs are configured. In production with HTTPS Vault and no certs, throws rather than connecting insecurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)