### PR TITLE
feat(federation): multi-cluster task routing with hub/spoke model

### DIFF
--- a/apps/web/prisma/migrations/23_add_federation/migration.sql
+++ b/apps/web/prisma/migrations/23_add_federation/migration.sql
@@ -1,0 +1,25 @@
+-- Add federation fields to Environment
+ALTER TABLE "Environment" ADD COLUMN IF NOT EXISTS "federationRole"  TEXT;
+ALTER TABLE "Environment" ADD COLUMN IF NOT EXISTS "federationToken" TEXT;
+ALTER TABLE "Environment" ADD COLUMN IF NOT EXISTS "spokeUrl"        TEXT;
+ALTER TABLE "Environment" ADD COLUMN IF NOT EXISTS "hubUrl"          TEXT;
+
+-- Add FederatedDispatch model
+CREATE TABLE IF NOT EXISTS "FederatedDispatch" (
+    "id"             TEXT NOT NULL,
+    "taskId"         TEXT NOT NULL,
+    "targetEnvId"    TEXT NOT NULL,
+    "spokeUrl"       TEXT NOT NULL,
+    "status"         TEXT NOT NULL DEFAULT 'dispatched',
+    "dispatchedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "acknowledgedAt" TIMESTAMP(3),
+    "completedAt"    TIMESTAMP(3),
+
+    CONSTRAINT "FederatedDispatch_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "FederatedDispatch_taskId_key" ON "FederatedDispatch"("taskId");
+CREATE INDEX IF NOT EXISTS "FederatedDispatch_targetEnvId_idx" ON "FederatedDispatch"("targetEnvId");
+
+ALTER TABLE "FederatedDispatch" ADD CONSTRAINT "FederatedDispatch_taskId_fkey"
+    FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/web/src/app/api/environments/[id]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/route.ts
@@ -100,6 +100,10 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     if (data.kubeconfig !== undefined && data.kubeconfig !== '••••') {
       updateData.kubeconfig = data.kubeconfig || null
     }
+    if (data.federationRole  !== undefined) updateData.federationRole  = data.federationRole  === 'standalone' ? null : (data.federationRole ?? null)
+    if (data.federationToken !== undefined) updateData.federationToken = data.federationToken ?? null
+    if (data.spokeUrl        !== undefined) updateData.spokeUrl        = data.spokeUrl        ?? null
+    if (data.hubUrl          !== undefined) updateData.hubUrl          = data.hubUrl          ?? null
 
     const env = await prisma.environment.update({
       where: { id: params.id },

--- a/apps/web/src/app/api/federation/status/route.ts
+++ b/apps/web/src/app/api/federation/status/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/federation/status
+ *
+ * Returns current instance load metrics. Used by hub instances to pick the
+ * least-loaded spoke for task routing.
+ *
+ * Auth: Bearer <federationToken> — must match any environment's federationToken.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+async function validateFederationToken(req: NextRequest): Promise<boolean> {
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return false
+  const token = auth.slice(7)
+
+  const env = await prisma.environment.findFirst({
+    where: { federationToken: token },
+    select: { id: true },
+  })
+  return env !== null
+}
+
+export async function GET(req: NextRequest) {
+  if (!(await validateFederationToken(req))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const [runningTasks, pendingTasks, agentCount, firstEnv] = await Promise.all([
+    prisma.task.count({ where: { status: 'in_progress' } }),
+    prisma.task.count({ where: { status: 'pending' } }),
+    prisma.agent.count({ where: { type: { not: 'human' } } }),
+    prisma.environment.findFirst({ select: { id: true } }),
+  ])
+
+  return NextResponse.json({
+    runningTasks,
+    pendingTasks,
+    agentCount,
+    environmentId: firstEnv?.id ?? null,
+  })
+}

--- a/apps/web/src/app/api/federation/tasks/[id]/status/route.ts
+++ b/apps/web/src/app/api/federation/tasks/[id]/status/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/federation/tasks/[id]/status
+ *
+ * Returns task status so a hub can poll for completion.
+ *
+ * Auth: Bearer <federationToken>
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+async function validateFederationToken(req: NextRequest): Promise<boolean> {
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return false
+  const token = auth.slice(7)
+
+  const env = await prisma.environment.findFirst({
+    where: { federationToken: token },
+    select: { id: true },
+  })
+  return env !== null
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!(await validateFederationToken(req))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const task = await prisma.task.findUnique({
+    where: { id: params.id },
+    select: { id: true, status: true, updatedAt: true, metadata: true },
+  })
+
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    taskId: task.id,
+    status: task.status,
+    updatedAt: task.updatedAt,
+  })
+}

--- a/apps/web/src/app/api/federation/tasks/route.ts
+++ b/apps/web/src/app/api/federation/tasks/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/federation/tasks
+ *
+ * Accept a task dispatched from a hub instance. Creates the task locally
+ * in this spoke's DB and marks it pending for the local worker to pick up.
+ *
+ * Auth: Bearer <federationToken>
+ * Body: { taskId, title, description?, agentId?, metadata? }
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+async function validateFederationToken(req: NextRequest): Promise<boolean> {
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) return false
+  const token = auth.slice(7)
+
+  const env = await prisma.environment.findFirst({
+    where: { federationToken: token },
+    select: { id: true },
+  })
+  return env !== null
+}
+
+export async function POST(req: NextRequest) {
+  if (!(await validateFederationToken(req))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: {
+    taskId?: string
+    title?: string
+    description?: string | null
+    agentId?: string | null
+    metadata?: Record<string, unknown> | null
+  }
+
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!body.taskId || !body.title) {
+    return NextResponse.json({ error: 'taskId and title are required' }, { status: 400 })
+  }
+
+  // Verify the agent exists on this spoke (if provided)
+  if (body.agentId) {
+    const agent = await prisma.agent.findUnique({
+      where: { id: body.agentId },
+      select: { id: true },
+    })
+    if (!agent) {
+      return NextResponse.json(
+        { error: `Agent ${body.agentId} not found on this spoke` },
+        { status: 422 },
+      )
+    }
+  }
+
+  // Create or upsert the task — the taskId is supplied by the hub so it can
+  // correlate status lookups by the same ID.
+  const task = await prisma.task.upsert({
+    where: { id: body.taskId },
+    create: {
+      id: body.taskId,
+      title: body.title,
+      description: body.description ?? null,
+      assignedAgent: body.agentId ?? null,
+      createdBy: 'federation',
+      status: 'pending',
+      metadata: {
+        ...(body.metadata as object | null ?? {}),
+        federatedFrom: 'hub',
+      } as object,
+    },
+    update: {
+      status: 'pending',
+    },
+    select: { id: true, status: true },
+  })
+
+  // Acknowledge the dispatch if a FederatedDispatch record exists for this task
+  await prisma.federatedDispatch
+    .updateMany({
+      where: { taskId: body.taskId, status: 'dispatched' },
+      data: { status: 'acknowledged', acknowledgedAt: new Date() },
+    })
+    .catch(() => {})
+
+  return NextResponse.json({ accepted: true, taskId: task.id }, { status: 201 })
+}

--- a/apps/web/src/components/environments/EnvironmentsPage.tsx
+++ b/apps/web/src/components/environments/EnvironmentsPage.tsx
@@ -78,8 +78,8 @@ const DEFAULT_INPUT_SCHEMA = `{
 
 // ─── Environment form ──────────────────────────────────────────────────────────
 
-interface EnvForm { name: string; type: string; description: string; gatewayUrl: string; gatewayToken: string; kubeconfig: string; nodeIp: string; talosConfig: string }
-const EMPTY_ENV: EnvForm = { name: '', type: 'cluster', description: '', gatewayUrl: '', gatewayToken: '', kubeconfig: '', nodeIp: '', talosConfig: '' }
+interface EnvForm { name: string; type: string; description: string; gatewayUrl: string; gatewayToken: string; kubeconfig: string; nodeIp: string; talosConfig: string; federationRole: string; federationToken: string; spokeUrl: string; hubUrl: string }
+const EMPTY_ENV: EnvForm = { name: '', type: 'cluster', description: '', gatewayUrl: '', gatewayToken: '', kubeconfig: '', nodeIp: '', talosConfig: '', federationRole: 'standalone', federationToken: '', spokeUrl: '', hubUrl: '' }
 
 // ─── Wrench form ────────────────────────────────────────────────────────────────
 
@@ -336,7 +336,8 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
   const openCreateEnv = () => { setEnvForm(EMPTY_ENV); setEnvError(null); setEnvModal('create') }
   const openEditEnv = (env: Environment) => {
     const meta = (env as unknown as { metadata?: Record<string, unknown> }).metadata ?? {}
-    setEnvForm({ name: env.name, type: env.type, description: env.description ?? '', gatewayUrl: env.gatewayUrl ?? '', gatewayToken: '', kubeconfig: '', nodeIp: (meta.nodeIp as string) ?? '', talosConfig: '' })
+    const fedEnv = env as unknown as { federationRole?: string | null; federationToken?: string | null; spokeUrl?: string | null; hubUrl?: string | null }
+    setEnvForm({ name: env.name, type: env.type, description: env.description ?? '', gatewayUrl: env.gatewayUrl ?? '', gatewayToken: '', kubeconfig: '', nodeIp: (meta.nodeIp as string) ?? '', talosConfig: '', federationRole: fedEnv.federationRole ?? 'standalone', federationToken: fedEnv.federationToken ?? '', spokeUrl: fedEnv.spokeUrl ?? '', hubUrl: fedEnv.hubUrl ?? '' })
     setEnvError(null)
     setEnvModal('edit')
   }
@@ -357,7 +358,19 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
           metaUpdate.talosConfig = btoa(unescape(encodeURIComponent(envForm.talosConfig.trim())))
         }
       }
-      const payload = { name: envForm.name.trim(), type: envForm.type, description: envForm.description || null, gatewayUrl: envForm.gatewayUrl || null, gatewayToken: envForm.gatewayToken || undefined, kubeconfig: kubeconfigB64, metadata: metaUpdate }
+      const payload = {
+        name: envForm.name.trim(),
+        type: envForm.type,
+        description: envForm.description || null,
+        gatewayUrl: envForm.gatewayUrl || null,
+        gatewayToken: envForm.gatewayToken || undefined,
+        kubeconfig: kubeconfigB64,
+        metadata: metaUpdate,
+        federationRole: (envForm.federationRole && envForm.federationRole !== 'standalone') ? envForm.federationRole : null,
+        federationToken: envForm.federationToken || null,
+        spokeUrl: envForm.spokeUrl || null,
+        hubUrl: envForm.hubUrl || null,
+      }
       const res = envModal === 'create'
         ? await fetch('/api/environments', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
         : await fetch(`/api/environments/${selected!.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -1228,6 +1241,74 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
                   </div>
                 </>
               )}
+
+              {/* ─── Federation section ─────────────────────────────────────── */}
+              <div className="border-t border-border-subtle pt-4 mt-2">
+                <p className="text-xs font-medium text-text-secondary mb-3 flex items-center gap-1.5">
+                  <Globe size={12} />
+                  Federation
+                </p>
+                <div className="space-y-3">
+                  <div>
+                    <label className={labelCls}>Role</label>
+                    <select
+                      value={envForm.federationRole}
+                      onChange={e => setEnvForm(f => ({ ...f, federationRole: e.target.value }))}
+                      className={inputCls}
+                    >
+                      <option value="standalone">Standalone (no federation)</option>
+                      <option value="hub">Hub (dispatch tasks to spokes)</option>
+                      <option value="spoke">Spoke (receive tasks from hub)</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className={labelCls}>Federation Token</label>
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        value={envForm.federationToken}
+                        onChange={e => setEnvForm(f => ({ ...f, federationToken: e.target.value }))}
+                        placeholder="Shared secret for hub&#x2194;spoke auth"
+                        className={inputCls}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const token = Array.from(crypto.getRandomValues(new Uint8Array(24)))
+                            .map(b => b.toString(16).padStart(2, '0'))
+                            .join('')
+                          setEnvForm(f => ({ ...f, federationToken: token }))
+                        }}
+                        className="shrink-0 px-3 py-1.5 text-xs rounded border border-border-subtle text-text-muted hover:text-text-primary transition-colors whitespace-nowrap"
+                      >
+                        Generate
+                      </button>
+                    </div>
+                  </div>
+                  {envForm.federationRole === 'spoke' && (
+                    <>
+                      <div>
+                        <label className={labelCls}>Spoke URL <span className="text-text-muted">(this instance&apos;s base URL, reachable by the hub)</span></label>
+                        <input
+                          value={envForm.spokeUrl}
+                          onChange={e => setEnvForm(f => ({ ...f, spokeUrl: e.target.value }))}
+                          placeholder="https://spoke-orion.example.com"
+                          className={inputCls}
+                        />
+                      </div>
+                      <div>
+                        <label className={labelCls}>Hub URL <span className="text-text-muted">(URL of the hub instance)</span></label>
+                        <input
+                          value={envForm.hubUrl}
+                          onChange={e => setEnvForm(f => ({ ...f, hubUrl: e.target.value }))}
+                          placeholder="https://hub-orion.example.com"
+                          className={inputCls}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
             </div>
 
             <div className="flex items-center gap-2 px-5 py-4 border-t border-border-subtle">

--- a/apps/web/src/lib/federation.ts
+++ b/apps/web/src/lib/federation.ts
@@ -1,0 +1,188 @@
+/**
+ * Federation lib — hub/spoke multi-cluster task routing.
+ *
+ * shouldFederate(): decide whether a task should be dispatched to a spoke.
+ * dispatchToSpoke(): POST the task to a spoke and record a FederatedDispatch row.
+ */
+
+import { prisma } from './db'
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface FederationDecision {
+  federate: boolean
+  spokeUrl?: string
+  token?: string
+}
+
+interface SpokeStatus {
+  runningTasks: number
+  pendingTasks: number
+  agentCount: number
+  environmentId: string
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch status from a spoke's /api/federation/status endpoint.
+ * Returns null on any network or auth error so callers can skip unreachable spokes.
+ */
+async function fetchSpokeStatus(spokeUrl: string, token: string): Promise<SpokeStatus | null> {
+  try {
+    const res = await fetch(`${spokeUrl}/api/federation/status`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    })
+    if (!res.ok) return null
+    return (await res.json()) as SpokeStatus
+  } catch {
+    return null
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether a task should be federated to a spoke.
+ *
+ * Rules:
+ * - If the task's agent has no linked environment, run locally.
+ * - If the environment role is 'hub': probe all spoke environments for load.
+ *   Route to the least-loaded spoke that is reachable.
+ * - If the environment role is 'spoke': this task was already dispatched here — run locally.
+ * - If standalone (no role): run locally.
+ */
+export async function shouldFederate(taskId: string): Promise<FederationDecision> {
+  // Load task with agent, then find agent's environments
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: { assignedAgent: true },
+  })
+  if (!task?.assignedAgent) return { federate: false }
+
+  const agentEnvs = await prisma.agentEnvironment.findMany({
+    where: { agentId: task.assignedAgent },
+    include: {
+      environment: {
+        select: {
+          id: true,
+          federationRole: true,
+          federationToken: true,
+          spokeUrl: true,
+          hubUrl: true,
+        },
+      },
+    },
+  })
+
+  // Find the first hub environment this agent belongs to
+  const hubEnv = agentEnvs.find(ae => ae.environment.federationRole === 'hub')?.environment
+  if (!hubEnv || !hubEnv.federationToken) return { federate: false }
+
+  // Find all spoke environments
+  const spokeEnvs = await prisma.environment.findMany({
+    where: { federationRole: 'spoke', spokeUrl: { not: null } },
+    select: { id: true, spokeUrl: true, federationToken: true },
+  })
+  if (spokeEnvs.length === 0) return { federate: false }
+
+  // Probe each spoke for load and pick the least-loaded reachable one
+  const results: Array<{ spokeUrl: string; load: number }> = []
+
+  await Promise.all(
+    spokeEnvs.map(async (spoke) => {
+      if (!spoke.spokeUrl || !spoke.federationToken) return
+      const status = await fetchSpokeStatus(spoke.spokeUrl, spoke.federationToken)
+      if (!status) return
+      results.push({
+        spokeUrl: spoke.spokeUrl,
+        load: status.runningTasks + status.pendingTasks,
+      })
+    }),
+  )
+
+  if (results.length === 0) return { federate: false }
+
+  // Also check local hub load for comparison
+  const localRunning = await prisma.task.count({ where: { status: 'in_progress' } })
+  const localPending  = await prisma.task.count({ where: { status: 'pending' } })
+  const localLoad = localRunning + localPending
+
+  results.sort((a, b) => a.load - b.load)
+  const best = results[0]
+
+  // Only federate if the best spoke is less loaded than the local hub
+  if (best.load >= localLoad) return { federate: false }
+
+  return {
+    federate: true,
+    spokeUrl: best.spokeUrl,
+    token: hubEnv.federationToken,
+  }
+}
+
+/**
+ * Dispatch a task to a spoke instance.
+ * - POSTs to {spokeUrl}/api/federation/tasks
+ * - Records a FederatedDispatch row
+ * - Returns true on success, false on failure
+ */
+export async function dispatchToSpoke(
+  taskId: string,
+  spokeUrl: string,
+  token: string,
+): Promise<boolean> {
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      assignedAgent: true,
+      metadata: true,
+    },
+  })
+  if (!task) return false
+
+  // Find the spoke environment id from spokeUrl
+  const spokeEnv = await prisma.environment.findFirst({
+    where: { spokeUrl },
+    select: { id: true },
+  })
+  const targetEnvId = spokeEnv?.id ?? 'unknown'
+
+  try {
+    const res = await fetch(`${spokeUrl}/api/federation/tasks`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        taskId: task.id,
+        title: task.title,
+        description: task.description,
+        agentId: task.assignedAgent,
+        metadata: task.metadata,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!res.ok) return false
+
+    // Record FederatedDispatch
+    await prisma.federatedDispatch.create({
+      data: {
+        taskId,
+        targetEnvId,
+        spokeUrl,
+        status: 'dispatched',
+      },
+    })
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -97,6 +97,11 @@ export const CreateEnvironmentSchema = z.object({
   policyConfig: z.record(z.unknown()).optional(),
   kubeconfig: z.string().max(50000).optional(),
   metadata: z.record(z.unknown()).optional(),
+  // Federation fields
+  federationRole:  z.enum(['hub', 'spoke', 'standalone']).nullable().optional(),
+  federationToken: z.string().max(500).nullable().optional(),
+  spokeUrl:        z.string().url().nullable().optional(),
+  hubUrl:          z.string().url().nullable().optional(),
 })
 
 // ── Note Schemas ──────────────────────────────────────────────────────────────

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -446,8 +446,6 @@ async function runTask(taskId: string): Promise<void> {
     log(`Starting task "${task.title}" (${taskId}) → agent "${agent.name}" [${modelId}]`)
 
     // ── Budget gate ────────────────────────────────────────────────────────────
-    // Check whether this agent has exceeded its daily or monthly token budget
-    // before starting the task. If over budget, pause the task immediately.
     const budgetCheck = await checkAgentBudget(agent.id)
     if (!budgetCheck.allowed) {
       const budgetMsg = `Budget gate: ${budgetCheck.reason} — task paused until budget resets or limit is increased.`
@@ -466,6 +464,32 @@ async function runTask(taskId: string): Promise<void> {
       return
     }
 
+    // ── Federation check ──────────────────────────────────────────────────────
+    try {
+      const fed = await shouldFederate(taskId)
+      if (fed.federate && fed.spokeUrl && fed.token) {
+        const dispatched = await dispatchToSpoke(taskId, fed.spokeUrl, fed.token)
+        if (dispatched) {
+          await prisma.task.update({
+            where: { id: taskId },
+            data: {
+              metadata: {
+                ...(taskMeta as object),
+                federated: true,
+                spokeUrl: fed.spokeUrl,
+              } as object,
+            },
+          })
+          await logTaskEvent(taskId, 'federated',
+            `Task dispatched to spoke at ${fed.spokeUrl} for execution`, agent.id)
+          log(`Task "${task.title}" (${taskId}) federated to spoke ${fed.spokeUrl}`)
+          return
+        }
+        log(`Federation dispatch for task ${taskId} to ${fed.spokeUrl} failed — running locally`)
+      }
+    } catch (fedErr) {
+      err(`Federation check for task ${taskId} failed (non-fatal): ${fedErr instanceof Error ? fedErr.message : String(fedErr)}`)
+    }
     // Mark task as in progress
     await prisma.task.update({ where: { id: taskId }, data: { status: 'in_progress' } })
 


### PR DESCRIPTION
## Summary

Adds hub/spoke federation so a hub Orion instance can route tasks to spoke instances based on load, enabling unified task management across multiple clusters.

## Changes

- **Schema**: `federationRole`/`federationToken`/`spokeUrl`/`hubUrl` on `Environment`; new `FederatedDispatch` model tracking dispatch status per task
- **`lib/federation.ts`**: `shouldFederate()` checks if hub has available spokes and picks the least-loaded one via `GET {spokeUrl}/api/federation/status`; `dispatchToSpoke()` POSTs the task and records the dispatch
- **Worker**: federation check before every task — if dispatched successfully, skips local execution; falls back to local on failure
- **Federation API routes**:
  - `GET /api/federation/status` — load info for spoke selection (auth: federation token)
  - `POST /api/federation/tasks` — accept task from hub and create it locally
  - `GET /api/federation/tasks/[id]/status` — hub polling for task completion
- **Environment UI**: federation role selector, token field (hub/spoke/standalone), spoke/hub URL fields
- **Environment PATCH**: accepts all federation fields

## Test plan

- [ ] Configure instance A as hub, instance B as spoke with shared token
- [ ] Create task on hub → verify it appears on spoke's task queue
- [ ] `GET /api/federation/status` on spoke → returns load metrics
- [ ] Spoke unreachable → task runs locally on hub (fallback)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_