### PR TITLE
fix(cost): fix missing return fields and regenerate Prisma client at build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "node server.ts",
-    "build": "next build && npm run build:worker",
+    "build": "prisma generate && next build && npm run build:worker",
     "build:worker": "esbuild src/worker.ts --bundle --platform=node --outfile=worker.js --external:@prisma/client --external:@anthropic-ai/claude-code --external:@anthropic-ai/sdk --log-level=warning",
     "start": "NODE_ENV=production node server.js",
     "lint": "next lint",

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -445,7 +445,7 @@ async function callOpenAIChat(
     })
     if (!res.ok) {
       console.error(`[room-agents] OpenAI-compat ${baseUrl} returned HTTP ${res.status}`)
-      return { reply: null, tokensUsed, contextLimit }
+      return { reply: null, tokensUsed, contextLimit, inputTokens: totalInputTokens, outputTokens: totalOutputTokens }
     }
 
     const data = await res.json() as OpenAIResponse


### PR DESCRIPTION
## Summary

Two build fixes following the token dashboard PR:

- **room-agents**: missing `inputTokens`/`outputTokens` on the early-return path when the OpenAI-compat endpoint returns a non-OK HTTP status (TS2739)
- **package.json**: prepend `prisma generate` to the `build` script so the Prisma client is always regenerated from the schema before `next build` type-checks it — fixes TS2322 from the stale generated types after `AgentTokenUsage.taskId` became `String?`

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_