### PR TITLE
fix: Nova/admin auth missing, generate-features/tasks unauth, rate limit XFF bypass

### DIFF
--- a/apps/web/src/app/api/admin/models/default/route.ts
+++ b/apps/web/src/app/api/admin/models/default/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 // PUT /api/admin/models/default  — set or clear the default model
 export async function PUT(req: NextRequest) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { modelId } = await req.json()
 
   if (!modelId) {

--- a/apps/web/src/app/api/epics/[id]/generate-features/route.ts
+++ b/apps/web/src/app/api/epics/[id]/generate-features/route.ts
@@ -6,9 +6,11 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 import { callDefaultModel } from '@/lib/default-model'
 
-export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireServiceAuth(req)
   const { id } = await params
 
   const epic = await prisma.epic.findUnique({

--- a/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
+++ b/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
@@ -6,9 +6,11 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 import { callDefaultModel } from '@/lib/default-model'
 
-export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireServiceAuth(req)
   const { id } = await params
 
   const feature = await prisma.feature.findUnique({

--- a/apps/web/src/app/api/novas/[id]/import/route.ts
+++ b/apps/web/src/app/api/novas/[id]/import/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 /**
  * POST /api/novas/[id]/import — Import a Nova
@@ -13,6 +14,9 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const body = await req.json()
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },

--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 /**
  * GET /api/novas/[id] — Get a specific Nova
@@ -34,6 +35,9 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const body = await req.json()
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },
@@ -84,6 +88,9 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },
     include: { _count: { select: { deployments: true } } },

--- a/apps/web/src/app/api/novas/route.ts
+++ b/apps/web/src/app/api/novas/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 import { getAllNovae, Nova, NovaCreateRequest } from '@/lib/nebula'
 
 /**
@@ -82,6 +83,9 @@ export async function GET(req: NextRequest) {
  * Only admin users can create user-created Novas.
  */
 export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const body: NovaCreateRequest = await req.json()
 
   // Validate required fields

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -13,12 +13,11 @@ wrapConsoleLog()
 import { rateLimitRedis } from './lib/rate-limit-redis'
 
 function getRateLimitKey(req: NextRequest): string {
-  // Use X-Forwarded-For if available (behind reverse proxy), else IP
-  const forwarded = req.headers.get('x-forwarded-for')
-  if (forwarded) {
-    // x-forwarded-for can contain multiple IPs: client, proxy1, proxy2
-    return forwarded.split(',')[0].trim()
-  }
+  // X-Forwarded-For is intentionally NOT used: the leftmost IP is client-supplied
+  // and completely spoofable, letting anyone rotate past rate limits by changing
+  // the header. req.ip is set by trusted infrastructure only.
+  // In self-hosted Next.js (Node runtime) req.ip is undefined; all unidentifiable
+  // clients then share one bucket ('unknown') which still bounds brute-force.
   return req.ip ?? 'unknown'
 }
 


### PR DESCRIPTION
## Summary

Four BLOCKERs from Opus review of features, epics, Nova catalog, and rate limiting.

**BLOCKER — Nova POST/PUT/DELETE/import had zero authorization**
Comments claimed "Only admin users can create" but nothing enforced it. Any authenticated user, including gateway service tokens, could create Nova definitions and import agents with attacker-controlled `systemPrompt`. Combined with gateway-token access, a tool-calling agent could self-replicate with arbitrary system prompts. Added `requireAdmin()` to all four write endpoints.

**BLOCKER — `admin/models/default` PUT had no authentication**
Any authenticated user could `PUT /api/admin/models/default` to change or clear the system-wide default LLM, redirecting all agent LLM calls to a different model or none at all. Added `requireAdmin()` as the first line.

**BLOCKER — `generate-features` and `generate-tasks` had no auth**
Both routes invoked the system default LLM with user-supplied IDs and no auth check — any authenticated user could trigger paid LLM calls on arbitrary epic/feature IDs (LLM-cost DoS). Added `requireServiceAuth()` to both.

**BLOCKER — Rate limit key used client-supplied `X-Forwarded-For`**
`getRateLimitKey` took the leftmost IP from the `X-Forwarded-For` header. Since XFF is entirely client-controlled, anyone could bypass all rate limits (login brute-force protection, API quotas) by rotating XFF per request. Changed to `req.ip` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)