### PR TITLE
fix(tools): add checkToolPermission to management tools in claude.ts and room-agents

### DIFF
--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -1491,6 +1491,19 @@ RULES FOR DOCKER COMPOSE FILES (critical — violations cause deployment failure
 
         const toolStart = Date.now()
         // ── Management tools — handled server-side by ORION ──────────────────
+        // Gate management tools through the same permission check as gateway tools.
+        // Previously these ran with NO checkToolPermission call, allowing any
+        // authenticated user to invoke orion_patch_environment (overwrites kubeconfig/
+        // gatewayUrl), orion_bootstrap_environment, and gitops_propose (auto-merge PRs).
+        {
+          const mgmtArgs = JSON.parse(tc.argsRaw || '{}') as Record<string, unknown>
+          const mgmtPerm = await checkToolPermission(tc.name, mgmtArgs, environmentId ?? '', conversationId, userId)
+          if (!mgmtPerm.allowed) {
+            result = `Permission denied: ${mgmtPerm.reason}`
+            messages.push({ role: 'tool' as const, content: result, tool_call_id: tc.id })
+            continue
+          }
+        }
         if (tc.name === 'propose_tool') {
           result = await handleProposeTool(tc.argsRaw, environmentId, conversationId)
         } else if (tc.name === 'orion_get_environment') {

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -18,6 +18,7 @@ import { prisma } from './db'
 import { setTyping, clearTyping } from './typing-state'
 import { buildToolDefinitions, TOOLS_SYSTEM_ADDENDUM, executeTool } from './agent-tools'
 import { getToolsForContext, executeRegisteredTool } from './tool-registry'
+import { checkToolPermission } from './tool-permissions'
 import { publishChatMessage } from './chat-redis'
 import { resolveAgentGateway } from './agent-gateway'
 import { buildAgentContext, buildAgentLocalContext, buildRoomLocalContext, invalidateSnapshotCache, getModelContextLimit, getClaudeContextLimit } from './agent-context'
@@ -489,7 +490,14 @@ async function callOpenAIChat(
         console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
         if (registryToolNames.has(tc.function.name)) {
-          // Registry tool — single source of truth, consistent across all contexts
+          // Gate registry tools through checkToolPermission before execution.
+          // Previously called executeRegisteredTool directly with NO permission check,
+          // allowing room agents to invoke destructive-tier tools without a grant.
+          const agentIdForPerm = toolContext?.agentId ?? null
+          const perm = await checkToolPermission(tc.function.name, agentIdForPerm, null)
+          if (!perm.allowed) {
+            result = `Permission denied: ${perm.reason ?? `tool '${tc.function.name}' is not permitted for this agent`}`
+          } else {
           result = await executeRegisteredTool(tc.function.name, args, {
             agentId: toolContext!.agentId,
             prisma,
@@ -498,6 +506,7 @@ async function callOpenAIChat(
               listTools: () => gateway.client.listTools(),
             } : undefined,
           })
+          }
         } else if (legacyToolNames.has(tc.function.name)) {
           // Legacy agent-tools (create_task, orion_manage_task, etc.)
           result = await executeTool(tc.function.name, args, {


### PR DESCRIPTION
## Summary

Two BLOCKERs from Opus review of agent runner and management tools.

**BLOCKER — `claude.ts` interactive chat path had no permission check on management tools**
`propose_tool`, `orion_get_environment`, `orion_patch_environment`, `orion_bootstrap_environment`, `gitops_propose`, and all `MANAGEMENT_TOOL_DEFS` were dispatched directly to handlers with no `checkToolPermission` call. The permission gate was only applied to gateway tools. Any authenticated user could invoke `orion_patch_environment` to overwrite `gatewayUrl`/`kubeconfig` (credential exfiltration), call `orion_bootstrap_environment` to deploy gateway workloads, or call `gitops_propose` to auto-merge PRs. Added the same `checkToolPermission` gate before management tool dispatch.

**BLOCKER — `room-agents.ts` called `executeRegisteredTool` with no permission check**
Registry tools (including destructive-tier tools like `orion_archive_agent`, `orion_bootstrap_environment`) were dispatched from the OpenAI-compat tool loop without `checkToolPermission`. This bypassed `ToolAgentRestriction` per-agent whitelists and `ToolExecutionGrant` requirements for destructive operations. Added `checkToolPermission` from `tool-permissions.ts` before `executeRegisteredTool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)