### PR TITLE
fix: input validation on agent-groups, tool-groups, and model admin API routes

### DIFF
--- a/apps/web/src/app/api/admin/models/[id]/route.ts
+++ b/apps/web/src/app/api/admin/models/[id]/route.ts
@@ -14,6 +14,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   const admin = await requireAdmin()
   const body = await req.json()
 
+  // Validate numeric and URL fields
+  if (body.timeoutSecs !== undefined && (typeof body.timeoutSecs !== 'number' || body.timeoutSecs < 1 || body.timeoutSecs > 600)) {
+    return NextResponse.json({ error: 'timeoutSecs must be a number between 1 and 600' }, { status: 400 })
+  }
+  if (body.maxTokens !== undefined && body.maxTokens !== null && (typeof body.maxTokens !== 'number' || body.maxTokens < 1)) {
+    return NextResponse.json({ error: 'maxTokens must be a positive number' }, { status: 400 })
+  }
+  if (body.baseUrl !== undefined && body.baseUrl !== null) {
+    try { new URL(body.baseUrl) } catch {
+      return NextResponse.json({ error: 'baseUrl must be a valid URL' }, { status: 400 })
+    }
+  }
+
   // Only update apiKey if a new one was provided
   const updateData: Record<string, unknown> = {}
   if (body.name        !== undefined) updateData.name        = body.name

--- a/apps/web/src/app/api/agent-groups/[id]/members/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/members/route.ts
@@ -5,7 +5,11 @@ import { requireAdmin } from '@/lib/auth'
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   await requireAdmin()
   const { agentId } = await req.json()
-  if (!agentId) return NextResponse.json({ error: 'agentId required' }, { status: 400 })
+  if (!agentId || typeof agentId !== 'string' || !agentId.trim()) {
+    return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
+  }
+  const agentExists = await prisma.agent.findUnique({ where: { id: agentId }, select: { id: true } })
+  if (!agentExists) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
   await prisma.agentGroupMember.create({ data: { agentGroupId: params.id, agentId } })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/agent-groups/[id]/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/route.ts
@@ -5,6 +5,9 @@ import { requireAdmin } from '@/lib/auth'
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   await requireAdmin()
   const body = await req.json()
+  if (body.name !== undefined && (!body.name || typeof body.name !== 'string' || !body.name.trim())) {
+    return NextResponse.json({ error: 'name must be a non-empty string' }, { status: 400 })
+  }
   const g = await prisma.agentGroup.update({
     where: { id: params.id },
     data: {

--- a/apps/web/src/app/api/agent-groups/route.ts
+++ b/apps/web/src/app/api/agent-groups/route.ts
@@ -19,6 +19,14 @@ export async function POST(req: NextRequest) {
   await requireAdmin()
   const body = await req.json()
   if (!body.name?.trim()) return NextResponse.json({ error: 'name required' }, { status: 400 })
+  const VALID_TIERS = ['viewer', 'editor', 'admin']
+  if (body.minimumTier !== undefined && !VALID_TIERS.includes(body.minimumTier)) {
+    return NextResponse.json({ error: `minimumTier must be one of: ${VALID_TIERS.join(', ')}` }, { status: 400 })
+  }
+  if (body.environmentId) {
+    const envExists = await prisma.environment.findUnique({ where: { id: body.environmentId }, select: { id: true } })
+    if (!envExists) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+  }
   const group = await prisma.agentGroup.create({
     data: { name: body.name.trim(), description: body.description ?? null },
     include: {

--- a/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
@@ -4,7 +4,11 @@ import { prisma } from '@/lib/db'
 // POST — add a tool to the group
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const { toolId } = await req.json()
-  if (!toolId) return NextResponse.json({ error: 'toolId required' }, { status: 400 })
+  if (!toolId || typeof toolId !== 'string' || !toolId.trim()) {
+    return NextResponse.json({ error: 'toolId is required' }, { status: 400 })
+  }
+  const toolExists = await prisma.mcpTool.findUnique({ where: { id: toolId }, select: { id: true } })
+  if (!toolExists) return NextResponse.json({ error: 'Tool not found' }, { status: 404 })
   await prisma.toolGroupTool.create({ data: { toolGroupId: params.id, toolId } })
   return NextResponse.json({ ok: true })
 }


### PR DESCRIPTION
## Summary

Adds proper input validation to 5 API routes that previously accepted unvalidated inputs, preventing orphaned FK inserts and type errors from reaching Prisma.

- **`agent-groups/[id]/members`** POST: validates `agentId` is a non-empty string and the agent exists in the DB before inserting
- **`tool-groups/[id]/tools`** POST: validates `toolId` is a non-empty string and the `McpTool` record exists before inserting
- **`agent-groups/[id]`** PUT: validates `body.name`, if provided, is a non-empty string (prevents `.trim()` crash on non-string values)
- **`admin/models/[id]`** PUT: validates `timeoutSecs` (number 1–600), `maxTokens` (positive number or null), and `baseUrl` (valid URL) before updating
- **`agent-groups`** POST: validates `minimumTier` against `['viewer', 'editor', 'admin']` enum and verifies `environmentId` exists in the DB before creating the group

## Test plan

- [ ] POST `/api/agent-groups/:id/members` with non-existent `agentId` → 404
- [ ] POST `/api/tool-groups/:id/tools` with non-existent `toolId` → 404
- [ ] PUT `/api/agent-groups/:id` with `name: ""` → 400
- [ ] PUT `/api/admin/models/:id` with `timeoutSecs: 9999` → 400
- [ ] PUT `/api/admin/models/:id` with `baseUrl: "not-a-url"` → 400
- [ ] POST `/api/agent-groups` with `minimumTier: "superadmin"` → 400
- [ ] POST `/api/agent-groups` with non-existent `environmentId` → 404

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_