### PR TITLE
fix(setup): first-admin guard, setup.completed gate on all wizard routes, ai-provider SSRF, IP validation

### DIFF
--- a/apps/web/src/app/api/setup/admin/route.ts
+++ b/apps/web/src/app/api/setup/admin/route.ts
@@ -15,6 +15,14 @@ export async function POST(req: NextRequest) {
   const username = data.username.trim()
   const password = data.password
 
+  // B1 fix: prevent creating additional admins after setup completes.
+  // No first-admin-only guard existed — any valid wizard cookie could mint
+  // unlimited admin accounts post-setup.
+  const setupCompleted = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
+  if (setupCompleted?.value) {
+    return NextResponse.json({ error: 'Setup already complete — cannot create additional admins via wizard' }, { status: 403 })
+  }
+
   const existing = await prisma.user.findUnique({ where: { username } })
   if (existing) {
     return NextResponse.json({ error: 'Username already taken' }, { status: 409 })

--- a/apps/web/src/app/api/setup/ai-provider/route.ts
+++ b/apps/web/src/app/api/setup/ai-provider/route.ts
@@ -26,6 +26,24 @@ export async function POST(req: NextRequest) {
   }
   const baseUrl = data.baseUrl || defaultBaseUrls[data.provider] || ''
 
+  // M1 fix: validate baseUrl to prevent SSRF. A custom baseUrl would be used for
+  // every subsequent LLM call — pointing it at 169.254.169.254 or internal hosts
+  // would make all agent LLM calls hit internal services.
+  if (baseUrl) {
+    try {
+      const parsed = new URL(baseUrl)
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return NextResponse.json({ error: 'baseUrl must use http or https' }, { status: 400 })
+      }
+      const PRIVATE = [/^127\./, /^10\./, /^192\.168\./, /^172\.(1[6-9]|2\d|3[01])\./, /^169\.254\./]
+      if (parsed.hostname === 'localhost' || PRIVATE.some(p => p.test(parsed.hostname))) {
+        return NextResponse.json({ error: 'baseUrl must not point to a private or internal host' }, { status: 400 })
+      }
+    } catch {
+      return NextResponse.json({ error: 'baseUrl is not a valid URL' }, { status: 400 })
+    }
+  }
+
   const created = await prisma.externalModel.create({
     data: {
       name: data.name,

--- a/apps/web/src/app/api/setup/domain/route.ts
+++ b/apps/web/src/app/api/setup/domain/route.ts
@@ -95,6 +95,14 @@ export async function POST(req: NextRequest) {
   const domain = internalDomain.trim().toLowerCase()
   const ip = managementIp.trim()
 
+  // M2 fix: validate that managementIp is a valid IPv4 address before interpolating
+  // it into the CoreDNS zone file. Without validation, arbitrary text (including
+  // newlines and zone-file syntax) could be injected into DNS records.
+  if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(ip) ||
+      ip.split('.').some((o: string) => parseInt(o) > 255)) {
+    return NextResponse.json({ error: 'managementIp must be a valid IPv4 address' }, { status: 400 })
+  }
+
   // Validate domain name (RFC 1035) — prevents path traversal at source
   const validated = validateDomain(domain)
   if (validated !== domain) {

--- a/apps/web/src/lib/setup-guard.ts
+++ b/apps/web/src/lib/setup-guard.ts
@@ -1,5 +1,6 @@
 import { type NextRequest } from 'next/server'
 import { jwtVerify } from 'jose'
+import { prisma } from './db'
 
 export async function requireWizardSession(req: NextRequest): Promise<boolean> {
   const token = req.cookies.get('__orion_wizard')?.value
@@ -11,7 +12,15 @@ export async function requireWizardSession(req: NextRequest): Promise<boolean> {
   try {
     const secretBytes = new TextEncoder().encode(secret)
     const { payload } = await jwtVerify(token, secretBytes)
-    return payload.wizard === true
+    if (payload.wizard !== true) return false
+
+    // B2 fix: wizard JWT carries no completion binding and lives for 1 hour.
+    // Without this check, a token obtained during install remains valid post-setup
+    // and can re-run any wizard route (re-init Vault, mint admins, repoint git).
+    const completed = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })
+    if (completed?.value) return false
+
+    return true
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

Four bugs from Opus review of the setup wizard routes.

**B1 — `setup/admin` could create unlimited admins post-setup**
No check that zero admins already exist, and no `setup.completed` check. Any valid wizard cookie could mint additional `role: 'admin'` users after the system is live. Added a `setup.completed` guard before username uniqueness check.

**B2 — No `setup.completed` check on any mutating wizard route**
Every mutating wizard route (`admin`, `vault`, `domain`, `ai-provider`, `git-provider`, `reverse-proxy`) only checked `requireWizardSession`. The wizard JWT carries no completion binding and lives for 1 hour — a token obtained during install remained valid post-setup and could re-run any wizard step (re-init Vault, repoint git provider, overwrite DNS). Added a `prisma.systemSetting` lookup in `requireWizardSession` itself so all routes get the fix automatically.

**M1 — `ai-provider` accepted arbitrary `baseUrl` without SSRF validation**
Unlike the sibling `git-provider` and `reverse-proxy` routes, `ai-provider` had no hostname validation. A wizard-provided `baseUrl` of `http://169.254.169.254/` or internal host would be stored as the system default model endpoint, causing every subsequent LLM call to hit internal services. Added the same private-host blocklist used elsewhere.

**M2 — `domain` route interpolated `managementIp` into zone file without IP format validation**
`managementIp` was trimmed but never validated as a proper IPv4 address before being interpolated into CoreDNS zone file A records. Arbitrary text (including zone-file syntax) could be injected. Added regex + octet-range validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)