### PR TITLE
fix: admin-gate system-settings GET, auth-gate agents/messages

### DIFF
--- a/apps/web/src/app/api/agents/messages/route.ts
+++ b/apps/web/src/app/api/agents/messages/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { getCurrentUser } from '@/lib/auth'
 
 export async function GET(req: NextRequest) {
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const { searchParams } = new URL(req.url)
   const limit   = parseInt(searchParams.get('limit') ?? '50')
   const channel = searchParams.get('channel') ?? undefined
@@ -10,13 +14,18 @@ export async function GET(req: NextRequest) {
   const messages = await prisma.agentMessage.findMany({
     where: { ...(channel ? { channel } : {}), ...(since ? { createdAt: { gt: since } } : {}) },
     orderBy: { createdAt: 'desc' },
-    take: limit,
+    take: Math.min(limit, 200),
     include: { agent: true },
   })
   return NextResponse.json(messages)
 }
 
 export async function POST(req: NextRequest) {
+  // MINOR fix: any logged-in user could inject arbitrary messages into agent channels,
+  // which is a prompt-injection delivery vector. Require authentication.
+  const user = await getCurrentUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
   const body = await req.json()
   const msg = await prisma.agentMessage.create({
     data: {

--- a/apps/web/src/app/api/system-settings/[key]/route.ts
+++ b/apps/web/src/app/api/system-settings/[key]/route.ts
@@ -1,31 +1,43 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+// Keys readable by any logged-in user (safe, non-sensitive UI config)
+const PUBLIC_SETTING_KEYS = new Set([
+  'site.name',
+  'site.logo',
+  'site.theme',
+  'cache.snapshot.ttl',
+  'cache.env.ttl',
+  'feature.dream.enabled',
+  'feature.nebula.enabled',
+])
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { key: string } }
 ) {
   try {
+    if (!PUBLIC_SETTING_KEYS.has(params.key)) {
+      // MINOR fix: any logged-in user could read any SystemSetting key, including
+      // vault.unsealKeys (encrypted) and other sensitive config. Admin-gate all
+      // non-public keys.
+      try { await requireAdmin() } catch {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+    }
+
     const setting = await prisma.systemSetting.findUnique({
       where: { key: params.key },
     })
 
     if (!setting) {
-      return NextResponse.json(
-        { error: 'Setting not found' },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: 'Setting not found' }, { status: 404 })
     }
 
-    return NextResponse.json({
-      key: setting.key,
-      value: setting.value,
-    })
+    return NextResponse.json({ key: setting.key, value: setting.value })
   } catch (error) {
     console.error('Error getting system setting:', error)
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary

**MINOR — system-settings GET any user reads any key**
Any logged-in user could `GET /api/system-settings/<key>` for *any* key — including `vault.unsealKeys` (encrypted ciphertext), internal config values, and other sensitive settings. Added `requireAdmin()` for all non-public keys. Added `PUBLIC_SETTING_KEYS` allowlist for safe UI config (theme, feature flags) that non-admins legitimately need.

**MINOR — agents/messages POST any user injects to agent feed**
`GET` and `POST /api/agents/messages` had no auth at all. `POST` is a prompt-injection delivery vector — agent runners poll these channels and incorporate message content into agent context. Added `getCurrentUser()` gate to both handlers. Also capped `limit` at 200 to prevent oversized responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)