### PR TITLE
fix(gateway): temp-file collision, missing ctx attribution, nsExists, schema gaps, SSRF

### DIFF
--- a/apps/gateway/src/builtin-tools/discovery.ts
+++ b/apps/gateway/src/builtin-tools/discovery.ts
@@ -25,6 +25,7 @@ async function orionFetch(path: string, options?: RequestInit): Promise<unknown>
   const res = await fetch(url, {
     ...options,
     headers: { ...headers, ...(options?.headers as Record<string, string> || {}) },
+    signal: AbortSignal.timeout(10_000), // N3: prevent indefinite hang on slow/unresponsive ORION
   })
   if (!res.ok) {
     const body = await res.text().catch(() => '')

--- a/apps/gateway/src/builtin-tools/knowledge-graph.ts
+++ b/apps/gateway/src/builtin-tools/knowledge-graph.ts
@@ -31,6 +31,7 @@ async function orionFetch(path: string, options?: RequestInit): Promise<unknown>
   const res = await fetch(url, {
     ...options,
     headers: { ...headers, ...(options?.headers as Record<string, string> || {}) },
+    signal: AbortSignal.timeout(10_000), // N3: prevent indefinite hang on slow/unresponsive ORION
   })
   if (!res.ok) {
     const body = await res.text().catch(() => '')

--- a/apps/gateway/src/builtin-tools/kubernetes.ts
+++ b/apps/gateway/src/builtin-tools/kubernetes.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { writeFileSync, unlinkSync } from 'fs'
+import { randomUUID } from 'crypto'
 
 const exec = promisify(execFile)
 
@@ -94,6 +95,7 @@ export const kubernetesTools = ([
         resource:  { type: 'string', description: 'Resource type, e.g. pod, deployment, service, deploymentconfig' },
         name:      { type: 'string', description: 'Resource name (omit to delete by selector/file)' },
         namespace: { type: 'string', description: 'Namespace (for namespaced resources)' },
+        selector:  { type: 'string', description: 'Label selector (e.g. app=nginx) — use instead of name to delete multiple resources' },
         ignoreNotFound: { type: 'boolean', description: 'Ignore if resource not found (default true)' },
       },
       required: ['resource'],
@@ -130,8 +132,18 @@ export const kubernetesTools = ([
     async execute(args: Record<string, unknown>) {
       const cmdArgs = ['get', String(args.resource)]
       if (args.name) cmdArgs.push(String(args.name))
-      if (args.namespace) cmdArgs.push('-n', String(args.namespace))
-      else if (!args.name) cmdArgs.push('-A')
+      if (args.namespace) {
+        cmdArgs.push('-n', String(args.namespace))
+      } else if (!args.name) {
+        // Only add -A for namespaced resources — cluster-scoped resources (nodes, pv,
+        // clusterrole, namespace, etc.) error or return nothing with -A.
+        const clusterScoped = ['node', 'nodes', 'persistentvolume', 'pv', 'storageclass',
+          'clusterrole', 'clusterrolebinding', 'namespace', 'ns', 'ingressclass',
+          'priorityclass', 'runtimeclass', 'crd', 'customresourcedefinition']
+        if (!clusterScoped.includes(String(args.resource).toLowerCase())) {
+          cmdArgs.push('-A')
+        }
+      }
       cmdArgs.push('-o', String(args.output ?? 'wide'))
       return kubectl(cmdArgs)
     },
@@ -180,7 +192,23 @@ export const kubernetesTools = ([
       required: ['url'],
     },
     async execute(args: Record<string, unknown>) {
-      const cmdArgs = ['apply', '-f', String(args.url)]
+      const rawUrl = String(args.url)
+      // N9 fix: validate URL to prevent SSRF to internal metadata services.
+      // kubectl fetches the manifest server-side — no validation would allow
+      // an agent to apply manifests from http://169.254.169.254/ or internal hosts.
+      try {
+        const parsed = new URL(rawUrl)
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          return `Error: URL must use http or https (got '${parsed.protocol}')`
+        }
+        const PRIVATE = [/^127\./, /^10\./, /^192\.168\./, /^172\.(1[6-9]|2\d|3[01])\./, /^169\.254\./]
+        if (parsed.hostname === 'localhost' || PRIVATE.some(p => p.test(parsed.hostname))) {
+          return `Error: URL must not point to a private or internal host`
+        }
+      } catch {
+        return `Error: invalid URL '${rawUrl}'`
+      }
+      const cmdArgs = ['apply', '-f', rawUrl]
       if (args.namespace) cmdArgs.push('-n', String(args.namespace))
       return kubectl(cmdArgs, 120_000) // 2 min — large manifests take time to download + apply
     },
@@ -197,7 +225,7 @@ export const kubernetesTools = ([
     },
     async execute(args: Record<string, unknown>) {
       const manifest = String(args.manifest)
-      const tmpFile = `/tmp/orion-manifest-${Date.now()}.yaml`
+      const tmpFile = `/tmp/orion-manifest-${randomUUID()}.yaml`
       writeFileSync(tmpFile, manifest, 'utf8')
       try {
         const { stdout, stderr } = await exec('kubectl', ['apply', '-f', tmpFile], { timeout: 60_000 })
@@ -359,9 +387,15 @@ export const kubernetesTools = ([
       properties: {},
     },
     async execute(_args: Record<string, unknown>) {
-      // Helper: check if a namespace exists
+      // Helper: check if a namespace exists.
+      // kubectl get namespace <ns> --ignore-not-found exits 0 and prints NOTHING
+      // when the namespace is absent, so checking exit code alone always returns true.
+      // Must check that stdout is non-empty to confirm the resource was found.
       async function nsExists(ns: string): Promise<boolean> {
-        try { await kubectl(['get', 'namespace', ns, '--ignore-not-found']); return true } catch { return false }
+        try {
+          const out = await kubectl(['get', 'namespace', ns, '--ignore-not-found', '--no-headers'])
+          return out.trim().length > 0
+        } catch { return false }
       }
 
       const [hasLonghorn, hasCeph] = await Promise.all([
@@ -456,7 +490,7 @@ export const kubernetesTools = ([
       if (args.valuesFile) {
         const { writeFileSync, unlinkSync } = await import('fs')
         const valuesFile = String(args.valuesFile)
-        const tmpFile = `/tmp/helm-values-${Date.now()}.yaml`
+        const tmpFile = `/tmp/helm-values-${randomUUID()}.yaml`
         writeFileSync(tmpFile, valuesFile, 'utf8')
         cmdArgs.push('--values', tmpFile)
         try {

--- a/apps/gateway/src/builtin-tools/localhost.ts
+++ b/apps/gateway/src/builtin-tools/localhost.ts
@@ -35,7 +35,7 @@ export const localhostTools = ([
       },
       required: ['command'],
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       const command = String(args.command ?? '').trim()
       if (!command) return 'Error: command is required'
 
@@ -69,7 +69,7 @@ export const localhostTools = ([
       },
       required: ['path'],
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       const filePath = String(args.path ?? '').trim()
       if (!filePath) return 'Error: path is required'
 
@@ -104,7 +104,7 @@ export const localhostTools = ([
       type: 'object',
       properties: {},
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       console.log(`[localhost] system_info`)
 
       const executionId = randomUUID()

--- a/apps/gateway/src/builtin-tools/talos.ts
+++ b/apps/gateway/src/builtin-tools/talos.ts
@@ -6,28 +6,15 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { writeFileSync, unlinkSync } from 'fs'
+import { randomUUID } from 'crypto'
 
 const exec = promisify(execFile)
 
-async function talosctl(
-  args: string[],
-  talosConfigB64: string,
-  timeoutMs = 60_000,
-): Promise<string> {
-  const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
-  writeFileSync(tmpFile, Buffer.from(talosConfigB64, 'base64').toString('utf8'), 'utf8')
-  try {
-    const { stdout, stderr } = await exec('talosctl', args, { timeout: timeoutMs })
-    return stdout || stderr
-  } finally {
-    try { unlinkSync(tmpFile) } catch { /* ignore */ }
-  }
-}
-
-function withConfig(talosConfigB64: string, args: string[]): string[] {
-  const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
-  writeFileSync(tmpFile, Buffer.from(talosConfigB64, 'base64').toString('utf8'), 'utf8')
-  return ['--talosconfig', tmpFile, ...args]
+// Unique temp file name using randomUUID to prevent collision under concurrent
+// calls (Date.now() has ms resolution → two simultaneous calls → same path →
+// cross-actor credential overwrite / ENOENT in the other call's finally).
+function tmpConfig(): string {
+  return `/tmp/orion-talosconfig-${randomUUID()}.yaml`
 }
 
 export const talosTools = ([
@@ -44,7 +31,7 @@ export const talosTools = ([
     },
     async execute(args: Record<string, unknown>) {
       const cfg = String(args.talosConfig)
-      const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
+      const tmpFile = tmpConfig()
       writeFileSync(tmpFile, Buffer.from(cfg, 'base64').toString('utf8'), 'utf8')
       try {
         const { stdout, stderr } = await exec('talosctl', [
@@ -72,7 +59,7 @@ export const talosTools = ([
       required: ['nodeIp', 'talosConfig'],
     },
     async execute(args: Record<string, unknown>) {
-      const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
+      const tmpFile = tmpConfig()
       writeFileSync(tmpFile, Buffer.from(String(args.talosConfig), 'base64').toString('utf8'), 'utf8')
       try {
         const { stdout, stderr } = await exec('talosctl', [
@@ -101,7 +88,7 @@ export const talosTools = ([
       required: ['nodeIp', 'talosConfig', 'patch'],
     },
     async execute(args: Record<string, unknown>) {
-      const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
+      const tmpFile = tmpConfig()
       writeFileSync(tmpFile, Buffer.from(String(args.talosConfig), 'base64').toString('utf8'), 'utf8')
       try {
         const { stdout, stderr } = await exec('talosctl', [
@@ -132,7 +119,7 @@ export const talosTools = ([
       required: ['nodeIp', 'talosConfig', 'installerImage'],
     },
     async execute(args: Record<string, unknown>) {
-      const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
+      const tmpFile = tmpConfig()
       writeFileSync(tmpFile, Buffer.from(String(args.talosConfig), 'base64').toString('utf8'), 'utf8')
       const preserve = args.preserve !== false
       try {
@@ -164,7 +151,7 @@ export const talosTools = ([
       required: ['nodeIp', 'talosConfig'],
     },
     async execute(args: Record<string, unknown>) {
-      const tmpFile = `/tmp/orion-talosconfig-${Date.now()}.yaml`
+      const tmpFile = tmpConfig()
       writeFileSync(tmpFile, Buffer.from(String(args.talosConfig), 'base64').toString('utf8'), 'utf8')
       try {
         const { stdout, stderr } = await exec('talosctl', [

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -260,12 +260,20 @@ async function persistCredentials(): Promise<void> {
 
 // ── Built-in tool registry ────────────────────────────────────────────────────
 
+type BuiltinToolCtx = {
+  agentId?: string
+  userId?: string
+  actorType?: 'agent' | 'human'
+}
+
 type BuiltinTool = {
   name: string
   description: string
   category: string
   inputSchema: Record<string, unknown>
-  execute: (args: Record<string, unknown>) => Promise<string>
+  // ctx is optional so tools that don't need attribution still work,
+  // but localhost tools use it for executor actor attribution (B3 fix).
+  execute: (args: Record<string, unknown>, ctx?: BuiltinToolCtx) => Promise<string>
 }
 
 const BUILTIN_REGISTRY: Record<string, BuiltinTool> = {}
@@ -342,7 +350,9 @@ server.setRequestHandler(CallToolRequestSchema, async (req: unknown) => {
   let result: string
   try {
     if (tool.builtIn && BUILTIN_REGISTRY[name]) {
-      result = await BUILTIN_REGISTRY[name].execute(args as Record<string, unknown>)
+      const sessionId = (req as any).sessionId ?? (req as any).params?.sessionId ?? 'unknown'
+      const mcpCtx: BuiltinToolCtx = { agentId: sessionId, actorType: 'agent' }
+      result = await BUILTIN_REGISTRY[name].execute(args as Record<string, unknown>, mcpCtx)
     } else {
       result = await runTool(tool, args as Record<string, unknown>)
     }
@@ -420,7 +430,9 @@ app.post('/tools/execute', requireAuth, async (req: Request, res: Response) => {
   try {
     let result: string
     if (builtin && (!tool || tool.builtIn)) {
-      result = await builtin.execute(args)
+      const callerAgentId = (req as any).agentId ?? req.body?.agent
+      const restCtx: BuiltinToolCtx = { agentId: callerAgentId, actorType: callerAgentId ? 'agent' : 'human' }
+      result = await builtin.execute(args, restCtx)
     } else {
       result = await runTool(tool!, args)
     }


### PR DESCRIPTION
## Summary

Multiple bugs from Opus deep review of gateway builtin tools.

**B1/B2 — Talos temp file credential collision under concurrency**
Dead helpers (`talosctl`, `withConfig`) removed — `talosctl` never passed `--talosconfig`, `withConfig` leaked the file (no finally). All `Date.now()` temp file names across `talos.ts` and `kubernetes.ts` replaced with `randomUUID()` — millisecond resolution means two concurrent calls write the same path, causing cross-actor credential overwrite or ENOENT in the other call's finally block.

**B3 — Built-in tools called without `ctx` — executor actor always `unknown`**
`localhost.ts` tools declare `execute(args, ctx)` to pass actor attribution to the executor service, but the `BuiltinTool` type only declared `(args)`. Both dispatch sites in `index.ts` passed only `args`, so `ctx` was always `undefined` — the executor received `actorId: 'unknown'` and `actorType: 'human'` on every shell command, defeating per-actor approval routing. Updated the type, both dispatch sites now build and pass a `BuiltinToolCtx`.

**M1 — `kubectl_delete` selector not in schema** — `args.selector` was used in the execute body but absent from `inputSchema`, making the label-selector delete path undiscoverable to MCP clients.

**M2 — `kubectl_get` incorrectly added `-A` for cluster-scoped resources** — nodes, pv, clusterrole, namespace, etc. error or return nothing with `--all-namespaces`. Added explicit list of cluster-scoped resource names that skips `-A`.

**M4 — `nsExists` always returned `true`** — `kubectl get namespace <ns> --ignore-not-found` exits 0 and prints nothing when absent. The function only checked the exit code, so `hasLonghorn`/`hasCeph` were always true, causing `storage_stats` to always try Longhorn CRD queries and fail. Now checks stdout is non-empty.

**N3 — No timeout on `orionFetch`** in `discovery.ts` and `knowledge-graph.ts` — a slow/unresponsive ORION API hangs tool calls indefinitely. Added `AbortSignal.timeout(10_000)`.

**N9 — `kubectl_apply_url` had no SSRF validation** — URL passed directly to `kubectl apply -f` without hostname validation. Added blocklist for localhost, RFC1918, and link-local ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)