### PR TITLE
fix(room-agents): fuzzy-resolve permission bypass, allowedTools enforcement, agent name injection (BLOCKER)

### DIFF
--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -489,7 +489,12 @@ async function callOpenAIChat(
       } else {
         console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
-        if (registryToolNames.has(tc.function.name)) {
+        // MINOR fix: allowedTools was applied only to the advertised tool list (prompt
+        // layer), not at execution. A jailbroken model emitting a tool name outside the
+        // whitelist still executed it. Enforce at dispatch time.
+        if (allowedTools && allowedTools.size > 0 && !allowedTools.has(tc.function.name)) {
+          result = `Permission denied: tool '${tc.function.name}' is not in this agent's allowed tool list`
+        } else if (registryToolNames.has(tc.function.name)) {
           // Gate registry tools through checkToolPermission before execution.
           // Previously called executeRegisteredTool directly with NO permission check,
           // allowing room agents to invoke destructive-tier tools without a grant.
@@ -524,6 +529,14 @@ async function callOpenAIChat(
             // Auto-correct: call the real tool without burning a round trip
             console.warn(`[room-agents] ${agentName}: auto-correcting hallucinated tool "${tc.function.name}" → "${resolved.name}"`)
             if (registryToolNames.has(resolved.name)) {
+              // MINOR fix: fuzzy-resolved registry tools were executed without checkToolPermission.
+              // A slightly-misspelled destructive tool name that resolved with high confidence
+              // bypassed the permission gate entirely. Apply the same check as the direct path.
+              const agentIdForPerm = toolContext?.agentId ?? null
+              const fuzzyPerm = await checkToolPermission(resolved.name, agentIdForPerm, null)
+              if (!fuzzyPerm.allowed) {
+                result = `Permission denied: ${fuzzyPerm.reason ?? `tool '${resolved.name}' is not permitted`}`
+              } else {
               result = await executeRegisteredTool(resolved.name, args, {
                 agentId: toolContext!.agentId,
                 prisma,
@@ -532,6 +545,7 @@ async function callOpenAIChat(
                   listTools:   () => gateway.client.listTools(),
                 } : undefined,
               })
+              }
             } else if (legacyToolNames.has(resolved.name)) {
               result = await executeTool(resolved.name, args, {
                 roomId:        toolContext!.roomId,

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -180,14 +180,17 @@ export const UpdateSystemPromptSchema = z.object({
 // ── Agent Schemas ──────────────────────────────────────────────────────────────
 
 export const CreateAgentSchema = z.object({
-  name: z.string().min(1).max(200),
+  // BLOCKER fix: agent name is interpolated unfenced into LLM system prompts in room-agents.ts.
+  // A name containing newlines/control chars injects arbitrary instructions into the prompt.
+  // Restrict to printable non-control chars (no \n, \r, \t, etc.).
+  name: z.string().min(1).max(200).regex(/^[^\x00-\x1f\x7f]+$/, 'Agent name must not contain control characters'),
   type: z.enum(['claude', 'ollama', 'human', 'custom']),
   role: z.string().max(100).optional(),
   metadata: z.record(z.unknown()).optional(),
 })
 
 export const UpdateAgentSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
+  name: z.string().min(1).max(200).regex(/^[^\x00-\x1f\x7f]+$/, 'Agent name must not contain control characters').optional(),
   type: z.enum(['claude', 'ollama', 'human', 'custom']).optional(),
   role: z.string().max(100).optional(),
   metadata: z.record(z.unknown()).optional(),


### PR DESCRIPTION
## Summary

**BLOCKER — agent name unfenced system prompt injection**
Agent `name` was `z.string().min(1).max(200)` — no character restriction. `room-agents.ts buildSystemPrompt()` interpolates the name directly: `You are ${agentName}...`. A name containing `\n\nIgnore all rules...` injects arbitrary instructions at the top of the system prompt. Restricted both `CreateAgentSchema` and `UpdateAgentSchema` to reject control characters (`/^[^\x00-\x1f\x7f]+$/`).

**MINOR — fuzzy-resolve branch bypassed `checkToolPermission`**
A slightly-misspelled destructive tool name that resolved with `confidence: 'high'` was executed directly via `executeRegisteredTool()` without the permission gate applied to the direct path. Applied the same `checkToolPermission()` check to the fuzzy-resolved registry branch.

**MINOR — `allowedTools` whitelist not enforced at execution time**
The per-agent `allowedTools` filter was applied only to the advertised tool list (what the LLM *sees*), not at dispatch. A jailbroken model emitting a tool name outside the whitelist still executed it. Added an explicit `allowedTools` check at the top of the dispatch block before any execution branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)