### PR TITLE
fix(gitops,tasks): manifest policy bypass, path traversal, task events unauth, agent ownership

### DIFF
--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { parseBodyOrError, UpdateAgentSchema } from '@/lib/validate'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
   const agent = await prisma.agent.findUnique({
@@ -15,6 +16,12 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  // Require admin — any authenticated user could otherwise overwrite any agent's
+  // systemPrompt or contextConfig (privilege escalation).
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Admin privileges required to modify agents' }, { status: 403 })
+  }
+
   // SOC2 [INPUT-001]: Validate request body with Zod schema
   const result = await parseBodyOrError(req, UpdateAgentSchema)
   if ('error' in result) return result.error
@@ -34,7 +41,11 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(agent)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Admin privileges required to delete agents' }, { status: 403 })
+  }
+
   // Unassign tasks first to avoid FK violation
   await prisma.task.updateMany({ where: { assignedAgent: params.id }, data: { assignedAgent: null } })
   await prisma.agent.delete({ where: { id: params.id } })

--- a/apps/web/src/app/api/tasks/[id]/events/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/events/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+const VALID_TASK_STATUSES = new Set([
+  'pending', 'in_progress', 'pending_validation', 'done', 'failed', 'blocked',
+])
 
 // GET /api/tasks/:id/events — fetch all events for a task
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
   const events = await prisma.taskEvent.findMany({
     where: { taskId: params.id },
     orderBy: { createdAt: 'asc' },
@@ -12,17 +18,42 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 
 // POST /api/tasks/:id/events — add a comment/status event to a task
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+
   const body = await req.json()
+
+  // Validate status transitions — prevents bypassing Veritas by driving tasks
+  // directly to 'done' via this route without going through pending_validation.
+  if (body.status !== undefined) {
+    const statusStr = String(body.status)
+    if (!VALID_TASK_STATUSES.has(statusStr)) {
+      return NextResponse.json(
+        { error: `Invalid status '${statusStr}'. Must be one of: ${[...VALID_TASK_STATUSES].join(', ')}` },
+        { status: 400 },
+      )
+    }
+    // Agents (non-admin service tokens) cannot transition directly to 'done' —
+    // that gate belongs to Veritas via orion_close_task which requires pending_validation first.
+    if (statusStr === 'done' && caller?.role !== 'admin') {
+      return NextResponse.json(
+        { error: "Cannot set status 'done' directly — transition to 'pending_validation' first, then use orion_close_task" },
+        { status: 403 },
+      )
+    }
+  }
+
   const event = await prisma.taskEvent.create({
     data: {
       taskId:    params.id,
-      eventType: body.eventType ?? 'comment', // comment | status_change | note
+      eventType: body.eventType ?? 'comment',
       content:   body.content ?? null,
+      agentId:   typeof (caller as any)?.agentId === 'string' ? (caller as any).agentId : null,
     },
   })
-  // Optionally update task status at the same time
+
   if (body.status) {
     await prisma.task.update({ where: { id: params.id }, data: { status: body.status } })
   }
+
   return NextResponse.json(event, { status: 201 })
 }

--- a/apps/web/src/lib/gitops.ts
+++ b/apps/web/src/lib/gitops.ts
@@ -20,9 +20,12 @@
 import { getGitProvider, type GitProvider } from './git-provider'
 import {
   classifyAndEvaluate,
+  classifyManifest,
+  evaluatePolicy,
   type PolicyConfig,
   type ChangeClassification,
 } from './gitops-policy'
+import path from 'node:path'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -82,11 +85,42 @@ export async function proposeChangeWithProvider(
   provider: GitProvider,
   opts: GitOpsChangeOptions,
 ): Promise<GitOpsChangeResult> {
-  const classification = classifyAndEvaluate(
+  // B2: Reject path traversal before any git operations. Normalise each path
+  // and refuse changes that contain '..' or would escape the repo root.
+  for (const change of opts.changes) {
+    const normalized = path.normalize(change.path)
+    if (normalized.startsWith('..') || normalized.includes('/..') || path.isAbsolute(normalized)) {
+      throw new Error(`Rejected: path '${change.path}' escapes repo root after normalisation ('${normalized}')`)
+    }
+    // Block writes to sensitive infra directories regardless of repoPath
+    const sensitive = ['.github/', '.gitlab/', 'argocd/', '.git/']
+    if (sensitive.some(s => normalized.startsWith(s))) {
+      throw new Error(`Rejected: path '${change.path}' targets sensitive directory. Direct agent writes to CI/CD and ArgoCD paths are not permitted.`)
+    }
+  }
+
+  // B1: Classify from BOTH the agent-supplied description AND the actual manifest
+  // content, and take the most restrictive result. Classifying only from the
+  // description allows an agent to auto-merge a ClusterRoleBinding by mislabelling
+  // it as "scale replicas".
+  const descClassification = classifyAndEvaluate(
     opts.operationDescription,
     opts.policy,
     'description',
   )
+  let classification = descClassification
+
+  for (const change of opts.changes) {
+    if (change.content) {
+      const contentOp = classifyManifest(change.content)
+      const contentClassification = evaluatePolicy(contentOp, opts.policy)
+      // Take the more restrictive: escalate > review > auto
+      const rank = { auto: 0, review: 1, escalate: 2 }
+      if ((rank[contentClassification.decision] ?? 0) > (rank[classification.decision] ?? 0)) {
+        classification = contentClassification
+      }
+    }
+  }
 
   // Unique branch name: orion/auto/scale-nginx-1713000000000
   const slug = opts.title


### PR DESCRIPTION
## Summary

Four bugs from Opus review of GitOps tools and task management system.

**B1 — GitOps auto-merge policy could be bypassed by mislabelling manifest content**
`proposeChangeWithProvider` called `classifyAndEvaluate` with the agent-supplied `operationDescription` string only. An agent could mislabel a `ClusterRoleBinding` or `ClusterRole` manifest as `"scale replicas"` and get it auto-merged without human review. Now also runs `classifyManifest` over each `change.content` and takes the most restrictive of description vs content. A privileged manifest (RBAC, privileged pod, etc.) is always escalated regardless of how the operation is described.

**B2 — Path traversal in gitops_propose**
Change paths were not normalized before git operations. `deployments/../.github/workflows/ci.yml` would pass the `startsWith` prefix check and write to `.github/` CI pipelines. `proposeChangeWithProvider` now normalizes each path with `path.normalize` and rejects any path starting with `..`, absolute paths, and paths targeting sensitive directories (`.github/`, `.gitlab/`, `argocd/`, `.git/`).

**B3 — `POST /api/tasks/[id]/events` had no auth and accepted arbitrary status**
Any session/token holder could POST `{ status: 'done' }` to bypass the `pending_validation → done` gate that Veritas enforces. Added `requireServiceAuth`, validated `status` against the allowed enum, and blocked non-admin callers from setting `status='done'` directly.

**M2 — `PUT`/`DELETE /api/agents/[id]` had no ownership auth**
Any authenticated user could `PUT` to overwrite any agent's `metadata` (which deep-merges `systemPrompt` and `contextConfig`) or `DELETE` any agent. Added `requireAdmin()` to both handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)