### PR TITLE
fix(executor): path traversal in file_read, token length crash, GET /executions unauth

### DIFF
--- a/apps/executor/src/auth.ts
+++ b/apps/executor/src/auth.ts
@@ -6,9 +6,11 @@ export function validateExecutorToken(token: string): boolean {
   if (!token || !EXECUTOR_TOKEN) {
     return false
   }
-  // Constant-time compare to prevent timing attacks
-  return crypto.timingSafeEqual(
-    Buffer.from(token),
-    Buffer.from(EXECUTOR_TOKEN)
-  )
+  // Hash both sides before comparing so timingSafeEqual always receives
+  // equal-length buffers. The raw form throws RangeError on length mismatch,
+  // which (a) leaks token length as a timing oracle and (b) surfaces as 500
+  // instead of 401. SHA-256 digests are always 32 bytes.
+  const a = crypto.createHash('sha256').update(token).digest()
+  const b = crypto.createHash('sha256').update(EXECUTOR_TOKEN).digest()
+  return crypto.timingSafeEqual(a, b)
 }

--- a/apps/executor/src/index.ts
+++ b/apps/executor/src/index.ts
@@ -252,7 +252,7 @@ fastify.post<{
 
 fastify.get<{
   Params: { id: string }
-}>('/executions/:id', async (request, reply) => {
+}>('/executions/:id', { onRequest: requireExecutorToken }, async (request, reply) => {
   const { id } = request.params
   const execution = await orionClient.getExecution(id)
   return execution

--- a/apps/executor/src/sandbox.ts
+++ b/apps/executor/src/sandbox.ts
@@ -1,5 +1,7 @@
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import path from 'path'
+import fs from 'fs'
 
 const execAsync = promisify(exec)
 
@@ -61,14 +63,28 @@ class Sandbox {
     }
   }
 
-  private async readFile(path: string): Promise<ExecuteResult> {
+  private async readFile(rawPath: string): Promise<ExecuteResult> {
     const startTime = Date.now()
-    if (!FILE_READ_ALLOWLIST.some(allowed => path.startsWith(allowed))) {
-      return { stdout: '', stderr: `Error: path '${path}' is not in the allowlist`, exitCode: 1, durationMs: 0 }
+    // Normalise and resolve the path to block traversal attacks.
+    // path.startsWith('/var/log') passes for '/var/log/../../etc/shadow' —
+    // resolving first ensures we compare against the actual target.
+    const resolved = path.resolve(rawPath)
+
+    // Verify the resolved path starts with an allowlisted prefix at a path boundary.
+    const isAllowed = FILE_READ_ALLOWLIST.some(allowed => {
+      const normalizedAllowed = path.resolve(allowed)
+      return resolved === normalizedAllowed || resolved.startsWith(normalizedAllowed + '/')
+    })
+    if (!isAllowed) {
+      return { stdout: '', stderr: `Error: path '${rawPath}' (resolved: '${resolved}') is not in the allowlist`, exitCode: 1, durationMs: 0 }
+    }
+    // Additional guard: refuse /proc and /sys paths that expose secrets,
+    // even if accidentally allowlisted via a misconfigured FILE_READ_ALLOWLIST.
+    if (resolved.startsWith('/proc/') || resolved.startsWith('/sys/')) {
+      return { stdout: '', stderr: `Error: reading '${resolved}' is not permitted`, exitCode: 1, durationMs: 0 }
     }
     try {
-      const fs = await import('fs')
-      const content = fs.readFileSync(path, 'utf-8') // lgtm[js/path-injection]
+      const content = fs.readFileSync(resolved, 'utf-8')
       return {
         stdout: content,
         stderr: '',


### PR DESCRIPTION
## Summary

Three bugs from Opus security review of the executor service.

**B4 — `file_read` path traversal to arbitrary files including service secrets**
`path.startsWith('/var/log')` passes for `/var/log/../../etc/shadow` and `/var/log/../../proc/1/environ` (which holds `ORION_EXECUTOR_TOKEN`, `HOST_AGENT_WEBHOOK_SECRET`, and every other secret injected into the process environment). Fixed: `path.resolve()` before the allowlist check, boundary-aware prefix comparison (`resolved + '/'`), and an explicit block on `/proc/` and `/sys/` paths.

**M1 — `validateExecutorToken` threw on wrong-length tokens**
`crypto.timingSafeEqual` throws `RangeError` when buffers differ in length. A token with the wrong number of bytes returned HTTP 500 instead of 401, leaking token length as a timing oracle. Fixed: hash both sides with SHA-256 before comparing (always 32-byte buffers).

**M2 — `GET /executions/:id` had no authentication**
Any caller who could reach the executor port could read execution records (including command args and output). Added the existing `requireExecutorToken` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)