### PR TITLE
fix(worker): remove duplicate planBeforeExecute declaration

### DIFF
--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -552,10 +552,6 @@ async function runTask(taskId: string): Promise<void> {
     // FIFO queue of open tool span IDs — tool_call pushes, tool_result shifts
     const toolSpanQueue: string[] = []
 
-    // Plan-before-execute gating: when enabled, the agent emits a <plan> block
-    // up front. If the plan is high/critical risk, we pause the task for human
-    // or supervisor approval before allowing ANY tool to run.
-    const planBeforeExecute = contextConfig.planBeforeExecute === true
     let pausedForApproval = false
 
     // Step-level checkpointing: load any existing checkpoints so we can record


### PR DESCRIPTION
## Summary

- Removes a duplicate `const planBeforeExecute` declaration in `worker.ts` that was introduced when feature branches were merged
- The second declaration (line ~557) lacked the `&& !planAlreadyApproved` guard and shadowed the correct one
- Fixes the TypeScript build error: `Cannot redeclare block-scoped variable 'planBeforeExecute'`

## Test plan

- [ ] `next build` passes with no type errors
- [ ] Plan-before-execute gating still works (approved plans skip the planning phase)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_