### PR TITLE
fix: Claude auth page falsely reports "service not reachable" (rate limit)

### DIFF
--- a/apps/web/src/app/(app)/admin/claude/page.tsx
+++ b/apps/web/src/app/(app)/admin/claude/page.tsx
@@ -102,7 +102,14 @@ export default function ClaudeOAuthPage() {
     setCodeErr(null)
     const res = await fetch('/api/admin/claude/oauth?action=login', { method: 'POST' }).catch(() => null)
     if (!res || !res.ok) {
-      setSvcErr('Claude Code service is not reachable. Make sure orion-claude is running.')
+      if (res?.status === 429) {
+        setSvcErr('Too many requests — please wait a moment and try again.')
+      } else if (!res) {
+        setSvcErr('Claude Code service is not reachable. Make sure orion-claude is running.')
+      } else {
+        const detail = await res.json().catch(() => null) as { error?: string } | null
+        setSvcErr(detail?.error ?? `Failed to start login (HTTP ${res.status}).`)
+      }
       setStarting(false)
       return
     }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -42,6 +42,10 @@ const RATE_LIMITS: Record<string, [number, number]> = {
   // UI polling endpoints — high limit (browser polls every few seconds)
   '/api/jobs': [2000, 15 * 60 * 1000],
   '/api/agents': [2000, 15 * 60 * 1000],
+  // Claude auth admin page polls /api/admin/claude/oauth?action=poll every 1.5s
+  // during login. Without a dedicated limit it exhausts the default bucket and
+  // every subsequent call (including ?action=login) gets a 429.
+  '/api/admin/claude': [2000, 15 * 60 * 1000],
 
   // Default — global limit
   'default': [100, 15 * 60 * 1000],


### PR DESCRIPTION
## Problem

The admin **Claude Code** auth settings page (`/admin/claude`) shows:

> Claude Code service is not reachable. Make sure orion-claude is running.

even though the `orion-claude` container is healthy and fully reachable from the orion container:

- `curl http://orion-claude:3100/health` → `{"ok":true}`
- `POST http://orion-claude:3100/auth/login` → HTTP 200 with a valid OAuth URL (verified via the orion container's own Node `fetch`)

So the failure is in ORION's own code, not in connectivity to the sidecar.

## Root cause

The auth page polls `GET /api/admin/claude/oauth?action=poll` **every 1.5s** while a login is in progress (and once more on mount). That endpoint had **no dedicated rate-limit config**, so it fell under the `default` bucket of **100 requests / 15 min**.

In self-hosted Next.js (Node runtime) `req.ip` is `undefined`, so every client shares the single `'unknown'` rate-limit bucket per path. The 1.5s poll exhausts the 100-request budget within a couple of minutes. After that, the middleware returns **429** to every `/api/admin/claude/*` request — including `POST ?action=login`.

The frontend's `startLogin()` treated *any* non-ok response (including a 429) as "Claude Code service is not reachable", producing the misleading message.

Confirmed live: hammering the poll endpoint returns `429` once the bucket is full.

## Fix

1. **middleware.ts** — give `/api/admin/claude` a dedicated high polling limit (`2000 / 15 min`), matching the existing exemptions for `/api/jobs` and `/api/agents`.
2. **admin/claude/page.tsx** — distinguish a `429` / generic HTTP error from genuine unreachability, so the surfaced message reflects what actually happened instead of always blaming the sidecar.

## Testing

- `tsc --noEmit` passes for the web app.
- Reproduced the 429 against the live endpoint before the fix; the new limit (2000/15min) comfortably covers a 1.5s poll cadence (~600 req/15min).

No Docker containers were restarted and no deploy/compose files were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)