### PR TITLE
fix(tasks): events POST input validation, generate-* ownership check + row cap

### DIFF
--- a/apps/web/src/app/api/epics/[id]/generate-features/route.ts
+++ b/apps/web/src/app/api/epics/[id]/generate-features/route.ts
@@ -6,11 +6,12 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { callDefaultModel } from '@/lib/default-model'
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
   const { id } = await params
 
   const epic = await prisma.epic.findUnique({
@@ -20,6 +21,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   if (!epic) return NextResponse.json({ error: 'Epic not found' }, { status: 404 })
   if (!epic.plan) return NextResponse.json({ error: 'Epic has no plan yet — plan with Claude first' }, { status: 400 })
+  // m3 fix: no ownership check — any user could trigger LLM generation against any epic
+  await assertCanModify(caller, isService, (epic as any).createdBy ?? '')
 
   const prompt = `You are extracting features from an epic plan for a software project.
 
@@ -63,8 +66,11 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON array
     return NextResponse.json({ error: 'Model returned an empty or invalid feature list' }, { status: 500 })
   }
 
+  // B2 fix: cap features created per call — unbounded model response wrote arbitrary rows
+  const MAX_GENERATED = 20
   const created = await Promise.all(
     parsed
+      .slice(0, MAX_GENERATED)
       .filter(f => f.title?.trim())
       .map(f =>
         prisma.feature.create({

--- a/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
+++ b/apps/web/src/app/api/features/[id]/generate-tasks/route.ts
@@ -6,11 +6,12 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { callDefaultModel } from '@/lib/default-model'
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
   const { id } = await params
 
   const feature = await prisma.feature.findUnique({
@@ -19,6 +20,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   })
 
   if (!feature) return NextResponse.json({ error: 'Feature not found' }, { status: 404 })
+  await assertCanModify(caller, isService, (feature as any).createdBy ?? '')
   if (!feature.plan) return NextResponse.json({ error: 'Feature has no plan yet — plan with Claude first' }, { status: 400 })
 
   const prompt = `You are breaking down a feature plan into concrete backlog tasks for a software project.
@@ -72,6 +74,7 @@ Return ONLY a valid JSON array. No markdown, no explanation, just the JSON:
 
   const created = await Promise.all(
     parsed
+      .slice(0, 20)
       .filter(t => t.title?.trim())
       .map(t =>
         prisma.task.create({

--- a/apps/web/src/app/api/tasks/[id]/events/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/events/route.ts
@@ -20,7 +20,21 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const caller = await requireServiceAuth(req)
 
-  const body = await req.json()
+  // M4 fix: previously no validation — malformed JSON threw 500; content/eventType were
+  // unbounded strings written directly to the DB.
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  if (body.content !== undefined && typeof body.content === 'string' && body.content.length > 10_000) {
+    return NextResponse.json({ error: 'content too long (max 10000 chars)' }, { status: 400 })
+  }
+  const VALID_EVENT_TYPES = new Set(['comment', 'status_change', 'note', 'tool_call', 'tool_result', 'system'])
+  if (body.eventType !== undefined && !VALID_EVENT_TYPES.has(String(body.eventType))) {
+    return NextResponse.json({ error: `Invalid eventType. Must be one of: ${[...VALID_EVENT_TYPES].join(', ')}` }, { status: 400 })
+  }
 
   // Validate status transitions — prevents bypassing Veritas by driving tasks
   // directly to 'done' via this route without going through pending_validation.
@@ -45,8 +59,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const event = await prisma.taskEvent.create({
     data: {
       taskId:    params.id,
-      eventType: body.eventType ?? 'comment',
-      content:   body.content ?? null,
+      eventType: (body.eventType as string) ?? 'comment',
+      content:   (body.content as string) ?? null,
       agentId:   typeof (caller as any)?.agentId === 'string' ? (caller as any).agentId : null,
     },
   })


### PR DESCRIPTION
## Summary

**MINOR — tasks/[id]/events POST had no input validation**
- Malformed JSON body threw an unhandled exception → HTTP 500
- `eventType` was an unbounded string written directly to the DB
- `content` had no length limit

Added: JSON parse try/catch → 400, `content` length cap (10,000 chars), `eventType` allowlist (`comment`, `status_change`, `note`, `tool_call`, `tool_result`, `system`).

**MINOR — generate-features / generate-tasks had no ownership check**
Any authenticated user could trigger paid LLM generation against any epic/feature id (via the B1 enumeration gap — any user can list all epics/features). Added `assertCanModify()` so only the owner, admin, or gateway service can trigger generation.

**MINOR — generate-features / generate-tasks wrote unbounded rows**
A verbose model response could create an arbitrary number of feature/task rows in one call. Capped at 20 items per generation call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)