### PR TITLE
fix: deprecate decryptJson plaintext passthrough, chatrooms createdBy, webhook note

### DIFF
--- a/apps/web/src/app/api/webhooks/gitea/route.ts
+++ b/apps/web/src/app/api/webhooks/gitea/route.ts
@@ -17,6 +17,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getGitProvider, getGitProviderConfig } from '@/lib/git-provider'
 
+// NOTE: No replay protection — a captured valid signed webhook can be re-delivered within
+// the signature window. Impact is limited to re-applying a PR status transition (closed/merged).
 export async function POST(req: NextRequest) {
   const rawBody = await req.text()
 


### PR DESCRIPTION
## Summary

Final sweep of remaining low-priority findings.

**MINOR — `decryptJson()` plaintext passthrough should be retired**
`decryptJson()` returns values without the `enc:v1:` prefix unchanged (legacy migration path). Now that `encryption-migrate.ts` has been fixed to use a raw client (#541), this passthrough is no longer needed for new data. Added `@deprecated` JSDoc pointing to `decryptJsonStrict()`.

**MINOR — chatrooms POST `createdBy` from request body**
When no session user was present (gateway token path), the route fell back to `body.createdBy` — letting gateway callers attribute room creation to an arbitrary user id. Changed to `session?.user?.id ?? 'gateway'`.

**MINOR — Gitea webhook has no replay protection**
Unlike the SIEM webhook path (which has `isWithinReplayWindow` + 24h dedup), the Gitea webhook has no replay check. A captured valid signed payload can be re-delivered. Impact is low — it only re-applies a PR `closed`/`merged` status transition. Added a comment documenting the limitation for future maintainers rather than implementing a timestamp check (which Gitea doesn't include in its payload by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)