### PR TITLE
feat: integrated planning-to-execution loop + agentic infrastructure improvements

### DIFF
--- a/apps/web/prisma/migrations/20_add_task_dependencies/migration.sql
+++ b/apps/web/prisma/migrations/20_add_task_dependencies/migration.sql
@@ -1,0 +1,14 @@
+-- Migration: Task dependencies + execution wave
+--
+-- Adds two columns to the Task table to support the integrated
+-- planning-to-execution loop:
+--   dependsOn — Task IDs that must reach status 'done' before this task runs.
+--               Prisma scalar string array; the worker checks dependency
+--               satisfaction in-memory because Postgres can't relationally
+--               filter "all elements of this array are in a done-set".
+--   wave      — execution wave computed at plan-approval time (0 = no deps,
+--               1 = depends on a wave-0 task, etc.). Drives poll ordering so
+--               earlier waves run first.
+
+ALTER TABLE "Task" ADD COLUMN "dependsOn" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "Task" ADD COLUMN "wave" INTEGER;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -267,6 +267,8 @@ model Task {
   retryCount     Int           @default(0)
   maxRetries     Int           @default(3)
   nextRetryAt    DateTime?
+  dependsOn      String[]      @default([]) // IDs of Task records that must be 'done' before this runs
+  wave           Int? // Execution wave (0 = no deps, 1 = depends on wave-0, etc.) — computed at plan approval time
   events         TaskEvent[]
   metadata       Json?
   chatRooms      ChatRoom[]    @relation("ChatRoomTask")

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { Sidebar } from '@/components/layout/Sidebar'
 import { Header } from '@/components/layout/Header'
 import { StatusBar } from '@/components/layout/StatusBar'
 import { BottomNav } from '@/components/layout/BottomNav'
+import { PendingPlanApprovals } from '@/components/notifications/PendingPlanApprovals'
 import { prisma } from '@/lib/db'
 import type { Metadata } from 'next'
 
@@ -27,6 +28,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       </div>
       <StatusBar />
       <BottomNav />
+      <PendingPlanApprovals />
     </>
   )
 }

--- a/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
+import { computeWaves } from '../../../features/[id]/approve-plan/route'
+
+/**
+ * POST /api/epics/:id/approve-plan
+ *
+ * Approves every feature under the epic that has a plan + tasks but is not yet
+ * approved. For each such feature it sets planApprovedAt/planApprovedBy and
+ * computes execution waves for its tasks.
+ */
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  const epic = await prisma.epic.findUnique({
+    where: { id: params.id },
+    include: {
+      features: {
+        include: { tasks: { select: { id: true, dependsOn: true } } },
+      },
+    },
+  })
+  if (!epic) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, epic.createdBy)
+
+  const approvedBy = caller?.id ?? 'gateway'
+
+  const toApprove = epic.features.filter(
+    f => f.plan && f.planApprovedAt === null && f.tasks.length > 0
+  )
+
+  const ops: Prisma.PrismaPromise<unknown>[] = []
+  for (const feature of toApprove) {
+    const waveMap = computeWaves(feature.tasks)
+    ops.push(
+      prisma.feature.update({
+        where: { id: feature.id },
+        data: { planApprovedAt: new Date(), planApprovedBy: approvedBy },
+      })
+    )
+    for (const t of feature.tasks) {
+      ops.push(prisma.task.update({ where: { id: t.id }, data: { wave: waveMap.get(t.id) ?? 0 } }))
+    }
+  }
+
+  if (ops.length > 0) await prisma.$transaction(ops)
+
+  return NextResponse.json({
+    ok: true,
+    epicId: epic.id,
+    approvedFeatures: toApprove.map(f => f.id),
+    approvedCount: toApprove.length,
+    planApprovedBy: approvedBy,
+  })
+}

--- a/apps/web/src/app/api/features/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/features/[id]/approve-plan/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
+
+interface WaveTask {
+  id: string
+  dependsOn: string[]
+}
+
+/**
+ * Compute the execution wave for every task in a feature.
+ *
+ * Wave 0 = task with no dependencies. Wave N = 1 + the max wave of its
+ * dependencies. Cycles are guarded (a task that transitively depends on
+ * itself resolves to wave 0 rather than recursing forever).
+ */
+export function computeWaves(tasks: WaveTask[]): Map<string, number> {
+  const waveMap = new Map<string, number>()
+  const taskMap = new Map(tasks.map(t => [t.id, t]))
+
+  function getWave(taskId: string, visited = new Set<string>()): number {
+    const cached = waveMap.get(taskId)
+    if (cached !== undefined) return cached
+    if (visited.has(taskId)) return 0 // cycle guard
+    visited.add(taskId)
+    const task = taskMap.get(taskId)
+    // Unknown dependency IDs (outside this feature) are treated as wave-0 anchors.
+    const deps = (task?.dependsOn ?? []).filter(depId => taskMap.has(depId))
+    if (!task || deps.length === 0) {
+      waveMap.set(taskId, 0)
+      return 0
+    }
+    const maxDepWave = Math.max(...deps.map(depId => getWave(depId, new Set(visited))))
+    const wave = maxDepWave + 1
+    waveMap.set(taskId, wave)
+    return wave
+  }
+
+  tasks.forEach(t => getWave(t.id))
+  return waveMap
+}
+
+/**
+ * POST /api/features/:id/approve-plan
+ *
+ * Gates feature execution: sets planApprovedAt/planApprovedBy and computes the
+ * execution wave for every task under the feature. The worker only picks up
+ * tasks whose feature has planApprovedAt set.
+ */
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  const feature = await prisma.feature.findUnique({
+    where: { id: params.id },
+    include: { tasks: { select: { id: true, dependsOn: true } } },
+  })
+  if (!feature) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, feature.createdBy)
+
+  if (!feature.plan) {
+    return NextResponse.json({ error: 'Feature has no plan to approve' }, { status: 400 })
+  }
+  if (feature.tasks.length === 0) {
+    return NextResponse.json({ error: 'Feature has no tasks to execute' }, { status: 400 })
+  }
+
+  const approvedBy = caller?.id ?? 'gateway'
+  const waveMap = computeWaves(feature.tasks)
+
+  await prisma.$transaction([
+    prisma.feature.update({
+      where: { id: feature.id },
+      data: { planApprovedAt: new Date(), planApprovedBy: approvedBy },
+    }),
+    ...feature.tasks.map(t =>
+      prisma.task.update({
+        where: { id: t.id },
+        data: { wave: waveMap.get(t.id) ?? 0 },
+      })
+    ),
+  ])
+
+  const waveCount = new Set(waveMap.values()).size
+  return NextResponse.json({
+    ok: true,
+    featureId: feature.id,
+    taskCount: feature.tasks.length,
+    waveCount,
+    planApprovedBy: approvedBy,
+  })
+}

--- a/apps/web/src/app/api/tasks/[id]/cancel/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/cancel/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
+
+/**
+ * POST /api/tasks/:id/cancel
+ *
+ * Cancels a task — used to reject a plan that paused for approval, or to stop a
+ * task before it runs. Marks the task 'failed' and records a TaskEvent.
+ */
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  const task = await prisma.task.findUnique({ where: { id: params.id } })
+  if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, task.createdBy)
+
+  const cancelledBy = caller?.id ?? 'gateway'
+
+  await prisma.task.update({ where: { id: task.id }, data: { status: 'failed' } })
+  await prisma.taskEvent.create({
+    data: {
+      taskId: task.id,
+      eventType: 'cancelled',
+      content: `Cancelled by user (${cancelledBy})`,
+      agentId: null,
+    },
+  })
+
+  return NextResponse.json({ ok: true, id: task.id, status: 'failed' })
+}

--- a/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
+
+/**
+ * POST /api/tasks/:id/resume-plan
+ *
+ * Approves a task that paused at plan-before-execute (status
+ * 'pending_validation'). Flips it back to 'pending' and records
+ * metadata.planApproved = true so the worker skips re-planning and executes
+ * the stored plan directly.
+ */
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  const task = await prisma.task.findUnique({ where: { id: params.id } })
+  if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, task.createdBy)
+
+  if (task.status !== 'pending_validation') {
+    return NextResponse.json(
+      { error: `Task is not awaiting plan approval (status: ${task.status})` },
+      { status: 400 }
+    )
+  }
+
+  const meta = (task.metadata ?? {}) as Record<string, unknown>
+  const planContent = (meta.planContent as string | undefined) ?? null
+  const approvedBy = caller?.id ?? 'gateway'
+
+  await prisma.task.update({
+    where: { id: task.id },
+    data: {
+      status: 'pending',
+      // Re-arm the retry gate so the poll loop picks it up immediately.
+      nextRetryAt: null,
+      planApprovedBy: approvedBy,
+      planApprovedAt: new Date(),
+      // Persist the approved plan text if the task didn't already have one.
+      ...(!task.plan && planContent ? { plan: planContent } : {}),
+      metadata: { ...meta, planApproved: true } as object,
+    },
+  })
+
+  await prisma.taskEvent.create({
+    data: {
+      taskId: task.id,
+      eventType: 'plan_approved',
+      content: `Plan approved by ${approvedBy} — resuming execution.`,
+      agentId: null,
+    },
+  })
+
+  return NextResponse.json({ ok: true, id: task.id, status: 'pending' })
+}

--- a/apps/web/src/components/notifications/PendingPlanApprovals.tsx
+++ b/apps/web/src/components/notifications/PendingPlanApprovals.tsx
@@ -1,0 +1,119 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { Pause, Play, XCircle, X, Loader2 } from 'lucide-react'
+
+interface PendingTask {
+  id: string
+  title: string
+  status: string
+  metadata: Record<string, unknown> | null
+}
+
+const RISK_COLORS: Record<string, string> = {
+  low: 'text-status-healthy',
+  medium: 'text-yellow-400',
+  high: 'text-orange-400',
+  critical: 'text-status-error',
+}
+
+/**
+ * Surfaces tasks paused at plan-before-execute (status 'pending_validation'
+ * with metadata.planApproved === false) as actionable notification cards.
+ * Resume → /api/tasks/:id/resume-plan, Cancel → /api/tasks/:id/cancel.
+ */
+export function PendingPlanApprovals() {
+  const [tasks, setTasks]         = useState<PendingTask[]>([])
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+  const [acting, setActing]       = useState<string | null>(null)
+
+  const fetchPending = useCallback(async () => {
+    try {
+      const data: PendingTask[] = await fetch('/api/tasks?status=pending_validation').then(r => r.json())
+      // Only show tasks that paused for plan approval (not those awaiting human
+      // validation of completed work — those have no planRisk in metadata).
+      setTasks(
+        (Array.isArray(data) ? data : []).filter(t => {
+          const meta = (t.metadata ?? {}) as Record<string, unknown>
+          return meta.planApproved === false && meta.planRisk !== undefined
+        })
+      )
+    } catch { /* silent */ }
+  }, [])
+
+  useEffect(() => {
+    fetchPending()
+    const timer = setInterval(fetchPending, 15_000)
+    return () => clearInterval(timer)
+  }, [fetchPending])
+
+  const resume = async (task: PendingTask) => {
+    setActing(task.id)
+    try {
+      await fetch(`/api/tasks/${task.id}/resume-plan`, { method: 'POST' })
+      setTasks(prev => prev.filter(t => t.id !== task.id))
+    } finally { setActing(null) }
+  }
+
+  const cancel = async (task: PendingTask) => {
+    setActing(task.id)
+    try {
+      await fetch(`/api/tasks/${task.id}/cancel`, { method: 'POST' })
+      setTasks(prev => prev.filter(t => t.id !== task.id))
+    } finally { setActing(null) }
+  }
+
+  const dismiss = (id: string) => setDismissed(prev => new Set([...prev, id]))
+
+  const visible = tasks.filter(t => !dismissed.has(t.id))
+  if (visible.length === 0) return null
+
+  return createPortal(
+    <div className="fixed bottom-16 right-4 z-40 flex flex-col gap-2 items-end max-w-sm">
+      {visible.map(task => {
+        const meta = (task.metadata ?? {}) as Record<string, unknown>
+        const risk = String(meta.planRisk ?? 'high')
+        const riskColor = RISK_COLORS[risk] ?? 'text-orange-400'
+        return (
+          <div key={task.id}
+            className="w-full rounded-xl border border-orange-500/40 bg-bg-sidebar shadow-2xl overflow-hidden animate-in slide-in-from-right-4 duration-200">
+            {/* Header */}
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-orange-500/20 bg-orange-500/5">
+              <Pause size={12} className="text-orange-400 flex-shrink-0" />
+              <span className="text-xs font-semibold text-orange-400 flex-1 truncate">Agent paused for approval</span>
+              <button onClick={() => dismiss(task.id)} className="p-0.5 rounded text-text-muted hover:text-text-primary transition-colors">
+                <X size={12} />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="px-3 py-2.5">
+              <p className="text-sm font-medium text-text-primary">{task.title}</p>
+              <p className="text-xs mt-0.5">
+                Risk level: <span className={`font-semibold uppercase ${riskColor}`}>{risk}</span>
+              </p>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 px-3 py-2 border-t border-border-subtle bg-bg-card">
+              <button
+                onClick={() => cancel(task)}
+                disabled={acting === task.id}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-medium text-status-error border border-status-error/30 hover:bg-status-error/10 transition-colors disabled:opacity-50">
+                <XCircle size={11} /> Cancel
+              </button>
+              <div className="flex-1" />
+              <button
+                onClick={() => resume(task)}
+                disabled={acting === task.id}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-medium bg-status-healthy/15 text-status-healthy border border-status-healthy/30 hover:bg-status-healthy/25 transition-colors disabled:opacity-50">
+                {acting === task.id ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />} Resume
+              </button>
+            </div>
+          </div>
+        )
+      })}
+    </div>,
+    document.body
+  )
+}

--- a/apps/web/src/components/tasks/EpicDetailPanel.tsx
+++ b/apps/web/src/components/tasks/EpicDetailPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Trash2, GitBranch, Plus, Sparkles, Loader2, MessageSquare } from 'lucide-react'
+import { Trash2, GitBranch, Plus, Sparkles, Loader2, MessageSquare, Rocket, CheckCircle2 } from 'lucide-react'
 import type { Epic, Feature } from '@/types/tasks'
 import { PlanWithAIButton } from './PlanWithAIButton'
 import { DetailPanelShell } from '../ui/DetailPanelShell'
@@ -26,8 +26,28 @@ export function EpicDetailPanel({ epic, onUpdate, onDelete, onPlanWithClaude, on
   const [generating, setGenerating] = useState(false)
   const [genError, setGenError]   = useState<string | null>(null)
   const [epicPlanningRoom, setEpicPlanningRoom] = useState<{ id: string } | null>(null)
+  const [approving, setApproving]   = useState(false)
+  const [justApproved, setJustApproved] = useState(false)
+
+  // Features that have a plan + tasks but are not yet approved.
+  const unapprovedFeatures = epic.features.filter(
+    f => f.plan && !f.planApprovedAt && (f._count?.tasks ?? 0) > 0
+  )
+
+  const handleApproveAll = async () => {
+    setApproving(true)
+    try {
+      const r = await fetch(`/api/epics/${epic.id}/approve-plan`, { method: 'POST' })
+      if (r.ok) setJustApproved(true)
+    } catch (e) {
+      console.error('[approve-epic]', e)
+    } finally {
+      setApproving(false)
+    }
+  }
 
   useEffect(() => {
+    setJustApproved(false)
     setTitle(epic.title)
     setDesc(epic.description ?? '')
     setPlan(epic.plan ?? '')
@@ -98,6 +118,21 @@ export function EpicDetailPanel({ epic, onUpdate, onDelete, onPlanWithClaude, on
             </button>
           )}
           {genError && <p className="text-[10px] text-status-error text-center">{genError}</p>}
+          {unapprovedFeatures.length > 0 && !justApproved && (
+            <button
+              onClick={handleApproveAll}
+              disabled={approving}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded bg-status-healthy/15 text-status-healthy border border-status-healthy/30 text-sm hover:bg-status-healthy/25 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {approving ? <Loader2 size={14} className="animate-spin" /> : <Rocket size={14} />}
+              Approve All Plans ({unapprovedFeatures.length})
+            </button>
+          )}
+          {justApproved && (
+            <p className="text-xs text-status-healthy text-center flex items-center justify-center gap-1.5">
+              <CheckCircle2 size={13} /> Plans approved — agents will begin shortly
+            </p>
+          )}
           <button
             onClick={onDelete}
             className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded border border-border-subtle text-text-muted text-sm hover:border-status-error hover:text-status-error transition-colors"
@@ -170,6 +205,11 @@ export function EpicDetailPanel({ epic, onUpdate, onDelete, onPlanWithClaude, on
             >
               <GitBranch size={11} className="text-text-muted flex-shrink-0" />
               <span className="text-xs text-text-primary flex-1 truncate">{f.title}</span>
+              {f.status === 'done'
+                ? <CheckCircle2 size={11} className="text-status-healthy flex-shrink-0" />
+                : f.planApprovedAt
+                  ? <Rocket size={11} className="text-status-healthy flex-shrink-0" />
+                  : null}
               <span className="text-[10px] text-text-muted">{f._count?.tasks ?? 0}</span>
             </div>
           ))}

--- a/apps/web/src/components/tasks/EpicTreeNav.tsx
+++ b/apps/web/src/components/tasks/EpicTreeNav.tsx
@@ -1,11 +1,11 @@
 'use client'
 import { useState } from 'react'
-import { ChevronRight, ChevronDown, Plus, Layers, GitBranch, Inbox } from 'lucide-react'
+import { ChevronRight, ChevronDown, Plus, Layers, GitBranch, Inbox, Check } from 'lucide-react'
 import type { Epic, SelectionState } from '@/types/tasks'
 
 interface Props {
   epics: Epic[]
-  tasks: { featureId: string | null }[]
+  tasks: { featureId: string | null; status: string }[]
   selection: SelectionState
   onSelect: (s: SelectionState) => void
   onNewEpic: () => void
@@ -26,6 +26,12 @@ export function EpicTreeNav({ epics, tasks, selection, onSelect, onNewEpic, onNe
 
   const epicTaskCount = (epic: Epic) =>
     epic.features.reduce((n, f) => n + (f._count?.tasks ?? 0), 0)
+
+  // Per-feature completion stats from the live task list.
+  const featureStats = (featureId: string) => {
+    const fTasks = tasks.filter(t => t.featureId === featureId)
+    return { total: fTasks.length, done: fTasks.filter(t => t.status === 'done').length }
+  }
 
   const isActive = (s: SelectionState) => {
     if (s.kind !== selection.kind) return false
@@ -83,15 +89,21 @@ export function EpicTreeNav({ epics, tasks, selection, onSelect, onNewEpic, onNe
                 <div className="ml-3 border-l border-border-subtle pl-2 mb-1">
                   {epic.features.map(f => {
                     const fSel: SelectionState = { kind: 'feature', epicId: epic.id, featureId: f.id }
+                    const stats = featureStats(f.id)
+                    const isDone = f.status === 'done' || (stats.total > 0 && stats.done === stats.total)
                     return (
                       <div
                         key={f.id}
                         onClick={() => onSelect(fSel)}
                         className={`${rowBase} ${isActive(fSel) ? rowActive : rowIdle}`}
                       >
-                        <GitBranch size={11} className="flex-shrink-0 text-text-muted" />
+                        {isDone
+                          ? <Check size={11} className="flex-shrink-0 text-status-healthy" />
+                          : <GitBranch size={11} className="flex-shrink-0 text-text-muted" />}
                         <span className="flex-1 truncate">{f.title}</span>
-                        <span className="text-[10px] text-text-muted">{f._count?.tasks ?? 0}</span>
+                        <span className="text-[10px] text-text-muted">
+                          {stats.total > 0 ? `${stats.done}/${stats.total}` : (f._count?.tasks ?? 0)}
+                        </span>
                       </div>
                     )
                   })}

--- a/apps/web/src/components/tasks/FeatureDetailPanel.tsx
+++ b/apps/web/src/components/tasks/FeatureDetailPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { Trash2, Sparkles, Loader2, MessageSquare } from 'lucide-react'
+import { Trash2, Sparkles, Loader2, MessageSquare, CheckCircle2, Lock, Rocket } from 'lucide-react'
 import type { Feature } from '@/types/tasks'
 import { PlanWithAIButton } from './PlanWithAIButton'
 import { DetailPanelShell } from '../ui/DetailPanelShell'
@@ -26,12 +26,24 @@ export function FeatureDetailPanel({ feature, epicTitle, onUpdate, onDelete, onP
   const [genError, setGenError]     = useState<string | null>(null)
   const [creatingRoom, setCreatingRoom] = useState(false)
 
+  const [taskCount, setTaskCount]       = useState(feature._count?.tasks ?? 0)
+  const [doneCount, setDoneCount]       = useState(0)
+  const [approvedAt, setApprovedAt]     = useState<string | null>(feature.planApprovedAt ?? null)
+  const [approvedBy, setApprovedBy]     = useState<string | null>(feature.planApprovedBy ?? null)
+  const [approving, setApproving]       = useState(false)
+  const [justApproved, setJustApproved] = useState(false)
+
   useEffect(() => {
     setTitle(feature.title)
     setDesc(feature.description ?? '')
     setPlan(feature.plan ?? '')
     setStatus(feature.status)
     setGenError(null)
+    setApprovedAt(feature.planApprovedAt ?? null)
+    setApprovedBy(feature.planApprovedBy ?? null)
+    setJustApproved(false)
+    setTaskCount(feature._count?.tasks ?? 0)
+    setDoneCount(0)
     // Fetch fresh data — plan may have been saved from the chat screen
     fetch(`/api/features/${feature.id}`)
       .then(r => r.ok ? r.json() : null)
@@ -41,9 +53,38 @@ export function FeatureDetailPanel({ feature, epicTitle, onUpdate, onDelete, onP
           setPlan(fresh.plan ?? '')
           onUpdate({ plan: fresh.plan ?? null }).catch((e) => console.error("[fetch]", e))
         }
+        setApprovedAt(fresh.planApprovedAt ?? null)
+        setApprovedBy(fresh.planApprovedBy ?? null)
+        if (typeof fresh._count?.tasks === 'number') setTaskCount(fresh._count.tasks)
+      })
+      .catch((e) => console.error("[fetch]", e))
+    // Fetch task completion stats for the progress bar
+    fetch(`/api/tasks?featureId=${feature.id}`)
+      .then(r => r.ok ? r.json() : null)
+      .then((tasks: Array<{ status: string }> | null) => {
+        if (!Array.isArray(tasks)) return
+        setTaskCount(tasks.length)
+        setDoneCount(tasks.filter(t => t.status === 'done').length)
       })
       .catch((e) => console.error("[fetch]", e))
   }, [feature.id])
+
+  const handleApprovePlan = async () => {
+    setApproving(true)
+    try {
+      const r = await fetch(`/api/features/${feature.id}/approve-plan`, { method: 'POST' })
+      if (r.ok) {
+        const now = new Date().toISOString()
+        setApprovedAt(now)
+        setJustApproved(true)
+        onUpdate({ planApprovedAt: now }).catch((e) => console.error('[approve]', e))
+      }
+    } catch (e) {
+      console.error('[approve]', e)
+    } finally {
+      setApproving(false)
+    }
+  }
 
   const handlePlanFeature = async () => {
     setCreatingRoom(true)
@@ -165,8 +206,56 @@ export function FeatureDetailPanel({ feature, epicTitle, onUpdate, onDelete, onP
         />
       </div>
 
+      {/* ── Plan approval gate ── */}
+      {plan && !approvedAt && taskCount > 0 && (
+        <div className="rounded-lg border border-status-healthy/30 bg-status-healthy/5 p-3 space-y-2">
+          <p className="text-xs font-medium text-text-primary">
+            {taskCount} {taskCount === 1 ? 'task' : 'tasks'} ready to run
+          </p>
+          {justApproved ? (
+            <p className="text-xs text-status-healthy flex items-center gap-1.5">
+              <CheckCircle2 size={13} /> Plan approved — agents will begin shortly
+            </p>
+          ) : (
+            <button
+              onClick={handleApprovePlan}
+              disabled={approving}
+              className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded bg-status-healthy/15 text-status-healthy border border-status-healthy/30 text-sm hover:bg-status-healthy/25 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {approving ? <Loader2 size={14} className="animate-spin" /> : <Rocket size={14} />}
+              Approve Plan &amp; Start Execution
+            </button>
+          )}
+        </div>
+      )}
+      {approvedAt && (
+        <p className="text-[11px] text-status-healthy flex items-center gap-1.5">
+          <Lock size={11} /> Plan approved {new Date(approvedAt).toLocaleDateString()}
+          {approvedBy ? ` by ${approvedBy}` : ''}
+        </p>
+      )}
+
+      {/* ── Task progress ── */}
+      {taskCount > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between text-[10px] text-text-muted">
+            <span className="flex items-center gap-1">
+              {feature.status === 'done' && <CheckCircle2 size={11} className="text-status-healthy" />}
+              {doneCount} / {taskCount} tasks complete
+            </span>
+            <span>{Math.round((doneCount / taskCount) * 100)}%</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-bg-raised overflow-hidden">
+            <div
+              className="h-full rounded-full bg-status-healthy transition-all"
+              style={{ width: `${taskCount > 0 ? (doneCount / taskCount) * 100 : 0}%` }}
+            />
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center gap-2 text-[10px] text-text-muted">
-        <span>{feature._count?.tasks ?? 0} tasks</span>
+        <span>{taskCount} tasks</span>
         <span>·</span>
         <span>Created {new Date(feature.createdAt).toLocaleDateString()}</span>
       </div>

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -446,6 +446,16 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
         : `I want to plan this task:\n\n**${target.title}**\n\n${target.description ?? 'No description yet.'}\n\nHelp me break this down into a clear implementation plan.`
     }
 
+    // For feature planning, prepend the task-creation contract so the agent
+    // decomposes the plan into dependency-ordered tasks via orion_create_task.
+    if (target.type === 'feature') {
+      const prefixRes = await fetch(`/api/admin/prompts/${encodeURIComponent('system.feature-planning-prefix')}`)
+      if (prefixRes.ok) {
+        const { content } = await prefixRes.json() as { content: string }
+        if (content?.trim()) initialContext = `${content}\n\n---\n\n${initialContext}`
+      }
+    }
+
     // Prepend parent context as background framing so Claude understands lineage without
     // treating the parent plan as the thing to produce — the specific item stays the ask.
     if (target.type === 'feature' && target.parentContext) {

--- a/apps/web/src/lib/system-prompts.ts
+++ b/apps/web/src/lib/system-prompts.ts
@@ -378,8 +378,33 @@ Your job:
 2. Structure it with: What it does, How it works (technical), Acceptance Criteria, Tasks (numbered list).
 3. After presenting, ask: "Does this look right? Save it with the Save as Plan button."
 4. Once confirmed saved, offer: "Want me to create the tasks on the board now? Each task will get a step-by-step implementation plan for the executing agent."
-5. Call orion_create_task for each task with a detailed numbered plan. Each step should be specific enough that a smaller LLM can execute it without additional context — include file paths, function names, expected outputs.
-6. After creating tasks, ask: "Tasks are on the board. Want to plan the next feature, or are we done for now?"`,
+5. Call orion_create_task for each task in the plan. For each task provide:
+   - A clear title and a numbered step-by-step implementation plan. Each step must be specific enough that a smaller LLM can execute it without additional context — include file paths, function names, expected outputs.
+   - depends_on: [taskId1, taskId2] — the IDs returned by earlier orion_create_task calls for any task that must complete first. Tasks with no dependencies start in wave 0; dependents run in later waves.
+   - priority: critical | high | medium | low.
+   - assignedAgent: the name of the specialist best suited to the task, when known.
+6. After creating all tasks, output a summary: "Created N tasks across M waves. Wave 0 tasks will start immediately on plan approval; Wave 1 tasks after Wave 0 completes."
+7. Then ask: "Tasks are on the board. Approve the plan from the feature panel to start execution, plan the next feature, or are we done for now?"`,
+  },
+
+  {
+    key: 'system.feature-planning-prefix',
+    name: 'Feature Planning — Task Creation Prefix',
+    category: 'system',
+    description: 'Prepended to the feature-planning chat context. Instructs the planning agent to decompose the feature into dependency-ordered tasks via orion_create_task. No dynamic variables.',
+    content: `## Planning → Execution Contract (REQUIRED)
+
+When asked to plan a feature, you MUST translate the plan into executable tasks:
+
+1. Write a structured plan as the feature plan (saved via the Save as Plan button).
+2. Call \`orion_create_task\` for EACH task in the plan. For every task provide:
+   - A clear **title** and a numbered, step-by-step implementation **plan** (file paths, function/component names, expected outputs — specific enough for a smaller LLM to execute without you).
+   - **depends_on**: an array of the Task IDs (returned by your earlier \`orion_create_task\` calls) that must reach status "done" before this task runs. Omit or pass [] for tasks with no prerequisites.
+   - **priority**: critical | high | medium | low.
+   - **assignedAgent**: the specialist name that should execute the task, when one is appropriate.
+3. After creating every task, output a summary line: "Created N tasks across M waves. Wave 0 tasks will start immediately on plan approval; Wave 1 tasks after Wave 0 completes."
+
+Dependencies are how execution order is expressed — ORION computes execution "waves" from your depends_on edges at plan-approval time. Wave 0 = no dependencies; wave K = depends on a wave-(K-1) task. Be deliberate: only add a dependency when one task genuinely needs another's output.`,
   },
 
   {

--- a/apps/web/src/lib/task-completion.ts
+++ b/apps/web/src/lib/task-completion.ts
@@ -1,0 +1,52 @@
+/**
+ * Completion rollup — when the last task of a feature reaches 'done', mark the
+ * feature done and post a summary to its chat room; likewise roll an epic up to
+ * 'done' when all its features are done.
+ *
+ * Invoked from the place a task transitions to 'done' (orion_close_task) so the
+ * rollup runs regardless of whether the close came from an agent or a human.
+ */
+import type { PrismaClient } from '@prisma/client'
+
+async function postRoomSummary(
+  prisma: PrismaClient,
+  where: { featureId: string } | { epicId: string },
+  content: string
+): Promise<void> {
+  const room = await prisma.chatRoom.findFirst({ where, select: { id: true } })
+  if (!room) return
+  await prisma.chatMessage
+    .create({ data: { roomId: room.id, senderType: 'system', content } })
+    .catch(() => {})
+}
+
+export async function checkEpicCompletion(epicId: string, prisma: PrismaClient): Promise<void> {
+  const epic = await prisma.epic.findUnique({
+    where: { id: epicId },
+    include: { features: { select: { status: true } } },
+  })
+  if (!epic) return
+  const allDone = epic.features.length > 0 && epic.features.every(f => f.status === 'done')
+  if (allDone && epic.status !== 'done') {
+    await prisma.epic.update({ where: { id: epicId }, data: { status: 'done' } })
+    await postRoomSummary(prisma, { epicId }, `✅ All features complete. Epic '${epic.title}' is done.`)
+  }
+}
+
+export async function checkFeatureCompletion(featureId: string, prisma: PrismaClient): Promise<void> {
+  const feature = await prisma.feature.findUnique({
+    where: { id: featureId },
+    include: { tasks: { select: { status: true } } },
+  })
+  if (!feature) return
+  const allDone = feature.tasks.length > 0 && feature.tasks.every(t => t.status === 'done')
+  if (allDone && feature.status !== 'done') {
+    await prisma.feature.update({ where: { id: featureId }, data: { status: 'done' } })
+    await postRoomSummary(
+      prisma,
+      { featureId },
+      `✅ All tasks complete. Feature '${feature.title}' is done.`
+    )
+    await checkEpicCompletion(feature.epicId, prisma)
+  }
+}

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -474,13 +474,21 @@ async function handleCloseTask(args: unknown, ctx: ToolExecutionContext): Promis
   if (!task_id) return 'Error: task_id is required'
   if (!summary?.trim()) return 'Error: summary is required'
 
-  const task = await ctx.prisma.task.findUnique({ where: { id: task_id }, select: { title: true, status: true } })
+  const task = await ctx.prisma.task.findUnique({ where: { id: task_id }, select: { title: true, status: true, featureId: true } })
   if (!task) return `Error: task ${task_id} not found`
   if (task.status !== 'pending_validation') {
     return `Error: task is "${task.status}" — orion_close_task only operates on pending_validation tasks`
   }
 
   await ctx.prisma.task.update({ where: { id: task_id }, data: { status: 'done' } })
+
+  // Completion rollup — if this was the last task of the feature, mark the
+  // feature (and possibly its epic) done and post summaries to their rooms.
+  if (task.featureId) {
+    const { checkFeatureCompletion } = await import('./task-completion')
+    await checkFeatureCompletion(task.featureId, ctx.prisma as unknown as import('@prisma/client').PrismaClient).catch(() => {})
+  }
+
   const msg = `✅ Validated & closed **${task.title}** — ${summary}`
   await auditLog(ctx.agentId ?? ctx.userId, msg)
   return `Closed task "${task.title}"`
@@ -716,17 +724,27 @@ async function handleCreateFeature(args: unknown, ctx: ToolExecutionContext): Pr
 }
 
 async function handleCreateTask(args: unknown, ctx: ToolExecutionContext): Promise<string> {
-  const { featureId, title, description, plan, targetEnvironment, dedup_key } = parseArgs(args) as {
+  const { featureId, title, description, plan, targetEnvironment, dedup_key, depends_on, priority } = parseArgs(args) as {
     featureId?: string
     title?: string
     description?: string
     plan?: string
     dedup_key?: string
+    depends_on?: unknown
+    priority?: string
     targetEnvironment?: { namespace?: string; hostname?: string; storageClass?: string; vaultPath?: string }
   }
   if (!featureId) return 'Error: featureId is required'
   if (!title?.trim()) return 'Error: title is required'
   if (!plan?.trim()) return 'Error: plan is required'
+
+  // Normalize depends_on to a clean string[] of non-empty task IDs.
+  const dependsOn: string[] = Array.isArray(depends_on)
+    ? depends_on.filter((d): d is string => typeof d === 'string' && d.trim().length > 0).map(d => d.trim())
+    : []
+
+  const validPriorities = ['critical', 'high', 'medium', 'low']
+  const taskPriority = priority && validPriorities.includes(priority) ? priority : 'medium'
 
   const feature = await ctx.prisma.feature.findUnique({ where: { id: featureId } })
   if (!feature) return `Error: feature ${featureId} not found`
@@ -756,7 +774,8 @@ async function handleCreateTask(args: unknown, ctx: ToolExecutionContext): Promi
       description: description || null,
       plan:        plan.trim(),
       status:      'pending',
-      priority:    'medium',
+      priority:    taskPriority,
+      dependsOn,
       createdBy:   actorId ?? 'agent',
       metadata:    {
         ...(targetEnvironment ? { targetEnvironment } : {}),
@@ -765,7 +784,7 @@ async function handleCreateTask(args: unknown, ctx: ToolExecutionContext): Promi
     },
   })
   await auditLog(actorId, `📋 Created task **${task.title}** (\`${task.id}\`) under feature \`${featureId}\`${targetEnvironment?.namespace ? ` → namespace: ${targetEnvironment.namespace}` : ''}`)
-  return JSON.stringify({ id: task.id, title: task.title, featureId: task.featureId, plan: task.plan, targetEnvironment: targetEnvironment ?? null }, null, 2)
+  return JSON.stringify({ id: task.id, title: task.title, featureId: task.featureId, plan: task.plan, dependsOn, priority: taskPriority, targetEnvironment: targetEnvironment ?? null }, null, 2)
 }
 
 async function handleProposeGitops(args: unknown, ctx: ToolExecutionContext): Promise<string> {
@@ -1720,6 +1739,16 @@ registerTool({
       dedup_key: {
         type: 'string',
         description: 'Optional deduplication key. If an open task (pending/running/pending_validation) with this exact key already exists under the same feature, creation is skipped and the existing task is returned. Use a stable identifier like "pulse:host:vault-proxy" or "pulse:node:talos-rpi2".',
+      },
+      depends_on: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Optional list of Task IDs that must reach status "done" before this task is allowed to run. Use the IDs returned by previous orion_create_task calls to express ordering (e.g. a deploy task that depends on a build task). Execution waves are computed from these dependencies at plan-approval time.',
+      },
+      priority: {
+        type: 'string',
+        enum: ['critical', 'high', 'medium', 'low'],
+        description: 'Optional task priority. Defaults to "medium". Higher-priority tasks within the same execution wave run first.',
       },
     },
     required: ['featureId', 'title', 'plan'],

--- a/apps/web/src/types/tasks.ts
+++ b/apps/web/src/types/tasks.ts
@@ -41,7 +41,9 @@ export interface Feature {
   status: string
   createdAt: string
   updatedAt: string
-  _count?: { tasks: number }
+  planApprovedAt?: string | null
+  planApprovedBy?: string | null
+  _count?: { tasks: number; doneTasks?: number }
 }
 
 export interface Epic {
@@ -52,6 +54,8 @@ export interface Epic {
   status: string
   createdAt: string
   updatedAt: string
+  planApprovedAt?: string | null
+  planApprovedBy?: string | null
   features: Feature[]
 }
 

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -341,10 +341,20 @@ async function runTask(taskId: string): Promise<void> {
     // inside createRunner() — no need to fetch them here.
     let systemPrompt = injectedPreamble + '\n\n' + agentSystemPrompt + agentsMdSection + wikiContext
 
-    // Prepend plan-before-execute instruction if configured on this agent
-    if (contextConfig.planBeforeExecute === true) {
+    // Plan-before-execute gating. If a previously-paused plan has been approved
+    // (metadata.planApproved === true, set by /api/tasks/:id/resume-plan), skip
+    // the planning phase entirely and execute the stored plan directly.
+    const taskMeta = (task.metadata ?? {}) as Record<string, unknown>
+    const planAlreadyApproved = taskMeta.planApproved === true
+    const planBeforeExecute = contextConfig.planBeforeExecute === true && !planAlreadyApproved
+    if (planBeforeExecute) {
       const planPrefix = await getPrompt('system.task-plan-prefix')
       systemPrompt = planPrefix + '\n\n' + systemPrompt
+    } else if (planAlreadyApproved) {
+      systemPrompt =
+        '## Plan Approved\n\nYour plan for this task has been reviewed and approved by a human. ' +
+        'Do NOT emit another <plan> block — proceed directly to executing the approved plan step by step.\n\n' +
+        systemPrompt
     }
 
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
@@ -399,6 +409,7 @@ async function runTask(taskId: string): Promise<void> {
     const runner = createRunner(modelId)
     let outputText = ''
     let toolsUsed: string[] = []
+    let pausedForApproval = false
 
     // Plan-before-execute gating: when enabled, the agent emits a <plan> block
     // up front. If the plan is high/critical risk, we pause the task for human
@@ -472,26 +483,35 @@ async function runTask(taskId: string): Promise<void> {
           throw new Error(event.error)
       }
 
-      // Stop consuming the runner once we've paused for plan approval — no further
-      // tools should execute until a human/supervisor approves the plan.
+      // Stop consuming the runner once we've paused for plan approval — no
+      // further tools should execute until a human approves the plan.
       if (pausedForApproval) break
     }
 
-    // Plan-before-execute: high/critical-risk plan paused for approval.
+    // Plan-before-execute: high/critical-risk plan paused for approval. Persist
+    // risk + plan text into metadata so the approval UI can surface them and
+    // /api/tasks/:id/resume-plan can restore the approved plan.
     if (pausedForApproval) {
       const plan = parsePlan(outputText)
       const risk = plan?.riskLevel ?? 'high'
+      const planText = plan?.raw ?? outputText.slice(0, 4000)
       const pauseMsg =
         `⏸️ **Plan paused for approval** (risk: ${risk})\n\n` +
-        `Task **${task.title}** produced a ${risk}-risk plan and is awaiting human or supervisor approval before any tools run.\n\n` +
+        `Task **${task.title}** produced a ${risk}-risk plan and is awaiting human approval before any tools run.\n\n` +
         (plan?.summary ? `Summary: ${plan.summary}\n` : '') +
         (plan?.rollbackSteps?.length
           ? `Rollback steps:\n${plan.rollbackSteps.map((s) => `  - ${s}`).join('\n')}\n`
           : plan?.rollbackStrategy ? `Rollback: ${plan.rollbackStrategy}\n` : '')
       await Promise.all([
-        prisma.task.update({ where: { id: taskId }, data: { status: 'pending_validation' } }),
+        prisma.task.update({
+          where: { id: taskId },
+          data: {
+            status: 'pending_validation',
+            metadata: { ...taskMeta, planRisk: risk, planContent: planText, planApproved: false } as object,
+          },
+        }),
         logTaskEvent(taskId, 'plan_pending_approval',
-          `Risk=${risk}. ${plan?.summary ?? ''}\n\n${plan?.raw ?? outputText.slice(0, 2000)}`, agent.id),
+          `Risk=${risk}. ${plan?.summary ?? ''}\n\n${planText}`, agent.id),
         postToFeed(agent.id, pauseMsg, taskId),
         ...(featureRoomId ? [postToRoom(featureRoomId, agent.id, pauseMsg, taskId)] : []),
       ])
@@ -685,7 +705,7 @@ export function parsePlan(text: string): ParsedPlan | null {
   }
 }
 
-/** High/critical-risk plans must be approved by a human or supervisor before tools run. */
+/** High/critical-risk plans must be approved by a human before tools run. */
 export function planRequiresApproval(plan: ParsedPlan | null): boolean {
   return plan?.riskLevel === 'high' || plan?.riskLevel === 'critical'
 }
@@ -1166,25 +1186,59 @@ async function pollOnce() {
   if (runningTasks.size >= MAX_CONCURRENT) return
 
   const available = MAX_CONCURRENT - runningTasks.size
-  const tasks = await prisma.task.findMany({
+
+  // Candidate pending tasks. Two gates beyond status='pending':
+  //  1. feature.planApprovedAt must be set — no feature-scoped task runs until
+  //     its feature plan is approved by a human (the plan-approval gate).
+  //     Tasks with no feature (ad-hoc/system tasks) are exempt.
+  //  2. all task.dependsOn IDs must be 'done' — checked in-memory below because
+  //     Postgres can't relationally filter "every element of this scalar array
+  //     is in a done-set".
+  // Ordered by wave so earlier waves drain before later ones.
+  const pending = await prisma.task.findMany({
     where: {
       status:        'pending',
       assignedAgent: { not: null },
-      OR: [{ nextRetryAt: null }, { nextRetryAt: { lte: new Date() } }],
+      AND: [
+        { OR: [{ nextRetryAt: null }, { nextRetryAt: { lte: new Date() } }] },
+        {
+          OR: [
+            { featureId: null },
+            { feature: { planApprovedAt: { not: null } } },
+          ],
+        },
+      ],
       agent: {
         NOT: {
           metadata: { path: ['archived'], equals: true },
         },
       },
     },
-    orderBy: [{ priority: 'desc' }, { createdAt: 'asc' }],
-    take: available,
-    select: { id: true },
+    orderBy: [{ wave: 'asc' }, { priority: 'desc' }, { createdAt: 'asc' }],
+    select: { id: true, dependsOn: true },
   })
 
-  for (const { id } of tasks) {
-    if (!runningTasks.has(id)) {
-      runTask(id).catch(e => err(`Unhandled error in runTask(${id}): ${e}`))
+  if (pending.length === 0) return
+
+  // Build the set of completed task IDs referenced by any candidate's deps.
+  const depIds = [...new Set(pending.flatMap(t => t.dependsOn))]
+  const completedTaskIds = new Set<string>()
+  if (depIds.length > 0) {
+    const doneDeps = await prisma.task.findMany({
+      where: { id: { in: depIds }, status: 'done' },
+      select: { id: true },
+    })
+    for (const d of doneDeps) completedTaskIds.add(d.id)
+  }
+
+  let launched = 0
+  for (const task of pending) {
+    if (launched >= available) break
+    // Dependency gate: every depended-upon task must be done.
+    if (!task.dependsOn.every(depId => completedTaskIds.has(depId))) continue
+    if (!runningTasks.has(task.id)) {
+      runTask(task.id).catch(e => err(`Unhandled error in runTask(${task.id}): ${e}`))
+      launched++
     }
   }
 }


### PR DESCRIPTION
## Summary

Full end-to-end agentic loop: state intent → agent decomposes into tasks → approve plan → agents execute autonomously in dependency order → loop closes on completion.

### Planning → Execution

- `Task.dependsOn String[]` + `Task.wave Int?` schema migration — enables DAG execution ordering
- Worker gates task pickup on `feature.planApprovedAt` (nothing runs until you approve)
- Dependency-aware poll: tasks only become eligible when all `dependsOn` tasks are `done`
- Wave-ordered execution: wave 0 tasks run in parallel, wave N waits for N-1
- `orion_create_task` now accepts `depends_on[]` so planning agents produce the full dependency graph

### Approval Gates

- `POST /api/features/:id/approve-plan` — computes topological waves, unblocks execution
- `POST /api/epics/:id/approve-plan` — approves all features at once
- `POST /api/tasks/:id/resume-plan` — resumes a `pending_validation` task, skips re-planning
- `POST /api/tasks/:id/cancel` — cancels a paused task

### UI

- `FeatureDetailPanel`: "Approve Plan & Start Execution" button, progress bar, lock indicator
- `EpicDetailPanel`: "Approve All Plans" + per-feature status icons
- `EpicTreeNav`: done/total count per feature
- `PendingPlanApprovals`: notification component that surfaces `pending_validation` tasks as actionable cards (Resume / Cancel) — fixes the gap where agents said "approve me" but nothing appeared

### Completion Rollup (`lib/task-completion.ts`)

- Task done → check all sibling tasks → mark feature done → check epic → mark epic done → post summary to chat room at each level

### Agent Intelligence (from prior commits)

- `verify_steps[]` + `rollback_steps[]` in plan schema — agents must verify after acting
- Auto-write task outcomes to knowledge base on completion — future agents learn from past resolutions
- Watcher state persistence — prevents re-assignment loops every 60s
- Role-aware tool grouping — agents get relevant tool subsets, not all 56 tools
- Remediation loop detection — escalates after 2 failed attempts
- Progressive context loading — `knowledge_load_context` tool for on-demand retrieval

### Gateway Tools

- `backup.ts` — Velero DR tools (5 tools)
- `kubectl_exec` in `kubernetes.ts` — allowlisted read-only exec (curl, nc, nslookup, dig, etc.)

## Test plan

- [ ] Create a feature, use "Plan with AI" — agent should call `orion_create_task` with `depends_on` fields
- [ ] Verify tasks appear with wave numbers after plan approval
- [ ] Approve plan via Feature panel — confirm tasks become eligible in the worker
- [ ] Confirm wave 0 tasks run in parallel, wave 1 waits
- [ ] Trigger a high/critical risk plan — confirm `PendingPlanApprovals` notification appears
- [ ] Resume and cancel from notification card
- [ ] Complete all tasks in a feature — confirm feature rolls to `done`, chat room summary posted
- [ ] Complete all features in an epic — confirm epic rolls to `done`

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_