### PR TITLE
fix: proper 400 responses for malformed JSON bodies across 13 API routes

### DIFF
--- a/apps/web/src/app/api/agent-groups/[id]/members/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/members/route.ts
@@ -4,7 +4,9 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   await requireAdmin()
-  const { agentId } = await req.json()
+  let parsed: unknown
+  try { parsed = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const { agentId } = parsed as { agentId?: string }
   if (!agentId || typeof agentId !== 'string' || !agentId.trim()) {
     return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
   }

--- a/apps/web/src/app/api/agent-groups/[id]/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/route.ts
@@ -4,15 +4,17 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   await requireAdmin()
-  const body = await req.json()
-  if (body.name !== undefined && (!body.name || typeof body.name !== 'string' || !body.name.trim())) {
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const b = body as { name?: unknown; description?: unknown }
+  if (b.name !== undefined && (!b.name || typeof b.name !== 'string' || !b.name.trim())) {
     return NextResponse.json({ error: 'name must be a non-empty string' }, { status: 400 })
   }
   const g = await prisma.agentGroup.update({
     where: { id: params.id },
     data: {
-      ...(body.name        !== undefined && { name:        body.name.trim() }),
-      ...(body.description !== undefined && { description: body.description }),
+      ...(b.name        !== undefined && { name:        (b.name as string).trim() }),
+      ...(b.description !== undefined && { description: b.description as string | null }),
     },
     include: { members: { include: { agent: true } }, toolAccess: { include: { toolGroup: true } } },
   })

--- a/apps/web/src/app/api/agent-groups/[id]/tool-access/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/tool-access/route.ts
@@ -4,7 +4,9 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   await requireAdmin()
-  const { toolGroupId } = await req.json()
+  let parsed: unknown
+  try { parsed = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const { toolGroupId } = parsed as { toolGroupId?: string }
   if (!toolGroupId) return NextResponse.json({ error: 'toolGroupId required' }, { status: 400 })
   await prisma.agentGroupToolAccess.create({ data: { agentGroupId: params.id, toolGroupId } })
   return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/agent-groups/route.ts
+++ b/apps/web/src/app/api/agent-groups/route.ts
@@ -17,18 +17,20 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   await requireAdmin()
-  const body = await req.json()
-  if (!body.name?.trim()) return NextResponse.json({ error: 'name required' }, { status: 400 })
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const b = body as { name?: string; description?: string | null; minimumTier?: string; environmentId?: string }
+  if (!b.name?.trim()) return NextResponse.json({ error: 'name required' }, { status: 400 })
   const VALID_TIERS = ['viewer', 'editor', 'admin']
-  if (body.minimumTier !== undefined && !VALID_TIERS.includes(body.minimumTier)) {
+  if (b.minimumTier !== undefined && !VALID_TIERS.includes(b.minimumTier)) {
     return NextResponse.json({ error: `minimumTier must be one of: ${VALID_TIERS.join(', ')}` }, { status: 400 })
   }
-  if (body.environmentId) {
-    const envExists = await prisma.environment.findUnique({ where: { id: body.environmentId }, select: { id: true } })
+  if (b.environmentId) {
+    const envExists = await prisma.environment.findUnique({ where: { id: b.environmentId }, select: { id: true } })
     if (!envExists) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
   }
   const group = await prisma.agentGroup.create({
-    data: { name: body.name.trim(), description: body.description ?? null },
+    data: { name: b.name.trim(), description: b.description ?? null },
     include: {
       members:    { include: { agent: true } },
       toolAccess: { include: { toolGroup: { include: { environment: { select: { id: true, name: true } } } } } },

--- a/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
@@ -32,8 +32,9 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = await req.json()
-  const parsed = bodySchema.safeParse(body)
+  let rawBody: unknown
+  try { rawBody = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const parsed = bodySchema.safeParse(rawBody)
   if (!parsed.success) {
     return NextResponse.json({ error: 'Invalid body: action must be "approve" or "deny"' }, { status: 400 })
   }

--- a/apps/web/src/app/api/monitoring/security/panic/route.ts
+++ b/apps/web/src/app/api/monitoring/security/panic/route.ts
@@ -36,7 +36,8 @@ export async function PUT(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = await req.json() as { active?: boolean }
+  let body: { active?: boolean }
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   if (typeof body.active !== 'boolean') {
     return NextResponse.json({ error: 'Body must be { active: boolean }' }, { status: 400 })
   }

--- a/apps/web/src/app/api/nova-definitions/[id]/route.ts
+++ b/apps/web/src/app/api/nova-definitions/[id]/route.ts
@@ -38,7 +38,8 @@ export async function PUT(
   } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
-  const body = await req.json()
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   // MAJOR fix: raw body was written directly to Prisma (mass assignment)
   const title       = body.title ? String(body.title).slice(0, 200) : undefined
   const category    = body.category === 'skill' || body.category === 'hook' ? body.category : undefined

--- a/apps/web/src/app/api/nova-definitions/route.ts
+++ b/apps/web/src/app/api/nova-definitions/route.ts
@@ -36,7 +36,8 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
-  const body = await req.json()
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   // MAJOR fix: raw body was passed directly to Prisma (mass assignment).
   // Whitelist allowed fields to prevent setting arbitrary columns.
   const name        = String(body.name ?? '').trim()

--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -38,7 +38,9 @@ export async function PUT(
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const body = await req.json()
+  let bodyRaw: Record<string, unknown>
+  try { bodyRaw = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const body = bodyRaw as { name?: string; displayName?: string; description?: string | null; category?: string; version?: string; config?: unknown; tags?: unknown; reasoning?: string }
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },
   })

--- a/apps/web/src/app/api/novas/route.ts
+++ b/apps/web/src/app/api/novas/route.ts
@@ -86,7 +86,8 @@ export async function POST(req: NextRequest) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const body: NovaCreateRequest = await req.json()
+  let body: NovaCreateRequest
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
 
   // Validate required fields
   if (!body.name?.trim()) {

--- a/apps/web/src/app/api/tool-approvals/[id]/route.ts
+++ b/apps/web/src/app/api/tool-approvals/[id]/route.ts
@@ -3,7 +3,8 @@ import { prisma } from '@/lib/db'
 
 // POST /api/tool-approvals/[id]  body: { action: 'approve'|'deny', adminNote?: string, approvedBy?: string }
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json()
+  let body: unknown
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const { action, adminNote, approvedBy } = body as { action: 'approve' | 'deny'; adminNote?: string; approvedBy?: string }
 
   const request = await prisma.toolApprovalRequest.findUnique({ where: { id: params.id } })

--- a/apps/web/src/app/api/tool-groups/[id]/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/route.ts
@@ -11,13 +11,15 @@ export async function GET(_: NextRequest, { params }: { params: { id: string } }
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
-  const body = await req.json()
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const b = body as { name?: string; description?: string | null; minimumTier?: string }
   const g = await prisma.toolGroup.update({
     where: { id: params.id },
     data: {
-      ...(body.name        !== undefined && { name:        body.name.trim() }),
-      ...(body.description !== undefined && { description: body.description }),
-      ...(body.minimumTier !== undefined && { minimumTier: body.minimumTier }),
+      ...(b.name        !== undefined && { name:        b.name.trim() }),
+      ...(b.description !== undefined && { description: b.description }),
+      ...(b.minimumTier !== undefined && { minimumTier: b.minimumTier }),
     },
     include: { tools: { include: { tool: true } }, agentAccess: { include: { agentGroup: true } } },
   })

--- a/apps/web/src/app/api/tool-groups/route.ts
+++ b/apps/web/src/app/api/tool-groups/route.ts
@@ -15,15 +15,17 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json()
-  if (!body.name?.trim())        return NextResponse.json({ error: 'name required' }, { status: 400 })
-  if (!body.environmentId)       return NextResponse.json({ error: 'environmentId required' }, { status: 400 })
+  let body: Record<string, unknown>
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
+  const b = body as { name?: string; description?: string | null; environmentId?: string; minimumTier?: string }
+  if (!b.name?.trim())        return NextResponse.json({ error: 'name required' }, { status: 400 })
+  if (!b.environmentId)       return NextResponse.json({ error: 'environmentId required' }, { status: 400 })
   const group = await prisma.toolGroup.create({
     data: {
-      name:          body.name.trim(),
-      description:   body.description ?? null,
-      environmentId: body.environmentId,
-      minimumTier:   body.minimumTier ?? 'viewer',
+      name:          b.name.trim(),
+      description:   b.description ?? null,
+      environmentId: b.environmentId,
+      minimumTier:   b.minimumTier ?? 'viewer',
     },
     include: { tools: { include: { tool: true } }, agentAccess: { include: { agentGroup: true } } },
   })


### PR DESCRIPTION
## Summary

Hardens 13 POST/PUT routes that were calling `await req.json()` bare — a malformed JSON body would throw and return a 500. All now wrap the parse in try/catch and return `{ error: 'Invalid JSON body' }` with status 400.

**Routes hardened:**
- `tool-approvals/[id]` POST
- `novas` POST, `novas/[id]` PUT
- `agent-groups` POST, `agent-groups/[id]` PUT
- `agent-groups/[id]/members` POST, `agent-groups/[id]/tool-access` POST
- `tool-groups` POST, `tool-groups/[id]` PUT
- `monitoring/security/approvals/[id]` POST
- `monitoring/security/panic` PUT
- `nova-definitions` POST, `nova-definitions/[id]` PUT

Also verified all 21 tool definitions in `executeTool()` have real implementations — no silent stubs.

## Test plan

- [ ] Send `curl -X POST /api/novas -H 'Content-Type: application/json' -d 'bad json'` → expect 400
- [ ] Same for a security approval route → expect 400, not 500
- [ ] Valid JSON body → continues to process normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_