### PR TITLE
fix: chat-redis null deref, jobs/gitops-prs missing auth

### DIFF
--- a/apps/web/src/app/api/gitops/prs/route.ts
+++ b/apps/web/src/app/api/gitops/prs/route.ts
@@ -10,8 +10,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 
 export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
   const { searchParams } = new URL(req.url)
   const status        = searchParams.get('status')        ?? undefined
   const environmentId = searchParams.get('environmentId') ?? undefined

--- a/apps/web/src/app/api/jobs/route.ts
+++ b/apps/web/src/app/api/jobs/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET(req: NextRequest) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { searchParams } = new URL(req.url)
   const includeArchived = searchParams.get('archived') === 'true'
 

--- a/apps/web/src/lib/chat-redis.ts
+++ b/apps/web/src/lib/chat-redis.ts
@@ -133,13 +133,16 @@ export async function subscribeToChatRoom(
     }
   }
 
-  if (!redisClient) {
+  // Guard checks redisClient availability but duplicate() calls redisPubClient —
+  // these are separate variables. A publish error can null redisPubClient while
+  // redisClient stays set, causing redisPubClient!.duplicate() to throw.
+  if (!redisClient || !redisPubClient) {
     return async () => {}
   }
 
   try {
     const channel = `chat:room:${roomId}`
-    const subscriber = redisPubClient!.duplicate()
+    const subscriber = redisPubClient.duplicate()
 
     subscriber.on('message', (_channel: string, message: string) => {
       try {


### PR DESCRIPTION
## Summary

Three bugs from Opus reviews.

**MAJOR — `chat-redis.ts` null dereference via mismatched guard**
`subscribeToChatRoom` guarded on `!redisClient` before calling `redisPubClient!.duplicate()`. These are separate module-level variables. A publish error can null `redisPubClient` while `redisClient` stays set, causing the non-null assertion to throw. Fixed: check both `!redisClient || !redisPubClient` and removed the `!` assertion.

**MAJOR — `/api/jobs` returned all background jobs to any authenticated session**
Background jobs contain task logs, agent output, and internal operation metadata. Any session (including `readonly` role) could read all 100 most recent jobs with no admin gate. Added `requireAdmin()`.

**MAJOR — `/api/gitops/prs` returned GitOps PRs across all environments to any session**
GitOps PRs show environment-specific deployment activity. No auth check beyond middleware session gate. Added `requireServiceAuth()` consistent with the broader gitops API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)