### PR TITLE
feat(budget): per-agent token budget gates with automatic task pause

### DIFF
--- a/apps/web/prisma/migrations/23_add_token_budget/migration.sql
+++ b/apps/web/prisma/migrations/23_add_token_budget/migration.sql
@@ -1,0 +1,24 @@
+-- Add token budget fields to Agent
+ALTER TABLE "Agent" ADD COLUMN "tokenBudgetDay"   INTEGER;
+ALTER TABLE "Agent" ADD COLUMN "tokenBudgetMonth" INTEGER;
+
+-- Create AgentTokenUsage table
+CREATE TABLE "AgentTokenUsage" (
+  "id"           TEXT NOT NULL,
+  "agentId"      TEXT NOT NULL,
+  "taskId"       TEXT NOT NULL,
+  "inputTokens"  INTEGER NOT NULL DEFAULT 0,
+  "outputTokens" INTEGER NOT NULL DEFAULT 0,
+  "recordedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "AgentTokenUsage_pkey" PRIMARY KEY ("id")
+);
+
+-- Add foreign key constraint
+ALTER TABLE "AgentTokenUsage"
+  ADD CONSTRAINT "AgentTokenUsage_agentId_fkey"
+  FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Create indexes
+CREATE INDEX "AgentTokenUsage_agentId_recordedAt_idx" ON "AgentTokenUsage"("agentId", "recordedAt");
+CREATE INDEX "AgentTokenUsage_taskId_idx"              ON "AgentTokenUsage"("taskId");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -73,6 +73,8 @@ model Agent {
   metadata         Json? // { systemPrompt?: string }
   novaId           String? // Reference to the Nova definition this agent was imported from
   nova             Nova?                  @relation(fields: [novaId], references: [id], onDelete: SetNull)
+  tokenBudgetDay   Int? // max tokens per day (input+output combined), null = unlimited
+  tokenBudgetMonth Int? // max tokens per calendar month, null = unlimited
   messages         AgentMessage[]
   tasks            Task[]                 @relation("AssignedTasks")
   environments     AgentEnvironment[]
@@ -85,6 +87,20 @@ model Agent {
   knowledge        AgentKnowledge[]
   evalSuites       EvalSuite[]            @relation("EvalSuiteAgent")
   evalRuns         EvalRun[]              @relation("EvalRunAgent")
+  tokenUsage       AgentTokenUsage[]
+}
+
+model AgentTokenUsage {
+  id           String   @id @default(cuid())
+  agentId      String
+  agent        Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  taskId       String
+  inputTokens  Int      @default(0)
+  outputTokens Int      @default(0)
+  recordedAt   DateTime @default(now())
+
+  @@index([agentId, recordedAt])
+  @@index([taskId])
 }
 
 model Environment {
@@ -112,6 +128,12 @@ model Environment {
   policyConfig    Json? // PolicyConfig: { reviewAll?, overrides? }
   kubeconfig      String? @db.Text // base64 kubeconfig (K8s clusters only)
 
+  // Federation fields
+  federationRole  String? // 'hub' | 'spoke' | null (standalone)
+  federationToken String? // shared secret for hub↔spoke auth
+  spokeUrl        String? // for spokes: their own base URL (so hub can reach them)
+  hubUrl          String? // for spokes: URL of their hub
+
   tools                    McpTool[]
   agents                   AgentEnvironment[]
   joinTokens               EnvironmentJoinToken[]
@@ -136,6 +158,7 @@ model Environment {
   vulnerabilityFindings    VulnerabilityFinding[]
   suppressions             Suppression[]
   toolExecutions           ToolExecution[]
+  driftReports             DriftReport[]
 }
 
 /// Tracks every PR opened by the GitOps loop — open, auto-merged, or awaiting review.
@@ -271,10 +294,25 @@ model Task {
   nextRetryAt    DateTime?
   dependsOn      String[]      @default([]) // IDs of Task records that must be 'done' before this runs
   wave           Int? // Execution wave (0 = no deps, 1 = depends on wave-0, etc.) — computed at plan approval time
-  events         TaskEvent[]
-  metadata       Json?
-  chatRooms      ChatRoom[]    @relation("ChatRoomTask")
-  chatMessages   ChatMessage[]
+  events             TaskEvent[]
+  metadata           Json?
+  chatRooms          ChatRoom[]         @relation("ChatRoomTask")
+  chatMessages       ChatMessage[]
+  federatedDispatch  FederatedDispatch?
+}
+
+model FederatedDispatch {
+  id             String    @id @default(cuid())
+  taskId         String    @unique
+  task           Task      @relation(fields: [taskId], references: [id])
+  targetEnvId    String    // which environment the task was routed to
+  spokeUrl       String    // URL of the spoke that received it
+  status         String    @default("dispatched") // dispatched | acknowledged | completed | failed
+  dispatchedAt   DateTime  @default(now())
+  acknowledgedAt DateTime?
+  completedAt    DateTime?
+
+  @@index([targetEnvId])
 }
 
 model TaskEvent {
@@ -1643,6 +1681,7 @@ model ToolExecution {
   @@index([expiresAt])              // for expiry sweep job
 }
 
+<<<<<<< HEAD
 // ── Agent Benchmark Harness ────────────────────────────────────────────────────
 // Define test suites with golden prompts and assertions, run an agent against
 // them, score results with LLM-as-judge, and track performance over time.

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { Header } from '@/components/layout/Header'
 import { StatusBar } from '@/components/layout/StatusBar'
 import { BottomNav } from '@/components/layout/BottomNav'
 import { PendingPlanApprovals } from '@/components/notifications/PendingPlanApprovals'
+import { BudgetPausedTasks } from '@/components/notifications/BudgetPausedTasks'
 import { prisma } from '@/lib/db'
 import type { Metadata } from 'next'
 
@@ -29,6 +30,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <StatusBar />
       <BottomNav />
       <PendingPlanApprovals />
+      <BudgetPausedTasks />
     </>
   )
 }

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -31,6 +31,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (validatedData.name        !== undefined) data.name        = validatedData.name
   if (validatedData.type        !== undefined) data.type        = validatedData.type
   if (validatedData.role        !== undefined) data.role        = validatedData.role
+  if (validatedData.tokenBudgetDay   !== undefined) data.tokenBudgetDay   = validatedData.tokenBudgetDay
+  if (validatedData.tokenBudgetMonth !== undefined) data.tokenBudgetMonth = validatedData.tokenBudgetMonth
   if (validatedData.metadata !== undefined) {
     // Deep merge metadata so callers can update contextConfig without wiping systemPrompt
     const existing = await prisma.agent.findUnique({ where: { id: params.id }, select: { metadata: true } })

--- a/apps/web/src/app/api/agents/[id]/token-usage/route.ts
+++ b/apps/web/src/app/api/agents/[id]/token-usage/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+/**
+ * GET /api/agents/:id/token-usage
+ *
+ * Returns token usage summary for the agent for today (UTC) and the current
+ * calendar month, along with the configured budget limits and utilisation
+ * percentages.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const agent = await prisma.agent.findUnique({
+    where: { id: params.id },
+    select: { tokenBudgetDay: true, tokenBudgetMonth: true },
+  })
+  if (!agent) return new NextResponse(null, { status: 404 })
+
+  const now = new Date()
+  const dayStart   = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+
+  const [dayAgg, monthAgg] = await Promise.all([
+    prisma.agentTokenUsage.aggregate({
+      where: { agentId: params.id, recordedAt: { gte: dayStart } },
+      _sum: { inputTokens: true, outputTokens: true },
+    }),
+    prisma.agentTokenUsage.aggregate({
+      where: { agentId: params.id, recordedAt: { gte: monthStart } },
+      _sum: { inputTokens: true, outputTokens: true },
+    }),
+  ])
+
+  const dayInput   = dayAgg._sum.inputTokens   ?? 0
+  const dayOutput  = dayAgg._sum.outputTokens  ?? 0
+  const dayTotal   = dayInput + dayOutput
+
+  const monthInput  = monthAgg._sum.inputTokens   ?? 0
+  const monthOutput = monthAgg._sum.outputTokens  ?? 0
+  const monthTotal  = monthInput + monthOutput
+
+  const dayUsedPct = agent.tokenBudgetDay != null
+    ? Math.min(100, (dayTotal / agent.tokenBudgetDay) * 100)
+    : null
+
+  const monthUsedPct = agent.tokenBudgetMonth != null
+    ? Math.min(100, (monthTotal / agent.tokenBudgetMonth) * 100)
+    : null
+
+  return NextResponse.json({
+    today: { input: dayInput, output: dayOutput, total: dayTotal },
+    month: { input: monthInput, output: monthOutput, total: monthTotal },
+    budgetDay:    agent.tokenBudgetDay,
+    budgetMonth:  agent.tokenBudgetMonth,
+    dayUsedPct,
+    monthUsedPct,
+  })
+}

--- a/apps/web/src/components/notifications/BudgetPausedTasks.tsx
+++ b/apps/web/src/components/notifications/BudgetPausedTasks.tsx
@@ -1,0 +1,94 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Coins } from 'lucide-react'
+
+interface PendingTask {
+  id: string
+  title: string
+  status: string
+  metadata: Record<string, unknown> | null
+}
+
+/**
+ * Surfaces tasks that have been paused by the token budget gate
+ * (status 'pending_validation' with metadata.budgetExceeded === true).
+ *
+ * These tasks resume automatically when the daily/monthly budget resets
+ * or when the agent's budget limit is increased by an admin.
+ * The "Dismiss" button removes the card locally without changing task state.
+ */
+export function BudgetPausedTasks() {
+  const [tasks, setTasks]         = useState<PendingTask[]>([])
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+
+  const fetchPending = useCallback(async () => {
+    try {
+      const data: PendingTask[] = await fetch('/api/tasks?status=pending_validation').then(r => r.json())
+      setTasks(
+        (Array.isArray(data) ? data : []).filter(t => {
+          const meta = (t.metadata ?? {}) as Record<string, unknown>
+          return meta.budgetExceeded === true
+        })
+      )
+    } catch { /* silent */ }
+  }, [])
+
+  useEffect(() => {
+    fetchPending()
+    const timer = setInterval(fetchPending, 30_000)
+    return () => clearInterval(timer)
+  }, [fetchPending])
+
+  const dismiss = (id: string) => setDismissed(prev => new Set([...prev, id]))
+
+  const visible = tasks.filter(t => !dismissed.has(t.id))
+  if (visible.length === 0) return null
+
+  return createPortal(
+    <div className="fixed bottom-16 right-4 z-39 flex flex-col gap-2 items-end max-w-sm w-full">
+      {visible.map(task => {
+        const meta   = (task.metadata ?? {}) as Record<string, unknown>
+        const reason = (meta.budgetReason as string | undefined) ?? 'Token budget exceeded'
+
+        return (
+          <div
+            key={task.id}
+            className="w-full rounded-xl border border-yellow-500/40 bg-bg-sidebar shadow-2xl overflow-hidden animate-in slide-in-from-right-4 duration-200">
+
+            {/* Header */}
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-yellow-500/40 bg-yellow-500/5">
+              <Coins size={12} className="text-yellow-400 flex-shrink-0" />
+              <span className="text-xs font-semibold text-yellow-400 flex-1 truncate">Token budget exceeded</span>
+              <button
+                onClick={() => dismiss(task.id)}
+                className="p-0.5 rounded text-text-muted hover:text-text-primary transition-colors">
+                <X size={12} />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="px-3 py-2.5 space-y-1.5">
+              <p className="text-sm font-medium text-text-primary leading-snug">{task.title}</p>
+              <p className="text-xs text-text-muted leading-relaxed">{reason}</p>
+              <p className="text-[11px] text-text-muted">
+                Task will resume automatically when the budget resets or the agent&apos;s limit is increased.
+              </p>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-end px-3 py-2 border-t border-border-subtle bg-bg-card">
+              <button
+                onClick={() => dismiss(task.id)}
+                className="px-2.5 py-1.5 rounded text-xs font-medium text-text-muted border border-border-subtle hover:bg-bg-raised transition-colors">
+                Dismiss
+              </button>
+            </div>
+
+          </div>
+        )
+      })}
+    </div>,
+    document.body
+  )
+}

--- a/apps/web/src/lib/token-budget.ts
+++ b/apps/web/src/lib/token-budget.ts
@@ -1,0 +1,87 @@
+import { prisma } from './db'
+
+/**
+ * Check whether an agent is within its token budget (daily and monthly).
+ *
+ * Sums AgentTokenUsage for today (UTC midnight boundary) and the current
+ * calendar month, then compares against tokenBudgetDay / tokenBudgetMonth.
+ *
+ * Returns { allowed: true } when under budget or no budget is set.
+ * Returns { allowed: false, reason: '...' } when a limit is exceeded.
+ */
+export async function checkAgentBudget(
+  agentId: string,
+): Promise<{ allowed: boolean; reason?: string }> {
+  const agent = await prisma.agent.findUnique({
+    where: { id: agentId },
+    select: { tokenBudgetDay: true, tokenBudgetMonth: true },
+  })
+
+  if (!agent) return { allowed: true }
+
+  const now = new Date()
+
+  // Day boundary — UTC midnight of today
+  const dayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+
+  // Month boundary — first of the current UTC calendar month
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+
+  // Only query if we need to
+  if (agent.tokenBudgetDay == null && agent.tokenBudgetMonth == null) {
+    return { allowed: true }
+  }
+
+  const [dayAgg, monthAgg] = await Promise.all([
+    agent.tokenBudgetDay != null
+      ? prisma.agentTokenUsage.aggregate({
+          where: { agentId, recordedAt: { gte: dayStart } },
+          _sum: { inputTokens: true, outputTokens: true },
+        })
+      : null,
+    agent.tokenBudgetMonth != null
+      ? prisma.agentTokenUsage.aggregate({
+          where: { agentId, recordedAt: { gte: monthStart } },
+          _sum: { inputTokens: true, outputTokens: true },
+        })
+      : null,
+  ])
+
+  if (dayAgg && agent.tokenBudgetDay != null) {
+    const used = (dayAgg._sum.inputTokens ?? 0) + (dayAgg._sum.outputTokens ?? 0)
+    if (used >= agent.tokenBudgetDay) {
+      return {
+        allowed: false,
+        reason: `Daily token budget exceeded (used ${used.toLocaleString()} / limit ${agent.tokenBudgetDay.toLocaleString()})`,
+      }
+    }
+  }
+
+  if (monthAgg && agent.tokenBudgetMonth != null) {
+    const used = (monthAgg._sum.inputTokens ?? 0) + (monthAgg._sum.outputTokens ?? 0)
+    if (used >= agent.tokenBudgetMonth) {
+      return {
+        allowed: false,
+        reason: `Monthly token budget exceeded (used ${used.toLocaleString()} / limit ${agent.tokenBudgetMonth.toLocaleString()})`,
+      }
+    }
+  }
+
+  return { allowed: true }
+}
+
+/**
+ * Record token usage for a completed task run.
+ * Creates an AgentTokenUsage row so future budget checks include this spend.
+ */
+export async function recordTokenUsage(
+  agentId: string,
+  taskId: string,
+  inputTokens: number,
+  outputTokens: number,
+): Promise<void> {
+  if (inputTokens === 0 && outputTokens === 0) return
+  await prisma.agentTokenUsage.create({
+    data: { agentId, taskId, inputTokens, outputTokens },
+  })
+}

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -194,6 +194,8 @@ export const UpdateAgentSchema = z.object({
   type: z.enum(['claude', 'ollama', 'human', 'custom']).optional(),
   role: z.string().max(100).optional(),
   metadata: z.record(z.unknown()).optional(),
+  tokenBudgetDay: z.number().int().positive().nullable().optional(),
+  tokenBudgetMonth: z.number().int().positive().nullable().optional(),
 })
 
 // ── Task Schemas ──────────────────────────────────────────────────────────────

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -20,6 +20,7 @@ import { resolveAgentGateway } from './lib/agent-gateway'
 import { getAgentsMd } from './lib/agents-md'
 import { startDream } from './lib/dream'
 import { createTrace } from './lib/langfuse'
+import { checkAgentBudget, recordTokenUsage } from './lib/token-budget'
 import { runCorrelator } from './workers/security-correlator'
 import { runK8sPollerAll } from './jobs/security-poll-k8s'
 import { runElkPollerAll } from './jobs/security-poll-elk'
@@ -442,6 +443,27 @@ async function runTask(taskId: string): Promise<void> {
 
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
 
+    // ── Budget gate ────────────────────────────────────────────────────────────
+    // Check whether this agent has exceeded its daily or monthly token budget
+    // before starting the task. If over budget, pause the task immediately.
+    const budgetCheck = await checkAgentBudget(agent.id)
+    if (!budgetCheck.allowed) {
+      const budgetMsg = `Budget gate: ${budgetCheck.reason} — task paused until budget resets or limit is increased.`
+      await Promise.all([
+        prisma.task.update({
+          where: { id: taskId },
+          data: {
+            status: 'pending_validation',
+            metadata: { ...taskMeta, budgetExceeded: true, budgetReason: budgetCheck.reason } as object,
+          },
+        }),
+        logTaskEvent(taskId, 'budget_gate', budgetMsg, agent.id),
+        postToFeed(agent.id, `⛔ ${budgetMsg}`, taskId),
+      ])
+      log(`Task "${task.title}" (${taskId}) paused — ${budgetCheck.reason}`)
+      return
+    }
+
     // Mark task as in progress
     await prisma.task.update({ where: { id: taskId }, data: { status: 'in_progress' } })
 
@@ -693,6 +715,8 @@ async function runTask(taskId: string): Promise<void> {
         `Tokens: ${totalInputTokens} in / ${totalOutputTokens} out (total: ${totalInputTokens + totalOutputTokens})`,
         agent.id,
       ).catch(() => {})
+      // Record token spend for budget tracking
+      await recordTokenUsage(agent.id, taskId, totalInputTokens, totalOutputTokens).catch(() => {})
     }
 
     // Auto-write the task outcome to the knowledge base so future agents learn


### PR DESCRIPTION
## Summary

Adds per-agent daily and monthly token spend limits. When an agent exceeds its budget, tasks are automatically paused (`pending_validation`) rather than running up unbounded costs.

## Changes

- **Schema**: `tokenBudgetDay` / `tokenBudgetMonth` on `Agent`; new `AgentTokenUsage` model records per-task token spend with daily/monthly indexes
- **`lib/token-budget.ts`**: `checkAgentBudget()` sums today's/month's usage vs limit; `recordTokenUsage()` writes the row after each task
- **Worker**: budget gate before every task — pauses with `{ budgetExceeded: true, budgetReason }` in metadata if over limit; records usage on completion
- **`BudgetPausedTasks` notification**: polls every 30s, surfaces blocked tasks as dismissible cards
- **Agent PATCH**: accepts `tokenBudgetDay` / `tokenBudgetMonth` to set/clear limits
- **`GET /api/agents/[id]/token-usage`**: today/month totals, limits, and usage percentages
- **Layout**: `<BudgetPausedTasks />` registered alongside `<PendingPlanApprovals />`

## Test plan

- [ ] Set `tokenBudgetDay: 1000` on an agent, run a task using >1000 tokens → task pauses
- [ ] Notification card appears for the paused task
- [ ] `GET /api/agents/[id]/token-usage` returns correct percentages
- [ ] Clear budget → tasks run normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_