### PR TITLE
feat(evals): agent benchmark harness — suites, cases, LLM-as-judge scoring, run history

### DIFF
--- a/apps/web/prisma/migrations/22_add_eval_benchmark/migration.sql
+++ b/apps/web/prisma/migrations/22_add_eval_benchmark/migration.sql
@@ -1,0 +1,98 @@
+-- CreateTable
+CREATE TABLE "EvalSuite" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "agentId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EvalSuite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EvalCase" (
+    "id" TEXT NOT NULL,
+    "suiteId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "expectedOutput" TEXT,
+    "assertions" TEXT NOT NULL,
+    "weight" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EvalCase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EvalRun" (
+    "id" TEXT NOT NULL,
+    "suiteId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "modelId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "scoreTotal" DOUBLE PRECISION,
+    "passCount" INTEGER NOT NULL DEFAULT 0,
+    "failCount" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EvalRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EvalCaseResult" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "caseId" TEXT NOT NULL,
+    "taskId" TEXT,
+    "passed" BOOLEAN,
+    "score" DOUBLE PRECISION,
+    "output" TEXT,
+    "assertions" TEXT NOT NULL,
+    "judgeReason" TEXT,
+    "durationMs" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EvalCaseResult_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EvalSuite_name_key" ON "EvalSuite"("name");
+
+-- CreateIndex
+CREATE INDEX "EvalSuite_agentId_idx" ON "EvalSuite"("agentId");
+
+-- CreateIndex
+CREATE INDEX "EvalCase_suiteId_idx" ON "EvalCase"("suiteId");
+
+-- CreateIndex
+CREATE INDEX "EvalRun_suiteId_idx" ON "EvalRun"("suiteId");
+
+-- CreateIndex
+CREATE INDEX "EvalRun_agentId_idx" ON "EvalRun"("agentId");
+
+-- CreateIndex
+CREATE INDEX "EvalCaseResult_runId_idx" ON "EvalCaseResult"("runId");
+
+-- CreateIndex
+CREATE INDEX "EvalCaseResult_caseId_idx" ON "EvalCaseResult"("caseId");
+
+-- AddForeignKey
+ALTER TABLE "EvalSuite" ADD CONSTRAINT "EvalSuite_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvalCase" ADD CONSTRAINT "EvalCase_suiteId_fkey" FOREIGN KEY ("suiteId") REFERENCES "EvalSuite"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvalRun" ADD CONSTRAINT "EvalRun_suiteId_fkey" FOREIGN KEY ("suiteId") REFERENCES "EvalSuite"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvalRun" ADD CONSTRAINT "EvalRun_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvalCaseResult" ADD CONSTRAINT "EvalCaseResult_runId_fkey" FOREIGN KEY ("runId") REFERENCES "EvalRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvalCaseResult" ADD CONSTRAINT "EvalCaseResult_caseId_fkey" FOREIGN KEY ("caseId") REFERENCES "EvalCase"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -83,6 +83,8 @@ model Agent {
   chatMessages     ChatMessage[]
   profiles         AgentProfile[]
   knowledge        AgentKnowledge[]
+  evalSuites       EvalSuite[]            @relation("EvalSuiteAgent")
+  evalRuns         EvalRun[]              @relation("EvalRunAgent")
 }
 
 model Environment {
@@ -1639,4 +1641,76 @@ model ToolExecution {
   @@index([status, createdAt])
   @@index([tool, createdAt])
   @@index([expiresAt])              // for expiry sweep job
+}
+
+// ── Agent Benchmark Harness ────────────────────────────────────────────────────
+// Define test suites with golden prompts and assertions, run an agent against
+// them, score results with LLM-as-judge, and track performance over time.
+
+model EvalSuite {
+  id          String     @id @default(cuid())
+  name        String     @unique
+  description String?
+  agentId     String?
+  agent       Agent?     @relation("EvalSuiteAgent", fields: [agentId], references: [id])
+  cases       EvalCase[]
+  runs        EvalRun[]
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+
+  @@index([agentId])
+}
+
+model EvalCase {
+  id             String           @id @default(cuid())
+  suiteId        String
+  suite          EvalSuite        @relation(fields: [suiteId], references: [id], onDelete: Cascade)
+  title          String
+  prompt         String           @db.Text
+  expectedOutput String?          @db.Text
+  assertions     String           @db.Text // JSON array of assertion objects
+  weight         Int              @default(1)
+  createdAt      DateTime         @default(now())
+  results        EvalCaseResult[]
+
+  @@index([suiteId])
+}
+
+model EvalRun {
+  id          String           @id @default(cuid())
+  suiteId     String
+  suite       EvalSuite        @relation(fields: [suiteId], references: [id])
+  agentId     String
+  agent       Agent            @relation("EvalRunAgent", fields: [agentId], references: [id])
+  modelId     String
+  status      String           @default("pending")
+  scoreTotal  Float?
+  passCount   Int              @default(0)
+  failCount   Int              @default(0)
+  results     EvalCaseResult[]
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime         @default(now())
+
+  @@index([suiteId])
+  @@index([agentId])
+}
+
+model EvalCaseResult {
+  id          String   @id @default(cuid())
+  runId       String
+  run         EvalRun  @relation(fields: [runId], references: [id], onDelete: Cascade)
+  caseId      String
+  case        EvalCase @relation(fields: [caseId], references: [id])
+  taskId      String?
+  passed      Boolean?
+  score       Float?
+  output      String?  @db.Text
+  assertions  String   @db.Text // JSON: assertion results
+  judgeReason String?  @db.Text
+  durationMs  Int?
+  createdAt   DateTime @default(now())
+
+  @@index([runId])
+  @@index([caseId])
 }

--- a/apps/web/src/app/(app)/evals/[id]/page.tsx
+++ b/apps/web/src/app/(app)/evals/[id]/page.tsx
@@ -1,0 +1,388 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { ArrowLeft, Play, Plus, Trash2, FlaskConical } from 'lucide-react'
+
+interface AssertionDef {
+  type: 'contains_text' | 'not_contains_text' | 'regex_match' | 'llm_judge'
+  value: string
+  weight?: number
+}
+
+interface EvalCase {
+  id: string
+  suiteId: string
+  title: string
+  prompt: string
+  expectedOutput: string | null
+  assertions: string // JSON
+  weight: number
+  createdAt: string
+}
+
+interface EvalRun {
+  id: string
+  agentId: string
+  modelId: string
+  status: string
+  scoreTotal: number | null
+  passCount: number
+  failCount: number
+  createdAt: string
+  agent: { id: string; name: string }
+}
+
+interface EvalSuite {
+  id: string
+  name: string
+  description: string | null
+  agentId: string | null
+  agent: { id: string; name: string } | null
+  cases: EvalCase[]
+  runs: EvalRun[]
+}
+
+interface Agent {
+  id: string
+  name: string
+}
+
+const ASSERTION_TYPE_COLORS: Record<string, string> = {
+  contains_text: 'bg-blue-500/20 text-blue-400',
+  not_contains_text: 'bg-orange-500/20 text-orange-400',
+  regex_match: 'bg-purple-500/20 text-purple-400',
+  llm_judge: 'bg-green-500/20 text-green-400',
+}
+
+export default function EvalSuiteDetailPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const [suite, setSuite] = useState<EvalSuite | null>(null)
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [runAgentId, setRunAgentId] = useState('')
+  const [showRunForm, setShowRunForm] = useState(false)
+  const [showNewCase, setShowNewCase] = useState(false)
+  const [newCase, setNewCase] = useState({
+    title: '',
+    prompt: '',
+    expectedOutput: '',
+    assertionType: 'contains_text' as AssertionDef['type'],
+    assertionValue: '',
+  })
+  const [addingCase, setAddingCase] = useState(false)
+
+  const loadSuite = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [sRes, aRes] = await Promise.all([
+        fetch(`/api/eval-suites/${params.id}`),
+        fetch('/api/agents'),
+      ])
+      if (sRes.ok) setSuite(await sRes.json())
+      if (aRes.ok) setAgents(await aRes.json())
+    } finally {
+      setLoading(false)
+    }
+  }, [params.id])
+
+  useEffect(() => {
+    void loadSuite()
+  }, [loadSuite])
+
+  async function triggerRun() {
+    if (!runAgentId) return
+    setRunning(true)
+    try {
+      const res = await fetch(`/api/eval-suites/${params.id}/run`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agentId: runAgentId }),
+      })
+      if (res.ok) {
+        setShowRunForm(false)
+        await loadSuite()
+      }
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  async function addCase() {
+    if (!newCase.title || !newCase.prompt || !newCase.assertionValue) return
+    setAddingCase(true)
+    try {
+      const assertions: AssertionDef[] = [
+        { type: newCase.assertionType, value: newCase.assertionValue },
+      ]
+      const res = await fetch(`/api/eval-suites/${params.id}/cases`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          title: newCase.title,
+          prompt: newCase.prompt,
+          expectedOutput: newCase.expectedOutput || undefined,
+          assertions,
+        }),
+      })
+      if (res.ok) {
+        setShowNewCase(false)
+        setNewCase({ title: '', prompt: '', expectedOutput: '', assertionType: 'contains_text', assertionValue: '' })
+        await loadSuite()
+      }
+    } finally {
+      setAddingCase(false)
+    }
+  }
+
+  async function deleteCase(caseId: string) {
+    if (!confirm('Delete this case?')) return
+    await fetch(`/api/eval-suites/${params.id}/cases/${caseId}`, { method: 'DELETE' })
+    await loadSuite()
+  }
+
+  function scoreColor(score: number | null | undefined) {
+    if (score === null || score === undefined) return 'text-text-muted'
+    if (score >= 80) return 'text-green-400'
+    if (score >= 50) return 'text-yellow-400'
+    return 'text-red-400'
+  }
+
+  function statusBadge(status: string) {
+    const colors: Record<string, string> = {
+      completed: 'bg-green-500/20 text-green-400',
+      running: 'bg-blue-500/20 text-blue-400',
+      pending: 'bg-yellow-500/20 text-yellow-400',
+      failed: 'bg-red-500/20 text-red-400',
+    }
+    return `inline-flex px-2 py-0.5 rounded text-xs font-medium ${colors[status] ?? 'bg-bg-raised text-text-muted'}`
+  }
+
+  if (loading) return <div className="p-6 text-text-muted text-sm">Loading...</div>
+  if (!suite) return <div className="p-6 text-text-muted text-sm">Suite not found.</div>
+
+  const defaultAgentId = runAgentId || suite.agentId || (agents[0]?.id ?? '')
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={() => router.push('/evals')}
+          className="text-text-muted hover:text-text-primary transition-colors"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <FlaskConical size={20} className="text-accent" />
+        <div className="flex-1">
+          <h1 className="text-xl font-semibold text-text-primary">{suite.name}</h1>
+          {suite.description && (
+            <p className="text-sm text-text-muted mt-0.5">{suite.description}</p>
+          )}
+        </div>
+        <button
+          onClick={() => setShowRunForm(true)}
+          className="flex items-center gap-2 px-3 py-1.5 bg-accent text-white rounded text-sm hover:bg-accent/80 transition-colors"
+        >
+          <Play size={14} />
+          Run Benchmark
+        </button>
+      </div>
+
+      {/* Run form */}
+      {showRunForm && (
+        <div className="mb-6 p-4 bg-bg-card border border-border-subtle rounded-lg">
+          <h2 className="text-sm font-medium text-text-primary mb-3">Run Benchmark</h2>
+          <select
+            className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary focus:outline-none focus:border-accent mb-3"
+            value={runAgentId || defaultAgentId}
+            onChange={e => setRunAgentId(e.target.value)}
+          >
+            <option value="">Select agent</option>
+            {agents.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+          <div className="flex gap-2">
+            <button
+              onClick={triggerRun}
+              disabled={running || !(runAgentId || defaultAgentId)}
+              className="px-3 py-1.5 bg-accent text-white rounded text-sm hover:bg-accent/80 disabled:opacity-50 transition-colors"
+            >
+              {running ? 'Starting...' : 'Start Run'}
+            </button>
+            <button
+              onClick={() => setShowRunForm(false)}
+              className="px-3 py-1.5 bg-bg-raised text-text-secondary rounded text-sm hover:bg-bg-hover transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Cases */}
+      <section className="mb-8">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-text-primary uppercase tracking-wide">
+            Test Cases ({suite.cases.length})
+          </h2>
+          <button
+            onClick={() => setShowNewCase(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs bg-bg-raised text-text-secondary border border-border-subtle rounded hover:bg-bg-hover transition-colors"
+          >
+            <Plus size={13} />
+            Add Case
+          </button>
+        </div>
+
+        {showNewCase && (
+          <div className="mb-3 p-4 bg-bg-card border border-accent/30 rounded-lg">
+            <h3 className="text-sm font-medium text-text-primary mb-3">New Test Case</h3>
+            <div className="space-y-2">
+              <input
+                className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                placeholder="Case title *"
+                value={newCase.title}
+                onChange={e => setNewCase(v => ({ ...v, title: e.target.value }))}
+              />
+              <textarea
+                className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none"
+                placeholder="Prompt to send to agent *"
+                rows={3}
+                value={newCase.prompt}
+                onChange={e => setNewCase(v => ({ ...v, prompt: e.target.value }))}
+              />
+              <textarea
+                className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent resize-none"
+                placeholder="Expected output (optional, used by llm_judge)"
+                rows={2}
+                value={newCase.expectedOutput}
+                onChange={e => setNewCase(v => ({ ...v, expectedOutput: e.target.value }))}
+              />
+              <div className="flex gap-2">
+                <select
+                  className="px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary focus:outline-none focus:border-accent"
+                  value={newCase.assertionType}
+                  onChange={e => setNewCase(v => ({ ...v, assertionType: e.target.value as AssertionDef['type'] }))}
+                >
+                  <option value="contains_text">contains_text</option>
+                  <option value="not_contains_text">not_contains_text</option>
+                  <option value="regex_match">regex_match</option>
+                  <option value="llm_judge">llm_judge</option>
+                </select>
+                <input
+                  className="flex-1 px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                  placeholder="Assertion value *"
+                  value={newCase.assertionValue}
+                  onChange={e => setNewCase(v => ({ ...v, assertionValue: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={addCase}
+                disabled={addingCase || !newCase.title || !newCase.prompt || !newCase.assertionValue}
+                className="px-3 py-1.5 bg-accent text-white rounded text-sm hover:bg-accent/80 disabled:opacity-50 transition-colors"
+              >
+                {addingCase ? 'Adding...' : 'Add Case'}
+              </button>
+              <button
+                onClick={() => setShowNewCase(false)}
+                className="px-3 py-1.5 bg-bg-raised text-text-secondary rounded text-sm hover:bg-bg-hover transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {suite.cases.length === 0 ? (
+            <div className="text-center py-8 text-text-muted text-sm border border-dashed border-border-subtle rounded-lg">
+              No test cases yet. Add a case to get started.
+            </div>
+          ) : (
+            suite.cases.map(c => {
+              let assertions: AssertionDef[] = []
+              try { assertions = JSON.parse(c.assertions) } catch { /* empty */ }
+              return (
+                <div key={c.id} className="p-3 bg-bg-card border border-border-subtle rounded-lg group">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-sm text-text-primary">{c.title}</div>
+                      <div className="text-xs text-text-muted mt-1 line-clamp-2">{c.prompt}</div>
+                      <div className="flex flex-wrap gap-1.5 mt-2">
+                        {assertions.map((a, i) => (
+                          <span
+                            key={i}
+                            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${ASSERTION_TYPE_COLORS[a.type] ?? 'bg-bg-raised text-text-muted'}`}
+                          >
+                            {a.type}
+                            <span className="opacity-70 max-w-[120px] truncate">{a.value}</span>
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => deleteCase(c.id)}
+                      className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-red-400 transition-all"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </section>
+
+      {/* Run History */}
+      <section>
+        <h2 className="text-sm font-semibold text-text-primary uppercase tracking-wide mb-3">
+          Run History
+        </h2>
+        {suite.runs.length === 0 ? (
+          <div className="text-center py-8 text-text-muted text-sm border border-dashed border-border-subtle rounded-lg">
+            No runs yet. Click &quot;Run Benchmark&quot; to start.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-subtle text-xs text-text-muted uppercase tracking-wide">
+                <th className="text-left py-2 pr-4">Date</th>
+                <th className="text-left py-2 pr-4">Agent</th>
+                <th className="text-left py-2 pr-4">Status</th>
+                <th className="text-right py-2 pr-4">Score</th>
+                <th className="text-right py-2">Pass / Fail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {suite.runs.map(run => (
+                <tr key={run.id} className="border-b border-border-subtle/50 hover:bg-bg-raised/50 transition-colors">
+                  <td className="py-2 pr-4 text-text-muted text-xs">
+                    {new Date(run.createdAt).toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-4 text-text-secondary">{run.agent?.name ?? run.agentId}</td>
+                  <td className="py-2 pr-4">
+                    <span className={statusBadge(run.status)}>{run.status}</span>
+                  </td>
+                  <td className={`py-2 pr-4 text-right font-medium ${scoreColor(run.scoreTotal)}`}>
+                    {run.scoreTotal !== null ? `${run.scoreTotal.toFixed(1)}%` : '--'}
+                  </td>
+                  <td className="py-2 text-right text-text-muted">
+                    <span className="text-green-400">{run.passCount}</span>
+                    {' / '}
+                    <span className="text-red-400">{run.failCount}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/evals/page.tsx
+++ b/apps/web/src/app/(app)/evals/page.tsx
@@ -1,0 +1,280 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Plus, Play, FlaskConical, ChevronRight } from 'lucide-react'
+
+interface EvalSuite {
+  id: string
+  name: string
+  description: string | null
+  agentId: string | null
+  agent: { id: string; name: string } | null
+  _count: { cases: number }
+  runs: Array<{ scoreTotal: number | null; status: string; createdAt: string }>
+  createdAt: string
+  updatedAt: string
+}
+
+interface EvalRun {
+  id: string
+  suiteId: string
+  agentId: string
+  modelId: string
+  status: string
+  scoreTotal: number | null
+  passCount: number
+  failCount: number
+  startedAt: string | null
+  completedAt: string | null
+  createdAt: string
+  suite: { id: string; name: string }
+  agent: { id: string; name: string }
+}
+
+interface Agent {
+  id: string
+  name: string
+}
+
+export default function EvalsPage() {
+  const router = useRouter()
+  const [tab, setTab] = useState<'suites' | 'runs'>('suites')
+  const [suites, setSuites] = useState<EvalSuite[]>([])
+  const [runs, setRuns] = useState<EvalRun[]>([])
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showNewSuite, setShowNewSuite] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newDesc, setNewDesc] = useState('')
+  const [newAgentId, setNewAgentId] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [sRes, aRes] = await Promise.all([
+        fetch('/api/eval-suites'),
+        fetch('/api/agents'),
+      ])
+      if (sRes.ok) setSuites(await sRes.json())
+      if (aRes.ok) setAgents(await aRes.json())
+
+      // Load recent runs across all suites
+      const suitesData: EvalSuite[] = sRes.ok ? await sRes.clone().json().catch(() => []) : []
+      const runPromises = suitesData.slice(0, 10).map((s: EvalSuite) =>
+        fetch(`/api/eval-suites/${s.id}/runs`).then(r => r.ok ? r.json() : [])
+      )
+      const allRunArrays = await Promise.all(runPromises)
+      const allRuns = allRunArrays.flat().sort(
+        (a: EvalRun, b: EvalRun) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )
+      setRuns(allRuns.slice(0, 50))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadData()
+  }, [loadData])
+
+  async function createSuite() {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      const res = await fetch('/api/eval-suites', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), description: newDesc || undefined, agentId: newAgentId || undefined }),
+      })
+      if (res.ok) {
+        setShowNewSuite(false)
+        setNewName('')
+        setNewDesc('')
+        setNewAgentId('')
+        await loadData()
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  function scoreColor(score: number | null | undefined) {
+    if (score === null || score === undefined) return 'text-text-muted'
+    if (score >= 80) return 'text-green-400'
+    if (score >= 50) return 'text-yellow-400'
+    return 'text-red-400'
+  }
+
+  function statusBadge(status: string) {
+    const colors: Record<string, string> = {
+      completed: 'bg-green-500/20 text-green-400',
+      running: 'bg-blue-500/20 text-blue-400',
+      pending: 'bg-yellow-500/20 text-yellow-400',
+      failed: 'bg-red-500/20 text-red-400',
+    }
+    return `inline-flex px-2 py-0.5 rounded text-xs font-medium ${colors[status] ?? 'bg-bg-raised text-text-muted'}`
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <FlaskConical size={22} className="text-accent" />
+          <h1 className="text-xl font-semibold text-text-primary">Agent Evals</h1>
+        </div>
+        <button
+          onClick={() => setShowNewSuite(true)}
+          className="flex items-center gap-2 px-3 py-1.5 bg-accent text-white rounded text-sm hover:bg-accent/80 transition-colors"
+        >
+          <Plus size={15} />
+          New Suite
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-border-subtle">
+        {(['suites', 'runs'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium capitalize transition-colors -mb-px border-b-2 ${
+              tab === t
+                ? 'border-accent text-accent'
+                : 'border-transparent text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {/* New Suite Form */}
+      {showNewSuite && (
+        <div className="mb-6 p-4 bg-bg-card border border-border-subtle rounded-lg">
+          <h2 className="text-sm font-medium text-text-primary mb-3">Create Eval Suite</h2>
+          <div className="space-y-3">
+            <input
+              className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              placeholder="Suite name *"
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+            />
+            <input
+              className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+              placeholder="Description (optional)"
+              value={newDesc}
+              onChange={e => setNewDesc(e.target.value)}
+            />
+            <select
+              className="w-full px-3 py-2 bg-bg-raised border border-border-subtle rounded text-sm text-text-primary focus:outline-none focus:border-accent"
+              value={newAgentId}
+              onChange={e => setNewAgentId(e.target.value)}
+            >
+              <option value="">No default agent</option>
+              {agents.map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex gap-2 mt-3">
+            <button
+              onClick={createSuite}
+              disabled={creating || !newName.trim()}
+              className="px-3 py-1.5 bg-accent text-white rounded text-sm hover:bg-accent/80 disabled:opacity-50 transition-colors"
+            >
+              {creating ? 'Creating...' : 'Create Suite'}
+            </button>
+            <button
+              onClick={() => setShowNewSuite(false)}
+              className="px-3 py-1.5 bg-bg-raised text-text-secondary rounded text-sm hover:bg-bg-hover transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-text-muted text-sm">Loading...</div>
+      ) : tab === 'suites' ? (
+        <div className="space-y-2">
+          {suites.length === 0 ? (
+            <div className="text-center py-12 text-text-muted text-sm">
+              No eval suites yet. Create one to get started.
+            </div>
+          ) : (
+            suites.map(suite => {
+              const latestRun = suite.runs[0]
+              return (
+                <div
+                  key={suite.id}
+                  className="flex items-center justify-between p-4 bg-bg-card border border-border-subtle rounded-lg hover:border-border-hover transition-colors cursor-pointer"
+                  onClick={() => router.push(`/evals/${suite.id}`)}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-text-primary">{suite.name}</span>
+                      <span className="text-xs text-text-muted bg-bg-raised px-2 py-0.5 rounded">
+                        {suite._count.cases} case{suite._count.cases !== 1 ? 's' : ''}
+                      </span>
+                      {suite.agent && (
+                        <span className="text-xs text-text-muted">
+                          Agent: {suite.agent.name}
+                        </span>
+                      )}
+                    </div>
+                    {suite.description && (
+                      <p className="text-xs text-text-muted mt-0.5 truncate">{suite.description}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 ml-4">
+                    {latestRun && (
+                      <div className="text-right">
+                        <div className={`text-sm font-medium ${scoreColor(latestRun.scoreTotal)}`}>
+                          {latestRun.scoreTotal !== null ? `${latestRun.scoreTotal.toFixed(1)}%` : '--'}
+                        </div>
+                        <div className={statusBadge(latestRun.status)}>{latestRun.status}</div>
+                      </div>
+                    )}
+                    <ChevronRight size={16} className="text-text-muted" />
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {runs.length === 0 ? (
+            <div className="text-center py-12 text-text-muted text-sm">No runs yet.</div>
+          ) : (
+            runs.map(run => (
+              <div key={run.id} className="flex items-center justify-between p-4 bg-bg-card border border-border-subtle rounded-lg">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-text-primary">{run.suite?.name ?? run.suiteId}</span>
+                    <span className={statusBadge(run.status)}>{run.status}</span>
+                  </div>
+                  <div className="text-xs text-text-muted mt-0.5">
+                    Agent: {run.agent?.name ?? run.agentId} &middot; Model: {run.modelId} &middot; {new Date(run.createdAt).toLocaleString()}
+                  </div>
+                </div>
+                <div className="ml-4 text-right">
+                  {run.scoreTotal !== null ? (
+                    <div className={`text-sm font-medium ${scoreColor(run.scoreTotal)}`}>
+                      {run.scoreTotal.toFixed(1)}%
+                    </div>
+                  ) : null}
+                  <div className="text-xs text-text-muted">
+                    {run.passCount} pass / {run.failCount} fail
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/api/eval-runs/[id]/route.ts
+++ b/apps/web/src/app/api/eval-runs/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const run = await prisma.evalRun.findUnique({
+    where: { id: params.id },
+    include: {
+      suite: { select: { id: true, name: true } },
+      agent: { select: { id: true, name: true } },
+      results: {
+        include: {
+          case: { select: { id: true, title: true, prompt: true, expectedOutput: true, weight: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!run) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(run)
+}

--- a/apps/web/src/app/api/eval-runs/[id]/score/route.ts
+++ b/apps/web/src/app/api/eval-runs/[id]/score/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+type AssertionDef = {
+  type: 'contains_text' | 'not_contains_text' | 'regex_match' | 'llm_judge'
+  value: string
+  weight?: number
+}
+
+type AssertionResult = AssertionDef & { passed: boolean; score: number; reason?: string }
+
+async function scoreAssertion(
+  assertion: AssertionDef,
+  output: string,
+  expectedOutput: string | null
+): Promise<AssertionResult> {
+  const out = output ?? ''
+
+  switch (assertion.type) {
+    case 'contains_text': {
+      const passed = out.toLowerCase().includes(assertion.value.toLowerCase())
+      return { ...assertion, passed, score: passed ? 1 : 0 }
+    }
+    case 'not_contains_text': {
+      const passed = !out.toLowerCase().includes(assertion.value.toLowerCase())
+      return { ...assertion, passed, score: passed ? 1 : 0 }
+    }
+    case 'regex_match': {
+      let passed = false
+      try {
+        passed = new RegExp(assertion.value, 'i').test(out)
+      } catch {
+        passed = false
+      }
+      return { ...assertion, passed, score: passed ? 1 : 0 }
+    }
+    case 'llm_judge': {
+      const apiKey = process.env.ANTHROPIC_API_KEY
+      if (!apiKey) {
+        return { ...assertion, passed: false, score: 0, reason: 'No ANTHROPIC_API_KEY configured' }
+      }
+
+      try {
+        const prompt = `You are evaluating an AI agent's response.
+Expected behavior: ${expectedOutput ?? assertion.value}
+Actual output: ${out}
+
+Does the response satisfy the expected behavior? Respond with JSON only:
+{"passed": boolean, "score": number (0-100), "reason": string}`
+
+        const res = await fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          headers: {
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: 'claude-haiku-4-5',
+            max_tokens: 256,
+            messages: [{ role: 'user', content: prompt }],
+          }),
+        })
+
+        const data = await res.json() as { content?: Array<{ text?: string }> }
+        const text = data.content?.[0]?.text ?? '{}'
+        const parsed = JSON.parse(text) as { passed?: boolean; score?: number; reason?: string }
+
+        return {
+          ...assertion,
+          passed: !!parsed.passed,
+          score: typeof parsed.score === 'number' ? parsed.score / 100 : (parsed.passed ? 1 : 0),
+          reason: parsed.reason,
+        }
+      } catch (err) {
+        return { ...assertion, passed: false, score: 0, reason: String(err) }
+      }
+    }
+    default:
+      return { ...assertion, passed: false, score: 0, reason: 'Unknown assertion type' }
+  }
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const run = await prisma.evalRun.findUnique({
+    where: { id: params.id },
+    include: {
+      results: {
+        include: { case: true },
+      },
+    },
+  })
+
+  if (!run) return NextResponse.json({ error: 'Run not found' }, { status: 404 })
+
+  type RunResult = (typeof run.results)[number]
+  const pendingResults = run.results.filter((r: RunResult) => r.taskId && r.score === null)
+
+  for (const result of pendingResults) {
+    const startedAt = Date.now()
+
+    // Fetch task output
+    let output = ''
+    if (result.taskId) {
+      const task = await prisma.task.findUnique({
+        where: { id: result.taskId },
+        include: {
+          events: {
+            orderBy: { createdAt: 'desc' },
+            take: 10,
+          },
+        },
+      })
+
+      if (task) {
+        // Try to get output from events
+        type TaskEvent = (typeof task.events)[number]
+        const outputEvent = task.events.find((e: TaskEvent) =>
+          e.eventType === 'output' || e.eventType === 'completed'
+        )
+        output = outputEvent?.content ?? task.events.find((e: TaskEvent) => e.content)?.content ?? ''
+      }
+    }
+
+    if (!output) {
+      // Task not yet complete — skip this result
+      continue
+    }
+
+    // Parse assertions from the case
+    let assertions: AssertionDef[] = []
+    try {
+      assertions = JSON.parse(result.case.assertions) as AssertionDef[]
+    } catch {
+      assertions = []
+    }
+
+    // Score each assertion
+    const assertionResults: AssertionResult[] = await Promise.all(
+      assertions.map(a => scoreAssertion(a, output, result.case.expectedOutput ?? null))
+    )
+
+    // Calculate weighted score
+    const totalWeight = assertionResults.reduce((sum, a) => sum + (a.weight ?? 1), 0)
+    const weightedScore =
+      totalWeight > 0
+        ? assertionResults.reduce((sum, a) => sum + a.score * (a.weight ?? 1), 0) / totalWeight
+        : 0
+
+    const passed = assertionResults.every(a => a.passed)
+    const judgeResult = assertionResults.find(a => a.type === 'llm_judge')
+
+    await prisma.evalCaseResult.update({
+      where: { id: result.id },
+      data: {
+        output,
+        passed,
+        score: weightedScore * 100,
+        assertions: JSON.stringify(assertionResults),
+        judgeReason: judgeResult?.reason ?? null,
+        durationMs: Date.now() - startedAt,
+      },
+    })
+  }
+
+  // Check if all results are scored
+  const allResults = await prisma.evalCaseResult.findMany({
+    where: { runId: params.id },
+  })
+
+  type CaseResult = (typeof allResults)[number]
+  const scoredResults = allResults.filter((r: CaseResult) => r.score !== null)
+  const allScored = scoredResults.length === allResults.length
+
+  if (allScored && allResults.length > 0) {
+    // Get the eval cases to get weights
+    const caseIds = allResults.map((r: CaseResult) => r.caseId)
+    const cases = await prisma.evalCase.findMany({
+      where: { id: { in: caseIds } },
+      select: { id: true, weight: true },
+    })
+    const caseWeightMap = new Map(cases.map((c: { id: string; weight: number }) => [c.id, c.weight]))
+
+    const totalWeight = allResults.reduce((sum: number, r: CaseResult) => sum + Number(caseWeightMap.get(r.caseId) ?? 1), 0)
+    const scoreTotal =
+      totalWeight > 0
+        ? allResults.reduce((sum: number, r: CaseResult) => sum + (r.score ?? 0) * Number(caseWeightMap.get(r.caseId) ?? 1), 0) / totalWeight
+        : 0
+
+    const passCount = allResults.filter((r: CaseResult) => r.passed === true).length
+    const failCount = allResults.filter((r: CaseResult) => r.passed === false).length
+
+    await prisma.evalRun.update({
+      where: { id: params.id },
+      data: {
+        status: 'completed',
+        scoreTotal,
+        passCount,
+        failCount,
+        completedAt: new Date(),
+      },
+    })
+  }
+
+  return NextResponse.json({ ok: true, scored: scoredResults.length, total: allResults.length })
+}

--- a/apps/web/src/app/api/eval-suites/[id]/cases/[caseId]/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/cases/[caseId]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string; caseId: string } }
+) {
+  await requireServiceAuth(req)
+
+  let body: {
+    title?: string
+    prompt?: string
+    expectedOutput?: string | null
+    assertions?: Array<{ type: string; value: string; weight?: number }>
+    weight?: number
+  }
+
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const evalCase = await prisma.evalCase.update({
+    where: { id: params.caseId },
+    data: {
+      ...(body.title !== undefined && { title: body.title }),
+      ...(body.prompt !== undefined && { prompt: body.prompt }),
+      ...(body.expectedOutput !== undefined && { expectedOutput: body.expectedOutput }),
+      ...(body.assertions !== undefined && { assertions: JSON.stringify(body.assertions) }),
+      ...(body.weight !== undefined && { weight: body.weight }),
+    },
+  })
+
+  return NextResponse.json(evalCase)
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string; caseId: string } }
+) {
+  await requireServiceAuth(req)
+
+  await prisma.evalCase.delete({ where: { id: params.caseId } })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/eval-suites/[id]/cases/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/cases/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const cases = await prisma.evalCase.findMany({
+    where: { suiteId: params.id },
+    orderBy: { createdAt: 'asc' },
+  })
+
+  return NextResponse.json(cases)
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  let body: {
+    title: string
+    prompt: string
+    expectedOutput?: string
+    assertions: Array<{ type: string; value: string; weight?: number }>
+    weight?: number
+  }
+
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!body.title || !body.prompt || !body.assertions) {
+    return NextResponse.json({ error: 'title, prompt, and assertions are required' }, { status: 400 })
+  }
+
+  const evalCase = await prisma.evalCase.create({
+    data: {
+      suiteId: params.id,
+      title: body.title,
+      prompt: body.prompt,
+      expectedOutput: body.expectedOutput ?? null,
+      assertions: JSON.stringify(body.assertions),
+      weight: body.weight ?? 1,
+    },
+  })
+
+  return NextResponse.json(evalCase, { status: 201 })
+}

--- a/apps/web/src/app/api/eval-suites/[id]/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const suite = await prisma.evalSuite.findUnique({
+    where: { id: params.id },
+    include: {
+      agent: { select: { id: true, name: true } },
+      cases: { orderBy: { createdAt: 'asc' } },
+      runs: {
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        include: {
+          agent: { select: { id: true, name: true } },
+          _count: { select: { results: true } },
+        },
+      },
+    },
+  })
+
+  if (!suite) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(suite)
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  let body: { name?: string; description?: string; agentId?: string | null }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const suite = await prisma.evalSuite.update({
+    where: { id: params.id },
+    data: {
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.description !== undefined && { description: body.description }),
+      ...(body.agentId !== undefined && { agentId: body.agentId }),
+    },
+  })
+
+  return NextResponse.json(suite)
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  await prisma.evalSuite.delete({ where: { id: params.id } })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/eval-suites/[id]/run/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/run/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const caller = await requireServiceAuth(req)
+
+  let body: { agentId: string; modelId?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!body.agentId) {
+    return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
+  }
+
+  // Load suite with cases
+  const suite = await prisma.evalSuite.findUnique({
+    where: { id: params.id },
+    include: { cases: true },
+  })
+  if (!suite) return NextResponse.json({ error: 'Suite not found' }, { status: 404 })
+  if (suite.cases.length === 0) {
+    return NextResponse.json({ error: 'Suite has no cases' }, { status: 400 })
+  }
+
+  // Resolve agent + modelId
+  const agent = await prisma.agent.findUnique({ where: { id: body.agentId } })
+  if (!agent) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
+
+  // Determine modelId: use provided, or fall back to agent metadata, or 'default'
+  let modelId = body.modelId
+  if (!modelId) {
+    const meta = agent.metadata as { modelId?: string } | null
+    modelId = meta?.modelId ?? 'default'
+  }
+
+  // Create EvalRun
+  const run = await prisma.evalRun.create({
+    data: {
+      suiteId: params.id,
+      agentId: body.agentId,
+      modelId,
+      status: 'pending',
+    },
+  })
+
+  // For each case: create a Task and an EvalCaseResult (pending)
+  const createdBy = caller?.id ?? 'eval-harness'
+  for (const evalCase of suite.cases) {
+    const task = await prisma.task.create({
+      data: {
+        title: evalCase.title,
+        description: evalCase.prompt,
+        assignedAgent: body.agentId,
+        status: 'pending',
+        priority: 'medium',
+        createdBy,
+      } as any,
+    })
+
+    await prisma.evalCaseResult.create({
+      data: {
+        runId: run.id,
+        caseId: evalCase.id,
+        taskId: task.id,
+        passed: null,
+        assertions: JSON.stringify([]),
+      },
+    })
+  }
+
+  // Update run to running
+  await prisma.evalRun.update({
+    where: { id: run.id },
+    data: { status: 'running', startedAt: new Date() },
+  })
+
+  return NextResponse.json({ runId: run.id }, { status: 201 })
+}

--- a/apps/web/src/app/api/eval-suites/[id]/runs/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/runs/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const runs = await prisma.evalRun.findMany({
+    where: { suiteId: params.id },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      agent: { select: { id: true, name: true } },
+      _count: { select: { results: true } },
+    },
+  })
+
+  return NextResponse.json(runs)
+}

--- a/apps/web/src/app/api/eval-suites/route.ts
+++ b/apps/web/src/app/api/eval-suites/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
+
+  const suites = await prisma.evalSuite.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      _count: { select: { cases: true } },
+      agent: { select: { id: true, name: true } },
+      runs: {
+        orderBy: { createdAt: 'desc' },
+        take: 1,
+        select: { scoreTotal: true, status: true, createdAt: true },
+      },
+    },
+  })
+
+  return NextResponse.json(suites)
+}
+
+export async function POST(req: NextRequest) {
+  await requireServiceAuth(req)
+
+  let body: { name: string; description?: string; agentId?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!body.name) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 })
+  }
+
+  const suite = await prisma.evalSuite.create({
+    data: {
+      name: body.name,
+      description: body.description ?? null,
+      agentId: body.agentId ?? null,
+    },
+  })
+
+  return NextResponse.json(suite, { status: 201 })
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import {
   Server, MessageSquare, Bot,
   Bell, ClipboardList,
-  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles, Shield,
+  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles, Shield, FlaskConical,
 } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 import { useUnackAlertCount } from '@/hooks/useSecurityAlerts'
@@ -19,6 +19,7 @@ const nav = [
   { href: '/security',       icon: Shield, label: 'Security' },
   { href: '/notes',          icon: BookOpen, label: 'Wiki' },
   { href: '/nova',           icon: Sparkles, label: 'Nova' },
+  { href: '/evals',          icon: FlaskConical, label: 'Evals' },
 ]
 
 export function Sidebar() {


### PR DESCRIPTION
## Summary

Adds a benchmark harness for evaluating agent capability — separate from the existing retrospective eval system (which scores real production runs). This lets you define test suites, run an agent against them, and track performance over time.

## New models (4)

- **`EvalSuite`** — named collection of test cases, optionally scoped to an agent
- **`EvalCase`** — individual test case: prompt, expected output, typed assertions
- **`EvalRun`** — a benchmark execution against a suite (agent, model, status, scores)
- **`EvalCaseResult`** — per-case result: actual output, assertion pass/fail, LLM judge reasoning

## Assertion types

| Type | How it's scored |
|---|---|
| `contains_text` | output includes the expected string (case-insensitive) |
| `not_contains_text` | output does NOT include the string |
| `regex_match` | output matches the regex pattern |
| `llm_judge` | Claude grades the output against the expected behavior (0–100 + reasoning) |

## API routes (8)

- `GET/POST /api/eval-suites` — list / create suites
- `GET/PUT/DELETE /api/eval-suites/[id]` — suite detail / update / delete
- `GET/POST /api/eval-suites/[id]/cases` — list / add cases
- `PUT/DELETE /api/eval-suites/[id]/cases/[caseId]` — update / delete case
- `POST /api/eval-suites/[id]/run` — trigger a benchmark run
- `GET /api/eval-suites/[id]/runs` — run history for suite
- `GET /api/eval-runs/[id]` — run detail with case results
- `POST /api/eval-runs/[id]/score` — score a completed run (called by worker or manually)

## UI

- `/evals` — dashboard: suites list with last score + case count, recent runs tab
- `/evals/[id]` — suite detail: cases list, assertion badges, run history table, "Run Benchmark" button
- Sidebar nav entry added

## Test plan

- [ ] Create a suite with 2–3 cases (mix of `contains_text` and `llm_judge` assertions)
- [ ] Run the suite against an agent → verify tasks are created and EvalRun shows `running`
- [ ] POST `/api/eval-runs/[id]/score` → verify case results with scores and judge reasoning
- [ ] Check `/evals` dashboard shows updated scores

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_