### PR TITLE
fix: agent count cap, bootstrap idempotency, reportTrace redaction

### DIFF
--- a/apps/gateway/src/orion-client.ts
+++ b/apps/gateway/src/orion-client.ts
@@ -151,6 +151,19 @@ export class OrionClient {
     }
   }
 
+  /** Redact sensitive patterns from tool args/results before transmitting. */
+  private redactForTrace(value: string | undefined): string | undefined {
+    if (!value) return value
+    const MAX_LEN = 4096
+    let redacted = value
+      .replace(/([A-Za-z0-9+/]{40,}={0,2})/g, (m) => m.length > 60 ? '[REDACTED_BASE64]' : m) // long base64
+      .replace(/\b(mcg|mcga|ghp|ghs|glpat)_[A-Za-z0-9]{20,}/g, '[REDACTED_TOKEN]') // PATs
+      .replace(/Bearer\s+[A-Za-z0-9._-]{20,}/g, 'Bearer [REDACTED]')
+      .replace(/password["\s:=]+[^\s"]{8,}/gi, 'password=[REDACTED]')
+    if (redacted.length > MAX_LEN) redacted = redacted.slice(0, MAX_LEN) + '[TRUNCATED]'
+    return redacted
+  }
+
   /** Report an AgentTrace to ORION */
   async reportTrace(data: {
     conversationId?: string
@@ -175,7 +188,12 @@ export class OrionClient {
       {
         method: 'POST',
         headers: this.headers(),
-        body: JSON.stringify(data),
+        body: JSON.stringify({
+          ...data,
+          toolArgs:   this.redactForTrace(data.toolArgs),
+          toolResult: this.redactForTrace(data.toolResult),
+          content:    this.redactForTrace(data.content),
+        }),
       },
     )
     if (!res.ok) {

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -297,6 +297,21 @@ async function handleCreateAgent(args: unknown, ctx: ToolExecutionContext): Prom
   if (!spec.role?.trim())         return 'Error: role is required'
   if (!spec.systemPrompt?.trim()) return 'Error: systemPrompt is required — agents without a system prompt will not behave correctly'
   if (spec.systemPrompt.trim().length < 20) return 'Error: systemPrompt is too short (minimum 20 characters) — provide a meaningful role description'
+  if (spec.systemPrompt.trim().length > 10_000) return 'Error: systemPrompt exceeds maximum length (10,000 characters)'
+
+  // Cap total non-archived agents to prevent runaway agent-creation loops.
+  const MAX_ACTIVE_AGENTS = 50
+  const activeCount = await ctx.prisma.agent.count({
+    where: {
+      NOT: {
+        metadata: { path: ['archived'], equals: true },
+      },
+    },
+  })
+  if (activeCount >= MAX_ACTIVE_AGENTS) {
+    return `Error: maximum active agent limit (${MAX_ACTIVE_AGENTS}) reached. Archive unused agents before creating new ones.`
+  }
+
 
   const actorId = ctx.agentId ?? ctx.userId
   if (RESERVED_AGENT_NAMES.includes(spec.name.toLowerCase())) {
@@ -1910,11 +1925,27 @@ registerTool({
       })
       if (!env) return `Error: environment "${environment_id}" not found`
       if (!env.kubeconfig) return 'Error: no kubeconfig stored for this environment. Patch it first using orion_patch_environment.'
+      if (env.status === 'connected') return `Environment "${env.name}" is already connected (status: connected). Bootstrapping again would re-deploy the gateway unnecessarily. To force re-bootstrap, first set status to 'pending' via orion_patch_environment.`
 
+      // Check for an already-running or queued bootstrap job
+      const existingJob = await ctx.prisma.backgroundJob.findFirst({
+        where: {
+          type: 'cluster-bootstrap',
+          metadata: { path: ['environmentId'], equals: env.id },
+          status: { in: ['queued', 'running'] },
+        },
+        select: { id: true, status: true },
+      })
+      if (existingJob) {
+        return `Error: a bootstrap job is already ${existingJob.status} for environment "${env.name}" (job: ${existingJob.id}). Wait for it to complete before starting another.`
+      }
+
+      const serviceToken = process.env.ORION_GATEWAY_TOKEN ?? process.env.ORION_MCP_TOKEN ?? ''
+      if (!serviceToken) return 'Error: no service token configured (ORION_GATEWAY_TOKEN or ORION_MCP_TOKEN required)'
       const baseUrl = process.env.ORION_CALLBACK_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
-      const res = await fetch(`${baseUrl}/api/environments/${environment_id}/bootstrap`, {
+      const res = await fetch(`${baseUrl}/api/environments/${env.id}/bootstrap`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-internal-call': '1' },
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceToken}` },
       })
       if (!res.ok) return `Bootstrap request failed: HTTP ${res.status}`
 


### PR DESCRIPTION
## Summary

Three bugs from Opus reviews.

**MAJOR — `orion_create_agent` had no agent count cap**
At `tier: 'write'` (allowed for all task agents), a misbehaving or compromised agent could create thousands of sub-agents each consuming worker-loop resources. Added `MAX_ACTIVE_AGENTS=50` guard before agent creation. Also added 10k char cap on `systemPrompt`.

**MAJOR — `orion_bootstrap_environment` was non-idempotent**
No check for an already-connected environment or an in-flight bootstrap job, so an agent could repeatedly trigger full cluster re-deployments. Added `status === 'connected'` guard and in-flight job check. Also fixed the internal HTTP call — the `x-internal-call: 1` header is never validated in middleware, so all previous bootstrap attempts returned HTTP 302 (redirect to /login). Now uses `ORION_GATEWAY_TOKEN` or `ORION_MCP_TOKEN` as the service credential.

**MAJOR — `reportTrace` sent tool args/results unredacted over potentially plaintext HTTP**
`toolArgs`, `toolResult`, and `content` are sent verbatim to ORION via `orion-client.ts`. Tool results can include kubectl output, secret listings, and pod logs containing credentials. Added `redactForTrace()` with patterns for base64, PATs, Bearer tokens, and password fields, plus 4096 char truncation per field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)