### PR TITLE
fix(chatrooms): GET messages and SSE stream missing auth, senderType spoofable

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/messages/route.ts
@@ -23,7 +23,18 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // B1 fix: GET had no auth or membership check — any user could read any room,
+  // including system.room.security where Warden posts incident details.
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { id } = await params
+  const membership = await getRoomMembership(id, session.user.id)
+  if (!membership.userId && !membership.agentId) {
+    return NextResponse.json({ error: 'Not a member of this room' }, { status: 403 })
+  }
+
   const { searchParams } = new URL(_req.url)
   const limit = Math.min(parseInt(searchParams.get('limit') ?? '50') || 50, 200)
   const before = searchParams.get('before')
@@ -79,7 +90,10 @@ export async function POST(
       roomId: id,
       userId: memberUserId ?? userId,
       agentId,
-      senderType: body.senderType ? String(body.senderType) : (agentId ? 'agent' : 'human'),
+      // M3 fix: senderType was attacker-controlled — callers could post with
+      // senderType:'compaction' to forge a context boundary, or 'system' to
+      // spoof system banners. Only 'human' and 'agent' are allowed from the POST path.
+      senderType: agentId ? 'agent' : 'human',
       content: content.trim(),
       attachments: (body.attachments as any) ?? undefined,
       taskId: taskId ?? null,

--- a/apps/web/src/app/api/chatrooms/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/stream/route.ts
@@ -43,6 +43,17 @@ export async function GET(
     return NextResponse.json({ error: 'Room not found' }, { status: 404 })
   }
 
+  // B2 fix: SSE stream only checked that a session exists, not that the user
+  // is a member of this room. Any logged-in user could subscribe to the security
+  // room and receive incident details live. Verify membership.
+  const membership = await prisma.chatRoomMember.findFirst({
+    where: { roomId, userId: session.user.id },
+    select: { userId: true },
+  })
+  if (!membership) {
+    return NextResponse.json({ error: 'Not a member of this room' }, { status: 403 })
+  }
+
   // Create SSE stream
   const encoder = new TextEncoder()
   let unsubscribe: (() => Promise<void>) | null = null


### PR DESCRIPTION
## Summary

Three bugs from Opus review of the chatrooms API.

**B1 — `GET /api/chatrooms/[id]/messages` had no auth or membership check**
Any logged-in user could read messages from any room — including `system.room.security` where Warden posts full incident details (attacker IPs, severity, rootCauseSummary, action proposals). Added `getServerSession` + `ChatRoomMember` lookup. Returns 401 if unauthenticated, 403 if not a member.

**B2 — SSE stream `/api/chatrooms/[id]/stream` only checked a session existed**
The stream verified `session?.user` but not that the caller was a member of the target room. Any authenticated user could subscribe to the security room's real-time feed and receive incident messages as they were posted. Added `ChatRoomMember` lookup after the session check.

**M3 — `senderType` was attacker-controlled on message POST**
Callers could POST with `body.senderType = 'compaction'` to forge a context boundary (causing the next compaction run to discard real history from that point), or `'system'` to spoof system banners in the UI. Changed to always derive `senderType` from whether `agentId` resolves: `'agent'` if the caller is a room-member agent, `'human'` otherwise. User-supplied `senderType` is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)