### PR TITLE
fix: remove stray closing brace in schema.prisma

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1829,4 +1829,3 @@ model NotificationChannel {
   enabled     Boolean  @default(true)
   createdAt   DateTime @default(now())
 }
-}


### PR DESCRIPTION
Removes a dangling `}` at line 1832 of `schema.prisma` that caused Prisma validation failure (P1012) during CI build — left over from the PR #581/#582 conflict resolution merge.

**Fix:** Deleted the extra closing brace after the `NotificationChannel` model.