### PR TITLE
fix(build): extract computeWaves to shared lib to fix broken epics import

### DIFF
--- a/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
-import { computeWaves } from '../../../features/[id]/approve-plan/route'
+import { computeWaves } from '@/lib/plan-waves'
 
 /**
  * POST /api/epics/:id/approve-plan

--- a/apps/web/src/app/api/features/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/features/[id]/approve-plan/route.ts
@@ -1,44 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
+import { computeWaves } from '@/lib/plan-waves'
 
-interface WaveTask {
-  id: string
-  dependsOn: string[]
-}
-
-/**
- * Compute the execution wave for every task in a feature.
- *
- * Wave 0 = task with no dependencies. Wave N = 1 + the max wave of its
- * dependencies. Cycles are guarded (a task that transitively depends on
- * itself resolves to wave 0 rather than recursing forever).
- */
-function computeWaves(tasks: WaveTask[]): Map<string, number> {
-  const waveMap = new Map<string, number>()
-  const taskMap = new Map(tasks.map(t => [t.id, t]))
-
-  function getWave(taskId: string, visited = new Set<string>()): number {
-    const cached = waveMap.get(taskId)
-    if (cached !== undefined) return cached
-    if (visited.has(taskId)) return 0 // cycle guard
-    visited.add(taskId)
-    const task = taskMap.get(taskId)
-    // Unknown dependency IDs (outside this feature) are treated as wave-0 anchors.
-    const deps = (task?.dependsOn ?? []).filter(depId => taskMap.has(depId))
-    if (!task || deps.length === 0) {
-      waveMap.set(taskId, 0)
-      return 0
-    }
-    const maxDepWave = Math.max(...deps.map(depId => getWave(depId, new Set(visited))))
-    const wave = maxDepWave + 1
-    waveMap.set(taskId, wave)
-    return wave
-  }
-
-  tasks.forEach(t => getWave(t.id))
-  return waveMap
-}
 
 /**
  * POST /api/features/:id/approve-plan

--- a/apps/web/src/lib/plan-waves.ts
+++ b/apps/web/src/lib/plan-waves.ts
@@ -1,0 +1,35 @@
+export interface WaveTask {
+  id: string
+  dependsOn: string[]
+}
+
+/**
+ * Compute the execution wave for every task in a feature.
+ * Wave 0 = task with no dependencies. Wave N = 1 + the max wave of its
+ * dependencies. Cycles are guarded (a task that transitively depends on
+ * itself resolves to wave 0 rather than recursing forever).
+ */
+export function computeWaves(tasks: WaveTask[]): Map<string, number> {
+  const waveMap = new Map<string, number>()
+  const taskMap = new Map(tasks.map(t => [t.id, t]))
+
+  function getWave(taskId: string, visited = new Set<string>()): number {
+    const cached = waveMap.get(taskId)
+    if (cached !== undefined) return cached
+    if (visited.has(taskId)) return 0
+    visited.add(taskId)
+    const task = taskMap.get(taskId)
+    const deps = (task?.dependsOn ?? []).filter(depId => taskMap.has(depId))
+    if (!task || deps.length === 0) {
+      waveMap.set(taskId, 0)
+      return 0
+    }
+    const maxDepWave = Math.max(...deps.map(depId => getWave(depId, new Set(visited))))
+    const wave = maxDepWave + 1
+    waveMap.set(taskId, wave)
+    return wave
+  }
+
+  for (const task of tasks) getWave(task.id)
+  return waveMap
+}


### PR DESCRIPTION
PR #584 removed the `export` from `computeWaves` in the features approve-plan route, but the epics approve-plan route was importing it from there — causing a new build error:

```
Type error: Module '.../features/[id]/approve-plan/route' declares 'computeWaves' locally, but it is not exported.
```

**Fix**: move `computeWaves` and `WaveTask` into `src/lib/plan-waves.ts` and update both routes to import from there. Eliminates the cross-route import entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_