### PR TITLE
fix(join-token): hash join tokens at rest, dual-lookup for backward compat

### DIFF
--- a/apps/web/src/app/api/environments/[id]/generate-join/route.ts
+++ b/apps/web/src/app/api/environments/[id]/generate-join/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
-import { randomBytes } from 'crypto'
+import { randomBytes, createHash } from 'crypto'
+
+/** Hash a join token for safe DB storage — store hash, return raw to the user. */
+function hashJoinToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex')
+}
 
 // Allowed gateway types — caller-supplied type is validated against this list
 // to prevent type confusion (e.g. forging localhost type to trigger Docker-socket paths)
@@ -23,12 +28,19 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     where: { environmentId: params.id, usedAt: null },
   })
 
-  const token = 'mcg_' + randomBytes(24).toString('hex')
+  const rawToken = 'mcg_' + randomBytes(24).toString('hex')
   const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24h
 
+  // Store SHA-256 hash of token, not the raw value — a DB read or backup
+  // should not yield usable join credentials. The raw token is returned to the
+  // admin and never persisted. Existing plaintext tokens in the DB still work
+  // via the dual-lookup in the join/manifest routes (hash-first, plaintext fallback).
   await prisma.environmentJoinToken.create({
-    data: { token, environmentId: params.id, expiresAt },
+    data: { token: hashJoinToken(rawToken), environmentId: params.id, expiresAt },
   })
+
+  // Replace token reference with rawToken in the commands below
+  const token = rawToken
 
   const body = await req.json().catch(() => ({}))
   const gatewayUrl: string = body.gatewayUrl ?? ''

--- a/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
+++ b/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
@@ -4,6 +4,7 @@
  * The user pipes this directly to kubectl apply.
  */
 import { NextRequest, NextResponse } from 'next/server'
+import { createHash } from 'crypto'
 import { prisma } from '@/lib/db'
 
 // SystemSetting.value is a Json column — narrow to string before using
@@ -12,7 +13,15 @@ function settingStr(setting: { value: unknown } | null, fallback: string): strin
 }
 
 export async function GET(req: NextRequest, { params }: { params: { token: string } }) {
+  // Dual lookup: hash-first (new tokens stored as SHA-256), plaintext fallback
+  // for tokens created before hashing was introduced. The raw token from the URL
+  // is still embedded in the returned manifest (gateway needs it); hashing only
+  // protects the at-rest DB copy.
+  const tokenHash = createHash('sha256').update(params.token).digest('hex')
   const record = await prisma.environmentJoinToken.findUnique({
+    where: { token: tokenHash },
+    include: { environment: true },
+  }) ?? await prisma.environmentJoinToken.findUnique({
     where: { token: params.token },
     include: { environment: true },
   })

--- a/apps/web/src/app/api/environments/join/route.ts
+++ b/apps/web/src/app/api/environments/join/route.ts
@@ -43,7 +43,14 @@ export async function POST(req: NextRequest) {
   const rawUrl: string | undefined = parsed.data.gatewayUrl
   const gatewayUrl = rawUrl && !rawUrl.startsWith('http') ? `http://${rawUrl}` : rawUrl
 
+  // Dual lookup: try SHA-256 hash first (new tokens), fall back to plaintext
+  // (tokens created before hashing was introduced). Drop plaintext fallback once
+  // all existing tokens expire (24h max lifetime).
+  const tokenHash = createHash('sha256').update(joinToken).digest('hex')
   const record = await prisma.environmentJoinToken.findUnique({
+    where: { token: tokenHash },
+    include: { environment: true },
+  }) ?? await prisma.environmentJoinToken.findUnique({
     where: { token: joinToken },
     include: { environment: true },
   })


### PR DESCRIPTION
## Summary

**MAJOR — Join tokens stored as plaintext in the DB**

Join tokens (`mcg_` + 24 random bytes) were stored verbatim in `EnvironmentJoinToken.token`. A DB read, backup leak, or SQL injection could yield usable join credentials — each token grants an environment join + implicitly generates a permanent gateway token with broad API access.

**Fix:** SHA-256 hash on creation, dual-lookup (hash-first, plaintext fallback) at consumption.

- `generate-join/route.ts`: generate the raw token, store `SHA-256(token)`, return raw to the admin
- `join/route.ts`: try hash lookup first, fall back to plaintext for tokens created before this fix
- `manifest/route.ts`: same dual-lookup (the third consumer — was missing from the original Opus finding)

The raw token is still embedded in the manifest YAML (the gateway needs it to register). Hashing only protects the at-rest DB copy.

**Migration:** The dual-lookup allows existing plaintext tokens to work through their 24h lifetime without any DB migration. Drop the plaintext fallback after one token cycle.

**Critical constraint:** All three lookup sites updated in one commit — leaving any out would cause gateway registration failures for new tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)