### PR TITLE
fix: improve UI resilience and eliminate silent failure gaps

### DIFF
--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -70,6 +70,7 @@ export default function SecurityDashboard() {
       if (!res.ok) throw new Error(`${res.status}`)
       const d = await res.json()
       setData(d)
+      setError(null)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load')
     } finally {
@@ -77,7 +78,11 @@ export default function SecurityDashboard() {
     }
   }, [])
 
-  useEffect(() => { loadOverview() }, [loadOverview])
+  useEffect(() => {
+    loadOverview()
+    const interval = setInterval(loadOverview, 30_000)
+    return () => clearInterval(interval)
+  }, [loadOverview])
 
   if (loading) {
     return (

--- a/apps/web/src/lib/agent-context.ts
+++ b/apps/web/src/lib/agent-context.ts
@@ -81,7 +81,10 @@ async function fetchSnapshot(): Promise<string> {
  */
 export async function buildAgentContext(query: string): Promise<string> {
   const [snapshot, knowledge] = await Promise.all([
-    getOrFetch('snapshot', 'cache.snapshot.ttl', fetchSnapshot).catch(() => ''),
+    getOrFetch('snapshot', 'cache.snapshot.ttl', fetchSnapshot).catch(e => {
+      console.error('[agent-context] Failed to build context:', e instanceof Error ? e.message : e)
+      return '' // still return empty string as fallback — don't crash the agent
+    }),
     retrieveKnowledgeContext(query, 3, 0.4),
   ])
 

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -174,7 +174,7 @@ async function auditLog(actorId: string | undefined, content: string): Promise<v
       content,
       messageType: 'task_update',
     },
-  }).catch(() => {})
+  }).catch(e => console.error('[tool-registry] auditLog write failed:', e instanceof Error ? e.message : e))
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -486,7 +486,7 @@ async function handleCloseTask(args: unknown, ctx: ToolExecutionContext): Promis
   // feature (and possibly its epic) done and post summaries to their rooms.
   if (task.featureId) {
     const { checkFeatureCompletion } = await import('./task-completion')
-    await checkFeatureCompletion(task.featureId, ctx.prisma as unknown as import('@prisma/client').PrismaClient).catch(() => {})
+    await checkFeatureCompletion(task.featureId, ctx.prisma as unknown as import('@prisma/client').PrismaClient).catch(e => console.error('[tool-registry] checkFeatureCompletion failed:', e instanceof Error ? e.message : e))
   }
 
   const msg = `✅ Validated & closed **${task.title}** — ${summary}`

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -529,7 +529,7 @@ async function runTask(taskId: string): Promise<void> {
           // Store message in conversation
           await prisma.message.create({
             data: { conversationId: conversation.id, role: 'assistant', content: event.content },
-          }).catch(() => {})
+          }).catch(e => err(`[worker] conversation message write failed: ${e instanceof Error ? e.message : e}`))
           break
 
         case 'tool_call':
@@ -557,7 +557,7 @@ async function runTask(taskId: string): Promise<void> {
               content: `[tool_call] ${event.tool}`,
               metadata: { toolCall: { name: event.tool, args: event.args } } as any,
             },
-          }).catch(() => {})
+          }).catch(e => err(`[worker] tool_call message write failed: ${e instanceof Error ? e.message : e}`))
           if (featureRoomId) {
             const argsSummary = String(event.args ?? '').slice(0, 200)
             await postToRoom(featureRoomId, agent.id, `🔧 \`${event.tool}\`(${argsSummary})`, taskId)
@@ -584,14 +584,14 @@ async function runTask(taskId: string): Promise<void> {
             where: { taskId_stepIndex: { taskId, stepIndex } },
             update: { result: redactedResult },
             create: { taskId, stepIndex, toolName: event.tool, argsHash: idemKeyForCheckpoint, result: redactedResult },
-          }).catch(() => {})
+          }).catch(e => err(`[worker] checkpoint upsert failed for task ${taskId} step ${stepIndex}: ${e instanceof Error ? e.message : e}`))
           checkpoints.set(stepIndex, redactedResult)
           await prisma.message.create({
             data: {
               conversationId: conversation.id, role: 'user',
               content: `[tool_result] ${event.tool}: ${redactedResult}`,
             },
-          }).catch(() => {})
+          }).catch(e => err(`[worker] tool_result message write failed: ${e instanceof Error ? e.message : e}`))
           if (featureRoomId) {
             const safeResult = redactedResult.slice(0, 300)
             await postToRoom(featureRoomId, agent.id, `↩ \`${event.tool}\`: ${safeResult}`, taskId)
@@ -682,7 +682,7 @@ async function runTask(taskId: string): Promise<void> {
           durationMs: Date.now() - startedAt,
           success:    true,
         },
-      }).catch(() => {}),
+      }).catch(e => err(`[worker] claudeInvocation write failed for task ${taskId}: ${e instanceof Error ? e.message : e}`)),
     ])
 
     // Log token usage to the task timeline when available.
@@ -755,7 +755,7 @@ async function runTask(taskId: string): Promise<void> {
           status: 'failed',
           metadata: { ...failMeta, remediation_attempts: remediationAttempts } as any,
         },
-      }).catch(() => {})
+      }).catch(e => err(`[worker] task status update failed for ${taskId}: ${e instanceof Error ? e.message : e}`))
       const escalationMsg =
         `Task '${failedTask?.title ?? taskId}' has failed ${remediationAttempts} times with the same approach. Escalating — human review required. Last error: ${errMsg.slice(0, 300)}`
       await logTaskEvent(taskId, 'escalated', escalationMsg, failedTask?.assignedAgent ?? undefined)
@@ -786,7 +786,7 @@ async function runTask(taskId: string): Promise<void> {
       await prisma.task.update({
         where: { id: taskId },
         data: { status: 'pending', retryCount: newRetryCount, nextRetryAt },
-      }).catch(() => {})
+      }).catch(e => err(`[worker] task retry status update failed for ${taskId}: ${e instanceof Error ? e.message : e}`))
       await logTaskEvent(taskId, 'system',
         `Transient failure (${errMsg.slice(0, 100)}) — retry ${newRetryCount}/${failedTask!.maxRetries ?? 3} scheduled in ${delayMs / 1000}s`,
         failedTask?.assignedAgent ?? undefined,
@@ -881,7 +881,7 @@ export function planRequiresApproval(plan: ParsedPlan | null): boolean {
 // ── DB helpers ─────────────────────────────────────────────────────────────────
 
 async function logTaskEvent(taskId: string, eventType: string, content: string, agentId?: string) {
-  await prisma.taskEvent.create({ data: { taskId, eventType, content, agentId: agentId ?? null } }).catch(() => {})
+  await prisma.taskEvent.create({ data: { taskId, eventType, content, agentId: agentId ?? null } }).catch(e => err(`[worker] logTaskEvent failed for task ${taskId}: ${e instanceof Error ? e.message : e}`))
 }
 
 async function postToFeed(agentId: string, content: string, taskId?: string) {


### PR DESCRIPTION
## Summary

- **SecurityDashboard**: adds `setError(null)` on successful load and a 30-second `setInterval` auto-refresh with cleanup — replaces single fire-on-mount load
- **Agent context silent failure**: `buildAgentContext` `.catch` now logs `console.error('[agent-context] Failed to build context:', ...)` before returning empty string
- **Critical fire-and-forget fixes** (9 empty catches across `tool-registry.ts` and `worker.ts`): `auditLog` DB writes, `checkFeatureCompletion`, conversation message writes, checkpoint upserts, `claudeInvocation` write, and task status updates during error recovery — all now log errors so failures surface in orchestrator stderr

## Test plan

- [ ] SecurityDashboard: verify it auto-refreshes every 30s and shows error state on failure
- [ ] Kill DB mid-agent-run — verify `[agent-context]` error appears in logs
- [ ] Verify tool-registry audit failures log rather than silently swallow

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_