### PR TITLE
fix: gitops/propose admin gate, DNS nodehosts+records auth + Corefile injection (BLOCKERs)

### DIFF
--- a/apps/web/src/app/api/dns/nodehosts/route.ts
+++ b/apps/web/src/app/api/dns/nodehosts/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getNodeHosts, upsertNodeHost } from '@/lib/dns'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET() {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+
   try {
     return NextResponse.json(await getNodeHosts())
   } catch (err) {
@@ -10,6 +13,8 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+
   const { ip, hostnames } = await req.json()
   if (!ip || !Array.isArray(hostnames) || hostnames.length === 0)
     return NextResponse.json({ error: 'ip and hostnames required' }, { status: 400 })

--- a/apps/web/src/app/api/dns/records/[ip]/route.ts
+++ b/apps/web/src/app/api/dns/records/[ip]/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { upsertCustomRecord, deleteCustomRecord } from '@/lib/dns'
+import { requireAdmin } from '@/lib/auth'
 
 export async function PUT(req: NextRequest, { params }: { params: { ip: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+
   const { ip, hostnames } = await req.json()
   try {
     await upsertCustomRecord(params.ip, hostnames)
@@ -12,6 +15,8 @@ export async function PUT(req: NextRequest, { params }: { params: { ip: string }
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { ip: string } }) {
+  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+
   try {
     const deleted = await deleteCustomRecord(params.ip)
     if (!deleted) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/gitops/propose/route.ts
+++ b/apps/web/src/app/api/gitops/propose/route.ts
@@ -16,9 +16,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { proposeChange } from '@/lib/gitops'
+import { requireAdmin } from '@/lib/auth'
 import type { PolicyConfig } from '@/lib/gitops-policy'
 
 export async function POST(req: NextRequest) {
+  // BLOCKER fix: no auth — any authenticated user could trigger auto-merge deploys to any env
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
   const body = await req.json()
   const { environmentId, title, reasoning, operationDescription, changes } = body
 

--- a/apps/web/src/lib/dns.ts
+++ b/apps/web/src/lib/dns.ts
@@ -41,12 +41,23 @@ export function serializeNodeHosts(entries: DnsEntry[]): string {
   return entries.map(e => `${e.ip} ${e.hostnames.join(' ')}`).join('\n') + '\n'
 }
 
+
+// Validate IP and hostnames to prevent Corefile injection via newline/whitespace
+function validateIp(ip: string): boolean {
+  return /^[\d.:a-fA-F]+$/.test(ip)
+}
+function validateHostname(h: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(h) && h.length <= 253
+}
+
+
 export async function getNodeHosts(): Promise<DnsEntry[]> {
   const cm = await getConfigMap('coredns')
   return parseNodeHosts(cm.data?.['NodeHosts'])
 }
 
 export async function upsertNodeHost(ip: string, hostnames: string[]): Promise<void> {
+  if (!validateIp(ip) || !hostnames.every(validateHostname)) throw new Error("Invalid IP or hostname")
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
       const cm = await getConfigMap('coredns')
@@ -122,6 +133,7 @@ export async function getCustomRecords(): Promise<DnsEntry[]> {
 }
 
 export async function upsertCustomRecord(ip: string, hostnames: string[]): Promise<void> {
+  if (!validateIp(ip) || !hostnames.every(validateHostname)) throw new Error("Invalid IP or hostname")
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
       const cm = await getOrCreateCustomConfigMap()


### PR DESCRIPTION
## Summary

**BLOCKER — gitops/propose had no auth**
Any authenticated user (including `role: 'user'`) could trigger the full GitOps auto-merge loop against any environment. Added `requireAdmin()`.

**BLOCKER — dns/nodehosts all methods had no auth → cluster DNS hijack**
Any authenticated user could write/delete CoreDNS host entries, hijacking any internal hostname across the cluster (MITM, credential capture). Added `requireAdmin()`.

**BLOCKER — dns/records/[ip] PUT/DELETE had no auth**
Same DNS-hijack impact — the item route was missed when the collection route was hardened. Added `requireAdmin()`.

**MAJOR — DNS values not validated → CoreDNS Corefile injection**
`ip`/`hostname` values were serialized verbatim into the Corefile hosts block. A hostname with a newline could inject arbitrary CoreDNS plugin directives. Added `validateIp()` and `validateHostname()` in `dns.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)