### PR TITLE
fix(worker): redact tool results before DB write; novas/evals GET auth

### DIFF
--- a/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
@@ -6,6 +7,8 @@ export const dynamic = 'force-dynamic'
 // Chart data for eval dashboard.
 // Query params: type=conversation|task|skill|hook, window=7|30|90
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const envId = params.id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })

--- a/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores/hook/[hookId]
 // Score for a specific hook NebulaInstance.
 export async function GET(_req: NextRequest, { params }: { params: { id: string; hookId: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const envId = params.id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })

--- a/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores
 // Score overview for all targets in an environment.
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const envId = params.id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })

--- a/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores/skill/[skillId]
 // Score for a specific skill NebulaInstance.
 export async function GET(_req: NextRequest, { params }: { params: { id: string; skillId: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const envId = params.id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })

--- a/apps/web/src/app/api/novas/[id]/revisions/route.ts
+++ b/apps/web/src/app/api/novas/[id]/revisions/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 /**
@@ -8,6 +9,8 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },
     include: {

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -32,6 +32,7 @@ const MAX_NOTE_LENGTH = 8000
 
 /**
  * Sanitize llm-context note content before injecting into system prompts (SOC2: [C-001]).
+ * Also exported via lib/sanitize-context.ts for use in the vector-search retrieval path.
  *
  * Mitigates prompt injection attacks where a malicious user could inject
  * system-level instructions through note content (e.g., "Ignore previous instructions").
@@ -361,16 +362,20 @@ async function runTask(taskId: string): Promise<void> {
           break
 
         case 'tool_result': {
-          await logTaskEvent(taskId, 'tool_result', event.result.slice(0, 2000), agent.id)
+          // MAJOR fix: redactSecrets was applied only to the room-feed copy; the
+          // logTaskEvent and Message writes stored raw tool results including any
+          // secrets/credentials returned by shell/kubectl/vault tools. Apply
+          // redaction consistently before any write.
+          const redactedResult = redactSecrets(event.result).slice(0, 2000)
+          await logTaskEvent(taskId, 'tool_result', redactedResult, agent.id)
           await prisma.message.create({
             data: {
               conversationId: conversation.id, role: 'user',
-              content: `[tool_result] ${event.tool}: ${event.result.slice(0, 2000)}`,
+              content: `[tool_result] ${event.tool}: ${redactedResult}`,
             },
           }).catch(() => {})
           if (featureRoomId) {
-            // SOC2: redact secrets, truncate to 300 chars before posting to room
-            const safeResult = redactSecrets(event.result).slice(0, 300)
+            const safeResult = redactedResult.slice(0, 300)
             await postToRoom(featureRoomId, agent.id, `↩ \`${event.tool}\`: ${safeResult}`, taskId)
           }
           break


### PR DESCRIPTION
## Summary

**MAJOR — worker.ts stored raw tool results containing secrets**
`redactSecrets()` was applied only to the room-feed copy of tool results. `logTaskEvent()` and `prisma.message.create()` both stored up to 2000 chars of raw tool output — meaning secrets, tokens, and kubeconfig credentials returned by shell/kubectl/vault tools landed in plaintext in `TaskEvent` and `Message` tables. Applied `redactSecrets()` before all three write paths.

**MINOR — novas/[id]/revisions GET had no auth**
Any logged-in user could read all nova definition revision diffs including full config history (system prompts, context configs embedded in specs). Added `requireAdmin()`.

**MINOR — evals GET routes had no auth beyond session**
`evals/scores`, `evals/scores/skill/[id]`, `evals/scores/hook/[id]`, and `evals/aggregate` returned any environment's evaluation data to any logged-in user with no environment ownership check. Added `requireAdmin()` to all four GET handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)