### PR TITLE
fix(audit): wire daily SOC2 export job; delete exact exported IDs not re-queried window

### DIFF
--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -22,6 +22,10 @@ export async function register() {
     const { ensureSecurityRetentionJobScheduled } = await import('./jobs/security-retention-daily')
     await ensureSecurityRetentionJobScheduled()
 
+    // Wire the daily SOC2 audit export (was dead code — never scheduled).
+    const { ensureAuditExportJobScheduled } = await import('./jobs/audit-export-daily')
+    await ensureAuditExportJobScheduled()
+
     const { ensureSocConfig } = await import('./lib/seed-soc-config')
     await ensureSocConfig()
   }

--- a/apps/web/src/lib/audit-export.ts
+++ b/apps/web/src/lib/audit-export.ts
@@ -153,6 +153,7 @@ async function exportLogsToFile(retentionDays: number): Promise<{
   recordCount: number
   startDate: Date
   endDate: Date
+  exportedIds: string[]  // exact IDs written to file — used to scope the delete
 }> {
   const cutoff = new Date(Date.now() - retentionDays * 86400000)
   const endDate = new Date()
@@ -251,6 +252,7 @@ async function exportLogsToFile(retentionDays: number): Promise<{
     recordCount: logs.length,
     startDate: logs[0].createdAt,
     endDate: logs[logs.length - 1].createdAt,
+    exportedIds: logs.map((l: any) => l.id),
   }
 }
 
@@ -370,27 +372,21 @@ export async function uploadToS3(
 /**
  * Delete exported logs from database
  */
-async function deleteExportedLogs(retentionDays: number): Promise<number> {
-  const cutoff = new Date(Date.now() - retentionDays * 86400000)
+// Delete exactly the rows that were exported (by ID), not a re-queried time window.
+// Re-querying by time would delete rows written between the export read and this
+// call that were never included in the export file — permanent audit gap.
+async function deleteExportedLogs(exportedIds: string[]): Promise<number> {
+  if (exportedIds.length === 0) return 0
 
   const BATCH_SIZE = 1000
   let totalDeleted = 0
 
-  while (true) {
-    const batch = await prisma.auditLog.findMany({
-      where: { createdAt: { lt: cutoff } },
-      select: { id: true },
-      take: BATCH_SIZE,
-    })
-
-    if (batch.length === 0) break
-
+  for (let i = 0; i < exportedIds.length; i += BATCH_SIZE) {
+    const batch = exportedIds.slice(i, i + BATCH_SIZE)
     const result = await prisma.auditLog.deleteMany({
-      where: { id: { in: batch.map((r: any) => r.id) } },
+      where: { id: { in: batch } },
     })
-
     totalDeleted += result.count
-    if (result.count === 0) break
   }
 
   return totalDeleted
@@ -423,8 +419,11 @@ export async function exportAuditLogs(config?: Partial<AuditExportConfig>): Prom
     // Get retention period
     const retentionDays = await getRetentionDays()
 
-    // Export logs to temporary gzipped file
-    const { filePath: logsFilePath, recordCount, startDate, endDate } = await exportLogsToFile(
+    // Export logs to temporary gzipped file.
+    // exportLogsToFile returns the exact IDs written; we pass them to
+    // deleteExportedLogs to avoid deleting rows that arrived after the
+    // export query completed but before the delete ran (B2 race).
+    const { filePath: logsFilePath, recordCount, startDate, endDate, exportedIds } = await exportLogsToFile(
       retentionDays
     )
 
@@ -442,8 +441,8 @@ export async function exportAuditLogs(config?: Partial<AuditExportConfig>): Prom
     const manifestPath = `s3://${finalConfig.bucketName}/${finalConfig.manifestPath}manifest-${exportDate}.json`
     await uploadManifestToS3(manifest, manifestPath, finalConfig)
 
-    // Delete exported logs from database
-    const deletedCount = await deleteExportedLogs(retentionDays)
+    // Delete exactly the exported rows (by ID) — not a fresh time-window query
+    const deletedCount = await deleteExportedLogs(exportedIds)
 
     // Store manifest hash for next export (chain)
     await storePreviousManifestHash(manifest.hashChain.manifest)


### PR DESCRIPTION
## Summary

Two critical bugs in the SOC2 audit export system found by Opus review.

**B1 — Daily audit export job was dead code; no automatic export was happening**
`ensureAuditExportJobScheduled` (and the entire `audit-export-daily.ts` module) was defined but never called from `instrumentation.ts` or `worker.ts`. The "daily at 2 AM" export described in the file header was simply not running. Exports could only happen via manual `POST /api/admin/audit-export`. Added the startup call to `instrumentation.ts` alongside the existing security retention job scheduling.

**B2 — Delete window was re-queried, not scoped to exported IDs**
`exportLogsToFile` queries `createdAt < cutoff` at time T. `deleteExportedLogs` then re-queries `createdAt < cutoff` at time T+N (a later wall-clock). Any audit row written between the two queries that happens to fall under the now-later cutoff gets deleted without ever being included in the export file — a permanent, silent audit gap.

Fixed: `exportLogsToFile` now returns `exportedIds` (the exact IDs written to the gzip file). `deleteExportedLogs` accepts those IDs and deletes by `{ id: { in: exportedIds } }` instead of re-querying by time window. The set of deleted rows is now identical to the set of exported rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)