### PR TITLE
fix: spawn auth, DNS admin gate, bug status enum, skill-loader crash

### DIFF
--- a/apps/gateway/src/skill-loader.ts
+++ b/apps/gateway/src/skill-loader.ts
@@ -20,7 +20,15 @@ export class SkillLoader {
     const msgLower = message.toLowerCase()
 
     for (const skill of skills) {
-      const spec = JSON.parse(skill.spec) as { triggerPatterns?: string[]; systemPrompt?: string }
+      // Wrap JSON.parse — a single malformed spec previously threw and aborted
+      // matching for ALL skills in the environment, not just the bad one.
+      let spec: { triggerPatterns?: string[]; systemPrompt?: string }
+      try {
+        spec = JSON.parse(skill.spec) as typeof spec
+      } catch {
+        console.warn(`[skill-loader] Skipping skill "${skill.name}" — malformed spec JSON`)
+        continue
+      }
       if (!spec?.triggerPatterns?.length) continue
 
       for (const pattern of spec.triggerPatterns) {

--- a/apps/web/src/app/api/agents/spawn/route.ts
+++ b/apps/web/src/app/api/agents/spawn/route.ts
@@ -1,12 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, AgentSpawnSchema, AGENT_TYPES } from '@/lib/validate'
 
 const RESERVED_NAMES = ['human', 'user', 'system', 'admin']
+const MAX_SYSTEM_PROMPT_LENGTH = 10_000
 
 // POST /api/agents/spawn — create a new agent and optionally start a planning conversation
 // Body: { name, role?, type?, description?, metadata?, startConversation? }
 export async function POST(req: NextRequest) {
+  // BLOCKER fix: no role check — any authenticated user (including readonly) could
+  // create agents with arbitrary systemPrompt, then Alpha would pick them up and
+  // execute them with full tool access against the cluster.
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   // SOC2 [INPUT-001]: Validate request body with Zod schema
   const result = await parseBodyOrError(req, AgentSpawnSchema)
   if ('error' in result) return result.error
@@ -21,13 +30,24 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  // Cap systemPrompt length in metadata to prevent oversized prompts being
+  // injected into every subsequent agent system prompt compilation.
+  let spawnMetadata = data.metadata as Record<string, unknown> | undefined
+  if (spawnMetadata?.systemPrompt && typeof spawnMetadata.systemPrompt === 'string' &&
+      spawnMetadata.systemPrompt.length > MAX_SYSTEM_PROMPT_LENGTH) {
+    return NextResponse.json(
+      { error: `metadata.systemPrompt exceeds maximum length of ${MAX_SYSTEM_PROMPT_LENGTH} characters` },
+      { status: 400 }
+    )
+  }
+
   const agent = await prisma.agent.create({
     data: {
       name: data.name,
       type: data.type ?? 'claude',
       role: data.role ?? null,
       description: data.description ?? null,
-      metadata: (data.metadata ?? undefined) as any,
+      metadata: (spawnMetadata ?? undefined) as any,
     },
   })
 

--- a/apps/web/src/app/api/bugs/[id]/route.ts
+++ b/apps/web/src/app/api/bugs/[id]/route.ts
@@ -12,6 +12,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(bug)
 }
 
+const VALID_BUG_STATUSES = new Set(['open', 'triaged', 'in_progress', 'resolved', 'wont_fix', 'closed'])
+
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
   const body = await req.json()
@@ -19,7 +21,16 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (body.title          !== undefined) data.title          = body.title
   if (body.description    !== undefined) data.description    = body.description
   if (body.severity       !== undefined) data.severity       = body.severity
-  if (body.status         !== undefined) data.status         = body.status
+  if (body.status !== undefined) {
+    const s = String(body.status)
+    if (!VALID_BUG_STATUSES.has(s)) {
+      return NextResponse.json(
+        { error: `Invalid status '${s}'. Must be one of: ${[...VALID_BUG_STATUSES].join(', ')}` },
+        { status: 400 }
+      )
+    }
+    data.status = s
+  }
   if (body.area           !== undefined) data.area           = body.area || null
   if (body.assignedUserId !== undefined) data.assignedUserId = body.assignedUserId || null
   const bug = await prisma.bug.update({

--- a/apps/web/src/app/api/dns/records/route.ts
+++ b/apps/web/src/app/api/dns/records/route.ts
@@ -1,22 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { getCustomRecords, upsertCustomRecord } from '@/lib/dns'
 
 export async function GET() {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   try {
     return NextResponse.json(await getCustomRecords())
-  } catch (err) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
+  } catch {
+    return NextResponse.json({ error: 'Failed to read DNS records' }, { status: 500 })
   }
 }
 
 export async function POST(req: NextRequest) {
+  // DNS records control internal name resolution — admin only.
+  // Previously had no auth: any authenticated user could write custom DNS records.
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { ip, hostnames } = await req.json()
   if (!ip || !Array.isArray(hostnames) || hostnames.length === 0)
     return NextResponse.json({ error: 'ip and hostnames required' }, { status: 400 })
   try {
     await upsertCustomRecord(ip, hostnames)
     return NextResponse.json({ ip, hostnames }, { status: 201 })
-  } catch (err) {
-    return NextResponse.json({ error: String(err) }, { status: 500 })
+  } catch {
+    return NextResponse.json({ error: 'Failed to write DNS record' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary

Four bugs from Opus reviews.

**BLOCKER — Agent spawn route had no authentication**
Any authenticated user (including `readonly` role) could `POST /api/agents/spawn` with arbitrary `metadata.systemPrompt`. Alpha auto-picks up new agents and executes them with full tool access. Low-privilege users could craft an agent system prompt to execute kubectl/docker commands against the cluster. Added `requireAdmin()` + 10k char cap on `systemPrompt`.

**MAJOR — `dns/records` POST had no admin gate**
DNS records control internal name resolution. Any authenticated session could write custom DNS records by posting to `/api/dns/records`. Added `requireAdmin()` to both GET and POST. Also removed `String(err)` raw error leakage from responses.

**MAJOR — Bug `PUT` accepted arbitrary status strings**
No enum validation on status update — any string was written to `bug.status`. Create-time had validation via `CreateBugSchema` but the update path did not. Added `VALID_BUG_STATUSES` enum check. Status values now aligned with the Prisma model comment (adds `triaged`, `closed`).

**MAJOR — Skill-loader `JSON.parse` not wrapped in try/catch**
A single malformed `spec` on any installed skill threw out of the `match()` loop, aborting skill matching for ALL skills in that environment — a DoS via one corrupt DB record. Now catches, logs a warning, and continues to the next skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)