### PR TITLE
fix: nova-definitions [id] GET auth + mass assign, nebula PUT mass assign (BLOCKER)

### DIFF
--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
@@ -49,9 +49,18 @@ export async function PUT(
   if (!existing) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
+  // BLOCKER fix: `{ ...body, isForked: true }` spread raw body into Prisma update,
+  // allowing caller to overwrite environmentId (move instance to another env),
+  // sourceNovaId, category, isInstalled, etc. Whitelist allowed fields only.
+  const updateData: Record<string, unknown> = { isForked: true }
+  if (body.spec !== undefined)        updateData.spec = typeof body.spec === 'string' ? body.spec : JSON.stringify(body.spec)
+  if (body.minimumTier !== undefined) updateData.minimumTier = String(body.minimumTier)
+  if (body.category !== undefined && ['skill', 'hook'].includes(body.category)) updateData.category = body.category
+  if (body.isInstalled !== undefined) updateData.isInstalled = Boolean(body.isInstalled)
+
   const entry = await prisma.nebulaInstance.update({
     where: { id: existing.id },
-    data: { ...body, isForked: true },
+    data: updateData,
   })
   return NextResponse.json(entry)
 }

--- a/apps/web/src/app/api/nova-definitions/[id]/route.ts
+++ b/apps/web/src/app/api/nova-definitions/[id]/route.ts
@@ -12,6 +12,10 @@ export async function GET(
   _req: Request,
   { params }: { params: { id: string } }
 ) {
+  // MAJOR fix: GET had no auth — any logged-in user could read nova definition specs
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const nova = await prisma.novaDefinition.findUnique({
     where: { id: params.id },
   })
@@ -35,9 +39,25 @@ export async function PUT(
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
   const body = await req.json()
+  // MAJOR fix: raw body was written directly to Prisma (mass assignment)
+  const title       = body.title ? String(body.title).slice(0, 200) : undefined
+  const category    = body.category === 'skill' || body.category === 'hook' ? body.category : undefined
+  const spec        = body.spec !== undefined ? (typeof body.spec === 'string' ? body.spec : JSON.stringify(body.spec)) : undefined
+  const description = body.description ? String(body.description).slice(0, 2000) : undefined
+  const version     = body.version ? String(body.version).slice(0, 50) : undefined
+  const metadata    = body.metadata !== undefined ? (typeof body.metadata === 'string' ? body.metadata : JSON.stringify(body.metadata)) : undefined
+
+  const updateData: Record<string, unknown> = {}
+  if (title !== undefined)       updateData.title = title
+  if (category !== undefined)    updateData.category = category
+  if (spec !== undefined)        updateData.spec = spec
+  if (description !== undefined) updateData.description = description
+  if (version !== undefined)     updateData.version = version
+  if (metadata !== undefined)    updateData.metadata = metadata
+
   const nova = await prisma.novaDefinition.update({
     where: { id: params.id },
-    data: body,
+    data: updateData,
   })
   return NextResponse.json(nova)
 }


### PR DESCRIPTION
## Summary

**MAJOR — nova-definitions [id] GET had no auth**
Any logged-in user could read any nova definition by id. Added `requireAdmin()`.

**MAJOR — nova-definitions [id] PUT mass assignment**
Raw body was written directly to `prisma.update` with no field allowlist. Added explicit whitelist: `title, category, spec, description, version, metadata`.

**BLOCKER — nebula [name] PUT mass assignment (env hijack)**
`data: { ...body, isForked: true }` spread the raw request body into `prisma.update`. A caller with operator access to env A could set `environmentId` to env B's id, moving the nebula instance to an environment they don't own. Also exposed `sourceNovaId`, `isInstalled`, and all other columns. Replaced with an explicit field whitelist: `spec, minimumTier, category, isInstalled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)