### PR TITLE
fix(auth): rate-limiter crash, SSO HMAC bypass, hardcoded wizard JWT secret

### DIFF
--- a/apps/web/src/app/api/setup/verify-token/route.ts
+++ b/apps/web/src/app/api/setup/verify-token/route.ts
@@ -30,8 +30,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid setup token' }, { status: 401 })
   }
 
-  // Issue short-lived wizard session JWT (1 hour)
-  const secret = new TextEncoder().encode(process.env.NEXTAUTH_SECRET ?? 'fallback-secret')
+  // Issue short-lived wizard session JWT (1 hour).
+  // NEXTAUTH_SECRET must be set — 'fallback-secret' would produce forgeable wizard
+  // tokens that grant full setup access to anyone who knows the hardcoded value.
+  const nextAuthSecret = process.env.NEXTAUTH_SECRET
+  if (!nextAuthSecret) {
+    return NextResponse.json({ error: 'Server misconfiguration: NEXTAUTH_SECRET is not set' }, { status: 500 })
+  }
+  const secret = new TextEncoder().encode(nextAuthSecret)
   const wizardJwt = await new SignJWT({ wizard: true })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime('1h')

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -257,18 +257,21 @@ async function validateSSoHeaderHmac(headers: Headers): Promise<boolean> {
             .update(canonical)
             .digest('hex')
           const expectedPrevBuf = Buffer.from(expectedPrev, 'hex')
-          timingSafeEqual(signatureBuf, expectedPrevBuf)
-          return true  // matched previous secret
+          // timingSafeEqual returns false on mismatch (does NOT throw).
+          // Capture the result — without this the return value was discarded
+          // and return true was always reached, accepting any equal-length signature.
+          return timingSafeEqual(signatureBuf, expectedPrevBuf)
         } catch {
           return false
         }
       }
       return false
     }
-    timingSafeEqual(signatureBuf, expectedBuf)
-    return true  // Signature matches
+    // timingSafeEqual returns false on mismatch (does NOT throw).
+    // The original code discarded the return value and always returned true
+    // for any equal-length signature — a complete HMAC bypass.
+    return timingSafeEqual(signatureBuf, expectedBuf)
   } catch {
-    // timingSafeEqual throws on mismatch
     return false
   }
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -19,7 +19,7 @@ function getRateLimitKey(req: NextRequest): string {
     // x-forwarded-for can contain multiple IPs: client, proxy1, proxy2
     return forwarded.split(',')[0].trim()
   }
-  return req.ip || ((null as any).remoteAddress) || 'unknown'
+  return req.ip ?? 'unknown'
 }
 
 // Per-path rate limit configs: [maxRequests, windowMs]


### PR DESCRIPTION
## Summary

Three auth bugs from Opus security review.

**B2 — Rate-limiter crashed middleware on every unauthenticated request with no `x-forwarded-for`**
`middleware.ts:22` contained `(null as any).remoteAddress` — a hardcoded null dereference that threw `TypeError` on every invocation where `req.ip` was falsy and no `x-forwarded-for` header was present. Fixed to `req.ip ?? 'unknown'`.

**M6 — SSO HMAC verification accepted any equal-length signature**
`auth.ts` called `timingSafeEqual(signatureBuf, expectedBuf)` but discarded the return value, then unconditionally reached `return true`. The comment stated timingSafeEqual "throws on mismatch" — it does not, it returns false. Any attacker with a same-length hex string could bypass SSO HMAC and authenticate as any user. Fixed: `return timingSafeEqual(...)` directly (both primary and previous-secret rotation paths).

**M3 — Wizard JWT signed with hardcoded secret when `NEXTAUTH_SECRET` unset**
`setup/verify-token/route.ts` used `process.env.NEXTAUTH_SECRET ?? 'fallback-secret'`. Since `'fallback-secret'` is in the public repo, anyone can forge a wizard session JWT granting full setup access (create admin account, repoint git provider, re-initialize Vault). Fixed: require `NEXTAUTH_SECRET`, return HTTP 500 if not set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)