### PR TITLE
fix: rebuild locally-built Docker services on every deploy

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -205,6 +205,14 @@ echo ""
 echo "Pulling images..."
 GITHUB_ORG="${GITHUB_ORG}" $COMPOSE pull
 
+# ── Rebuild locally-built services ───────────────────────────────────────────
+# These services use build: in docker-compose.yml and are not pushed to a
+# registry, so `pull` is a no-op for them. Rebuild on every deploy so that
+# source changes (e.g. deploy/orion-claude/server.js) are picked up.
+echo ""
+echo "Building local services..."
+GITHUB_ORG="${GITHUB_ORG}" $COMPOSE build vault-unsealer orion-claude claude-refresh orion-executor
+
 # ── Start stack ───────────────────────────────────────────────────────────────
 echo ""
 echo "Starting stack..."


### PR DESCRIPTION
## Summary
- `vault-unsealer`, `orion-claude`, `claude-refresh`, and `orion-executor` all use `build:` in `docker-compose.yml` — they are not pushed to a registry
- `docker compose pull` is a no-op for these services, so source changes never land until the image is manually rebuilt
- This caused the `deploy/orion-claude/server.js` OAuth fix (PR #557) to not take effect after deploy
- Adds `$COMPOSE build <local-services>` in `bootstrap.sh` before `up -d` so every deploy picks up source changes

## Test plan
- [ ] Deploy pipeline rebuilds `orion-claude` and picks up server.js changes
- [ ] Claude OAuth code submission works without "Invalid code format"