### PR TITLE
feat(tasks): partial plan approval — block individual steps before resuming

### DIFF
--- a/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
@@ -9,6 +9,11 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
  * 'pending_validation'). Flips it back to 'pending' and records
  * metadata.planApproved = true so the worker skips re-planning and executes
  * the stored plan directly.
+ *
+ * Body (optional JSON):
+ *   { blockedSteps?: number[] }  — zero-based indices of plan steps to skip.
+ *     When provided, the worker injects a note telling the agent to skip these
+ *     steps before executing the rest of the approved plan.
  */
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const caller = await requireServiceAuth(req)
@@ -25,32 +30,44 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     )
   }
 
+  // Parse optional blockedSteps from request body
+  let blockedSteps: number[] = []
+  try {
+    const body = await req.json().catch(() => ({}))
+    if (Array.isArray(body?.blockedSteps)) {
+      blockedSteps = body.blockedSteps.filter((n: unknown) => typeof n === 'number' && Number.isInteger(n) && n >= 0)
+    }
+  } catch { /* no body — treat as full approval */ }
+
   const meta = (task.metadata ?? {}) as Record<string, unknown>
   const planContent = (meta.planContent as string | undefined) ?? null
+  const planSteps = (meta.planSteps as string[] | undefined) ?? []
   const approvedBy = caller?.id ?? 'gateway'
 
   await prisma.task.update({
     where: { id: task.id },
     data: {
       status: 'pending',
-      // Re-arm the retry gate so the poll loop picks it up immediately.
       nextRetryAt: null,
       planApprovedBy: approvedBy,
       planApprovedAt: new Date(),
-      // Persist the approved plan text if the task didn't already have one.
       ...(!task.plan && planContent ? { plan: planContent } : {}),
-      metadata: { ...meta, planApproved: true } as object,
+      metadata: { ...meta, planApproved: true, blockedSteps } as object,
     },
   })
+
+  const blockedNote = blockedSteps.length > 0
+    ? ` Blocked steps: ${blockedSteps.map(i => `#${i + 1} (${planSteps[i] ?? '?'})`).join(', ')}.`
+    : ''
 
   await prisma.taskEvent.create({
     data: {
       taskId: task.id,
       eventType: 'plan_approved',
-      content: `Plan approved by ${approvedBy} — resuming execution.`,
+      content: `Plan approved by ${approvedBy} — resuming execution.${blockedNote}`,
       agentId: null,
     },
   })
 
-  return NextResponse.json({ ok: true, id: task.id, status: 'pending' })
+  return NextResponse.json({ ok: true, id: task.id, status: 'pending', blockedSteps })
 }

--- a/apps/web/src/components/notifications/PendingPlanApprovals.tsx
+++ b/apps/web/src/components/notifications/PendingPlanApprovals.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { Pause, Play, XCircle, X, Loader2 } from 'lucide-react'
+import { Pause, Play, XCircle, X, Loader2, ChevronDown, ChevronUp, ShieldAlert, ShieldOff } from 'lucide-react'
 
 interface PendingTask {
   id: string
@@ -11,27 +11,39 @@ interface PendingTask {
 }
 
 const RISK_COLORS: Record<string, string> = {
-  low: 'text-status-healthy',
-  medium: 'text-yellow-400',
-  high: 'text-orange-400',
+  low:      'text-status-healthy',
+  medium:   'text-yellow-400',
+  high:     'text-orange-400',
   critical: 'text-status-error',
+}
+
+const RISK_BORDER: Record<string, string> = {
+  low:      'border-status-healthy/40',
+  medium:   'border-yellow-500/40',
+  high:     'border-orange-500/40',
+  critical: 'border-status-error/40',
 }
 
 /**
  * Surfaces tasks paused at plan-before-execute (status 'pending_validation'
  * with metadata.planApproved === false) as actionable notification cards.
- * Resume → /api/tasks/:id/resume-plan, Cancel → /api/tasks/:id/cancel.
+ *
+ * Supports partial plan approval: each plan step can be individually blocked
+ * before resuming. Blocked steps are skipped by the agent when it resumes.
  */
 export function PendingPlanApprovals() {
   const [tasks, setTasks]         = useState<PendingTask[]>([])
   const [dismissed, setDismissed] = useState<Set<string>>(new Set())
   const [acting, setActing]       = useState<string | null>(null)
+  const [actionError, setActionError] = useState<Record<string, string>>({})
+  // Per-task: set of step indices the human has blocked
+  const [blockedSteps, setBlockedSteps] = useState<Record<string, Set<number>>>({})
+  // Per-task: whether the steps panel is expanded
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
   const fetchPending = useCallback(async () => {
     try {
       const data: PendingTask[] = await fetch('/api/tasks?status=pending_validation').then(r => r.json())
-      // Only show tasks that paused for plan approval (not those awaiting human
-      // validation of completed work — those have no planRisk in metadata).
       setTasks(
         (Array.isArray(data) ? data : []).filter(t => {
           const meta = (t.metadata ?? {}) as Record<string, unknown>
@@ -47,20 +59,49 @@ export function PendingPlanApprovals() {
     return () => clearInterval(timer)
   }, [fetchPending])
 
+  const toggleStep = (taskId: string, stepIdx: number) => {
+    setBlockedSteps(prev => {
+      const current = new Set(prev[taskId] ?? [])
+      if (current.has(stepIdx)) current.delete(stepIdx)
+      else current.add(stepIdx)
+      return { ...prev, [taskId]: current }
+    })
+  }
+
+  const toggleExpanded = (taskId: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(taskId)) next.delete(taskId)
+      else next.add(taskId)
+      return next
+    })
+  }
+
   const resume = async (task: PendingTask) => {
     setActing(task.id)
+    setActionError(prev => ({ ...prev, [task.id]: '' }))
+    const blocked = [...(blockedSteps[task.id] ?? [])]
     try {
-      await fetch(`/api/tasks/${task.id}/resume-plan`, { method: 'POST' })
-      setTasks(prev => prev.filter(t => t.id !== task.id))
-    } finally { setActing(null) }
+      const r = await fetch(`/api/tasks/${task.id}/resume-plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ blockedSteps: blocked }),
+      })
+      if (r.ok) setTasks(prev => prev.filter(t => t.id !== task.id))
+      else setActionError(prev => ({ ...prev, [task.id]: 'Failed to resume task' }))
+    } catch { setActionError(prev => ({ ...prev, [task.id]: 'Network error' })) }
+    finally { setActing(null) }
   }
 
   const cancel = async (task: PendingTask) => {
     setActing(task.id)
+    setActionError(prev => ({ ...prev, [task.id]: '' }))
     try {
-      await fetch(`/api/tasks/${task.id}/cancel`, { method: 'POST' })
-      setTasks(prev => prev.filter(t => t.id !== task.id))
-    } finally { setActing(null) }
+      const r = await fetch(`/api/tasks/${task.id}/cancel`, { method: 'POST' })
+      if (r.ok) setTasks(prev => prev.filter(t => t.id !== task.id))
+      else setActionError(prev => ({ ...prev, [task.id]: 'Failed to cancel task' }))
+    } catch { setActionError(prev => ({ ...prev, [task.id]: 'Network error' })) }
+    finally { setActing(null) }
   }
 
   const dismiss = (id: string) => setDismissed(prev => new Set([...prev, id]))
@@ -69,47 +110,119 @@ export function PendingPlanApprovals() {
   if (visible.length === 0) return null
 
   return createPortal(
-    <div className="fixed bottom-16 right-4 z-40 flex flex-col gap-2 items-end max-w-sm">
+    <div className="fixed bottom-16 right-4 z-40 flex flex-col gap-2 items-end max-w-sm w-full">
       {visible.map(task => {
-        const meta = (task.metadata ?? {}) as Record<string, unknown>
-        const risk = String(meta.planRisk ?? 'high')
-        const riskColor = RISK_COLORS[risk] ?? 'text-orange-400'
+        const meta    = (task.metadata ?? {}) as Record<string, unknown>
+        const risk    = String(meta.planRisk ?? 'high')
+        const steps   = (meta.planSteps as string[] | undefined) ?? []
+        const summary = (meta.planContent as string | undefined)?.slice(0, 200) ?? ''
+        const riskColor  = RISK_COLORS[risk]  ?? 'text-orange-400'
+        const riskBorder = RISK_BORDER[risk]  ?? 'border-orange-500/40'
+        const blocked    = blockedSteps[task.id] ?? new Set<number>()
+        const isExpanded = expanded.has(task.id)
+        const blockedCount = blocked.size
+        const isActing = acting === task.id
+
         return (
           <div key={task.id}
-            className="w-full rounded-xl border border-orange-500/40 bg-bg-sidebar shadow-2xl overflow-hidden animate-in slide-in-from-right-4 duration-200">
+            className={`w-full rounded-xl border ${riskBorder} bg-bg-sidebar shadow-2xl overflow-hidden animate-in slide-in-from-right-4 duration-200`}>
+
             {/* Header */}
-            <div className="flex items-center gap-2 px-3 py-2 border-b border-orange-500/20 bg-orange-500/5">
-              <Pause size={12} className="text-orange-400 flex-shrink-0" />
-              <span className="text-xs font-semibold text-orange-400 flex-1 truncate">Agent paused for approval</span>
+            <div className={`flex items-center gap-2 px-3 py-2 border-b ${riskBorder} bg-orange-500/5`}>
+              <Pause size={12} className={`${riskColor} flex-shrink-0`} />
+              <span className={`text-xs font-semibold ${riskColor} flex-1 truncate`}>Agent paused for approval</span>
               <button onClick={() => dismiss(task.id)} className="p-0.5 rounded text-text-muted hover:text-text-primary transition-colors">
                 <X size={12} />
               </button>
             </div>
 
             {/* Body */}
-            <div className="px-3 py-2.5">
-              <p className="text-sm font-medium text-text-primary">{task.title}</p>
-              <p className="text-xs mt-0.5">
-                Risk level: <span className={`font-semibold uppercase ${riskColor}`}>{risk}</span>
+            <div className="px-3 py-2.5 space-y-1.5">
+              <p className="text-sm font-medium text-text-primary leading-snug">{task.title}</p>
+              <p className="text-xs text-text-muted">
+                Risk: <span className={`font-semibold uppercase ${riskColor}`}>{risk}</span>
+                {steps.length > 0 && (
+                  <span className="ml-2 text-text-muted">· {steps.length} step{steps.length !== 1 ? 's' : ''}</span>
+                )}
+                {blockedCount > 0 && (
+                  <span className="ml-1 text-status-error font-medium">· {blockedCount} blocked</span>
+                )}
               </p>
+              {summary && !isExpanded && (
+                <p className="text-[11px] text-text-muted leading-relaxed line-clamp-2">{summary}</p>
+              )}
             </div>
+
+            {/* Steps panel — toggle */}
+            {steps.length > 0 && (
+              <>
+                <button
+                  onClick={() => toggleExpanded(task.id)}
+                  className="w-full flex items-center justify-between px-3 py-1.5 text-xs text-text-muted hover:text-text-primary border-t border-border-subtle bg-bg-card/50 transition-colors">
+                  <span>{isExpanded ? 'Hide steps' : 'Review steps'}</span>
+                  {isExpanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+                </button>
+
+                {isExpanded && (
+                  <div className="border-t border-border-subtle bg-bg-raised divide-y divide-border-subtle">
+                    <p className="px-3 py-1.5 text-[10px] text-text-muted uppercase tracking-wide">
+                      Toggle steps to block — blocked steps will be skipped
+                    </p>
+                    {steps.map((step, i) => {
+                      const isBlocked = blocked.has(i)
+                      return (
+                        <button
+                          key={i}
+                          onClick={() => toggleStep(task.id, i)}
+                          className={`w-full flex items-start gap-2 px-3 py-2 text-left transition-colors hover:bg-bg-sidebar
+                            ${isBlocked ? 'bg-status-error/5' : ''}`}>
+                          <div className="mt-0.5 flex-shrink-0">
+                            {isBlocked
+                              ? <ShieldOff size={12} className="text-status-error" />
+                              : <ShieldAlert size={12} className="text-status-healthy" />}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <span className={`text-[11px] leading-relaxed ${isBlocked ? 'line-through text-text-muted' : 'text-text-primary'}`}>
+                              <span className="font-mono text-text-muted mr-1">{i + 1}.</span>
+                              {step}
+                            </span>
+                          </div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Error */}
+            {actionError[task.id] && (
+              <p className="px-3 py-1.5 text-xs text-status-error bg-status-error/10 border-t border-status-error/20">
+                {actionError[task.id]}
+              </p>
+            )}
 
             {/* Actions */}
             <div className="flex items-center gap-2 px-3 py-2 border-t border-border-subtle bg-bg-card">
               <button
                 onClick={() => cancel(task)}
-                disabled={acting === task.id}
+                disabled={isActing}
                 className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-medium text-status-error border border-status-error/30 hover:bg-status-error/10 transition-colors disabled:opacity-50">
                 <XCircle size={11} /> Cancel
               </button>
               <div className="flex-1" />
+              {blockedCount > 0 && (
+                <span className="text-[10px] text-status-error">{blockedCount} step{blockedCount !== 1 ? 's' : ''} blocked</span>
+              )}
               <button
                 onClick={() => resume(task)}
-                disabled={acting === task.id}
+                disabled={isActing}
                 className="flex items-center gap-1 px-2.5 py-1.5 rounded text-xs font-medium bg-status-healthy/15 text-status-healthy border border-status-healthy/30 hover:bg-status-healthy/25 transition-colors disabled:opacity-50">
-                {acting === task.id ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />} Resume
+                {isActing ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />}
+                {blockedCount > 0 ? 'Approve (partial)' : 'Approve & Resume'}
               </button>
             </div>
+
           </div>
         )
       })}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -424,10 +424,20 @@ async function runTask(taskId: string): Promise<void> {
       const planPrefix = await getPrompt('system.task-plan-prefix')
       systemPrompt = planPrefix + '\n\n' + systemPrompt
     } else if (planAlreadyApproved) {
-      systemPrompt =
-        '## Plan Approved\n\nYour plan for this task has been reviewed and approved by a human. ' +
-        'Do NOT emit another <plan> block — proceed directly to executing the approved plan step by step.\n\n' +
-        systemPrompt
+      const blockedSteps = (taskMeta.blockedSteps as number[] | undefined) ?? []
+      const planSteps = (taskMeta.planSteps as string[] | undefined) ?? []
+      let approvedNote = '## Plan Approved\n\nYour plan for this task has been reviewed and approved by a human. ' +
+        'Do NOT emit another <plan> block — proceed directly to executing the approved plan step by step.\n\n'
+      if (blockedSteps.length > 0 && planSteps.length > 0) {
+        const blockedDescriptions = blockedSteps
+          .filter(i => i >= 0 && i < planSteps.length)
+          .map(i => `  - Step ${i + 1}: ${planSteps[i]}`)
+          .join('\n')
+        approvedNote +=
+          `**The following steps were BLOCKED by the approver and must NOT be executed:**\n${blockedDescriptions}\n\n` +
+          'Skip these steps entirely and proceed with the remaining approved steps.\n\n'
+      }
+      systemPrompt = approvedNote + systemPrompt
     }
 
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
@@ -625,7 +635,13 @@ async function runTask(taskId: string): Promise<void> {
           where: { id: taskId },
           data: {
             status: 'pending_validation',
-            metadata: { ...taskMeta, planRisk: risk, planContent: planText, planApproved: false } as object,
+            metadata: {
+              ...taskMeta,
+              planRisk: risk,
+              planContent: planText,
+              planSteps: plan?.steps ?? [],
+              planApproved: false,
+            } as object,
           },
         }),
         logTaskEvent(taskId, 'plan_pending_approval',
@@ -811,6 +827,8 @@ export interface ParsedPlan {
   estimatedDuration: string | null
   /** @deprecated prose fallback kept for backwards compat — prefer rollbackSteps */
   rollbackStrategy: string | null
+  /** Execution steps from <steps> — used for partial plan approval UI. */
+  steps: string[]
   /** How the agent will confirm the action worked (parsed from <verify_steps>). */
   verifySteps: string[]
   /** Concrete tool-call steps to undo the change (parsed from <rollback_steps>). */
@@ -848,6 +866,7 @@ export function parsePlan(text: string): ParsedPlan | null {
     riskLevel,
     estimatedDuration: tag('estimated_duration'),
     rollbackStrategy: tag('rollback_strategy'),
+    steps: stepList('steps'),
     verifySteps: stepList('verify_steps'),
     rollbackSteps: stepList('rollback_steps'),
     raw: planMatch[0],


### PR DESCRIPTION
## Summary

Completes the HITL story by allowing humans to approve or block individual plan steps rather than accepting/rejecting the whole plan.

- **ParsedPlan.steps**: parse `<steps>` from plan XML (already in the plan schema) — stored alongside `verifySteps`/`rollbackSteps`
- **Worker**: persists `metadata.planSteps[]` when pausing a task for approval
- **Worker**: injects a "blocked steps" note into the system prompt when resuming an approved plan, so the agent skips those specific steps
- **resume-plan API**: accepts optional `{ blockedSteps: number[] }` body; stores indices in task metadata; includes them in the `plan_approved` audit event
- **PendingPlanApprovals UI**: expandable step list with per-step approve/block toggles — `ShieldAlert` (green) = approved, `ShieldOff` (red) = blocked; blocked steps shown with strikethrough; button changes to "Approve (partial)" when any steps are blocked; blocked count shown in header

## How it works

1. Agent emits a `<plan>` with `<steps>` before any tools run
2. Worker parses steps and stores them in `metadata.planSteps`
3. Notification card appears — human clicks "Review steps" to expand
4. Human toggles any steps they want to block (e.g. a destructive delete step)
5. Human clicks "Approve (partial)" → `POST /api/tasks/:id/resume-plan` with `{ blockedSteps: [2] }`
6. Worker resumes and injects: *"Step 3 was BLOCKED by the approver and must NOT be executed"*
7. Agent skips the blocked step and proceeds with the rest

## Test plan

- [ ] Create a high-risk task with `planBeforeExecute: true` — confirm `metadata.planSteps` is populated when it pauses
- [ ] Open the notification card — confirm steps expand when clicking "Review steps"
- [ ] Block one step — confirm it shows strikethrough and blocked count updates
- [ ] Click "Approve (partial)" — confirm `plan_approved` TaskEvent includes the blocked step description
- [ ] Confirm the resumed agent's system prompt contains the "BLOCKED" note for the skipped step
- [ ] Full approve (no steps blocked) — confirm button shows "Approve & Resume" and `blockedSteps: []` is stored

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_