### PR TITLE
fix: gateway-client timeout; gitops_propose fail-closed when repoPath unset

### DIFF
--- a/apps/web/src/lib/agent-runner/gateway-client.ts
+++ b/apps/web/src/lib/agent-runner/gateway-client.ts
@@ -22,6 +22,10 @@ export class GatewayClient {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify({ name, arguments: args }),
+      // Per-tool-call timeout — a hung gateway would previously block the entire
+      // agent turn indefinitely (no signal on the fetch). 120s covers slow ops
+      // (kubectl rollout, helm install) without blocking forever on a dead gateway.
+      signal: AbortSignal.timeout(120_000),
     })
     const data = await res.json() as { result?: string; error?: string }
     if (!res.ok || data.error) throw new Error(data.error ?? `Tool ${name} failed: ${res.status}`)

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -794,12 +794,18 @@ async function handleProposeGitops(args: unknown, ctx: ToolExecutionContext): Pr
     // any path that still escapes the watched directory (e.g. absolute paths, ../traversal)
     // Live ArgoCD path takes precedence over DB repoPath.
     const repoPath = liveWatchedPath ?? ((env as Record<string, unknown>).repoPath as string | undefined)
-    const normalizedChanges = repoPath
-      ? changes.map(c => ({
-          ...c,
-          path: c.path.startsWith(`${repoPath}/`) ? c.path : `${repoPath}/${c.path}`,
-        }))
-      : changes
+
+    // Fail closed when repoPath cannot be determined: the path escape check only
+    // runs inside `if (repoPath)`, so without it all paths are allowed through
+    // including .github/workflows/, ArgoCD root, and other sensitive directories.
+    if (!repoPath) {
+      return `Error: cannot determine the watched repo path for this environment (ArgoCD unreachable and no repoPath in environment config). Configure repoPath in environment settings or ensure ArgoCD is accessible before proposing changes.`
+    }
+
+    const normalizedChanges = changes.map(c => ({
+      ...c,
+      path: c.path.startsWith(`${repoPath}/`) ? c.path : `${repoPath}/${c.path}`,
+    }))
 
     if (repoPath) {
       const escaping = normalizedChanges.filter(c => !c.path.startsWith(`${repoPath}/`))


### PR DESCRIPTION
## Summary

**MAJOR — `gateway-client.ts executeTool` had no per-call timeout**
A hung or unresponsive gateway would block the entire agent turn indefinitely — `fetch()` had no `AbortSignal`. Added `AbortSignal.timeout(120_000)` giving slow operations (kubectl rollout, helm install) sufficient time while preventing permanent stalls on a dead gateway.

**MAJOR — `gitops_propose` path escape check skipped when `repoPath` unset**
The path boundary validation (`if (repoPath)`) was skipped when neither ArgoCD nor the environment config yielded a watched directory path, allowing arbitrary repo paths through — including `.github/workflows/`, ArgoCD root manifests, etc. Now returns an error when `repoPath` cannot be determined rather than proceeding with unvalidated paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)