### PR TITLE
fix(siem): volumetric detection gap + CrowdSec app-layer bouncer

### DIFF
--- a/apps/web/src/app/api/monitoring/security/actions/route.ts
+++ b/apps/web/src/app/api/monitoring/security/actions/route.ts
@@ -10,7 +10,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { requireAdmin } from '@/lib/auth'
 import { decide, execute, gatewayExecutor } from '@/lib/security/action-service'
 import { type ActionRequest } from '@/lib/security/types'
 

--- a/apps/web/src/app/api/monitoring/security/alerts/ack/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/ack/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { requireAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/web/src/app/api/monitoring/security/config/route.ts
+++ b/apps/web/src/app/api/monitoring/security/config/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
-import { requireAdmin } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 

--- a/apps/web/src/jobs/security-poll-ntopng.ts
+++ b/apps/web/src/jobs/security-poll-ntopng.ts
@@ -114,8 +114,17 @@ export async function runNtopngPoller(envId: string): Promise<PollResult> {
 
           const parsed = normalizedEventSchema.parse(event)
 
-          // Skip low-severity normal flows for performance
-          if (parsed.severity < 15 && parsed.type === 'ntopng_flow') {
+          // Skip low-severity, low-volume flows only. High-bytes flows must
+          // be retained regardless of threat score so the volume_sum correlation
+          // rule can detect large data transfers (e.g. data exfiltration).
+          // 50MB threshold: a single flow moving >50MB is worth recording even
+          // if it isn't flagged as a threat by ntopng's heuristics.
+          const flowBytes =
+            (raw.bytes ?? 0) +
+            (raw.source_to_dest_bytes ?? 0) +
+            (raw.destination_to_source_bytes ?? 0)
+          const isLargeTransfer = flowBytes > 50 * 1024 * 1024 // 50 MB
+          if (parsed.severity < 15 && parsed.type === 'ntopng_flow' && !isLargeTransfer) {
             result.eventsSkipped++
             continue
           }

--- a/apps/web/src/lib/security/crowdsec-bouncer.ts
+++ b/apps/web/src/lib/security/crowdsec-bouncer.ts
@@ -1,0 +1,175 @@
+/**
+ * Application-layer CrowdSec bouncer.
+ *
+ * Queries the CrowdSec LAPI for active ban decisions and caches them in
+ * Redis so middleware can check every incoming request without a synchronous
+ * LAPI round-trip.
+ *
+ * Architecture:
+ *   - Decision list is fetched from CROWDSEC_API/v1/decisions?type=ban
+ *   - Each banned IP is stored in Redis under crowdsec:block:{ip} with a
+ *     TTL equal to the decision's remaining duration (min 60s, max 7d).
+ *   - isIpBlocked() reads from Redis (O(1)); falls back to in-memory Set
+ *     if Redis is unavailable.
+ *   - syncDecisions() is called by the worker every 60s. On first call
+ *     it also uses stream=true to get the full list.
+ *
+ * Env vars:
+ *   CROWDSEC_API       — LAPI base URL (e.g. http://crowdsec-lapi.crowdsec:8080)
+ *   CROWDSEC_API_KEY   — Bouncer API key
+ *   CROWDSEC_BLOCK_TTL — Override Redis TTL in seconds (default: decision duration)
+ */
+
+const REDIS_PREFIX = 'crowdsec:block:'
+const FALLBACK_TTL = 300 // seconds; used when decision has no duration
+
+// In-memory fallback for when Redis is unavailable.
+// Keyed by IP, value = expiry timestamp (ms).
+const memoryBlocklist = new Map<string, number>()
+
+interface CrowdSecDecision {
+  id: number
+  origin: string
+  type: string
+  scope: string
+  value: string       // the blocked IP or CIDR
+  duration: string    // e.g. "3h59m51.33s"
+  scenario?: string
+  simulated?: boolean
+}
+
+function parseDurationSeconds(d: string): number {
+  // Parse Go duration strings: "3h59m51.33s", "86400s", "24h0m0s"
+  let total = 0
+  const hours = d.match(/(\d+(?:\.\d+)?)h/)
+  const mins  = d.match(/(\d+(?:\.\d+)?)m(?!s)/) // 'm' not followed by 's' (avoid 'ms')
+  const secs  = d.match(/(\d+(?:\.\d+)?)s/)
+  if (hours) total += parseFloat(hours[1]) * 3600
+  if (mins)  total += parseFloat(mins[1]) * 60
+  if (secs)  total += parseFloat(secs[1])
+  return Math.max(60, Math.ceil(total)) // minimum 60s TTL
+}
+
+// ── Redis lazy client ─────────────────────────────────────────────────────────
+
+let redisClient: any = null
+
+async function getRedis(): Promise<any | null> {
+  if (redisClient) return redisClient
+  try {
+    const ioredis = await import('ioredis')
+    const Redis = ioredis.default || ioredis
+    const sentinelMaster = process.env.REDIS_SENTINEL_MASTER
+    const sentinelNodes  = process.env.REDIS_SENTINEL_NODES
+    let client: any
+    if (sentinelMaster && sentinelNodes) {
+      const nodes = sentinelNodes.split(',').map(n => {
+        const [host, port] = n.trim().split(':')
+        return { host, port: parseInt(port || '26379', 10) }
+      })
+      client = new Redis({ sentinels: nodes, name: sentinelMaster, password: process.env.REDIS_PASSWORD })
+    } else {
+      const url = process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL || 'redis://localhost:6379/0'
+      client = new Redis(url)
+    }
+    await client.ping()
+    redisClient = client
+    return redisClient
+  } catch {
+    return null
+  }
+}
+
+// ── Decision sync ─────────────────────────────────────────────────────────────
+
+let lastSyncAt = 0
+const SYNC_INTERVAL_MS = 60_000
+
+/**
+ * Fetch all current ban decisions from the CrowdSec LAPI and write them
+ * to Redis (and the in-memory fallback). Safe to call on every worker tick.
+ * No-ops if CROWDSEC_API is not configured.
+ */
+export async function syncCrowdSecDecisions(): Promise<void> {
+  const api = process.env.CROWDSEC_API
+  const key = process.env.CROWDSEC_API_KEY
+  if (!api || !key) return
+
+  const now = Date.now()
+  if (now - lastSyncAt < SYNC_INTERVAL_MS) return
+  lastSyncAt = now
+
+  let decisions: CrowdSecDecision[]
+  try {
+    const res = await fetch(`${api}/v1/decisions?type=ban`, {
+      headers: { 'X-Api-Key': key },
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) {
+      console.warn(`[crowdsec-bouncer] LAPI returned ${res.status} — skipping sync`)
+      return
+    }
+    const body = await res.json()
+    decisions = Array.isArray(body) ? body : []
+  } catch (err) {
+    console.warn(`[crowdsec-bouncer] LAPI fetch failed: ${err instanceof Error ? err.message : err}`)
+    return
+  }
+
+  const redis = await getRedis()
+  const overrideTtl = process.env.CROWDSEC_BLOCK_TTL ? parseInt(process.env.CROWDSEC_BLOCK_TTL, 10) : null
+
+  for (const d of decisions) {
+    if (d.type !== 'ban' || !d.value || d.simulated) continue
+    const ttl = overrideTtl ?? parseDurationSeconds(d.duration ?? '')
+    const ip  = d.value
+
+    // Write to Redis
+    if (redis) {
+      await redis.setex(`${REDIS_PREFIX}${ip}`, ttl, '1').catch(() => {/* best-effort */})
+    }
+
+    // Write to in-memory fallback
+    memoryBlocklist.set(ip, now + ttl * 1000)
+  }
+
+  // Evict expired entries from the in-memory fallback
+  const cutoff = Date.now()
+  for (const [ip, exp] of memoryBlocklist) {
+    if (exp < cutoff) memoryBlocklist.delete(ip)
+  }
+}
+
+// ── IP check ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the given IP has an active CrowdSec ban decision.
+ * Checks Redis first; falls back to the in-memory cache.
+ *
+ * This is a pure read path — it does NOT call the LAPI on each request.
+ * Sync is driven by the worker (syncCrowdSecDecisions every 60s).
+ *
+ * NOTE: does not check CIDR blocks, only exact IP matches. CrowdSec
+ * decisions targeting ranges (scope=Range) are not checked here.
+ */
+export async function isIpBlocked(ip: string): Promise<boolean> {
+  if (!ip || ip === 'unknown') return false
+
+  const redis = await getRedis()
+  if (redis) {
+    try {
+      const hit = await redis.exists(`${REDIS_PREFIX}${ip}`)
+      return hit === 1
+    } catch {
+      // fall through to memory
+    }
+  }
+
+  const exp = memoryBlocklist.get(ip)
+  if (!exp) return false
+  if (exp < Date.now()) {
+    memoryBlocklist.delete(ip)
+    return false
+  }
+  return true
+}

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -34,6 +34,10 @@ export type RuleParams =
   | { type: 'malware'; ruleLevel: number; field: string }
   | { type: 'process'; commandPattern: string; window: number }
   | { type: 'composite'; rules: RuleParams[]; combine: 'all' | 'any'; window: number }
+  // volume_sum: aggregates a numeric JSON field from rawEvent across all matching
+  // events in the window. Fires when the total exceeds `thresholdBytes`.
+  // Designed for high-egress / large-transfer detection from ntopng flows.
+  | { type: 'volume_sum'; jsonPath: string; thresholdBytes: number; window: number; sourceFilter?: string[]; groupBy?: string[] }
 
 // ── Correlation ───────────────────────────────────────────────────────────────
 
@@ -210,6 +214,9 @@ export async function correlateEvents(
           break
         case 'composite':
           result = await runCompositeRule(envId, params, since)
+          break
+        case 'volume_sum':
+          result = await runVolumeSumRule(envId, params, since)
           break
       }
       if (result) {
@@ -567,6 +574,84 @@ async function runCompositeRule(
   }
 }
 
+// ── Volume-sum rule ───────────────────────────────────────────────────────────
+
+/**
+ * Volume-sum rule: aggregate a numeric JSON field from rawEvent across all
+ * matching events in the window. Fires when the total exceeds thresholdBytes.
+ *
+ * Used for high-egress / large-transfer detection. Individual ntopng flows
+ * have low per-flow severity even during a multi-GB exfiltration; this rule
+ * aggregates total bytes across flows so the correlator can detect the pattern.
+ *
+ * jsonPath supports one level of dot-notation (e.g. "bytes" or "metadata.bytes").
+ * Postgres CAST is used to extract numeric values from the rawEvent JSON blob.
+ */
+async function runVolumeSumRule(
+  envId: string,
+  params: Extract<RuleParams, { type: 'volume_sum' }>,
+  since: Date
+): Promise<IncidentDraft | null> {
+  const ruleSince = params.window > 0
+    ? new Date(Date.now() - params.window * 1000)
+    : since
+  const effectiveSince = ruleSince < since ? since : ruleSince
+
+  const envFilter = envIdFilter(envId)
+  const sourceFilter = params.sourceFilter ?? []
+
+  // Build a safe JSON path for Postgres: "rawEvent"->'field' or "rawEvent"->'parent'->>'child'
+  const pathParts = params.jsonPath.split('.')
+  let jsonExtract: string
+  if (pathParts.length === 1) {
+    jsonExtract = `("rawEvent"->>'${pathParts[0]}')`
+  } else {
+    const parent = pathParts.slice(0, -1).map(p => `'${p}'`).join('->')
+    const leaf = pathParts[pathParts.length - 1]
+    jsonExtract = `("rawEvent"->${parent}->>'${leaf}')`
+  }
+
+  // Raw SQL: SUM the JSON field across events in the window.
+  // We group by source IP (attackerKey) when groupBy is specified so a single
+  // high-volume sender can be identified in the incident.
+  const rows = await prisma.$queryRawUnsafe<Array<{ total: string; event_ids: string; top_source: string | null }>>(
+    `
+    SELECT
+      COALESCE(SUM(CAST(NULLIF(${jsonExtract}, '') AS BIGINT)), 0)::text AS total,
+      string_agg(id::text, ',' ORDER BY "createdAt" DESC) AS event_ids,
+      (rawEvent->>'source_ip') AS top_source
+    FROM "SecurityEvent"
+    WHERE
+      "createdAt" >= $1
+      ${envFilter !== null ? 'AND "environmentId" = $2' : 'AND "environmentId" IS NULL'}
+      ${sourceFilter.length > 0 ? `AND source = ANY($${envFilter !== null ? 3 : 2}::text[])` : ''}
+    GROUP BY (rawEvent->>'source_ip')
+    ORDER BY SUM(CAST(NULLIF(${jsonExtract}, '') AS BIGINT)) DESC NULLS LAST
+    LIMIT 1
+    `,
+    ...[effectiveSince, ...(envFilter !== null ? [envFilter] : []), ...(sourceFilter.length > 0 ? [sourceFilter] : [])]
+  )
+
+  if (!rows.length) return null
+
+  const totalBytes = Number(rows[0].total ?? 0)
+  if (totalBytes < params.thresholdBytes) return null
+
+  const eventIds = (rows[0].event_ids ?? '').split(',').filter(Boolean).slice(0, 100)
+  const topSource = rows[0].top_source ?? null
+  const gb = (totalBytes / (1024 ** 3)).toFixed(1)
+  const threshold = (params.thresholdBytes / (1024 ** 3)).toFixed(0)
+
+  return {
+    severity: 75,
+    rootCauseSummary: `High traffic volume: ${gb} GB transferred in ${Math.round(params.window / 60)} min (threshold: ${threshold} GB)`,
+    attackerKey: topSource,
+    eventIds,
+    ruleName: 'volume_sum',
+    environmentId: envId,
+  }
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
@@ -583,5 +668,6 @@ async function runSingleRule(
     case 'malware': return runMalwareRule(envId, params, since)
     case 'process': return runProcessRule(envId, params, since)
     case 'composite': return null // handled by runCompositeRule
+    case 'volume_sum': return runVolumeSumRule(envId, params, since)
   }
 }

--- a/apps/web/src/lib/seed-correlation-rules.ts
+++ b/apps/web/src/lib/seed-correlation-rules.ts
@@ -300,6 +300,46 @@ const DEFAULT_RULES = [
     window: 3600,
     enabledByDefault: false,
   },
+
+  // ── Traffic volume anomaly rules ──────────────────────────────────────────
+  // Detects large data transfers that individual flow threat scores would miss.
+  // 84GB uploaded in a day = data exfiltration scenario the SIEM previously
+  // could not catch because per-flow severity was < 15 and flows were dropped.
+  //
+  // Two rules:
+  //   net.high_egress — total outbound bytes from a single source IP > 10 GB/hr
+  //   net.high_total  — total bytes across ALL flows in the env > 50 GB/hr
+  //
+  // Thresholds are intentionally conservative: tune via SecurityConfig if
+  // this is too noisy for your network baseline.
+
+  {
+    name: 'net.high_egress',
+    ruleType: 'volume_sum',
+    params: {
+      type: 'volume_sum',
+      jsonPath: 'source_to_dest_bytes',
+      thresholdBytes: 10 * 1024 * 1024 * 1024, // 10 GB
+      window: 3600, // 1 hour
+      sourceFilter: ['ntopng'],
+    },
+    severity: 75,
+    window: 3600,
+  },
+
+  {
+    name: 'net.high_total',
+    ruleType: 'volume_sum',
+    params: {
+      type: 'volume_sum',
+      jsonPath: 'bytes',
+      thresholdBytes: 50 * 1024 * 1024 * 1024, // 50 GB
+      window: 3600, // 1 hour
+      sourceFilter: ['ntopng'],
+    },
+    severity: 80,
+    window: 3600,
+  },
 ]
 
 /**

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -11,6 +11,7 @@ wrapConsoleLog()
 // See: src/lib/rate-limit-redis.ts
 
 import { rateLimitRedis } from './lib/rate-limit-redis'
+import { isIpBlocked } from './lib/security/crowdsec-bouncer'
 
 function getRateLimitKey(req: NextRequest): string {
   // X-Forwarded-For is intentionally NOT used: the leftmost IP is client-supplied
@@ -204,6 +205,19 @@ export async function middleware(req: NextRequest) {
 
   // ── Generate correlation ID for error tracking (SOC2: [H-002]) ──────────────
   const correlationId = getOrCreateCorrelationId(Object.fromEntries(req.headers))
+
+  // ── CrowdSec IP block check ────────────────────────────────────────────────
+  // Skip for security webhooks (CrowdSec POSTs to us) and health checks —
+  // blocking those would create a feedback loop or break monitoring.
+  const isCrowdSecWebhook = pathname.startsWith('/api/monitoring/security/webhooks')
+  const isHealthCheck     = pathname === '/api/health'
+  if (!isCrowdSecWebhook && !isHealthCheck) {
+    const clientIp = req.ip ?? 'unknown'
+    const blocked = await isIpBlocked(clientIp).catch(() => false)
+    if (blocked) {
+      return new NextResponse('Forbidden', { status: 403 })
+    }
+  }
 
   // SOC2: [M-003] Apply rate limiting before auth check (prevents auth DoS)
   // Public endpoints that are rate-limited still get the check, others skip

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -23,6 +23,7 @@ import { runElkPollerAll } from './jobs/security-poll-elk'
 import { runNtopngPollerAll } from './jobs/security-poll-ntopng'
 import { runDailyScan, runEventTriggeredScan } from './jobs/security-scan-vulns'
 import { runGoalHeartbeat } from './jobs/goal-heartbeat'
+import { syncCrowdSecDecisions } from './lib/security/crowdsec-bouncer'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -906,6 +907,14 @@ async function main() {
     if (runningNtopngPoller) return
     runningNtopngPoller = true
     runNtopngPollerAll().catch(e => err(`ntopng poller failed: ${e}`)).finally(() => { runningNtopngPoller = false })
+  }, 30_000)
+
+  // CrowdSec decision sync — refresh the application-layer blocklist every 60s.
+  // Runs independently of the ntopng/ELK pollers so a slow LAPI doesn't block
+  // event ingestion. syncCrowdSecDecisions() has its own internal debounce so
+  // calling it on a 30s interval is harmless.
+  setInterval(() => {
+    syncCrowdSecDecisions().catch(e => err(`CrowdSec sync failed: ${e}`))
   }, 30_000)
 
   // ── Phase 3: vulnerability scanning ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause of 84 GB undetected**: ntopng flows with severity < 15 were silently dropped before reaching the DB. Large data transfers score low on per-flow threat heuristics, so the entire transfer was invisible to the correlator.
- **New `volume_sum` rule type**: aggregates a numeric JSON field across all matching events in a time window; fires when the total exceeds a configurable byte threshold.
- **Two new correlation rules**: `net.high_egress` (>10 GB/hr from a single source IP) and `net.high_total` (>50 GB/hr total ntopng traffic).
- **CrowdSec application-layer bouncer**: syncs ban decisions into Redis every 60s; middleware checks `isIpBlocked()` before processing any request — defense-in-depth if the Kubernetes ingress bouncer is bypassed.
- **Build fixes**: removed duplicate `requireAdmin` imports in `actions/`, `alerts/ack/`, and `config/` routes that were breaking the webpack compile.

## Changes

| File | Change |
|------|--------|
| `security-poll-ntopng.ts` | Retain flows >50 MB regardless of severity score |
| `rule-engine.ts` | Add `volume_sum` RuleParams type + `runVolumeSumRule` using Postgres raw SUM |
| `seed-correlation-rules.ts` | Add `net.high_egress` and `net.high_total` volume rules |
| `crowdsec-bouncer.ts` | New — Redis-cached CrowdSec LAPI decision sync + `isIpBlocked()` |
| `middleware.ts` | Check `isIpBlocked()` early; skip webhooks/health to avoid feedback loops |
| `worker.ts` | Import + schedule `syncCrowdSecDecisions` every 30s |
| `actions/`, `alerts/ack/`, `config/` routes | Remove duplicate `requireAdmin` import (build fix) |

## Test plan

- [ ] Build passes (verified: `npm run build` exits 0)
- [ ] Low-severity ntopng flow with `bytes > 50MB` now ingests into SecurityEvent
- [ ] `net.high_egress` rule fires when total `source_to_dest_bytes` > 10 GB within 1 hour
- [ ] `net.high_total` rule fires when total `bytes` > 50 GB within 1 hour
- [ ] Middleware returns 403 for an IP present in CrowdSec LAPI decisions
- [ ] Webhooks (`/api/monitoring/security/webhooks/*`) are NOT blocked even for a blocked IP
- [ ] Worker log shows `CrowdSec sync` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)