### PR TITLE
fix(git-provider): webhook HMAC bypass via missing decrypt; SSRF on provider URL; all providers fail-open

### DIFF
--- a/apps/web/src/app/api/setup/git-provider/route.ts
+++ b/apps/web/src/app/api/setup/git-provider/route.ts
@@ -27,6 +27,16 @@ import { encryptJson } from '@/lib/encryption'
 import { randomBytes } from 'crypto'
 import { seedSystemNebula } from '@/lib/seed-system-nebula'
 
+function isPrivateHost(hostname: string): boolean {
+  if (hostname === 'localhost') return true
+  const privatePatterns = [
+    /^127\./, /^10\./, /^192\.168\./,
+    /^172\.(1[6-9]|2\d|3[01])\./, /^169\.254\./,
+    /^::1$/, /^fc00:/i, /^fe80:/i,
+  ]
+  return privatePatterns.some(p => p.test(hostname))
+}
+
 export async function POST(req: NextRequest) {
   if (!await requireWizardSession(req)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -83,6 +93,29 @@ export async function POST(req: NextRequest) {
     }
     if ((type === 'gitea' || type === 'gitlab') && !url) {
       return NextResponse.json({ error: 'url is required for this provider type' }, { status: 400 })
+    }
+  }
+
+  // ── SSRF validation — block private/internal hosts ───────────────────────
+  // The provider URL is used for a server-side fetch (provider.isHealthy()).
+  // Without this check, an operator can point the provider at an internal
+  // service (169.254.169.254, 10.x.x.x, localhost) and read the response
+  // via error messages. The reverse-proxy endpoint already implements this
+  // protection; applying the same check here.
+  if (url) {
+    try {
+      const parsed = new URL(url)
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return NextResponse.json({ error: 'Provider URL must use http or https' }, { status: 400 })
+      }
+      if (isPrivateHost(parsed.hostname)) {
+        return NextResponse.json(
+          { error: 'Provider URL must not point to a private/internal host' },
+          { status: 400 }
+        )
+      }
+    } catch {
+      return NextResponse.json({ error: 'Invalid provider URL' }, { status: 400 })
     }
   }
 

--- a/apps/web/src/app/api/webhooks/gitea/route.ts
+++ b/apps/web/src/app/api/webhooks/gitea/route.ts
@@ -15,7 +15,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { getGitProvider } from '@/lib/git-provider'
+import { getGitProvider, getGitProviderConfig } from '@/lib/git-provider'
 
 export async function POST(req: NextRequest) {
   const rawBody = await req.text()
@@ -24,12 +24,14 @@ export async function POST(req: NextRequest) {
   const headers: Record<string, string> = {}
   req.headers.forEach((value, key) => { headers[key.toLowerCase()] = value })
 
-  // Load provider config to get webhook secret and verify signature
+  // Load provider config to get webhook secret and verify signature.
+  // Previously read setting.value as a plain object, but it is encrypted
+  // (enc:v1:... string) — the cast to { webhookSecret } always returned
+  // undefined, so secret fell through to '' and HMAC verification was
+  // unconditionally bypassed on this PUBLIC_PATHS endpoint.
   const provider = await getGitProvider()
-  const setting = await prisma.systemSetting.findUnique({ where: { key: 'git.provider.config' } })
-  const secret = (setting?.value as { webhookSecret?: string } | null)?.webhookSecret
-    ?? process.env.GITEA_WEBHOOK_SECRET
-    ?? ''
+  const config = await getGitProviderConfig()
+  const secret = config?.webhookSecret ?? process.env.GITEA_WEBHOOK_SECRET ?? ''
 
   if (!provider.verifyWebhookSignature(rawBody, headers, secret)) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })

--- a/apps/web/src/lib/git-provider/gitea-provider.ts
+++ b/apps/web/src/lib/git-provider/gitea-provider.ts
@@ -262,7 +262,7 @@ export class GiteaGitProvider implements GitProvider {
 
   verifyWebhookSignature(rawBody: string, headers: Record<string, string>, secret: string): boolean {
     const signature = headers['x-gitea-signature'] ?? ''
-    if (!secret) return true
+    if (!secret) return false // fail closed — unsigned webhooks on a public endpoint are not trusted
     const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
     try {
       return timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expected, 'hex'))

--- a/apps/web/src/lib/git-provider/github-provider.ts
+++ b/apps/web/src/lib/git-provider/github-provider.ts
@@ -256,7 +256,7 @@ export class GitHubGitProvider implements GitProvider {
     // GitHub sends: X-Hub-Signature-256: sha256=<hex>
     const header = headers['x-hub-signature-256'] ?? ''
     const signature = header.startsWith('sha256=') ? header.slice(7) : ''
-    if (!secret) return true
+    if (!secret) return false // fail closed — unsigned webhooks on a public endpoint are not trusted
     const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
     try {
       return timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(expected, 'hex'))

--- a/apps/web/src/lib/git-provider/gitlab-provider.ts
+++ b/apps/web/src/lib/git-provider/gitlab-provider.ts
@@ -247,7 +247,7 @@ export class GitLabGitProvider implements GitProvider {
 
   verifyWebhookSignature(rawBody: string, headers: Record<string, string>, secret: string): boolean {
     // GitLab uses plain token comparison (not HMAC)
-    if (!secret) return true
+    if (!secret) return false // fail closed — unsigned webhooks on a public endpoint are not trusted
     const token = headers['x-gitlab-token'] ?? ''
     try {
       return timingSafeEqual(Buffer.from(token), Buffer.from(secret))


### PR DESCRIPTION
## Summary

Three BLOCKERs from Opus security review of git provider integration.

**BLOCKER 1 — Webhook HMAC auth unconditionally bypassed**
The webhook route (`/api/webhooks/gitea`, a `PUBLIC_PATHS` endpoint) read `git.provider.config` and cast it to `{ webhookSecret?: string }`. But wizard-configured provider configs are stored AES-encrypted (`enc:v1:...` string) — the cast always returned `undefined`, so `secret` fell through to `''`. Every `verifyWebhookSignature` call was a no-op for wizard-configured providers. Any unauthenticated attacker could POST forged push/PR events and drive GitOpsPR status changes. Fixed: use `getGitProviderConfig()` which calls `decryptJson` internally.

**BLOCKER 2 — All three git providers fail-open when secret is empty**
Every `verifyWebhookSignature` implementation (Gitea, GitHub, GitLab) had `if (!secret) return true`. Any deployment with `GITEA_WEBHOOK_SECRET` unset accepted all unsigned webhooks. Changed to `return false` (fail closed) — if no secret is configured, the endpoint rejects all requests.

**BLOCKER 3 — No SSRF validation on git provider URL**
For `type=gitea` or `type=gitlab`, the user-supplied URL was immediately used for a server-side `provider.isHealthy()` fetch with zero hostname validation. Error messages reflected the upstream response body, making it a fully readable SSRF to `http://169.254.169.254/` (cloud metadata), `http://127.0.0.1:*`, and RFC1918 ranges. The sibling `setup/reverse-proxy` endpoint already has the correct `isPrivateHost()` check — applied the same pattern to `setup/git-provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)