### PR TITLE
feat(scheduler): cron-style recurring task scheduling with UI

### DIFF
--- a/apps/web/prisma/migrations/24_add_scheduled_tasks/migration.sql
+++ b/apps/web/prisma/migrations/24_add_scheduled_tasks/migration.sql
@@ -1,0 +1,24 @@
+-- Add ScheduledTask table for cron-style recurring task scheduling
+
+CREATE TABLE "ScheduledTask" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "agentId" TEXT NOT NULL,
+  "cronExpr" TEXT NOT NULL,
+  "taskTitle" TEXT NOT NULL,
+  "taskDesc" TEXT,
+  "taskMeta" TEXT,
+  "enabled" BOOLEAN NOT NULL DEFAULT true,
+  "lastRunAt" TIMESTAMPTZ(3),
+  "nextRunAt" TIMESTAMPTZ(3),
+  "lastTaskId" TEXT,
+  "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT (now()),
+  "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+  CONSTRAINT "ScheduledTask_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ScheduledTask_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "ScheduledTask_agentId_idx" ON "ScheduledTask"("agentId");
+CREATE INDEX "ScheduledTask_nextRunAt_enabled_idx" ON "ScheduledTask"("nextRunAt", "enabled");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Agent {
   evalSuites       EvalSuite[]            @relation("EvalSuiteAgent")
   evalRuns         EvalRun[]              @relation("EvalRunAgent")
   tokenUsage       AgentTokenUsage[]
+  scheduledTasks   ScheduledTask[]        @relation("ScheduledTaskAgent")
 }
 
 model AgentTokenUsage {
@@ -1765,4 +1766,29 @@ model DriftReport {
   scannedAt     DateTime    @default(now())
 
   @@index([environmentId, scannedAt])
+}
+
+// ── Scheduled Tasks ───────────────────────────────────────────────────────────
+// Cron-style recurring task scheduling. Each record defines a schedule that
+// spawns a new Task when nextRunAt <= now(). The worker polls every 60s.
+
+model ScheduledTask {
+  id          String    @id @default(cuid())
+  name        String
+  description String?
+  agentId     String
+  agent       Agent     @relation("ScheduledTaskAgent", fields: [agentId], references: [id])
+  cronExpr    String
+  taskTitle   String
+  taskDesc    String?   @db.Text
+  taskMeta    String?   @db.Text
+  enabled     Boolean   @default(true)
+  lastRunAt   DateTime?
+  nextRunAt   DateTime?
+  lastTaskId  String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([agentId])
+  @@index([nextRunAt, enabled])
 }

--- a/apps/web/src/app/(app)/scheduled-tasks/page.tsx
+++ b/apps/web/src/app/(app)/scheduled-tasks/page.tsx
@@ -1,0 +1,343 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { Plus, Trash2, Play, Clock, Check, X } from 'lucide-react'
+
+interface Agent {
+  id: string
+  name: string
+}
+
+interface ScheduledTask {
+  id: string
+  name: string
+  description?: string | null
+  agentId: string
+  agent: Agent
+  cronExpr: string
+  taskTitle: string
+  taskDesc?: string | null
+  enabled: boolean
+  lastRunAt?: string | null
+  nextRunAt?: string | null
+  lastTaskId?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return '—'
+  try {
+    return new Date(dateStr).toLocaleString()
+  } catch {
+    return dateStr
+  }
+}
+
+export default function ScheduledTasksPage() {
+  const [schedules, setSchedules] = useState<ScheduledTask[]>([])
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showForm, setShowForm] = useState(false)
+  const [triggering, setTriggering] = useState<string | null>(null)
+  const [toggling, setToggling] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const [form, setForm] = useState({
+    name: '',
+    agentId: '',
+    cronExpr: '',
+    taskTitle: '',
+    taskDesc: '',
+    enabled: true,
+  })
+
+  const load = useCallback(async () => {
+    try {
+      const [schedulesRes, agentsRes] = await Promise.all([
+        fetch('/api/scheduled-tasks'),
+        fetch('/api/agents'),
+      ])
+      if (schedulesRes.ok) setSchedules(await schedulesRes.json())
+      if (agentsRes.ok) {
+        const agentsData = await agentsRes.json()
+        setAgents(Array.isArray(agentsData) ? agentsData : (agentsData.agents ?? []))
+      }
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError(null)
+    try {
+      const res = await fetch('/api/scheduled-tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name:      form.name,
+          agentId:   form.agentId,
+          cronExpr:  form.cronExpr,
+          taskTitle: form.taskTitle,
+          taskDesc:  form.taskDesc || undefined,
+          enabled:   form.enabled,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        setFormError(data.error ?? 'Failed to create schedule')
+        return
+      }
+      setShowForm(false)
+      setForm({ name: '', agentId: '', cronExpr: '', taskTitle: '', taskDesc: '', enabled: true })
+      await load()
+    } catch (e) {
+      setFormError(String(e))
+    }
+  }
+
+  async function handleToggle(schedule: ScheduledTask) {
+    setToggling(schedule.id)
+    try {
+      await fetch(`/api/scheduled-tasks/${schedule.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: !schedule.enabled }),
+      })
+      await load()
+    } finally {
+      setToggling(null)
+    }
+  }
+
+  async function handleTrigger(id: string) {
+    setTriggering(id)
+    try {
+      const res = await fetch(`/api/scheduled-tasks/${id}/trigger`, { method: 'POST' })
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error ?? 'Failed to trigger')
+      } else {
+        await load()
+      }
+    } finally {
+      setTriggering(null)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm('Delete this scheduled task?')) return
+    setDeleting(id)
+    try {
+      await fetch(`/api/scheduled-tasks/${id}`, { method: 'DELETE' })
+      await load()
+    } finally {
+      setDeleting(null)
+    }
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-semibold text-text-primary">Scheduled Tasks</h1>
+          <p className="text-sm text-text-secondary mt-0.5">Cron-style recurring task scheduling</p>
+        </div>
+        <button
+          onClick={() => setShowForm(v => !v)}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent/80 transition-colors"
+        >
+          <Plus size={15} />
+          New Schedule
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded text-sm text-red-400 flex items-center justify-between">
+          {error}
+          <button onClick={() => setError(null)}><X size={14} /></button>
+        </div>
+      )}
+
+      {showForm && (
+        <div className="mb-6 p-4 bg-bg-raised border border-border-subtle rounded-lg">
+          <h2 className="text-sm font-semibold text-text-primary mb-4">New Scheduled Task</h2>
+          <form onSubmit={handleCreate} className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label className="block text-xs text-text-secondary mb-1">Schedule Name</label>
+              <input
+                className="w-full px-3 py-1.5 text-sm bg-bg-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent"
+                placeholder="e.g. Daily health check"
+                value={form.name}
+                onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-secondary mb-1">Agent</label>
+              <select
+                className="w-full px-3 py-1.5 text-sm bg-bg-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent"
+                value={form.agentId}
+                onChange={e => setForm(f => ({ ...f, agentId: e.target.value }))}
+                required
+              >
+                <option value="">Select agent...</option>
+                {agents.map(a => (
+                  <option key={a.id} value={a.id}>{a.name}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-text-secondary mb-1">Cron Expression</label>
+              <input
+                className="w-full px-3 py-1.5 text-sm bg-bg-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent font-mono"
+                placeholder="0 2 * * *  (daily at 02:00)"
+                value={form.cronExpr}
+                onChange={e => setForm(f => ({ ...f, cronExpr: e.target.value }))}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-text-secondary mb-1">Task Title</label>
+              <input
+                className="w-full px-3 py-1.5 text-sm bg-bg-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent"
+                placeholder="Title for each spawned task"
+                value={form.taskTitle}
+                onChange={e => setForm(f => ({ ...f, taskTitle: e.target.value }))}
+                required
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className="block text-xs text-text-secondary mb-1">Task Description (optional)</label>
+              <textarea
+                className="w-full px-3 py-1.5 text-sm bg-bg-base border border-border-subtle rounded text-text-primary focus:outline-none focus:border-accent resize-none"
+                rows={2}
+                placeholder="Description for each spawned task"
+                value={form.taskDesc}
+                onChange={e => setForm(f => ({ ...f, taskDesc: e.target.value }))}
+              />
+            </div>
+            <div className="md:col-span-2 flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.enabled}
+                  onChange={e => setForm(f => ({ ...f, enabled: e.target.checked }))}
+                  className="accent-accent"
+                />
+                Enabled
+              </label>
+              {formError && <span className="text-xs text-red-400">{formError}</span>}
+              <div className="ml-auto flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => { setShowForm(false); setFormError(null) }}
+                  className="px-3 py-1.5 text-sm border border-border-subtle rounded text-text-secondary hover:bg-bg-raised"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-3 py-1.5 text-sm bg-accent text-white rounded hover:bg-accent/80"
+                >
+                  Create
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-sm text-text-secondary">Loading...</div>
+      ) : schedules.length === 0 ? (
+        <div className="text-sm text-text-secondary py-8 text-center">
+          No scheduled tasks yet. Click &quot;New Schedule&quot; to create one.
+        </div>
+      ) : (
+        <div className="border border-border-subtle rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-bg-raised border-b border-border-subtle">
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Name</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Agent</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Cron</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Next Run</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Last Run</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Enabled</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-subtle">
+              {schedules.map(s => (
+                <tr key={s.id} className="hover:bg-bg-raised/50 transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-text-primary">{s.name}</div>
+                    {s.description && (
+                      <div className="text-xs text-text-secondary mt-0.5">{s.description}</div>
+                    )}
+                    <div className="text-xs text-text-muted mt-0.5">{s.taskTitle}</div>
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary">{s.agent.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-text-primary">{s.cronExpr}</td>
+                  <td className="px-4 py-3 text-xs text-text-secondary whitespace-nowrap">
+                    <span className="flex items-center gap-1">
+                      <Clock size={11} />
+                      {formatDate(s.nextRunAt)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-text-secondary whitespace-nowrap">
+                    {formatDate(s.lastRunAt)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => handleToggle(s)}
+                      disabled={toggling === s.id}
+                      title={s.enabled ? 'Disable' : 'Enable'}
+                      className={`w-8 h-5 rounded-full transition-colors flex items-center justify-center ${
+                        s.enabled
+                          ? 'bg-green-500/80 hover:bg-green-500'
+                          : 'bg-bg-raised hover:bg-bg-raised/80 border border-border-subtle'
+                      }`}
+                    >
+                      {s.enabled
+                        ? <Check size={11} className="text-white" />
+                        : <X size={11} className="text-text-muted" />
+                      }
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleTrigger(s.id)}
+                        disabled={triggering === s.id}
+                        title="Trigger now"
+                        className="p-1.5 text-text-secondary hover:text-accent hover:bg-accent/10 rounded transition-colors"
+                      >
+                        <Play size={13} />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(s.id)}
+                        disabled={deleting === s.id}
+                        title="Delete"
+                        className="p-1.5 text-text-secondary hover:text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { parseCron, nextRun } from '@/lib/cron'
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const task = await prisma.scheduledTask.findUnique({
+    where: { id: params.id },
+    include: { agent: { select: { id: true, name: true } } },
+  })
+
+  if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(task)
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { name, cronExpr, taskTitle, taskDesc, enabled } = body as Record<string, unknown>
+
+  const newCronExpr = typeof cronExpr === 'string' ? cronExpr : existing.cronExpr
+  if (typeof cronExpr === 'string' && !parseCron(cronExpr)) {
+    return NextResponse.json({ error: `Invalid cron expression: "${cronExpr}"` }, { status: 400 })
+  }
+
+  const cronChanged = typeof cronExpr === 'string' && cronExpr !== existing.cronExpr
+  const newNextRunAt = cronChanged ? nextRun(newCronExpr) : existing.nextRunAt
+
+  const updated = await prisma.scheduledTask.update({
+    where: { id: params.id },
+    data: {
+      ...(typeof name === 'string' && { name }),
+      ...(typeof cronExpr === 'string' && { cronExpr }),
+      ...(typeof taskTitle === 'string' && { taskTitle }),
+      ...(typeof taskDesc === 'string' && { taskDesc }),
+      ...(typeof enabled === 'boolean' && { enabled }),
+      nextRunAt: newNextRunAt,
+    },
+    include: { agent: { select: { id: true, name: true } } },
+  })
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  await prisma.scheduledTask.delete({ where: { id: params.id } })
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { nextRun } from '@/lib/cron'
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
+
+  const schedule = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
+  if (!schedule) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const now = new Date()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const taskData: any = {
+    title:       schedule.taskTitle,
+    description: schedule.taskDesc ?? null,
+    status:      'pending',
+    priority:    'medium',
+    assignedAgent: schedule.agentId,
+    createdBy:   'scheduler',
+  }
+
+  if (schedule.taskMeta) {
+    try { taskData.metadata = JSON.parse(schedule.taskMeta) } catch { /* ignore */ }
+  }
+
+  const task = await prisma.task.create({ data: taskData })
+
+  const computedNextRun = nextRun(schedule.cronExpr, now)
+
+  await prisma.scheduledTask.update({
+    where: { id: schedule.id },
+    data: {
+      lastRunAt:  now,
+      lastTaskId: task.id,
+      nextRunAt:  computedNextRun,
+    },
+  })
+
+  return NextResponse.json({ taskId: task.id, nextRunAt: computedNextRun })
+}

--- a/apps/web/src/app/api/scheduled-tasks/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { parseCron, nextRun } from '@/lib/cron'
+
+export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
+
+  const tasks = await prisma.scheduledTask.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: { agent: { select: { id: true, name: true } } },
+  })
+
+  return NextResponse.json(tasks)
+}
+
+export async function POST(req: NextRequest) {
+  await requireServiceAuth(req)
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { name, agentId, cronExpr, taskTitle, taskDesc, enabled } = body as Record<string, unknown>
+
+  if (!name || typeof name !== 'string') return NextResponse.json({ error: 'name is required' }, { status: 400 })
+  if (!agentId || typeof agentId !== 'string') return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
+  if (!cronExpr || typeof cronExpr !== 'string') return NextResponse.json({ error: 'cronExpr is required' }, { status: 400 })
+  if (!taskTitle || typeof taskTitle !== 'string') return NextResponse.json({ error: 'taskTitle is required' }, { status: 400 })
+
+  if (!parseCron(cronExpr)) {
+    return NextResponse.json({ error: `Invalid cron expression: "${cronExpr}"` }, { status: 400 })
+  }
+
+  const agent = await prisma.agent.findUnique({ where: { id: agentId }, select: { id: true } })
+  if (!agent) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
+
+  const initialNextRun = nextRun(cronExpr)
+
+  const task = await prisma.scheduledTask.create({
+    data: {
+      name,
+      agentId,
+      cronExpr,
+      taskTitle,
+      taskDesc: typeof taskDesc === 'string' ? taskDesc : null,
+      enabled:  enabled !== false,
+      nextRunAt: initialNextRun,
+    },
+    include: { agent: { select: { id: true, name: true } } },
+  })
+
+  return NextResponse.json(task, { status: 201 })
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import {
   Server, MessageSquare, Bot,
   Bell, ClipboardList,
-  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles, Shield, FlaskConical,
+  ChevronLeft, ChevronRight, BookOpen, Settings2, Sparkles, Shield, FlaskConical, Calendar,
 } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 import { useUnackAlertCount } from '@/hooks/useSecurityAlerts'
@@ -20,6 +20,7 @@ const nav = [
   { href: '/notes',          icon: BookOpen, label: 'Wiki' },
   { href: '/nova',           icon: Sparkles, label: 'Nova' },
   { href: '/evals',          icon: FlaskConical, label: 'Evals' },
+  { href: '/scheduled-tasks', icon: Calendar, label: 'Schedules' },
 ]
 
 export function Sidebar() {

--- a/apps/web/src/jobs/task-scheduler.ts
+++ b/apps/web/src/jobs/task-scheduler.ts
@@ -1,0 +1,66 @@
+/**
+ * Cron-style task scheduler job.
+ *
+ * Runs every 60s (registered in worker.ts).
+ * Finds enabled ScheduledTask records where nextRunAt <= now(),
+ * creates a Task for each, then updates the schedule's lastRunAt / nextRunAt.
+ */
+
+import { prisma } from '@/lib/db'
+import { nextRun } from '@/lib/cron'
+
+function log(msg: string) { process.stdout.write(`[task-scheduler] ${msg}\n`) }
+function err(msg: string) { process.stderr.write(`[task-scheduler] ERROR: ${msg}\n`) }
+
+export async function runScheduler(): Promise<void> {
+  const now = new Date()
+
+  const due = await prisma.scheduledTask.findMany({
+    where: {
+      enabled: true,
+      nextRunAt: { lte: now },
+    },
+    include: { agent: { select: { id: true, name: true } } },
+  })
+
+  if (due.length === 0) return
+
+  log(`Found ${due.length} scheduled task(s) due`)
+
+  for (const schedule of due) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const taskData: any = {
+        title:       schedule.taskTitle,
+        description: schedule.taskDesc ?? null,
+        status:      'pending',
+        priority:    'medium',
+        assignedAgent: schedule.agentId,
+        createdBy:   'scheduler',
+      }
+
+      if (schedule.taskMeta) {
+        try { taskData.metadata = JSON.parse(schedule.taskMeta) } catch { /* ignore */ }
+      }
+
+      const task = await prisma.task.create({ data: taskData })
+
+      // Compute next run time
+      const computedNextRun = nextRun(schedule.cronExpr, now)
+
+      // Update the schedule record
+      await prisma.scheduledTask.update({
+        where: { id: schedule.id },
+        data: {
+          lastRunAt:  now,
+          lastTaskId: task.id,
+          nextRunAt:  computedNextRun,
+        },
+      })
+
+      log(`Spawned task "${task.id}" for schedule "${schedule.name}" (agent: ${schedule.agent.name}), next run: ${computedNextRun.toISOString()}`)
+    } catch (e) {
+      err(`Failed to process schedule "${schedule.name}" (${schedule.id}): ${e}`)
+    }
+  }
+}

--- a/apps/web/src/lib/cron.ts
+++ b/apps/web/src/lib/cron.ts
@@ -1,0 +1,168 @@
+/**
+ * Minimal 5-field cron expression parser — no external dependencies.
+ *
+ * Field order: minute hour day-of-month month day-of-week
+ * Ranges:  [0-59] [0-23] [1-31] [1-12] [0-6]  (0 = Sunday)
+ *
+ * Supports:
+ *   *           — any value
+ *   5           — specific value
+ *   1-5         — range
+ *   1,3,5       — list
+ *   *\/5         — step over wildcard
+ *   1-5/2       — step over range
+ */
+
+interface CronField {
+  values: Set<number>
+}
+
+const FIELD_RANGES = [
+  { min: 0, max: 59 }, // minute
+  { min: 0, max: 23 }, // hour
+  { min: 1, max: 31 }, // day-of-month
+  { min: 1, max: 12 }, // month
+  { min: 0, max: 6  }, // day-of-week
+]
+
+function parseField(expr: string, min: number, max: number): CronField | null {
+  const values = new Set<number>()
+
+  for (const part of expr.split(',')) {
+    if (part === '*') {
+      for (let i = min; i <= max; i++) values.add(i)
+      continue
+    }
+
+    const stepMatch = part.match(/^(.+)\/(\d+)$/)
+    if (stepMatch) {
+      const [, rangeExpr, stepStr] = stepMatch
+      const step = parseInt(stepStr, 10)
+      if (step < 1) return null
+
+      let start = min
+      let end = max
+
+      if (rangeExpr !== '*') {
+        const rangeParts = rangeExpr.match(/^(\d+)-(\d+)$/)
+        if (!rangeParts) {
+          const v = parseInt(rangeExpr, 10)
+          if (isNaN(v) || v < min || v > max) return null
+          start = v
+        } else {
+          start = parseInt(rangeParts[1], 10)
+          end   = parseInt(rangeParts[2], 10)
+          if (start < min || end > max || start > end) return null
+        }
+      }
+
+      for (let i = start; i <= end; i += step) values.add(i)
+      continue
+    }
+
+    const rangeMatch = part.match(/^(\d+)-(\d+)$/)
+    if (rangeMatch) {
+      const lo = parseInt(rangeMatch[1], 10)
+      const hi = parseInt(rangeMatch[2], 10)
+      if (lo < min || hi > max || lo > hi) return null
+      for (let i = lo; i <= hi; i++) values.add(i)
+      continue
+    }
+
+    const v = parseInt(part, 10)
+    if (isNaN(v) || v < min || v > max) return null
+    values.add(v)
+  }
+
+  return { values }
+}
+
+function parseCronFields(expr: string): CronField[] | null {
+  const parts = expr.trim().split(/\s+/)
+  if (parts.length !== 5) return null
+
+  const fields: CronField[] = []
+  for (let i = 0; i < 5; i++) {
+    const field = parseField(parts[i], FIELD_RANGES[i].min, FIELD_RANGES[i].max)
+    if (!field) return null
+    fields.push(field)
+  }
+  return fields
+}
+
+/**
+ * Validate a 5-field cron expression.
+ * Returns true if the expression is valid, false otherwise.
+ */
+export function parseCron(expr: string): boolean {
+  return parseCronFields(expr) !== null
+}
+
+/**
+ * Compute the next run time after `from` (defaults to now) for the given cron expression.
+ * Throws if the expression is invalid.
+ */
+export function nextRun(expr: string, from: Date = new Date()): Date {
+  const fields = parseCronFields(expr)
+  if (!fields) throw new Error(`Invalid cron expression: "${expr}"`)
+
+  const [minuteField, hourField, domField, monthField, dowField] = fields
+
+  // Start searching from the next minute
+  const cursor = new Date(from)
+  cursor.setSeconds(0, 0)
+  cursor.setMinutes(cursor.getMinutes() + 1)
+
+  // Search up to 4 years out to handle rare expressions
+  const limit = new Date(from)
+  limit.setFullYear(limit.getFullYear() + 4)
+
+  while (cursor < limit) {
+    // month check (1-indexed)
+    const month = cursor.getMonth() + 1
+    if (!monthField.values.has(month)) {
+      cursor.setDate(1)
+      cursor.setHours(0)
+      cursor.setMinutes(0)
+      cursor.setMonth(cursor.getMonth() + 1)
+      continue
+    }
+
+    // day-of-month check
+    const dom = cursor.getDate()
+    if (!domField.values.has(dom)) {
+      cursor.setDate(cursor.getDate() + 1)
+      cursor.setHours(0)
+      cursor.setMinutes(0)
+      continue
+    }
+
+    // day-of-week check (0=Sunday)
+    const dow = cursor.getDay()
+    if (!dowField.values.has(dow)) {
+      cursor.setDate(cursor.getDate() + 1)
+      cursor.setHours(0)
+      cursor.setMinutes(0)
+      continue
+    }
+
+    // hour check
+    const hour = cursor.getHours()
+    if (!hourField.values.has(hour)) {
+      cursor.setHours(cursor.getHours() + 1)
+      cursor.setMinutes(0)
+      continue
+    }
+
+    // minute check
+    const minute = cursor.getMinutes()
+    if (!minuteField.values.has(minute)) {
+      cursor.setMinutes(cursor.getMinutes() + 1)
+      continue
+    }
+
+    return new Date(cursor)
+  }
+
+  throw new Error(`Could not find next run time for cron expression "${expr}" within 4 years`)
+}

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -29,6 +29,7 @@ import { runDailyScan, runEventTriggeredScan } from './jobs/security-scan-vulns'
 import { runGoalHeartbeat } from './jobs/goal-heartbeat'
 import { detectGitOpsDrift } from './jobs/gitops-drift'
 import { syncCrowdSecDecisions } from './lib/security/crowdsec-bouncer'
+import { runScheduler } from './jobs/task-scheduler'
 
 const POLL_INTERVAL_MS = 15_000
 const MAX_CONCURRENT   = 3
@@ -184,6 +185,7 @@ let runningElkPoller = false
 let runningNtopngPoller = false
 let runningVulnScan = false
 let runningDriftDetector = false
+let runningScheduler = false
 
 const TASK_TIMEOUT_MS = 60 * 60 * 1000 // 60 minutes
 
@@ -1619,6 +1621,12 @@ async function main() {
     runningDriftDetector = true
     detectGitOpsDrift().catch(e => err(`GitOps drift detection failed: ${e}`)).finally(() => { runningDriftDetector = false })
   }, 5 * 60_000)
+
+  setInterval(() => {
+    if (runningScheduler) return
+    runningScheduler = true
+    runScheduler().catch(e => err(`Scheduler failed: ${e}`)).finally(() => { runningScheduler = false })
+  }, 60_000)
 }
 
 process.on('unhandledRejection', (reason, promise) => {


### PR DESCRIPTION
## Summary

Adds cron-style recurring task scheduling — define a schedule once and ORION spawns tasks automatically on the configured interval.

## Changes

- **`ScheduledTask` model**: name, agent, cron expression, task title/description templates, enabled toggle, last/next run timestamps, last spawned task ID
- **`lib/cron.ts`**: zero-dependency 5-field cron parser supporting `*`, specific values, ranges (`1-5`), lists (`1,3,5`), steps (`*/5`, `1-5/2`). Exports `parseCron()` (validate) and `nextRun()` (compute next fire time)
- **`jobs/task-scheduler.ts`**: `runScheduler()` finds due schedules, spawns Tasks, updates `lastRunAt`/`nextRunAt`/`lastTaskId`
- **Worker**: scheduler runs every 60s with overlap guard
- **API**: `GET/POST /api/scheduled-tasks`, `GET/PUT/DELETE /api/scheduled-tasks/[id]`, `POST .../trigger` (manual fire)
- **UI**: table with next/last run times, enable toggle, trigger-now button, inline create form
- **Sidebar**: "Schedules" nav entry with calendar icon

## Test plan

- [ ] Create schedule `*/5 * * * *` (every 5 min), wait → task appears in task list
- [ ] `parseCron` rejects invalid expressions (e.g. `99 * * * *`) → 400 on create
- [ ] Disable schedule → no new tasks spawned
- [ ] Manual trigger → task created immediately, `lastRunAt` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_