### PR TITLE
fix(tool-registry): orion_patch_environment to destructive tier; fix bootstrap internal call

### DIFF
--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -1801,7 +1801,7 @@ registerTool({
 
 registerTool({
   name: 'orion_patch_environment',
-  description: 'Update fields on an ORION environment (e.g. save kubeconfig, update gatewayUrl).',
+  description: 'Update fields on an ORION environment (e.g. save kubeconfig, update gatewayUrl). Requires a ToolExecutionGrant because kubeconfig writes grant cluster admin to whoever controls the kubeconfig.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -1810,7 +1810,10 @@ registerTool({
     },
     required: ['environment_id', 'body'],
   },
-  tier: 'write',
+  // Upgraded from 'write' to 'destructive': kubeconfig is in the allowed fields
+  // and writing cluster credentials is equivalent to gaining cluster admin. Any
+  // agent calling this must have a one-time ToolExecutionGrant from an operator.
+  tier: 'destructive',
   parallelSafe: false,
   availableIn: 'chat',
   category: 'environment',
@@ -1911,10 +1914,19 @@ registerTool({
       if (!env) return `Error: environment "${environment_id}" not found`
       if (!env.kubeconfig) return 'Error: no kubeconfig stored for this environment. Patch it first using orion_patch_environment.'
 
+      // x-internal-call header was never checked in middleware — the bootstrap
+      // self-call always failed because /api/environments is a BEARER_PATH that
+      // requires Authorization: Bearer. Use ORION_GATEWAY_TOKEN (the local
+      // gateway's token) or ORION_MCP_TOKEN as the service credential.
+      const serviceToken = process.env.ORION_GATEWAY_TOKEN ?? process.env.ORION_MCP_TOKEN ?? ''
+      if (!serviceToken) return 'Error: no service token configured (ORION_GATEWAY_TOKEN or ORION_MCP_TOKEN required for internal bootstrap call)'
       const baseUrl = process.env.ORION_CALLBACK_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
       const res = await fetch(`${baseUrl}/api/environments/${environment_id}/bootstrap`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-internal-call': '1' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${serviceToken}`,
+        },
       })
       if (!res.ok) return `Bootstrap request failed: HTTP ${res.status}`
 


### PR DESCRIPTION
## Summary

Two bugs from Opus review of tool-registry management handlers.

**MAJOR — `orion_patch_environment` was `tier: 'write'` despite allowing kubeconfig writes**
`kubeconfig` is in the `ALLOWED` field list for this tool. Cluster credentials in the wrong hands = effective cluster admin. The `write` tier is allowed by default for any task agent — no ToolExecutionGrant required. Upgraded to `tier: 'destructive'` so an operator must explicitly approve via a one-time grant before any agent can call it.

**MAJOR — `orion_bootstrap_environment` internal self-call always failed silently**
The tool POSTed to `/api/environments/[id]/bootstrap` with `'x-internal-call': '1'`. This header is **never validated anywhere** in middleware. `/api/environments` is a `BEARER_PATH` that requires `Authorization: Bearer` — without it, the request redirected to `/login` and the tool returned `Bootstrap request failed: HTTP 302`. Every agent-initiated environment bootstrap was silently broken. Fixed by using `ORION_GATEWAY_TOKEN` or `ORION_MCP_TOKEN` as the service credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)