### PR TITLE
fix(rate-limit,compaction): INCR for ZADD uniqueness, transactional compaction idempotency

### DIFF
--- a/apps/web/src/lib/compaction.ts
+++ b/apps/web/src/lib/compaction.ts
@@ -183,20 +183,37 @@ async function _compactRoom(roomId: string): Promise<void> {
     throw new Error('[compaction] failed to generate summary — no usable model found')
   }
 
-  // Persist as a compaction message and reset the room's token counter
-  const compactionMsg = await prisma.chatMessage.create({
-    data: {
-      roomId,
-      senderType: 'compaction',
-      content: summary,
-      attachments: { originalMessageCount: messages.length, compactedAt: new Date().toISOString() } as unknown as object,
-    },
+  // Transactional idempotency re-check: verify no other process compacted this
+  // window while our LLM call was in flight (compactingRooms only guards within
+  // a single process; multiple Next.js workers can race).
+  // Re-read the boundary inside the transaction and bail if it changed.
+  const compactionMsg = await prisma.$transaction(async (tx) => {
+    // Re-check that no other worker compacted this room while the LLM was running
+    const currentBoundary = await tx.chatMessage.findFirst({
+      where: { roomId, senderType: 'compaction' },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true },
+    })
+    if (currentBoundary?.id !== lastCompaction?.id) {
+      console.warn(`[compaction] room ${roomId}: another worker compacted concurrently — skipping duplicate`)
+      return null
+    }
+    const msg = await tx.chatMessage.create({
+      data: {
+        roomId,
+        senderType: 'compaction',
+        content: summary,
+        attachments: { originalMessageCount: messages.length, compactedAt: new Date().toISOString() } as unknown as object,
+      },
+    })
+    await tx.chatRoom.update({
+      where: { id: roomId },
+      data: { tokenCount: 0, updatedAt: new Date() },
+    })
+    return msg
   })
 
-  await prisma.chatRoom.update({
-    where: { id: roomId },
-    data: { tokenCount: 0, updatedAt: new Date() },
-  })
+  if (!compactionMsg) return  // concurrent compaction won the race
 
   // Publish via Redis so the UI shows the compaction message live
   await publishChatMessage(roomId, {

--- a/apps/web/src/lib/rate-limit-redis.ts
+++ b/apps/web/src/lib/rate-limit-redis.ts
@@ -170,8 +170,14 @@ export async function rateLimitRedis(
         return {0, count, reset_ts}
       end
 
-      -- Add current request (unique member: score + random suffix)
-      redis.call('ZADD', key, now, now .. ':' .. math.random(1000000))
+      -- Add current request with a microsecond-precision unique member.
+      -- math.random(1000000) is NOT safe: Redis deterministically seeds Lua's RNG
+      -- per-script, so two concurrent scripts in the same ms get the same member,
+      -- causing ZADD to overwrite the existing entry and undercount the window.
+      -- redis.call('TIME') returns [seconds, microseconds] — unique per Redis op.
+      local t = redis.call('TIME')
+      local member = now .. ':' .. t[1] .. t[2]
+      redis.call('ZADD', key, now, member)
 
       -- Set TTL to 2x window for auto-cleanup
       redis.call('EXPIRE', key, math.ceil((window_ms * 2) / 1000))

--- a/apps/web/src/lib/rate-limit-redis.ts
+++ b/apps/web/src/lib/rate-limit-redis.ts
@@ -170,14 +170,14 @@ export async function rateLimitRedis(
         return {0, count, reset_ts}
       end
 
-      -- Add current request with a microsecond-precision unique member.
-      -- math.random(1000000) is NOT safe: Redis deterministically seeds Lua's RNG
-      -- per-script, so two concurrent scripts in the same ms get the same member,
-      -- causing ZADD to overwrite the existing entry and undercount the window.
-      -- redis.call('TIME') returns [seconds, microseconds] — unique per Redis op.
-      local t = redis.call('TIME')
-      local member = now .. ':' .. t[1] .. t[2]
-      redis.call('ZADD', key, now, member)
+      -- Add current request with a strictly unique member via monotonic INCR.
+      -- math.random is NOT safe: Redis deterministically re-seeds Lua's RNG per
+      -- EVAL call, so concurrent scripts in the same ms produce identical members.
+      -- redis.call('TIME') microseconds are still collision-prone under heavy load.
+      -- INCR on a per-key sequence counter is collision-free and replication-safe.
+      local seq = redis.call('INCR', key .. ':seq')
+      redis.call('EXPIRE', key .. ':seq', math.ceil((window_ms * 2) / 1000))
+      redis.call('ZADD', key, now, now .. ':' .. seq)
 
       -- Set TTL to 2x window for auto-cleanup
       redis.call('EXPIRE', key, math.ceil((window_ms * 2) / 1000))


### PR DESCRIPTION
## Summary

**MAJOR — Rate-limit ZADD member collision**
`math.random(1000000)` in the Lua script was not safe: Redis deterministically re-seeds Lua's PRNG per EVAL invocation, so two concurrent scripts always produce the same first random value. Switched from `redis.call('TIME')` (still slightly collision-prone at microsecond level) to `INCR` on a per-key sequence counter — strictly collision-free and replication-safe.

**MAJOR — Compaction distributed race condition**
The `compactingRooms` in-process `Set` doesn't prevent concurrent compaction across multiple Next.js worker processes. Two workers racing on the same room both summarize the same message window, producing duplicate compaction messages and wasted LLM calls. Added a `prisma.$transaction` re-check inside the persist phase: re-reads the current compaction boundary and bails if another worker already created a new one while the LLM was running. No schema change or Redis required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)