### PR TITLE
fix(gateway-core): tool policy bypass, empty-token auth, IPv6 SSRF dead code

### DIFF
--- a/apps/gateway/src/builtin-tools/localhost.ts
+++ b/apps/gateway/src/builtin-tools/localhost.ts
@@ -35,7 +35,7 @@ export const localhostTools = ([
       },
       required: ['command'],
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       const command = String(args.command ?? '').trim()
       if (!command) return 'Error: command is required'
 
@@ -69,7 +69,7 @@ export const localhostTools = ([
       },
       required: ['path'],
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       const filePath = String(args.path ?? '').trim()
       if (!filePath) return 'Error: path is required'
 
@@ -104,7 +104,7 @@ export const localhostTools = ([
       type: 'object',
       properties: {},
     },
-    async execute(args: Record<string, unknown>, ctx: Record<string, unknown>) {
+    async execute(args: Record<string, unknown>, ctx?: { agentId?: string; userId?: string; actorType?: 'agent' | 'human' }) {
       console.log(`[localhost] system_info`)
 
       const executionId = randomUUID()

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -260,12 +260,18 @@ async function persistCredentials(): Promise<void> {
 
 // ── Built-in tool registry ────────────────────────────────────────────────────
 
+type BuiltinToolCtx = {
+  agentId?: string
+  userId?: string
+  actorType?: 'agent' | 'human'
+}
+
 type BuiltinTool = {
   name: string
   description: string
   category: string
   inputSchema: Record<string, unknown>
-  execute: (args: Record<string, unknown>) => Promise<string>
+  execute: (args: Record<string, unknown>, ctx?: BuiltinToolCtx) => Promise<string>
 }
 
 const BUILTIN_REGISTRY: Record<string, BuiltinTool> = {}
@@ -372,6 +378,14 @@ app.use(express.json())
 // response-time side channels. The === operator short-circuits on the first mismatched
 // byte, allowing an attacker to recover the token byte-by-byte through timing measurements.
 function requireAuth(req: Request, res: Response, next: NextFunction) {
+  // M2 fix: an empty GATEWAY_TOKEN makes expected = 'Bearer ', which any request
+  // with that exact header would pass. Guard here so misconfigured deploys fail
+  // closed rather than accepting all traffic. The startup check below enforces
+  // this before the server begins serving, but defence-in-depth here too.
+  if (!GATEWAY_TOKEN) {
+    res.status(503).json({ error: 'Gateway not configured: GATEWAY_TOKEN not set' })
+    return
+  }
   const auth = req.headers.authorization
   const expected = `Bearer ${GATEWAY_TOKEN}`
   if (!auth || !timingSafeCompare(auth, expected)) {
@@ -414,13 +428,23 @@ app.post('/tools/execute', requireAuth, async (req: Request, res: Response) => {
   const tool = activeTools.find(t => t.name === name)
   const builtin = BUILTIN_REGISTRY[name]
 
-  // Built-in tools are always executable regardless of ORION tool config
+  // B1 fix: built-ins previously ran regardless of ORION's activeTools policy.
+  // ORION disabling a built-in tool (e.g. shell_exec) had no effect on this path.
+  // Now require the tool to appear in activeTools (same as the MCP path does).
+  // If ORION hasn't fetched tools yet (empty activeTools on startup), fall back
+  // to allowing built-ins so the gateway doesn't brick on first-boot.
+  const isActiveToolsLoaded = activeTools.length > 0
+  if (!tool && builtin && isActiveToolsLoaded) {
+    res.status(403).json({ error: `Tool '${name}' is not enabled by ORION tool policy` }); return
+  }
   if (!tool && !builtin) { res.status(404).json({ error: `Unknown tool: ${name}` }); return }
 
   try {
     let result: string
     if (builtin && (!tool || tool.builtIn)) {
-      result = await builtin.execute(args)
+      const callerAgentId = (req as any).agentId ?? req.body?.agent
+      const restCtx: BuiltinToolCtx = { agentId: callerAgentId, actorType: callerAgentId ? 'agent' : 'human' }
+      result = await builtin.execute(args, restCtx)
     } else {
       result = await runTool(tool!, args)
     }

--- a/apps/gateway/src/tool-runner.ts
+++ b/apps/gateway/src/tool-runner.ts
@@ -58,11 +58,17 @@ async function validateHttpUrl(url: string): Promise<string> {
 }
 
 function isAllowedIp(ip: string): boolean {
-  // Allow public IPs and K8s internal DNS (non-IP hostnames resolve through DNS lookup path)
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(ip)) return true // not a raw IPv4, skip check
-  // Block IPv6 loopback (::1) and private ranges (fc00::/7, fe80::/10)
-  if (ip === '::1' || ip === '::' || ip.toLowerCase().startsWith('fc') || ip.toLowerCase().startsWith('fd')) return false
-  if (ip.toLowerCase().startsWith('fe80:')) return false // link-local
+  const lower = ip.toLowerCase().replace(/^\[|\]$/g, '') // strip IPv6 brackets
+
+  // IPv6 private/reserved ranges — must be checked BEFORE the early-return for non-IPv4.
+  // The previous code returned true for all non-IPv4 strings on the first line,
+  // making every IPv6 check below it dead code. ::1, fc00::/7, fe80::/10 were never blocked.
+  if (lower === '::1' || lower === '::') return false  // loopback
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return false  // ULA fc00::/7
+  if (lower.startsWith('fe80:')) return false  // link-local fe80::/10
+
+  // Skip further checks for non-IPv4 (DNS-resolved addresses pass as IPv4 from dnsLookup)
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(ip)) return true
 
   const parts = ip.split('.').map(Number)
   if (parts.length !== 4) return false


### PR DESCRIPTION
## Summary

Three bugs from Opus review of the gateway core (index.ts + tool-runner.ts).

**B1 — Built-in tools bypassed ORION activeTools policy**
The REST `/tools/execute` path had an explicit comment *"Built-in tools are always executable regardless of ORION tool config"* and dispatched any built-in registered in `BUILTIN_REGISTRY` regardless of whether it appeared in `activeTools`. ORION disabling `kubectl_delete`, `shell_exec`, or any other built-in had no effect on this path — callers with the gateway token could always invoke them. The MCP path correctly gated on `activeTools`; the REST path now does too (with a startup-bootstrap exception when `activeTools` is still empty on first boot).

**M2 — Empty `GATEWAY_TOKEN` accepted `'Bearer '`**
If `GATEWAY_TOKEN` is unset or empty, `expected = 'Bearer '` — any request with exactly that 7-character authorization header passed `timingSafeCompare`. Added a fail-closed guard in `requireAuth`: returns HTTP 503 if `GATEWAY_TOKEN` is empty, preventing misconfigured deploys from silently accepting all traffic.

**M4 — IPv6 private-range checks in `isAllowedIp` were dead code**
The first line `if (!/^\d+\.\d+\.\d+\.\d+$/.test(ip)) return true` returned `true` for any non-IPv4 string — including `::1`, `fc00::1`, `fe80::1`. The IPv6 loopback/private-range checks below it (checking for `::1`, `fc`, `fd`, `fe80:` prefixes) were therefore unreachable. IPv6 loopback and private addresses were never actually blocked by the SSRF allowlist. Moved IPv6 checks before the early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)