### PR TITLE
fix: truncate oversized prompts before passing to claude CLI (E2BIG)

### DIFF
--- a/deploy/orion-claude/server.js
+++ b/deploy/orion-claude/server.js
@@ -69,6 +69,20 @@ function sanitizeSystemPrompt(systemPrompt) {
   return systemPrompt.slice(0, 20000)
 }
 
+// Linux ARG_MAX is typically 128KB. We reserve headroom for env vars and flags.
+// Prompts exceeding this cause execFile to fail with E2BIG (silently, due to unref).
+const PROMPT_CHAR_LIMIT = 80000
+
+function sanitizePrompt(prompt) {
+  const s = String(prompt || '')
+  if (s.length <= PROMPT_CHAR_LIMIT) return s
+  // Keep the tail (most recent messages) — the model needs recency more than deep history.
+  const truncated = s.slice(s.length - PROMPT_CHAR_LIMIT)
+  // Trim to a clean line boundary so we don't split mid-word.
+  const newline = truncated.indexOf('\n')
+  return newline > 0 ? truncated.slice(newline + 1) : truncated
+}
+
 function sanitizeMaxTurns(maxTurns, fallback = 20) {
   const n = Number(maxTurns)
   if (!Number.isFinite(n)) return fallback
@@ -115,7 +129,8 @@ function runClaude(prompt, { systemPrompt, model, maxTurns = 20, timeout = 12000
     const useMcp          = !!agentId
     const safeMaxTurns    = sanitizeMaxTurns(maxTurns, useMcp ? 10 : 1)
 
-    const args = ['-p', String(prompt), '--output-format', 'json']
+    const safePrompt = sanitizePrompt(prompt)
+    const args = ['-p', safePrompt, '--output-format', 'json']
     if (safeModel)        args.push('--model', safeModel)
     if (safeSystemPrompt) args.push('--append-system-prompt', safeSystemPrompt)
     args.push('--max-turns', String(safeMaxTurns))


### PR DESCRIPTION
## Summary
- When a room accumulates a lot of history (e.g. cascading "service error" notices), the combined `-p <history>` + `--append-system-prompt <system>` args can exceed Linux `ARG_MAX` (128KB)
- `execFile` fails with `E2BIG`, but `child.unref()` suppresses the error callback, so the error is swallowed — no log, silent failure
- room-agents gets a fast HTTP 500 with no body → `mapClaudeError` → `'service error'` → another notice posted → history grows → loop
- Archivist room had 430 agent messages / 154KB, well over the limit

## Fix
- `sanitizePrompt()` caps the prompt at 80KB, keeping the **tail** (most recent messages) so the model has recency context
- Prompt tail is trimmed to a clean newline boundary
- System prompt already capped at 20KB by `sanitizeSystemPrompt`; combined headroom leaves ~28KB for env vars + flags

## Also fixed (manually)
- Inserted a compaction message into the Archivist room to break the immediate cascade

## Test plan
- [ ] Deploy rebuilds orion-claude via bootstrap.sh (PR #559)
- [ ] Archivist responds normally at next heartbeat
- [ ] Alpha responds normally to chat messages