### PR TITLE
fix(chat): conversation ownership — stamp ownerId, scope all 5 routes (4 BLOCKERs)

### DIFF
--- a/apps/web/src/app/api/chat/conversations/[id]/memory/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/memory/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { getToken } from 'next-auth/jwt'
+import { assertConversationOwner } from '@/lib/conversation-owner'
 
 /**
  * GET /api/chat/conversations/[id]/memory
@@ -10,17 +10,9 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
-  if (!token?.sub) {
-    return new Response('Unauthorized', { status: 401 })
-  }
-
-  const conversation = await prisma.conversation.findUnique({
-    where: { id: params.id },
-  })
-  if (!conversation) {
-    return new Response('Conversation not found', { status: 404 })
-  }
+  // B2 fix: any user could inject/read memories in any conversation (no ownership check)
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
 
   const memories = await prisma.memory.findMany({
     where: { conversationId: params.id },
@@ -38,17 +30,9 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
-  if (!token?.sub) {
-    return new Response('Unauthorized', { status: 401 })
-  }
-
-  const conversation = await prisma.conversation.findUnique({
-    where: { id: params.id },
-  })
-  if (!conversation) {
-    return new Response('Conversation not found', { status: 404 })
-  }
+  // B2 fix: any user could inject/read memories in any conversation (no ownership check)
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
 
   const { key, value, context } = await req.json()
 
@@ -97,10 +81,8 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
-  if (!token?.sub) {
-    return new Response('Unauthorized', { status: 401 })
-  }
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
 
   const searchParams = req.nextUrl.searchParams
   const key = searchParams.get('key')

--- a/apps/web/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { assertConversationOwner } from '@/lib/conversation-owner'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  // B1 fix: this route had no auth at all — any caller could read any conversation's messages
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
+
   const messages = await prisma.message.findMany({
     where: { conversationId: params.id },
     orderBy: { createdAt: 'asc' },

--- a/apps/web/src/app/api/chat/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/route.ts
@@ -1,25 +1,38 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { assertConversationOwner } from '@/lib/conversation-owner'
 import { parseBodyOrError, UpdateConversationSchema } from '@/lib/validate'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
   const convo = await prisma.conversation.findUnique({ where: { id: params.id } })
   if (!convo) return new NextResponse(null, { status: 404 })
   return NextResponse.json(convo)
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
+
   // SOC2 [INPUT-001]: Validate request body with Zod schema
   const result = await parseBodyOrError(req, UpdateConversationSchema)
   if ('error' in result) return result.error
   const { data } = result
 
+  const existingMeta = check.conversation.metadata as Record<string, unknown> | null ?? {}
+  const ownerId = existingMeta.ownerId  // preserve — never let caller overwrite
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const updateData: Record<string, any> = {}
-  if (data.title    !== undefined) updateData.title    = data.title ?? null
-  if (data.metadata !== undefined) updateData.metadata = data.metadata
+  if (data.title !== undefined) updateData.title = data.title ?? null
+  if (data.metadata !== undefined) {
+    // M2 fix: merge metadata, protecting ownerId from being overwritten
+    updateData.metadata = { ...existingMeta, ...data.metadata, ownerId }
+  }
+
   const convo = await prisma.conversation.update({
     where: { id: params.id },
     data: updateData,
@@ -28,7 +41,9 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(convo)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const check = await assertConversationOwner(req, params.id)
+  if (check instanceof NextResponse) return check
   await prisma.conversation.update({
     where: { id: params.id },
     data: { archivedAt: new Date() },

--- a/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
@@ -1,3 +1,5 @@
+import { NextResponse } from "next/server"
+import { assertConversationOwner } from "@/lib/conversation-owner"
 import { NextRequest } from 'next/server'
 import { createSSEStream } from '@/lib/sse'
 import { streamClaudeResponse, streamAgentChat, streamOllamaChat, streamGeminiChat, streamOpenAIChat, type AgentContextConfig } from '@/lib/claude'
@@ -23,11 +25,15 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
   const { id: conversationId } = params
 
+  // B3 fix: stream route had no ownership check — any user could read/write any conversation via streaming
+  const ownerCheck = await assertConversationOwner(req, conversationId)
+  if (ownerCheck instanceof NextResponse) return ownerCheck
+
   // Get the current user from session (used for permission checks in tool loop)
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
   const userId = token?.sub as string | undefined
 
-  // Verify conversation exists and get metadata
+  // Conversation already verified by assertConversationOwner above
   const convo = await prisma.conversation.findUnique({ where: { id: conversationId } })
   if (!convo) {
     return new Response('Conversation not found', { status: 404 })

--- a/apps/web/src/app/api/chat/conversations/route.ts
+++ b/apps/web/src/app/api/chat/conversations/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import type { Prisma } from '@prisma/client'
+import { getCallerId } from '@/lib/conversation-owner'
 import { CreateConversationSchema } from '@/lib/validate'
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  // B1 fix: scope list to conversations owned by the caller
+  const callerId = await getCallerId(req)
+  if (!callerId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const convos = await prisma.conversation.findMany({
-    where: { archivedAt: null },
+    where: {
+      archivedAt: null,
+      // Filter by ownerId stored in metadata (added at creation time).
+      // Legacy rows without ownerId won't appear — acceptable; admins can
+      // access those via direct id lookup.
+      metadata: { path: ['ownerId'], equals: callerId },
+    },
     orderBy: { updatedAt: 'desc' },
     take: 50,
     include: { _count: { select: { messages: true } } },
@@ -14,7 +24,10 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  // SOC2: Input validation — validate and sanitize all request body fields
+  // Stamp ownerId at creation so all subsequent reads can be scoped
+  const callerId = await getCallerId(req)
+  if (!callerId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const rawBody = await req.json().catch(() => ({}))
   const body = typeof rawBody === 'object' && rawBody !== null ? rawBody : {}
 
@@ -26,7 +39,9 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const meta: Record<string, unknown> = {}
+  const meta: Record<string, unknown> = {
+    ownerId: callerId,  // B1 fix: stamp owner for future scoping
+  }
   if (parsed.data.initialContext) meta.initialContext = parsed.data.initialContext
   if (parsed.data.planTarget)     meta.planTarget     = parsed.data.planTarget
   if (parsed.data.planModel)      meta.planModel      = parsed.data.planModel
@@ -38,7 +53,7 @@ export async function POST(req: NextRequest) {
   const convo = await prisma.conversation.create({
     data: {
       title: parsed.data.title ? parsed.data.title.slice(0, 200) : null,
-      metadata: Object.keys(meta).length ? (meta as any) : undefined,
+      metadata: meta as any,
     },
     include: { _count: { select: { messages: true } } },
   })

--- a/apps/web/src/lib/conversation-owner.ts
+++ b/apps/web/src/lib/conversation-owner.ts
@@ -1,0 +1,58 @@
+/**
+ * Conversation ownership helpers — metadata-based scoping (no schema migration).
+ *
+ * Since `Conversation` has no owner field, we store `ownerId` in `metadata`
+ * at creation time and enforce it on all subsequent operations.
+ * Legacy rows without `ownerId` are accessible to admins only.
+ */
+import { getToken } from 'next-auth/jwt'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from './db'
+import { requireAdmin } from './auth'
+
+/** Resolve the caller's userId from the JWT token (null if unauthenticated). */
+export async function getCallerId(req: NextRequest): Promise<string | null> {
+  const token = await getToken({ req })
+  return (token?.sub as string) ?? null
+}
+
+/**
+ * Assert the caller owns the conversation. Returns 401/403 response on failure,
+ * or the conversation on success. Admins bypass ownership check.
+ */
+export async function assertConversationOwner(
+  req: NextRequest,
+  conversationId: string,
+): Promise<{ conversation: { id: string; metadata: unknown } } | NextResponse> {
+  const callerId = await getCallerId(req)
+  if (!callerId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const convo = await prisma.conversation.findUnique({
+    where: { id: conversationId },
+    select: { id: true, metadata: true },
+  })
+  if (!convo) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const meta = convo.metadata as Record<string, unknown> | null
+  const ownerId = meta?.ownerId as string | undefined
+
+  // Legacy rows with no ownerId: require admin
+  if (!ownerId) {
+    try { await requireAdmin() } catch {
+      return NextResponse.json(
+        { error: 'This conversation predates ownership tracking — admin access required' },
+        { status: 403 },
+      )
+    }
+    return { conversation: convo }
+  }
+
+  if (ownerId !== callerId) {
+    // Allow admins to access any conversation
+    try { await requireAdmin() } catch {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+  }
+
+  return { conversation: convo }
+}


### PR DESCRIPTION
## Summary

4 BLOCKERs from Opus deep review of the conversations API.

The `Conversation` schema has **no owner field** — any authenticated user could read/write/delete any conversation. This is a complete IDOR across all conversation routes.

**Fix approach:** Zero-migration metadata-based ownership. `ownerId` is stamped into `metadata` at creation and enforced by `assertConversationOwner()` at every handler. Admins bypass ownership for legacy rows (no `ownerId`).

**B1 — All conversation routes exposed to any user**
- `GET /conversations` now filters by `metadata.ownerId`
- `GET/PATCH/DELETE /conversations/[id]` now enforce ownership
- `GET /conversations/[id]/messages` — **had no auth at all** — added ownership check

**B2 — Memory injection into any conversation**
Any user could `POST /conversations/[id]/memory` to inject persistent context into any conversation, poisoning the LLM context for the owner's next session. Added ownership check to all three memory handlers.

**B3 — Stream endpoint exposed**
`POST /conversations/[id]/stream` had no ownership check — any user could read history, continue any conversation, and execute tools with their own permissions against any conversation context. Added ownership check before streaming begins.

**M2 — PATCH could overwrite `ownerId`**
`UpdateConversationSchema.metadata` is `z.record(z.unknown())` — a caller could set `metadata.ownerId` to steal/transfer ownership. PATCH now merges metadata while preserving the existing `ownerId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)