### PR TITLE
fix: nova-definitions auth/mass-assign, dream watermark, rate limit cleanup, bugs gateway blocker

### DIFF
--- a/apps/web/src/app/api/nova-definitions/route.ts
+++ b/apps/web/src/app/api/nova-definitions/route.ts
@@ -39,19 +39,20 @@ export async function POST(req: NextRequest) {
   const body = await req.json()
   // MAJOR fix: raw body was passed directly to Prisma (mass assignment).
   // Whitelist allowed fields to prevent setting arbitrary columns.
-  const name    = String(body.name ?? '').trim()
-  const category = body.category === 'skill' || body.category === 'hook' ? body.category : 'skill'
-  const spec    = typeof body.spec === 'string' ? body.spec : JSON.stringify(body.spec ?? {})
-  const displayName = body.displayName ? String(body.displayName).slice(0, 200) : name
-  const description = body.description ? String(body.description).slice(0, 2000) : undefined
-  const minimumTier = body.minimumTier ? String(body.minimumTier) : undefined
+  const name        = String(body.name ?? '').trim()
+  const category    = body.category === 'skill' || body.category === 'hook' ? body.category : 'skill'
+  const spec        = typeof body.spec === 'string' ? body.spec : JSON.stringify(body.spec ?? {})
+  const title       = body.title ? String(body.title).slice(0, 200) : name
+  const description = body.description ? String(body.description).slice(0, 2000) : ''
+  const version     = body.version ? String(body.version).slice(0, 50) : '1.0'
+  const metadata    = body.metadata ? (typeof body.metadata === 'string' ? body.metadata : JSON.stringify(body.metadata)) : undefined
 
   if (!name) return NextResponse.json({ error: 'name is required' }, { status: 400 })
 
   const nova = await prisma.novaDefinition.upsert({
     where: { name },
-    update: { category, spec, displayName, description, minimumTier },
-    create: { name, category, spec, displayName, description, minimumTier },
+    update: { category, spec, title, description, version, metadata },
+    create: { name, category, spec, title, description, version, metadata },
   })
   return NextResponse.json(nova)
 }

--- a/apps/web/src/app/api/nova-definitions/route.ts
+++ b/apps/web/src/app/api/nova-definitions/route.ts
@@ -11,6 +11,10 @@ export const dynamic = 'force-dynamic'
  *   - category: "skill" | "hook"
  */
 export async function GET(req: NextRequest) {
+  // MAJOR fix: GET had no auth — any logged-in user could enumerate nova definitions
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { searchParams } = new URL(req.url)
   const category = searchParams.get('category')
   const where: Record<string, unknown> = {}
@@ -33,10 +37,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
   const body = await req.json()
+  // MAJOR fix: raw body was passed directly to Prisma (mass assignment).
+  // Whitelist allowed fields to prevent setting arbitrary columns.
+  const name    = String(body.name ?? '').trim()
+  const category = body.category === 'skill' || body.category === 'hook' ? body.category : 'skill'
+  const spec    = typeof body.spec === 'string' ? body.spec : JSON.stringify(body.spec ?? {})
+  const displayName = body.displayName ? String(body.displayName).slice(0, 200) : name
+  const description = body.description ? String(body.description).slice(0, 2000) : undefined
+  const minimumTier = body.minimumTier ? String(body.minimumTier) : undefined
+
+  if (!name) return NextResponse.json({ error: 'name is required' }, { status: 400 })
+
   const nova = await prisma.novaDefinition.upsert({
-    where: { name: (body as any).name },
-    update: body as any,
-    create: body as any,
+    where: { name },
+    update: { category, spec, displayName, description, minimumTier },
+    create: { name, category, spec, displayName, description, minimumTier },
   })
   return NextResponse.json(nova)
 }

--- a/apps/web/src/lib/dream.ts
+++ b/apps/web/src/lib/dream.ts
@@ -207,7 +207,25 @@ export async function runExtraction(): Promise<void> {
     return `[${e.eventType}] ${task}${(e.content ?? '').slice(0, 400)}`
   })
 
-  const corpus = [...messageLines, ...eventLines].join('\n').slice(0, 12_000)
+  // BLOCKER fix: build corpus with a budget and track the watermark to only the
+  // last row that actually fit. Previously: all rows were fetched, corpus was
+  // blindly sliced to 12k, but watermark advanced to now() unconditionally —
+  // content past the 12k cut was permanently skipped on the next run.
+  const allRows = [
+    ...messages.map(m => ({ ts: m.createdAt, line: messageLines[messages.indexOf(m)] })),
+    ...events.map(e => ({ ts: e.createdAt, line: eventLines[events.indexOf(e)] })),
+  ].sort((a, b) => a.ts.getTime() - b.ts.getTime())
+
+  let corpusBudget = 0
+  let processedThrough = lastRun
+  const corpusLines: string[] = []
+  for (const row of allRows) {
+    if (corpusBudget + row.line.length + 1 > 12_000) break
+    corpusLines.push(row.line)
+    corpusBudget += row.line.length + 1
+    processedThrough = row.ts
+  }
+  const corpus = corpusLines.join('\n')
 
   const extractionPrompt = `You are a memory consolidation system for an AI agent team managing a Kubernetes homelab cluster.
 
@@ -281,8 +299,10 @@ If nothing is worth remembering, return an empty array: []`
     }
   }
 
-  await setSetting('dream.extractionLastRun', String(now.getTime()))
-  console.log(`[dream] Extraction complete — wrote ${written}/${extracted.length} memories`)
+  // Use the watermark of the last processed row, not now(), to avoid skipping
+  // content that didn't fit in the 12k corpus window
+  await setSetting('dream.extractionLastRun', String(processedThrough.getTime()))
+  console.log(`[dream] Extraction complete — wrote ${written}/${extracted.length} memories (processed through ${processedThrough.toISOString()})`)
 }
 
 // ── Synthesis ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/rate-limit-redis.ts
+++ b/apps/web/src/lib/rate-limit-redis.ts
@@ -120,6 +120,12 @@ async function initRedisClient(): Promise<boolean> {
     // Test the connection
     await redisClient.ping()
     redisAvailable = true
+    // MAJOR fix: clear stale in-memory fallback state on Redis reconnect.
+    // Traffic that accumulated in fallbackStore during an outage is not
+    // double-counted (each request hit exactly one store), but stale entries
+    // linger indefinitely for low-traffic keys that never hit the cleanup
+    // threshold, causing a slow memory leak.
+    if (fallbackStore.size > 0) fallbackStore.clear()
     return true
   } catch (error) {
     redisClient = null

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -246,9 +246,15 @@ export async function middleware(req: NextRequest) {
     gatewayToken &&
     timingSafeCompare(req.headers.get('authorization') ?? '', `Bearer ${gatewayToken}`)
   ) {
-    // Gateway can do anything except DELETE on notes (safety)
-    if (req.method === 'DELETE' && pathname.startsWith('/api/notes')) {
-      // fall through to session auth for DELETE on notes
+    // Gateway can do anything except:
+    // - DELETE on notes (safety — prevents gateway from wiping knowledge base)
+    // - DELETE/PUT/POST on bugs (bugs are human tracking, not gateway-owned)
+    // - Any method on admin routes (gateway should not manage users/prompts)
+    const isNotesDelete    = req.method === 'DELETE' && pathname.startsWith('/api/notes')
+    const isBugsMutate     = ['DELETE','PUT','POST','PATCH'].includes(req.method) && pathname.startsWith('/api/bugs')
+    const isAdminMutate    = ['DELETE','PUT','POST','PATCH'].includes(req.method) && pathname.startsWith('/api/admin')
+    if (isNotesDelete || isBugsMutate || isAdminMutate) {
+      // fall through to session auth
     } else {
       return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
     }


### PR DESCRIPTION
## Summary

5 bugs from parallel Opus reviews.

**MAJOR — nova-definitions GET had no auth**
Any logged-in user could enumerate all nova definitions (skill/hook specs). Added `requireAdmin()`.

**MAJOR — nova-definitions POST mass-assigned raw body to Prisma**
No field allowlist — an admin could set arbitrary schema columns. Added explicit allowlist: `name, category, spec, title, description, version, metadata`.

**BLOCKER — dream extraction watermark advanced past unprocessed content**
The watermark advanced to `now()` unconditionally even when the corpus was truncated at 12k chars. Content past the cutoff was permanently skipped on all future runs. Fixed: build corpus row-by-row with a budget tracker, advance watermark only to the timestamp of the last included row.

**MAJOR — rate limit in-memory fallback store never cleared on Redis reconnect**
Stale entries from outage periods accumulated indefinitely for low-traffic keys (cleanup only triggers at `count % 100`). Added `fallbackStore.clear()` on successful Redis reconnect.

**BLOCKER — gateway service token could mutate bugs and admin routes**
Middleware only exempted `DELETE /api/notes` from the gateway token bypass. Any holder of `ORION_GATEWAY_TOKEN` could `DELETE/PUT/POST` on `/api/bugs` and `/api/admin` routes. Extended the exclusion to cover bugs mutations and admin mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)