### PR TITLE
fix: add agentName to plan_approval_needed notification event to fix build

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -9,7 +9,7 @@ export type NotificationEvent =
   | { type: 'task_completed'; taskId: string; taskTitle: string; agentId: string; agentName: string; durationMs?: number }
   | { type: 'task_failed';    taskId: string; taskTitle: string; agentId: string; agentName: string; error?: string }
   | { type: 'budget_exceeded'; agentId: string; agentName: string; reason: string }
-  | { type: 'plan_approval_needed'; taskId: string; taskTitle: string; agentId: string; riskLevel: string }
+  | { type: 'plan_approval_needed'; taskId: string; taskTitle: string; agentId: string; agentName: string; riskLevel: string }
 
 function colorForEvent(type: NotificationEvent['type']): { slack: string; discord: number } {
   switch (type) {

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -700,7 +700,7 @@ async function runTask(taskId: string): Promise<void> {
         postToFeed(agent.id, pauseMsg, taskId),
         ...(featureRoomId ? [postToRoom(featureRoomId, agent.id, pauseMsg, taskId)] : []),
       ])
-      notify({ type: 'plan_approval_needed', taskId, taskTitle: task.title, agentId: agent.id, riskLevel: risk }).catch(() => {})
+      notify({ type: 'plan_approval_needed', taskId, taskTitle: task.title, agentId: agent.id, agentName: agent.name, riskLevel: risk }).catch(() => {})
       log(`Task "${task.title}" (${taskId}) paused for ${risk}-risk plan approval`)
       return
     }


### PR DESCRIPTION
## What was broken

The `main` build was failing with a TypeScript error in `apps/web/src/lib/notifications.ts:43`:

```
Type error: Property 'agentName' does not exist on type
'{ type: "plan_approval_needed"; taskId: string; taskTitle: string; agentId: string; riskLevel: string; }'.
```

The `plan_approval_needed` variant of `NotificationEvent` was missing an `agentName` field, yet `formatSlack` (line 43), `formatDiscord` (line 79), and `formatWebhook` (line 99) all reference `event.agentName`. Since the other event variants carry `agentName`, this variant was inconsistent and broke type checking during `next build`.

## How it was fixed

- Added `agentName: string` to the `plan_approval_needed` member of the `NotificationEvent` union in `apps/web/src/lib/notifications.ts`.
- Supplied `agentName: agent.name` at the dispatch site in `apps/web/src/worker.ts` (line 703); `agent.name` was already in scope.

## Verification

`npx tsc --noEmit -p apps/web/tsconfig.json` is now clean except for the pre-existing, unrelated `TS5101` (`downlevelIteration` deprecation) warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_