### PR TITLE
fix(build): remove accidental export from computeWaves in approve-plan route

### DIFF
--- a/apps/web/src/app/api/features/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/features/[id]/approve-plan/route.ts
@@ -14,7 +14,7 @@ interface WaveTask {
  * dependencies. Cycles are guarded (a task that transitively depends on
  * itself resolves to wave 0 rather than recursing forever).
  */
-export function computeWaves(tasks: WaveTask[]): Map<string, number> {
+function computeWaves(tasks: WaveTask[]): Map<string, number> {
   const waveMap = new Map<string, number>()
   const taskMap = new Map(tasks.map(t => [t.id, t]))
 


### PR DESCRIPTION
Fixes build failure introduced when `computeWaves` was accidentally exported from the `approve-plan` route. Next.js treats any named export from a route file as a valid HTTP method or config, so `export function computeWaves` caused a type error and broke the Docker build.

Fix: remove the `export` keyword — the function is only used internally within the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_