### PR TITLE
fix: api-keys admin gate, k8s logs validation, AgentGroupToolAccess, observability auth, ingress CRUD auth

### DIFF
--- a/apps/web/src/app/api/api-keys/route.ts
+++ b/apps/web/src/app/api/api-keys/route.ts
@@ -10,9 +10,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
+import { authOptions, requireAdmin } from '@/lib/auth'
 import { createApiKey, listUserKeys, verifyApiKey } from '@/lib/api-key'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
+import { prisma } from '@/lib/db'
+
+const MAX_KEYS_PER_USER = 20
 
 type User = { id: string }
 
@@ -61,14 +64,28 @@ export async function GET(req: NextRequest) {
   }
 }
 
-// POST /api/api-keys — create a new API key
+// POST /api/api-keys — create a new API key (admin only)
 export async function POST(req: NextRequest) {
   try {
-    const result = await resolveUser(req)
-    if (result.error) {
-      return NextResponse.json({ error: result.error }, { status: result.status! })
+    // MAJOR fix: the docstring says "Only admins can create API keys" but resolveUser()
+    // accepted any session (including readonly role). Changed to requireAdmin().
+    let adminUser: { id: string }
+    try { adminUser = await requireAdmin() } catch {
+      return NextResponse.json({ error: 'Admin privileges required to create API keys' }, { status: 401 })
     }
+
+    // Cap keys per user to prevent key-spray
+    const existingCount = await prisma.apiKey.count({ where: { userId: adminUser.id, active: true } })
+    if (existingCount >= MAX_KEYS_PER_USER) {
+      return NextResponse.json(
+        { error: `Maximum of ${MAX_KEYS_PER_USER} active API keys per user. Revoke unused keys first.` },
+        { status: 429 }
+      )
+    }
+
     const body = await req.json()
+    // Reuse adminUser.id instead of the generic resolveUser result
+    const resolvedUserId = adminUser.id
 
     // Validate API key creation input
     const parsed = z.object({
@@ -79,11 +96,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
     }
 
-    const apiKeyResult = await createApiKey(result.user!.id, parsed.data.name, parsed.data.expiresInDays)
+    const apiKeyResult = await createApiKey(resolvedUserId, parsed.data.name, parsed.data.expiresInDays)
 
     // SOC2: [M-005] Audit API key creation (non-blocking)
     logAudit({
-      userId: result.user!.id,
+      userId: resolvedUserId,
       action: 'api_key_create',
       target: `api_key:${apiKeyResult.info.id}`,
       detail: { name: apiKeyResult.info.name, expiresInDays: parsed.data.expiresInDays },

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
@@ -8,6 +8,7 @@
  * Streams SSE: { type: 'log', message } | { type: 'done', success, error? }
  */
 import { NextRequest } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { buildZoneFile, syncToKubernetes, syncToDocker } from '@/lib/dns-sync'
 
@@ -166,6 +167,7 @@ export async function POST(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const domain = await prisma.domain.findUnique({
     where: { id: params.id },
     include: { coreDnsEnvironment: true, dnsRecords: { where: { enabled: true } } },

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/records/[recordId]/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/records/[recordId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { syncDomainDns } from '@/lib/dns-sync'
 
@@ -26,6 +27,7 @@ async function maybeSync(domainId: string) {
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string; recordId: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const record = await prisma.dnsRecord.update({
     where: { id: params.recordId },
@@ -41,6 +43,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string; recordId: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   await prisma.dnsRecord.delete({ where: { id: params.recordId } })
   await maybeSync(params.id)
   return new NextResponse(null, { status: 204 })

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/records/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/records/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { syncDomainDns } from '@/lib/dns-sync'
 
@@ -22,6 +23,7 @@ async function getGatewayExec(envId: string) {
 }
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const records = await prisma.dnsRecord.findMany({
     where: { domainId: params.id },
     orderBy: { ip: 'asc' },
@@ -30,6 +32,7 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 }
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   if (!body.ip || !Array.isArray(body.hostnames) || body.hostnames.length === 0) {
     return NextResponse.json({ error: 'ip and hostnames required' }, { status: 400 })

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/sync/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/sync/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { syncDomainDns } from '@/lib/dns-sync'
 
 export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const domain = await prisma.domain.findUnique({ where: { id: params.id } })
   if (!domain) return NextResponse.json({ error: 'Domain not found' }, { status: 404 })
   if (!domain.coreDnsEnvironmentId || domain.coreDnsStatus !== 'bootstrapped') {

--- a/apps/web/src/app/api/ingress/domains/[id]/points/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/points/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const point = await prisma.ingressPoint.create({
     data: {

--- a/apps/web/src/app/api/ingress/domains/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const domain = await prisma.domain.update({
     where: { id: params.id },
@@ -26,6 +28,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   await prisma.domain.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/domains/route.ts
+++ b/apps/web/src/app/api/ingress/domains/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function GET() {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   // Auto-seed domains from system settings if the table is empty
   const count = await prisma.domain.count()
   if (count === 0) {
@@ -34,6 +36,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const domain = await prisma.domain.create({
     data: {

--- a/apps/web/src/app/api/ingress/middlewares/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/middlewares/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const middleware = await prisma.ingressMiddleware.update({
     where: { id: params.id },
@@ -16,6 +18,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   await prisma.ingressMiddleware.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/points/[id]/middlewares/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/middlewares/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const middleware = await prisma.ingressMiddleware.create({
     data: {

--- a/apps/web/src/app/api/ingress/points/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const point = await prisma.ingressPoint.update({
     where: { id: params.id },
@@ -25,6 +27,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   await prisma.ingressPoint.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/points/[id]/routes/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/routes/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const route = await prisma.ingressRoute.create({
     data: {

--- a/apps/web/src/app/api/ingress/routes/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/routes/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const route = await prisma.ingressRoute.update({
     where: { id: params.id },
@@ -17,6 +19,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   await prisma.ingressRoute.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/routes/[id]/toggle/route.ts
+++ b/apps/web/src/app/api/ingress/routes/[id]/toggle/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
+import { requireAdmin } from '@/lib/auth'
 
 export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const session = await getServerSession(authOptions)
 
   const current = await prisma.ingressRoute.findUniqueOrThrow({ where: { id: params.id } })

--- a/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
+++ b/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { coreApi } from '@/lib/k8s'
-import { getCurrentUser } from '@/lib/auth'
+import { requireAdmin } from '@/lib/auth'
 import { redactSensitive } from '@/lib/redact'
 
 export const dynamic = 'force-dynamic'
@@ -11,8 +11,17 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: { ns: string; pod: string } }
 ) {
-  const user = await getCurrentUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Validate namespace and pod name as DNS-1123 labels to prevent
+  // path-based enumeration of the API server
+  const DNS_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+  if (!DNS_LABEL.test(params.ns) || !DNS_LABEL.test(params.pod)) {
+    return NextResponse.json({ error: 'Invalid namespace or pod name' }, { status: 400 })
+  }
+
   return createSSEStream((send, close) => {
     ;(async () => {
       try {

--- a/apps/web/src/app/api/observability/trace/route.ts
+++ b/apps/web/src/app/api/observability/trace/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireAdmin, requireServiceAuth } from '@/lib/auth'
 import { parseBodyOrError } from '@/lib/validate'
 
 export const dynamic = 'force-dynamic'
@@ -26,14 +26,19 @@ const CreateTraceSchema = z.object({
   costCents: z.number().min(0).optional(),
 })
 
-// GET /api/observability/trace — Query traces
+// GET /api/observability/trace — Query traces (admin only)
 // Query params: conversationId, taskId, limit (default 100), type (optional filter)
 export async function GET(req: Request) {
+  // BLOCKER fix: traces contain toolArgs/toolResult across all conversations —
+  // exposing all system traces to any authenticated user leaks tool outputs.
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { searchParams } = new URL(req.url)
   const conversationId = searchParams.get('conversationId')
   const taskId = searchParams.get('taskId')
   const type = searchParams.get('type')
-  const limit = parseInt(searchParams.get('limit') || '100')
+  const limit = Math.min(parseInt(searchParams.get('limit') || '100'), 500)
 
   const where: Record<string, unknown> = {}
   if (conversationId) where.conversationId = conversationId

--- a/apps/web/src/lib/claude.ts
+++ b/apps/web/src/lib/claude.ts
@@ -1020,11 +1020,14 @@ async function handleOrionBootstrapEnvironment(argsRaw: string): Promise<string>
     if (!env) return `Error: environment "${environment_id}" not found`
     if (!env.kubeconfig) return 'Error: no kubeconfig stored for this environment. Patch it first using orion_patch_environment.'
 
-    // Call the bootstrap endpoint internally
+    // Call the bootstrap endpoint with the service token — x-internal-call is
+    // never validated by middleware and the endpoint requires Bearer auth.
+    const serviceToken = process.env.ORION_GATEWAY_TOKEN ?? process.env.ORION_MCP_TOKEN ?? ''
+    if (!serviceToken) return 'Error: no service token configured (ORION_GATEWAY_TOKEN or ORION_MCP_TOKEN required)'
     const baseUrl = process.env.ORION_CALLBACK_URL ?? `http://localhost:${process.env.PORT ?? 3000}`
     const res = await fetch(`${baseUrl}/api/environments/${environment_id}/bootstrap`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-internal-call': '1' },
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceToken}` },
     })
     if (!res.ok) return `Bootstrap request failed: HTTP ${res.status}`
 

--- a/apps/web/src/lib/tool-permissions.ts
+++ b/apps/web/src/lib/tool-permissions.ts
@@ -72,6 +72,44 @@ export async function checkToolPermission(
     }
   }
 
+  // ── AgentGroupToolAccess check ────────────────────────────────────────────
+  // If this tool belongs to any ToolGroup(s) in this environment, an agent may
+  // only call it if it is a member of an AgentGroup granted access to one of
+  // those ToolGroups. Tools in no ToolGroup remain unrestricted.
+  // Previously this mechanism was stored in the DB but never enforced — the
+  // admin UI showed group→tool-group access grants that had zero runtime effect.
+  if (resolvedEnvId) {
+    const groupMemberships = await prisma.toolGroupTool.findMany({
+      where: { tool: { name: toolName, environmentId: resolvedEnvId } },
+      select: { toolGroupId: true },
+    })
+
+    if (groupMemberships.length > 0) {
+      if (!agentId) {
+        return {
+          allowed: false,
+          reason: `\`${toolName}\` belongs to a restricted tool group and requires agent-group authorization, but no agent context is available.`,
+        }
+      }
+
+      const toolGroupIds = groupMemberships.map(m => m.toolGroupId)
+      const grantedAccess = await prisma.agentGroupToolAccess.findFirst({
+        where: {
+          toolGroupId: { in: toolGroupIds },
+          agentGroup:  { members: { some: { agentId } } },
+        },
+        select: { agentGroupId: true },
+      })
+
+      if (!grantedAccess) {
+        return {
+          allowed: false,
+          reason: `\`${toolName}\` belongs to a tool group this agent has not been granted access to. Add the agent to an agent group with access to the tool group.`,
+        }
+      }
+    }
+  }
+
   // ── Tier check from unified tool registry ────────────────────────────────
   const def = getToolDefinition(toolName)
   if (!def) {


### PR DESCRIPTION
## Summary

Multiple bugs from Opus reviews of tool permissions, API keys, and remaining routes.

**MAJOR — api-keys POST had no admin gate**
Despite the docstring saying "Only admins can create API keys," `POST /api/api-keys` accepted any authenticated session including `readonly` role. Added `requireAdmin()` + `MAX_KEYS_PER_USER=20` cap. Also fixed `claude.ts` bootstrap internal call — replaced the never-validated `x-internal-call: 1` header with proper `Authorization: Bearer` service token.

**MAJOR — k8s logs: requireAdmin() + DNS label validation**
Changed from `getCurrentUser()` (any session) to `requireAdmin()`. Added regex validation on `ns`/`pod` parameters to prevent API server path enumeration.

**MAJOR — AgentGroupToolAccess was dead code**
The admin UI allowed configuring agent group → tool group access grants with zero runtime effect. Added enforcement to `tool-permissions.ts`: if a tool belongs to a `ToolGroup`, agents must be in an `AgentGroup` with `AgentGroupToolAccess` to that group.

**BLOCKER — observability/trace GET exposed all traces to any authenticated user**
`GET /api/observability/trace` returned all system traces (tool args, results, conversation contents) with no scoping, no auth, and unbounded `limit`. Added `requireAdmin()` and capped limit to 500.

**BLOCKER — ingress CRUD routes had no admin gate**
13 ingress route handlers (domains, DNS records, routes, points, middlewares) had no `requireAdmin()`. Any authenticated user could create/modify/delete DNS records and ingress routes — a routing/traffic-hijack and phishing vector. Added `requireAdmin()` to all 13 handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)