### PR TITLE
fix: sanitize vector search injection, compaction transaction, encryption strict, notes embed path

### DIFF
--- a/apps/web/src/app/api/internal/vault/unseal-keys/route.ts
+++ b/apps/web/src/app/api/internal/vault/unseal-keys/route.ts
@@ -9,7 +9,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { encrypt, encryptJson, decryptJson } from '@/lib/encryption'
+import { encrypt, encryptJson, decryptJsonStrict } from '@/lib/encryption'
 
 const UNSEALER_TOKEN = process.env.ORION_UNSEALER_TOKEN
 
@@ -34,7 +34,7 @@ export async function GET(req: NextRequest) {
     )
   }
 
-  const keys = decryptJson<string[]>(setting.value)
+  const keys = decryptJsonStrict<string[]>(setting.value, "vault.unsealKeys")
   return NextResponse.json({ keys })
 }
 

--- a/apps/web/src/lib/compaction.ts
+++ b/apps/web/src/lib/compaction.ts
@@ -183,26 +183,38 @@ async function _compactRoom(roomId: string): Promise<void> {
     throw new Error('[compaction] failed to generate summary — no usable model found')
   }
 
-  // Persist as a compaction message and reset the room's token counter
-  const compactionMsg = await prisma.chatMessage.create({
-    data: {
-      roomId,
-      senderType: 'compaction',
-      content: summary,
-      attachments: { originalMessageCount: messages.length, compactedAt: new Date().toISOString() } as unknown as object,
-    },
-  })
+  // Cap summary length to prevent unbounded growth: summaries are prepended into
+  // each subsequent compaction transcript, so an uncapped summary can grow
+  // monotonically and eventually exceed the model's context window.
+  const MAX_SUMMARY_CHARS = 8000
+  const cappedSummary = summary.length > MAX_SUMMARY_CHARS
+    ? summary.slice(0, MAX_SUMMARY_CHARS) + '\n\n[Summary truncated — exceeded max length]'
+    : summary
 
-  await prisma.chatRoom.update({
-    where: { id: roomId },
-    data: { tokenCount: 0, updatedAt: new Date() },
-  })
+  // Persist as a compaction message and reset the room's token counter.
+  // Wrapped in a transaction so a partial failure (create succeeds but update fails)
+  // doesn't leave the room wedged with high tokenCount that re-triggers compaction
+  // on every subsequent turn without ever resetting.
+  const [compactionMsg] = await prisma.$transaction([
+    prisma.chatMessage.create({
+      data: {
+        roomId,
+        senderType: 'compaction',
+        content: cappedSummary,
+        attachments: { originalMessageCount: messages.length, compactedAt: new Date().toISOString() } as unknown as object,
+      },
+    }),
+    prisma.chatRoom.update({
+      where: { id: roomId },
+      data: { tokenCount: 0, updatedAt: new Date() },
+    }),
+  ])
 
   // Publish via Redis so the UI shows the compaction message live
   await publishChatMessage(roomId, {
     id:          compactionMsg.id,
     senderType:  'compaction',
-    content:     summary,
+    content:     cappedSummary,
     attachments: { originalMessageCount: messages.length, compactedAt: compactionMsg.createdAt instanceof Date ? compactionMsg.createdAt.toISOString() : compactionMsg.createdAt },
     sender:      { type: 'system', id: null, name: 'System' },
     createdAt:   compactionMsg.createdAt instanceof Date ? compactionMsg.createdAt.toISOString() : compactionMsg.createdAt,

--- a/apps/web/src/lib/embeddings.ts
+++ b/apps/web/src/lib/embeddings.ts
@@ -10,6 +10,7 @@
  */
 
 import { prisma } from './db'
+import { sanitizeContextNote } from './sanitize-context'
 
 // ── Providers ────────────────────────────────────────────────────────────────
 
@@ -292,12 +293,16 @@ export async function retrieveKnowledgeContext(
     const relevant = hits.filter(h => h.score >= minScore)
     if (relevant.length === 0) return ''
 
+    // Sanitize all retrieved notes before injecting into agent system prompts.
+    // Previously this path applied no sanitization — dream-extracted notes and
+    // any user-authored note could inject instructions via vector search.
     return relevant
       .map(h => {
         const typeTag = h.type !== 'note' ? ` [${h.type}]` : ''
-        const body = h.content.length > 1500
-          ? h.content.slice(0, 1500) + '\n[…]'
-          : h.content
+        const sanitizedContent = sanitizeContextNote(h.title, h.content)
+        const body = sanitizedContent.length > 1500
+          ? sanitizedContent.slice(0, 1500) + '\n[…]'
+          : sanitizedContent
         return `### ${h.title}${typeTag}\n${body}`
       })
       .join('\n\n')

--- a/apps/web/src/lib/encryption.ts
+++ b/apps/web/src/lib/encryption.ts
@@ -58,6 +58,25 @@ export function decryptJson<T>(value: unknown): T {
 }
 
 /**
+ * Strict variant of decryptJson — throws if the value is not encrypted with the prefix.
+ *
+ * Use for high-value secrets (vault tokens, git provider config, API keys) where
+ * a missing prefix should be a hard failure, not a silent passthrough. The passthrough
+ * in decryptJson means an attacker who can write a SystemSetting row can substitute
+ * unauthenticated plaintext for a secret without triggering any error.
+ */
+export function decryptJsonStrict<T>(value: unknown, keyName?: string): T {
+  if (typeof value !== 'string' || !value.startsWith(PREFIX)) {
+    throw new Error(
+      `decryptJsonStrict: expected an encrypted value${keyName ? ` for '${keyName}'` : ''} but got ` +
+      `${typeof value === 'string' ? `a plaintext string (len ${value.length})` : typeof value}. ` +
+      `This may indicate a manual DB edit, partial migration, or a substitution attack.`
+    )
+  }
+  return JSON.parse(decrypt(value)) as T
+}
+
+/**
  * Encrypt with a custom key (for key rotation).
  * keyBase64: 32-byte key in base64 format
  */

--- a/apps/web/src/lib/git-provider/index.ts
+++ b/apps/web/src/lib/git-provider/index.ts
@@ -9,7 +9,7 @@
  */
 
 import { prisma } from '@/lib/db'
-import { decryptJson } from '@/lib/encryption'
+import { decryptJson, decryptJsonStrict } from '@/lib/encryption'
 import { GiteaGitProvider } from './gitea-provider'
 import { GitHubGitProvider } from './github-provider'
 import { GitLabGitProvider } from './gitlab-provider'
@@ -170,7 +170,7 @@ export async function getGitProvider(): Promise<GitProvider> {
   })
 
   if (setting) {
-    _cached = createProvider(decryptJson<GitProviderConfig>(setting.value))
+    _cached = createProvider(decryptJsonStrict<GitProviderConfig>(setting.value, 'git.provider.config'))
     return _cached
   }
 
@@ -197,5 +197,5 @@ export async function getGitProviderConfig(): Promise<GitProviderConfig | null> 
     where: { key: 'git.provider.config' },
   })
   if (!setting) return null
-  return decryptJson<GitProviderConfig>(setting.value)
+  return decryptJsonStrict<GitProviderConfig>(setting.value, 'git.provider.config')
 }

--- a/apps/web/src/lib/sanitize-context.ts
+++ b/apps/web/src/lib/sanitize-context.ts
@@ -1,0 +1,40 @@
+/**
+ * Sanitize user/agent/dream-generated content before injecting into LLM system prompts.
+ * Strips known prompt-injection patterns and truncates oversized content.
+ *
+ * SOC2: [C-001] — prevents prompt injection via notes, knowledge base, or dream extraction.
+ * Applied to ALL context injection paths (worker.ts llm-context notes + vector search retrieval).
+ */
+
+const MAX_NOTE_LENGTH = 8000
+
+const INJECTION_PATTERNS = [
+  /^\s*(ignore\s+(previous|above|prior)\s+(instructions|prompts|context|system))/im,
+  /^\s*(you\s+are\s+now)/im,
+  /^\s*(from\s+now\s+on)/im,
+  /^\s*(override\s+(all|the)?\s*(system|previous|original)\s*(instructions|prompt|rules|behavior))/im,
+  /^\s*(do\s+not\s+(follow|obey|respond))/im,
+  /^\s*(disregard\s+(all|the)?\s*(instructions|previous|context))/im,
+  /^\s*(begin\s+(new|all)\s*(instructions|system))/im,
+  /^\s*(change\s+(your|the)?\s*(role|persona|identity))/im,
+  /^\s*(reveal|print|output|show|display|dump|list)\s+(your|the)?\s*(system|original|full|complete)\s*(prompt|instructions|rules|context)/im,
+  /^\s*(show\s+me\s+(your|the|this))\s+(prompt|instructions|context)/im,
+]
+
+export function sanitizeContextNote(title: string, content: string): string {
+  for (const pattern of INJECTION_PATTERNS) {
+    if (pattern.test(content)) {
+      console.warn(`[C-001] Potential prompt injection in note "${title}" — stripping suspicious lines`)
+      content = content.split('\n')
+        .filter(line => !INJECTION_PATTERNS.some(p => p.test(line)))
+        .join('\n')
+    }
+  }
+
+  if (content.length > MAX_NOTE_LENGTH) {
+    content = content.slice(0, MAX_NOTE_LENGTH) + '\n\n[Note truncated]'
+  }
+
+  content = content.replace(/^---+$/, '---')
+  return content
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -91,7 +91,7 @@ const PUBLIC_PATHS = [
   '/api/setup',
   '/api/auth',
   '/api/health',
-  '/api/notes/embed',       // embed rebuild — bypassed via x-embed-token header
+  '/api/notes/embed/rebuild', // embed rebuild — bypassed via x-embed-token header; scoped to exact path to avoid auto-exempting future /api/notes/embed* routes
   '/api/environments/join', // gateway registration — no session, token IS the auth
   '/api/webhooks',          // git provider webhooks — HMAC signature is the auth
   '/api/monitoring/security/webhooks', // security source webhooks (Falco, CrowdSec, Wazuh) — HMAC is the auth


### PR DESCRIPTION
## Summary

Five bugs from Opus reviews of embeddings, compaction, and encryption.

**BLOCKER — `retrieveKnowledgeContext` had no prompt injection sanitization**
The worker's `sanitizeContextNote` (SOC2 C-001) was applied only to `llm-context` notes in the worker loop — not to the vector-search path used by `buildAgentContext` (called from both `room-agents.ts` and `agent-runner`). Dream-extracted notes (pulled from raw chat/task content) could inject malicious instructions into all agent system prompts via vector search. Created `lib/sanitize-context.ts` (shared sanitizer) and applied it in `embeddings.ts:retrieveKnowledgeContext`. All three context injection paths are now sanitized.

**BLOCKER — Compaction create+reset was non-transactional**
`prisma.chatMessage.create` (summary) and `prisma.chatRoom.update` (tokenCount reset) ran as separate queries. If the update failed, tokenCount stayed high and the room permanently re-triggered compaction on every turn. Wrapped in `prisma.$transaction`.

**MAJOR — Compaction summaries had no length cap**
Summaries are prepended to every subsequent compaction transcript. A verbose model could produce a larger summary than the messages it replaced, growing monotonically. Added 8000 char cap.

**MAJOR — `decryptJson` passthrough accepts unauthenticated plaintext for sensitive keys**
An attacker who can write a `SystemSetting` row can substitute plaintext for `vault.unsealKeys` or `git.provider.config` without triggering any error — the GCM auth-tag guarantee is bypassed. Added `decryptJsonStrict<T>()` that throws when a value lacks the `enc:v1:` prefix. Applied to vault unseal-keys route and both git-provider call sites.

**MAJOR — `PUBLIC_PATHS '/api/notes/embed'` was too broad**
The `startsWith` check would auto-bypass auth for any future `/api/notes/embed*` route. Tightened to `/api/notes/embed/rebuild` (the only actual route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)