### PR TITLE
fix(gateway-watchers): YAML injection in ArgoCD secret, premature state commit

### DIFF
--- a/apps/gateway/src/argocd-bootstrap.ts
+++ b/apps/gateway/src/argocd-bootstrap.ts
@@ -116,9 +116,14 @@ export async function bootstrapArgoCD(
       const repoUrl = `${gitConfig.url}/${gitConfig.org}`
       const username = gitConfig.type === 'github' ? 'x-access-token' : 'orion'
 
-      const safeRepoUrl  = repoUrl.replace(/[\r\n]/g, '')
-      const safeToken    = gitConfig.token.replace(/[\r\n]/g, '')
-      const safeUsername = username.replace(/[\r\n]/g, '')
+      // B1 fix: YAML injection — the previous code only stripped \r\n but
+      // other YAML metacharacters (colons, leading spaces, anchors, etc.) in
+      // repoUrl/token/username can corrupt the document or inject extra fields.
+      // JSON-encode each value: YAML is a JSON superset so JSON strings are valid
+      // YAML scalars and escape all special characters.
+      const yamlRepoUrl  = JSON.stringify(repoUrl)
+      const yamlToken    = JSON.stringify(gitConfig.token)
+      const yamlUsername = JSON.stringify(username)
 
       const secretYaml = `apiVersion: v1
 kind: Secret
@@ -129,9 +134,9 @@ metadata:
     argocd.argoproj.io/secret-type: repository
 stringData:
   type: git
-  url: ${safeRepoUrl}
-  password: ${safeToken}
-  username: ${safeUsername}`
+  url: ${yamlRepoUrl}
+  password: ${yamlToken}
+  username: ${yamlUsername}`
 
       // Write to a temp file and apply — avoids stdin piping issues with exec
       const tmpDir = mkdtempSync(tmpdir() + '/argocd-bootstrap-')

--- a/apps/gateway/src/argocd-watcher.ts
+++ b/apps/gateway/src/argocd-watcher.ts
@@ -72,20 +72,25 @@ export class ArgoCDWatcher {
     const apps: ArgoCDApp[] = items.map((item: unknown) => parseApp(item))
     const changed: ArgoCDApp[] = []
 
+    const pendingUpdates: Array<{ key: string; snapshot: string }> = []
     for (const app of apps) {
       const key = app.name
       const snapshot = `${app.syncStatus}:${app.healthStatus}:${app.revision}`
       if (this.lastState.get(key) !== snapshot) {
-        this.lastState.set(key, snapshot)
+        pendingUpdates.push({ key, snapshot })
         changed.push(app)
       }
     }
 
-    // Always report on first poll (lastState is empty); subsequent polls only on change
-    const isFirstPoll = this.lastState.size === apps.length && changed.length === apps.length
+    const isFirstPoll = this.lastState.size === 0 && changed.length > 0
     if (changed.length > 0) {
       console.log(`[argocd-watcher] ${isFirstPoll ? 'Initial state' : 'State changed'}: ${changed.map(a => `${a.name}=${a.syncStatus}/${a.healthStatus}`).join(', ')}`)
+      // M5 fix: commit state AFTER a successful onChanged so a failed report
+      // is retried on the next poll instead of being silently lost.
       await this.onChanged(apps) // send full state, not just changed apps
+      for (const { key, snapshot } of pendingUpdates) {
+        this.lastState.set(key, snapshot)
+      }
     }
   }
 }

--- a/apps/gateway/src/ingress-watcher.ts
+++ b/apps/gateway/src/ingress-watcher.ts
@@ -94,10 +94,12 @@ export class IngressWatcher {
     // Only report when something changed
     const snapshot = JSON.stringify(rules.map(r => `${r.host}:${r.paths.join(',')}`).sort())
     if (snapshot === this.lastSnapshot) return
-    this.lastSnapshot = snapshot
 
-    const isFirst = this.lastSnapshot === snapshot && rules.length > 0
+    const isFirst = this.lastSnapshot === ''
     console.log(`[ingress-watcher] ${isFirst ? 'Initial' : 'Changed'}: ${rules.length} ingress rule(s)`)
+    // M6 fix: commit state AFTER a successful onChanged so a failed report
+    // is retried on the next poll instead of being silently lost.
     await this.onChanged(rules)
+    this.lastSnapshot = snapshot
   }
 }


### PR DESCRIPTION
## Summary

Three bugs from Opus review of the gateway watcher modules.

**B1 — YAML injection in ArgoCD repository Secret**
`argocd-bootstrap.ts` string-interpolated `repoUrl`, `token`, and `username` into a YAML `stringData` block with only `\r\n` stripped. YAML metacharacters in these values (colons, leading spaces, `{`, anchors, multiline-looking strings) can corrupt the document or inject extra YAML fields into the secret. Fixed by using `JSON.stringify()` for each value — YAML is a JSON superset so JSON strings are valid YAML scalars that escape all special characters.

**M5 — ArgoCD watcher committed state before `onChanged`**
`this.lastState.set(key, snapshot)` ran inside the loop before `await this.onChanged(apps)`. If the ORION report failed (network error, 5xx), state was already advanced and the change was silently lost — never retried on the next poll. Deferred all state updates to after a successful `onChanged` call. Also fixed the dead first-poll detection logic (`this.lastState.size === apps.length && changed.length === apps.length` was always wrong after state mutation in the loop).

**M6 — Same premature-commit in `ingress-watcher`**
`this.lastSnapshot = snapshot` was set before `await this.onChanged(rules)`. Same data-loss pattern as M5. Now commits only after successful report. Also fixed the always-true `isFirst` check (`this.lastSnapshot === snapshot` is always true immediately after assignment; changed to check for empty string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)