### PR TITLE
feat(security): real data pipeline, audit trail from agent tools, default correlation rules

### DIFF
--- a/apps/web/src/app/api/monitoring/security/demo-events/route.ts
+++ b/apps/web/src/app/api/monitoring/security/demo-events/route.ts
@@ -1,0 +1,136 @@
+/**
+ * POST /api/monitoring/security/demo-events
+ *
+ * Injects a batch of realistic sample security events for demo/testing.
+ * Creates events without requiring external integrations.
+ */
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+function randIp() {
+  return `${10 + Math.floor(Math.random() * 245)}.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}`
+}
+
+function ago(minutes: number) {
+  return new Date(Date.now() - minutes * 60 * 1000)
+}
+
+export async function POST() {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+  // Get first available environment (or null for global events)
+  const env = await prisma.environment.findFirst({ select: { id: true } })
+  const envId = env?.id ?? null
+
+  const attackerIp = randIp()
+  const now = Date.now()
+
+  const events = [
+    // Brute force sequence
+    ...Array.from({ length: 8 }, (_, i) => ({
+      type: 'auth_failure',
+      source: 'wazuh',
+      severity: 55,
+      title: `Failed SSH login from ${attackerIp}`,
+      description: `Authentication failure for user root from ${attackerIp} (attempt ${i + 1})`,
+      attackerIp,
+      dedupKey: `demo-brute-${attackerIp}-${i}-${now}`,
+      firstSeen: ago(10 - i),
+      lastSeen: ago(10 - i),
+    })),
+    // CrowdSec block
+    {
+      type: 'crowdsec_block',
+      source: 'crowdsec',
+      severity: 65,
+      title: `IP ${attackerIp} blocked by CrowdSec`,
+      description: `CrowdSec community blocklist match: known scanner/brute-force source`,
+      attackerIp,
+      dedupKey: `demo-crowdsec-${attackerIp}-${now}`,
+      firstSeen: ago(8),
+      lastSeen: ago(8),
+    },
+    // Port scan
+    ...Array.from({ length: 25 }, (_, i) => ({
+      type: 'connection_refused',
+      source: 'ntopng',
+      severity: 40,
+      title: `Port scan detected from ${randIp()}`,
+      description: `Connection refused on port ${1024 + i * 100}`,
+      attackerIp: randIp(),
+      dedupKey: `demo-portscan-${i}-${now}`,
+      firstSeen: ago(15),
+      lastSeen: ago(15),
+    })),
+    // K8s warnings
+    {
+      type: 'k8s_warning',
+      source: 'k8s_events',
+      severity: 45,
+      title: 'Pod OOMKilled in namespace production',
+      description: 'Container memory limit exceeded, process killed',
+      dedupKey: `demo-k8s-oom-${now}`,
+      firstSeen: ago(5),
+      lastSeen: ago(5),
+    },
+    {
+      type: 'k8s_warning',
+      source: 'k8s_events',
+      severity: 50,
+      title: 'ImagePullBackOff: suspicious image tag in namespace default',
+      description: 'Unknown image tag pulled from external registry',
+      dedupKey: `demo-k8s-image-${now}`,
+      firstSeen: ago(3),
+      lastSeen: ago(3),
+    },
+    // Anomaly
+    {
+      type: 'anomaly',
+      source: 'elk',
+      severity: 60,
+      title: 'Unusual outbound traffic spike detected',
+      description: 'Network baseline deviation: 5x normal egress volume in last 10 minutes',
+      attackerIp: randIp(),
+      dedupKey: `demo-anomaly-${now}`,
+      firstSeen: ago(2),
+      lastSeen: ago(2),
+    },
+    // High-severity malware signal
+    {
+      type: 'malware',
+      source: 'wazuh',
+      severity: 90,
+      title: 'Malware signature match on web-01',
+      description: 'File /tmp/.svc matches known trojan dropper signature (EICAR-like)',
+      attackerIp: '10.0.0.1',
+      dedupKey: `demo-malware-${now}`,
+      firstSeen: ago(1),
+      lastSeen: ago(1),
+    },
+  ]
+
+  let inserted = 0
+  for (const ev of events) {
+    const { attackerIp: aIp, ...rest } = ev as any
+    await prisma.securityEvent.create({
+      data: {
+        environmentId: envId,
+        type: rest.type,
+        source: rest.source,
+        severity: rest.severity,
+        title: rest.title,
+        description: rest.description ?? null,
+        rawEvent: { demo: true, attackerIp: aIp ?? null },
+        dedupKey: rest.dedupKey,
+        firstSeen: rest.firstSeen,
+        lastSeen: rest.lastSeen,
+      },
+    })
+    inserted++
+  }
+
+  return NextResponse.json({ inserted, message: `Injected ${inserted} demo security events` })
+}

--- a/apps/web/src/app/api/monitoring/security/demo-events/route.ts
+++ b/apps/web/src/app/api/monitoring/security/demo-events/route.ts
@@ -10,6 +10,18 @@ import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
+interface DemoEvent {
+  type: string
+  source: string
+  severity: number
+  title: string
+  description: string
+  attackerIp?: string
+  dedupKey: string
+  firstSeen: Date
+  lastSeen: Date
+}
+
 function randIp() {
   return `${10 + Math.floor(Math.random() * 245)}.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}`
 }
@@ -21,16 +33,17 @@ function ago(minutes: number) {
 export async function POST() {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  // Get first available environment (or null for global events)
   const env = await prisma.environment.findFirst({ select: { id: true } })
   const envId = env?.id ?? null
 
   const attackerIp = randIp()
+  // Port scanner uses a single IP so the threshold rule (groupBy attackerIp, threshold 20) fires
+  const scannerIp = randIp()
   const now = Date.now()
 
-  const events = [
-    // Brute force sequence
-    ...Array.from({ length: 8 }, (_, i) => ({
+  const events: DemoEvent[] = [
+    // Brute force sequence — same IP, fires brute_force rule (threshold 5 in 300s)
+    ...Array.from({ length: 8 }, (_, i): DemoEvent => ({
       type: 'auth_failure',
       source: 'wazuh',
       severity: 55,
@@ -38,32 +51,32 @@ export async function POST() {
       description: `Authentication failure for user root from ${attackerIp} (attempt ${i + 1})`,
       attackerIp,
       dedupKey: `demo-brute-${attackerIp}-${i}-${now}`,
-      firstSeen: ago(10 - i),
-      lastSeen: ago(10 - i),
+      firstSeen: ago(10 - i * 0.5),
+      lastSeen: ago(10 - i * 0.5),
     })),
-    // CrowdSec block
+    // CrowdSec block — fires crowdsec_block pattern rule
     {
       type: 'crowdsec_block',
       source: 'crowdsec',
       severity: 65,
       title: `IP ${attackerIp} blocked by CrowdSec`,
-      description: `CrowdSec community blocklist match: known scanner/brute-force source`,
+      description: 'CrowdSec community blocklist match: known scanner/brute-force source',
       attackerIp,
       dedupKey: `demo-crowdsec-${attackerIp}-${now}`,
       firstSeen: ago(8),
       lastSeen: ago(8),
     },
-    // Port scan
-    ...Array.from({ length: 25 }, (_, i) => ({
+    // Port scan — 25 events from the SAME IP fires port_scan threshold rule (>20 in 120s)
+    ...Array.from({ length: 25 }, (_, i): DemoEvent => ({
       type: 'connection_refused',
       source: 'ntopng',
       severity: 40,
-      title: `Port scan detected from ${randIp()}`,
+      title: `Port scan detected from ${scannerIp}`,
       description: `Connection refused on port ${1024 + i * 100}`,
-      attackerIp: randIp(),
-      dedupKey: `demo-portscan-${i}-${now}`,
-      firstSeen: ago(15),
-      lastSeen: ago(15),
+      attackerIp: scannerIp,
+      dedupKey: `demo-portscan-${scannerIp}-${i}-${now}`,
+      firstSeen: ago(1),
+      lastSeen: ago(1),
     })),
     // K8s warnings
     {
@@ -93,12 +106,12 @@ export async function POST() {
       severity: 60,
       title: 'Unusual outbound traffic spike detected',
       description: 'Network baseline deviation: 5x normal egress volume in last 10 minutes',
-      attackerIp: randIp(),
+      attackerIp,
       dedupKey: `demo-anomaly-${now}`,
       firstSeen: ago(2),
       lastSeen: ago(2),
     },
-    // High-severity malware signal
+    // High-severity malware signal — fires malware_detection pattern rule
     {
       type: 'malware',
       source: 'wazuh',
@@ -112,25 +125,28 @@ export async function POST() {
     },
   ]
 
-  let inserted = 0
-  for (const ev of events) {
-    const { attackerIp: aIp, ...rest } = ev as any
-    await prisma.securityEvent.create({
-      data: {
-        environmentId: envId,
-        type: rest.type,
-        source: rest.source,
-        severity: rest.severity,
-        title: rest.title,
-        description: rest.description ?? null,
-        rawEvent: { demo: true, attackerIp: aIp ?? null },
-        dedupKey: rest.dedupKey,
-        firstSeen: rest.firstSeen,
-        lastSeen: rest.lastSeen,
-      },
-    })
-    inserted++
+  try {
+    await prisma.$transaction(
+      events.map(ev =>
+        prisma.securityEvent.create({
+          data: {
+            environmentId: envId,
+            type: ev.type,
+            source: ev.source,
+            severity: ev.severity,
+            title: ev.title,
+            description: ev.description,
+            rawEvent: { demo: true, attackerIp: ev.attackerIp ?? null },
+            dedupKey: ev.dedupKey,
+            firstSeen: ev.firstSeen,
+            lastSeen: ev.lastSeen,
+          },
+        })
+      )
+    )
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 
-  return NextResponse.json({ inserted, message: `Injected ${inserted} demo security events` })
+  return NextResponse.json({ inserted: events.length, message: `Injected ${events.length} demo security events` })
 }

--- a/apps/web/src/app/api/monitoring/security/overview/route.ts
+++ b/apps/web/src/app/api/monitoring/security/overview/route.ts
@@ -58,12 +58,12 @@ export async function GET() {
 
   // Pending approvals
   const pendingApprovals = await prisma.actionAudit.count({
-    where: envId ? { environmentId: envId, status: 'denied', tier: 'approve' } : { status: 'denied', tier: 'approve' },
+    where: envId ? { environmentId: envId, status: 'pending', tier: 'approve' } : { status: 'pending', tier: 'approve' },
   })
 
   // Pending approval list
   const pendingApprovalsList = await prisma.actionAudit.findMany({
-    where: envId ? { environmentId: envId, status: 'denied', tier: 'approve' } : { status: 'denied', tier: 'approve' },
+    where: envId ? { environmentId: envId, status: 'pending', tier: 'approve' } : { status: 'pending', tier: 'approve' },
     orderBy: { createdAt: 'desc' },
     take: 10,
     select: {

--- a/apps/web/src/app/api/monitoring/security/overview/route.ts
+++ b/apps/web/src/app/api/monitoring/security/overview/route.ts
@@ -17,19 +17,11 @@ export async function GET() {
     include: { environment: true },
   })
 
-  // Count by type and severity
+  // Count by type
   const typeCounts = await prisma.securityEvent.groupBy({
     by: ['type'],
     where: envId ? { environmentId: envId } : undefined,
     _count: true,
-  })
-
-  const severityDist = await prisma.securityEvent.groupBy({
-    by: ['severity'],
-    where: envId ? { environmentId: envId } : undefined,
-    _count: { id: true },
-    orderBy: { severity: 'desc' },
-    take: 5,
   })
 
   const criticalCount = recentAlerts.filter(a => a.severity >= 80).length
@@ -110,7 +102,7 @@ export async function GET() {
       ...inv,
       _count: inv._count,
     })),
-    pendingApprovalsList: pendingApprovalsList.map((a: any) => ({
+    pendingApprovalsList: pendingApprovalsList.map(a => ({
       ...a,
       createdAt: a.createdAt.toISOString(),
     })),

--- a/apps/web/src/app/api/monitoring/security/seed-rules/route.ts
+++ b/apps/web/src/app/api/monitoring/security/seed-rules/route.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/monitoring/security/seed-rules
+ *
+ * Seeds default correlation rules for common attack patterns.
+ * Safe to call multiple times — uses upsert by name.
+ */
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+const DEFAULT_RULES = [
+  {
+    name: 'brute_force',
+    ruleType: 'threshold',
+    severity: 75,
+    window: 300,
+    params: { eventType: 'auth_failure', threshold: 5, groupBy: 'attackerIp' },
+  },
+  {
+    name: 'port_scan',
+    ruleType: 'threshold',
+    severity: 60,
+    window: 120,
+    params: { eventType: 'connection_refused', threshold: 20, groupBy: 'attackerIp' },
+  },
+  {
+    name: 'malware_detection',
+    ruleType: 'pattern',
+    severity: 90,
+    window: 60,
+    params: { eventTypes: ['malware', 'trojan', 'ransomware'], matchAny: true },
+  },
+  {
+    name: 'k8s_warning_burst',
+    ruleType: 'threshold',
+    severity: 50,
+    window: 300,
+    params: { source: 'k8s_events', threshold: 10, groupBy: 'namespace' },
+  },
+  {
+    name: 'crowdsec_block',
+    ruleType: 'pattern',
+    severity: 65,
+    window: 60,
+    params: { eventTypes: ['crowdsec_block'], matchAny: true },
+  },
+  {
+    name: 'anomaly_cluster',
+    ruleType: 'threshold',
+    severity: 55,
+    window: 600,
+    params: { eventType: 'anomaly', threshold: 3, groupBy: 'attackerIp' },
+  },
+  {
+    name: 'privilege_escalation',
+    ruleType: 'pattern',
+    severity: 85,
+    window: 60,
+    params: { eventTypes: ['privilege_escalation', 'sudo_abuse', 'container_escape'], matchAny: true },
+  },
+  {
+    name: 'data_exfil',
+    ruleType: 'threshold',
+    severity: 80,
+    window: 300,
+    params: { eventType: 'large_outbound', threshold: 3, groupBy: 'sourceIp' },
+  },
+]
+
+export async function POST() {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+  const results = await Promise.all(
+    DEFAULT_RULES.map(rule =>
+      prisma.correlationRule.upsert({
+        where: { name: rule.name },
+        update: {},
+        create: {
+          name: rule.name,
+          ruleType: rule.ruleType,
+          severity: rule.severity,
+          window: rule.window,
+          params: rule.params,
+          enabled: true,
+        },
+      })
+    )
+  )
+
+  return NextResponse.json({ seeded: results.length, rules: results.map(r => r.name) })
+}
+
+export async function GET() {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+  const rules = await prisma.correlationRule.findMany({
+    orderBy: { name: 'asc' },
+    select: { id: true, name: true, ruleType: true, severity: true, enabled: true, window: true },
+  })
+
+  return NextResponse.json({ rules })
+}

--- a/apps/web/src/app/api/monitoring/security/seed-rules/route.ts
+++ b/apps/web/src/app/api/monitoring/security/seed-rules/route.ts
@@ -72,24 +72,34 @@ const DEFAULT_RULES = [
 export async function POST() {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const results = await Promise.all(
-    DEFAULT_RULES.map(rule =>
-      prisma.correlationRule.upsert({
-        where: { name: rule.name },
-        update: {},
-        create: {
-          name: rule.name,
-          ruleType: rule.ruleType,
-          severity: rule.severity,
-          window: rule.window,
-          params: rule.params,
-          enabled: true,
-        },
-      })
+  try {
+    const results = await Promise.all(
+      DEFAULT_RULES.map(rule =>
+        prisma.correlationRule.upsert({
+          where: { name: rule.name },
+          // Always restore defaults — ensures re-seed is idempotent AND recovers disabled/edited rules
+          update: {
+            ruleType: rule.ruleType,
+            severity: rule.severity,
+            window: rule.window,
+            params: rule.params,
+            enabled: true,
+          },
+          create: {
+            name: rule.name,
+            ruleType: rule.ruleType,
+            severity: rule.severity,
+            window: rule.window,
+            params: rule.params,
+            enabled: true,
+          },
+        })
+      )
     )
-  )
-
-  return NextResponse.json({ seeded: results.length, rules: results.map(r => r.name) })
+    return NextResponse.json({ seeded: results.length, rules: results.map(r => r.name) })
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
 }
 
 export async function GET() {

--- a/apps/web/src/components/security/SecurityDashboard.tsx
+++ b/apps/web/src/components/security/SecurityDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Shield, AlertTriangle, Activity, Zap, CheckCircle2, Loader2 } from 'lucide-react'
+import { Shield, AlertTriangle, Activity, Zap, CheckCircle2, Loader2, Info } from 'lucide-react'
 import Link from 'next/link'
 import AlertFeed from './AlertFeed'
 import FlowTable from './FlowTable'
@@ -145,6 +145,24 @@ export default function SecurityDashboard() {
             <StatCard icon={CheckCircle2} label="Blocks" value={data?.blockCount ?? 0} color="text-blue-400" />
             <StatCard icon={Zap} label="Anomalies" value={data?.anomalyCount ?? 0} color="text-purple-400" />
           </div>
+
+          {!data?.recentAlerts?.length && !data?.activeIncidents && (
+            <div className="rounded-lg border border-border-subtle bg-bg-surface px-5 py-6 flex gap-4 items-start">
+              <Info size={18} className="text-accent shrink-0 mt-0.5" />
+              <div className="space-y-2 text-sm">
+                <div className="font-medium text-text-primary">No security signals yet</div>
+                <p className="text-xs text-text-muted leading-relaxed">
+                  To start monitoring, connect external sources (CrowdSec, Wazuh, ELK, ntopng) or add K8s cluster environments.
+                  The correlator automatically groups raw events into incidents.
+                </p>
+                <ol className="text-xs text-text-muted space-y-1 list-decimal list-inside">
+                  <li>Go to the <strong className="text-text-primary">Settings</strong> tab and seed default correlation rules</li>
+                  <li>Configure source URLs or connect a cluster environment in Infrastructure</li>
+                  <li>Optionally inject demo events to test the pipeline end-to-end</li>
+                </ol>
+              </div>
+            </div>
+          )}
 
           {data?.recentIncidents?.length ? (
             <div className="bg-bg-surface border border-border-subtle rounded-xl">

--- a/apps/web/src/components/security/SecuritySettings.tsx
+++ b/apps/web/src/components/security/SecuritySettings.tsx
@@ -75,9 +75,9 @@ export default function SecuritySettings() {
     try {
       const res = await fetch('/api/monitoring/security/seed-rules', { method: 'POST' })
       const data = await res.json()
+      if (!res.ok) { setSeedRulesMsg(data.error ?? 'Failed to seed rules'); return }
       setSeedRulesMsg(`Seeded ${data.seeded} correlation rules`)
-      setRules(data.rules?.map((name: string) => ({ id: name, name, ruleType: '', severity: 0, enabled: true })) ?? [])
-      // Reload rules
+      // Reload the full rule list with all fields
       const r2 = await fetch('/api/monitoring/security/seed-rules')
       const d2 = await r2.json()
       setRules(d2.rules ?? [])
@@ -95,6 +95,7 @@ export default function SecuritySettings() {
     try {
       const res = await fetch('/api/monitoring/security/demo-events', { method: 'POST' })
       const data = await res.json()
+      if (!res.ok) { setSeedDemoMsg(data.error ?? 'Failed to inject demo events'); return }
       setSeedDemoMsg(data.message ?? 'Demo events injected')
     } catch {
       setSeedDemoMsg('Failed to inject demo events')

--- a/apps/web/src/components/security/SecuritySettings.tsx
+++ b/apps/web/src/components/security/SecuritySettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Shield, CheckCircle2, XCircle, Loader2, RefreshCw, Save } from 'lucide-react'
+import { Shield, CheckCircle2, XCircle, Loader2, RefreshCw, Save, Database, Zap } from 'lucide-react'
 
 const sources = [
   { key: 'CROWDSEC_API', name: 'CrowdSec', desc: 'Brute-force & IP blocking', default: 'http://crowdsec-lapi.crowdsec:8080' },
@@ -17,13 +17,23 @@ export default function SecuritySettings() {
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [results, setResults] = useState<Record<string, 'ok' | 'error' | null>>({})
+  const [rules, setRules] = useState<{ id: string; name: string; ruleType: string; severity: number; enabled: boolean }[]>([])
+  const [seedingRules, setSeedingRules] = useState(false)
+  const [seedRulesMsg, setSeedRulesMsg] = useState<string | null>(null)
+  const [seedingDemo, setSeedingDemo] = useState(false)
+  const [seedDemoMsg, setSeedDemoMsg] = useState<string | null>(null)
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/api/monitoring/security/config')
-        const data = await res.json()
-        setConfig(data.config ?? {})
+        const [cfgRes, rulesRes] = await Promise.all([
+          fetch('/api/monitoring/security/config'),
+          fetch('/api/monitoring/security/seed-rules'),
+        ])
+        const cfgData = await cfgRes.json()
+        setConfig(cfgData.config ?? {})
+        const rulesData = await rulesRes.json()
+        setRules(rulesData.rules ?? [])
       } catch {}
     }
     load()
@@ -59,55 +69,164 @@ export default function SecuritySettings() {
     }
   }
 
+  async function seedRules() {
+    setSeedingRules(true)
+    setSeedRulesMsg(null)
+    try {
+      const res = await fetch('/api/monitoring/security/seed-rules', { method: 'POST' })
+      const data = await res.json()
+      setSeedRulesMsg(`Seeded ${data.seeded} correlation rules`)
+      setRules(data.rules?.map((name: string) => ({ id: name, name, ruleType: '', severity: 0, enabled: true })) ?? [])
+      // Reload rules
+      const r2 = await fetch('/api/monitoring/security/seed-rules')
+      const d2 = await r2.json()
+      setRules(d2.rules ?? [])
+    } catch {
+      setSeedRulesMsg('Failed to seed rules')
+    } finally {
+      setSeedingRules(false)
+      setTimeout(() => setSeedRulesMsg(null), 4000)
+    }
+  }
+
+  async function injectDemoEvents() {
+    setSeedingDemo(true)
+    setSeedDemoMsg(null)
+    try {
+      const res = await fetch('/api/monitoring/security/demo-events', { method: 'POST' })
+      const data = await res.json()
+      setSeedDemoMsg(data.message ?? 'Demo events injected')
+    } catch {
+      setSeedDemoMsg('Failed to inject demo events')
+    } finally {
+      setSeedingDemo(false)
+      setTimeout(() => setSeedDemoMsg(null), 5000)
+    }
+  }
+
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2 mb-2">
-        <Shield size={20} className="text-accent" />
-        <h2 className="text-base font-semibold text-text-primary">Security Sources</h2>
-      </div>
-      <p className="text-xs text-text-muted">Configure and test connections to security monitoring sources.</p>
+    <div className="space-y-6">
+      {/* Source config */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <Shield size={20} className="text-accent" />
+          <h2 className="text-base font-semibold text-text-primary">Security Sources</h2>
+        </div>
+        <p className="text-xs text-text-muted mb-3">Configure and test connections to security monitoring sources.</p>
 
-      <div className="space-y-3">
-        {sources.map(source => (
-          <div key={source.key} className="bg-bg-surface border border-border-subtle rounded-xl p-4">
-            <div className="flex items-start justify-between mb-2">
-              <div>
-                <div className="text-sm font-medium text-text-primary">{source.name}</div>
-                <div className="text-[11px] text-text-muted">{source.desc}</div>
+        <div className="space-y-3">
+          {sources.map(source => (
+            <div key={source.key} className="bg-bg-raised border border-border-subtle rounded-xl p-4">
+              <div className="flex items-start justify-between mb-2">
+                <div>
+                  <div className="text-sm font-medium text-text-primary">{source.name}</div>
+                  <div className="text-[11px] text-text-muted">{source.desc}</div>
+                </div>
+                <button
+                  onClick={() => testConnection(source.key)}
+                  disabled={testing === source.key}
+                  className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-primary border border-border-subtle rounded-md disabled:opacity-50"
+                >
+                  {testing === source.key ? <Loader2 size={12} className="animate-spin" /> :
+                    results[source.key] === 'ok' ? <CheckCircle2 size={12} className="text-status-success" /> :
+                    results[source.key] === 'error' ? <XCircle size={12} className="text-status-error" /> :
+                    <RefreshCw size={12} />}
+                  Test
+                </button>
               </div>
-              <button
-                onClick={() => testConnection(source.key)}
-                disabled={testing === source.key}
-                className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-primary border border-border-subtle rounded-md disabled:opacity-50"
-              >
-                {testing === source.key ? <Loader2 size={12} className="animate-spin" /> :
-                  results[source.key] === 'ok' ? <CheckCircle2 size={12} className="text-status-success" /> :
-                  results[source.key] === 'error' ? <XCircle size={12} className="text-status-error" /> :
-                  <RefreshCw size={12} />}
-                Test
-              </button>
+              <input
+                type="text"
+                value={config[source.key] || source.default}
+                onChange={e => setConfig(prev => ({ ...prev, [source.key]: e.target.value }))}
+                className="w-full px-3 py-1.5 text-xs bg-bg-surface border border-border-subtle rounded-md font-mono text-text-primary focus:outline-none focus:border-accent"
+                placeholder={source.default}
+              />
             </div>
-            <input
-              type="text"
-              value={config[source.key] || source.default}
-              onChange={e => setConfig(prev => ({ ...prev, [source.key]: e.target.value }))}
-              className="w-full px-3 py-1.5 text-xs bg-bg-raised border border-border-subtle rounded-md font-mono text-text-primary focus:outline-none focus:border-accent"
-              placeholder={source.default}
-            />
-          </div>
-        ))}
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3 mt-3">
+          <button
+            onClick={saveConfig}
+            disabled={saving}
+            className="flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+          >
+            {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+            Save Configuration
+          </button>
+          {saved && <span className="text-xs text-status-healthy flex items-center gap-1"><CheckCircle2 size={12} /> Saved</span>}
+        </div>
       </div>
 
-      <div className="flex items-center gap-3">
-        <button
-          onClick={saveConfig}
-          disabled={saving}
-          className="flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
-        >
-          {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
-          Save Configuration
-        </button>
-        {saved && <span className="text-xs text-status-healthy flex items-center gap-1"><CheckCircle2 size={12} /> Saved</span>}
+      {/* Correlation rules */}
+      <div className="border-t border-border-subtle pt-5">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+              <Database size={16} className="text-accent" />
+              Correlation Rules
+            </h3>
+            <p className="text-xs text-text-muted mt-0.5">
+              Rules that group raw events into incidents. {rules.length > 0 ? `${rules.length} rules loaded.` : 'No rules configured.'}
+            </p>
+          </div>
+          <button
+            onClick={seedRules}
+            disabled={seedingRules}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border border-border-subtle rounded-lg hover:bg-bg-raised disabled:opacity-50 transition-colors"
+          >
+            {seedingRules ? <Loader2 size={12} className="animate-spin" /> : <Database size={12} />}
+            {rules.length > 0 ? 'Re-seed defaults' : 'Seed default rules'}
+          </button>
+        </div>
+
+        {seedRulesMsg && (
+          <div className="text-xs text-status-healthy mb-2">{seedRulesMsg}</div>
+        )}
+
+        {rules.length > 0 ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {rules.map(rule => (
+              <div key={rule.id} className="bg-bg-raised border border-border-subtle rounded-lg px-3 py-2">
+                <div className="text-xs font-medium text-text-primary">{rule.name.replace(/_/g, ' ')}</div>
+                <div className="text-[10px] text-text-muted mt-0.5">{rule.ruleType} · sev {rule.severity}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-border-subtle px-4 py-6 text-center text-xs text-text-muted">
+            No correlation rules found. Click "Seed default rules" to get started.
+          </div>
+        )}
+      </div>
+
+      {/* Demo data */}
+      <div className="border-t border-border-subtle pt-5">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+              <Zap size={16} className="text-accent" />
+              Demo Data
+            </h3>
+            <p className="text-xs text-text-muted mt-0.5">
+              Inject realistic sample security events to test the pipeline end-to-end.
+            </p>
+          </div>
+          <button
+            onClick={injectDemoEvents}
+            disabled={seedingDemo}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border border-status-warning/40 text-status-warning rounded-lg hover:bg-status-warning/5 disabled:opacity-50 transition-colors"
+          >
+            {seedingDemo ? <Loader2 size={12} className="animate-spin" /> : <Zap size={12} />}
+            Inject demo events
+          </button>
+        </div>
+        {seedDemoMsg && (
+          <div className="text-xs text-status-healthy mt-1">{seedDemoMsg}</div>
+        )}
+        <p className="text-[11px] text-text-muted mt-1">
+          Injects brute-force, port scan, K8s warnings, anomalies, and a malware signal. Run the correlator after to generate incidents.
+        </p>
       </div>
     </div>
   )

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -495,21 +495,12 @@ async function callOpenAIChat(
       } else {
         console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
 
-        // Emit security audit event for high-risk tool calls (fire-and-forget)
-        if (toolContext?.agentId) {
-          auditToolCall({
-            toolName: tc.function.name,
-            args,
-            agentId: toolContext.agentId,
-            agentName,
-          })
-        }
-
         // MINOR fix: allowedTools was applied only to the advertised tool list (prompt
         // layer), not at execution. A jailbroken model emitting a tool name outside the
         // whitelist still executed it. Enforce at dispatch time.
         if (allowedTools && allowedTools.size > 0 && !allowedTools.has(tc.function.name)) {
           result = `Permission denied: tool '${tc.function.name}' is not in this agent's allowed tool list`
+          if (toolContext?.agentId) auditToolCall({ toolName: tc.function.name, args, agentId: toolContext.agentId, agentName, outcome: 'denied' })
         } else if (registryToolNames.has(tc.function.name)) {
           // Gate registry tools through checkToolPermission before execution.
           // Previously called executeRegisteredTool directly with NO permission check,
@@ -518,6 +509,7 @@ async function callOpenAIChat(
           const perm = await checkToolPermission(tc.function.name, agentIdForPerm, null)
           if (!perm.allowed) {
             result = `Permission denied: ${perm.reason ?? `tool '${tc.function.name}' is not permitted for this agent`}`
+            if (toolContext?.agentId) auditToolCall({ toolName: tc.function.name, args, agentId: toolContext.agentId, agentName, outcome: 'denied' })
           } else {
           result = await executeRegisteredTool(tc.function.name, args, {
             agentId: toolContext!.agentId,
@@ -527,6 +519,7 @@ async function callOpenAIChat(
               listTools: () => gateway.client.listTools(),
             } : undefined,
           })
+          if (toolContext?.agentId) auditToolCall({ toolName: tc.function.name, args, agentId: toolContext.agentId, agentName, outcome: 'executed' })
           }
         } else if (legacyToolNames.has(tc.function.name)) {
           // Legacy agent-tools (create_task, orion_manage_task, etc.)
@@ -535,9 +528,11 @@ async function callOpenAIChat(
             callerAgentId: toolContext!.agentId,
             callerLlm:     toolContext!.llm,
           })
+          if (toolContext?.agentId) auditToolCall({ toolName: tc.function.name, args, agentId: toolContext.agentId, agentName, outcome: 'executed' })
         } else if (gateway && gatewayToolNames.has(tc.function.name)) {
           // Known gateway tool
           result = await gateway.client.executeTool(tc.function.name, args)
+          if (toolContext?.agentId) auditToolCall({ toolName: tc.function.name, args, agentId: toolContext.agentId, agentName, outcome: 'executed' })
         } else {
           // Hallucinated or unknown tool name — attempt fuzzy resolution before giving up.
           const resolved = resolveToolName(tc.function.name, allKnownToolNames)

--- a/apps/web/src/lib/room-agents.ts
+++ b/apps/web/src/lib/room-agents.ts
@@ -24,6 +24,7 @@ import { resolveAgentGateway } from './agent-gateway'
 import { buildAgentContext, buildAgentLocalContext, buildRoomLocalContext, invalidateSnapshotCache, getModelContextLimit, getClaudeContextLimit } from './agent-context'
 import { compactRoom, publishCompactionWarning, publishTokenUpdate } from './compaction'
 import { recordTokenUsage } from './token-budget'
+import { auditToolCall } from './security/audit-emitter'
 import { getPrompt } from './system-prompts'
 import type { AgentGateway } from './agent-gateway'
 import type { GatewayTool } from './agent-runner/types'
@@ -493,6 +494,16 @@ async function callOpenAIChat(
         result = `[Cached result — fetched earlier this session]\n${cached.result}`
       } else {
         console.log(`[room-agents] ${agentName} calling tool: ${tc.function.name}`, args)
+
+        // Emit security audit event for high-risk tool calls (fire-and-forget)
+        if (toolContext?.agentId) {
+          auditToolCall({
+            toolName: tc.function.name,
+            args,
+            agentId: toolContext.agentId,
+            agentName,
+          })
+        }
 
         // MINOR fix: allowedTools was applied only to the advertised tool list (prompt
         // layer), not at execution. A jailbroken model emitting a tool name outside the

--- a/apps/web/src/lib/security/audit-emitter.ts
+++ b/apps/web/src/lib/security/audit-emitter.ts
@@ -1,0 +1,107 @@
+/**
+ * Security audit emitter — emit SecurityEvents from server-side tool execution.
+ *
+ * Called from the tool execution hot path (room-agents.ts) for high-risk operations.
+ * Writes directly to the DB (no HTTP round-trip) and fires-and-forgets so it
+ * never blocks the agent response.
+ */
+
+import crypto from 'crypto'
+import { prisma } from '../db'
+
+interface AuditEvent {
+  toolName: string
+  args: Record<string, unknown>
+  agentId: string
+  agentName?: string
+  environmentId?: string | null
+}
+
+/** Tools and their risk classification (severity 0-100). */
+const TOOL_RISK: Record<string, { severity: number; type: string; label: string }> = {
+  // Container / process execution
+  kubectl_exec:           { severity: 75, type: 'container_exec',     label: 'kubectl exec into container' },
+  docker_exec:            { severity: 75, type: 'container_exec',     label: 'docker exec into container' },
+  execute_command:        { severity: 60, type: 'shell_execution',    label: 'Shell command executed' },
+  bash:                   { severity: 60, type: 'shell_execution',    label: 'Bash command executed' },
+  run_command:            { severity: 60, type: 'shell_execution',    label: 'Command executed' },
+  // K8s destructive ops
+  kubectl_delete:         { severity: 70, type: 'k8s_delete',         label: 'Kubernetes resource deleted' },
+  kubectl_apply:          { severity: 55, type: 'k8s_modify',         label: 'Kubernetes resource modified' },
+  kubectl_patch:          { severity: 55, type: 'k8s_modify',         label: 'Kubernetes resource patched' },
+  kubectl_scale:          { severity: 50, type: 'k8s_modify',         label: 'Kubernetes deployment scaled' },
+  // Security policy changes
+  crowdsec_create_decision: { severity: 65, type: 'security_policy',  label: 'CrowdSec decision created' },
+  crowdsec_delete_decision: { severity: 65, type: 'security_policy',  label: 'CrowdSec decision deleted' },
+  // File system ops
+  write_file:             { severity: 40, type: 'file_write',         label: 'File written by agent' },
+  delete_file:            { severity: 65, type: 'file_delete',        label: 'File deleted by agent' },
+}
+
+/** Patterns in command args that bump severity. */
+const DANGEROUS_PATTERNS = [
+  /rm\s+-rf/i, /DROP\s+TABLE/i, /chmod\s+777/i,
+  /curl.*\|\s*bash/i, /wget.*\|\s*sh/i,
+  /base64\s+-d/i, /\/etc\/passwd/i, /\/etc\/shadow/i,
+]
+
+function scanArgsForDangerousPatterns(args: Record<string, unknown>): boolean {
+  const flat = JSON.stringify(args)
+  return DANGEROUS_PATTERNS.some(re => re.test(flat))
+}
+
+/**
+ * Emit a SecurityEvent if the tool is considered high-risk.
+ * Fires and forgets — never throws, never blocks the caller.
+ */
+export function auditToolCall(event: AuditEvent): void {
+  const risk = TOOL_RISK[event.toolName]
+  const hasDangerousArgs = scanArgsForDangerousPatterns(event.args)
+
+  // Skip if low-risk tool and args are clean
+  if (!risk && !hasDangerousArgs) return
+
+  const severity = risk
+    ? (hasDangerousArgs ? Math.min(100, risk.severity + 20) : risk.severity)
+    : (hasDangerousArgs ? 70 : 40)
+
+  const type = risk?.type ?? 'shell_execution'
+  const label = risk?.label ?? `Tool call: ${event.toolName}`
+  const agentLabel = event.agentName ? `agent:${event.agentName}` : `agent:${event.agentId.slice(0, 8)}`
+
+  const dedupKey = crypto.createHash('sha256')
+    .update(`${event.toolName}:${event.agentId}:${Math.floor(Date.now() / 60_000)}`)
+    .digest('hex')
+
+  const now = new Date()
+
+  // Fire and forget — log errors but never surface them to the caller
+  prisma.securityEvent.findFirst({ where: { dedupKey }, select: { id: true } }).then(existing =>
+    existing
+      ? prisma.securityEvent.update({ where: { id: existing.id }, data: { lastSeen: now } })
+      : prisma.securityEvent.create({
+          data: {
+            environmentId: event.environmentId ?? null,
+            type,
+            source: 'gateway_audit',
+            severity,
+            title: `${label} by ${agentLabel}`,
+            description: hasDangerousArgs
+              ? `Dangerous pattern detected in args. Tool: ${event.toolName}`
+              : `High-risk tool called by ${agentLabel}`,
+            rawEvent: JSON.parse(JSON.stringify({ toolName: event.toolName, args: event.args, agentId: event.agentId })),
+            dedupKey,
+            firstSeen: now,
+            lastSeen: now,
+          },
+        })
+  ).then(() =>
+    prisma.sourceHealth.upsert({
+      where: { source: 'gateway_audit' },
+      update: { lastSeenAt: new Date() },
+      create: { source: 'gateway_audit', lastSeenAt: new Date(), lastWatermark: null, staleAfterMs: 3_600_000 },
+    })
+  ).catch(err => {
+    console.warn('[security-audit] failed to emit event:', err)
+  })
+}

--- a/apps/web/src/lib/security/audit-emitter.ts
+++ b/apps/web/src/lib/security/audit-emitter.ts
@@ -7,47 +7,71 @@
  */
 
 import crypto from 'crypto'
+import { Prisma } from '@prisma/client'
 import { prisma } from '../db'
 
-interface AuditEvent {
+export interface AuditEvent {
   toolName: string
   args: Record<string, unknown>
   agentId: string
   agentName?: string
   environmentId?: string | null
+  /** Whether the tool was actually executed or denied by permission checks. */
+  outcome: 'executed' | 'denied'
 }
 
 /** Tools and their risk classification (severity 0-100). */
 const TOOL_RISK: Record<string, { severity: number; type: string; label: string }> = {
   // Container / process execution
-  kubectl_exec:           { severity: 75, type: 'container_exec',     label: 'kubectl exec into container' },
-  docker_exec:            { severity: 75, type: 'container_exec',     label: 'docker exec into container' },
-  execute_command:        { severity: 60, type: 'shell_execution',    label: 'Shell command executed' },
-  bash:                   { severity: 60, type: 'shell_execution',    label: 'Bash command executed' },
-  run_command:            { severity: 60, type: 'shell_execution',    label: 'Command executed' },
+  kubectl_exec:              { severity: 75, type: 'container_exec',  label: 'kubectl exec into container' },
+  docker_exec:               { severity: 75, type: 'container_exec',  label: 'docker exec into container' },
+  docker_run:                { severity: 65, type: 'container_exec',  label: 'docker run' },
+  execute_command:           { severity: 60, type: 'shell_execution', label: 'Shell command executed' },
+  bash:                      { severity: 60, type: 'shell_execution', label: 'Bash command executed' },
+  run_command:               { severity: 60, type: 'shell_execution', label: 'Command executed' },
   // K8s destructive ops
-  kubectl_delete:         { severity: 70, type: 'k8s_delete',         label: 'Kubernetes resource deleted' },
-  kubectl_apply:          { severity: 55, type: 'k8s_modify',         label: 'Kubernetes resource modified' },
-  kubectl_patch:          { severity: 55, type: 'k8s_modify',         label: 'Kubernetes resource patched' },
-  kubectl_scale:          { severity: 50, type: 'k8s_modify',         label: 'Kubernetes deployment scaled' },
+  kubectl_delete:            { severity: 70, type: 'k8s_delete',      label: 'Kubernetes resource deleted' },
+  kubectl_apply:             { severity: 55, type: 'k8s_modify',      label: 'Kubernetes resource modified' },
+  kubectl_patch:             { severity: 55, type: 'k8s_modify',      label: 'Kubernetes resource patched' },
+  kubectl_scale:             { severity: 50, type: 'k8s_modify',      label: 'Kubernetes deployment scaled' },
+  kubectl_drain:             { severity: 70, type: 'k8s_modify',      label: 'Kubernetes node drained' },
+  kubectl_rollout:           { severity: 55, type: 'k8s_modify',      label: 'Kubernetes rollout triggered' },
   // Security policy changes
-  crowdsec_create_decision: { severity: 65, type: 'security_policy',  label: 'CrowdSec decision created' },
-  crowdsec_delete_decision: { severity: 65, type: 'security_policy',  label: 'CrowdSec decision deleted' },
+  crowdsec_create_decision:  { severity: 65, type: 'security_policy', label: 'CrowdSec decision created' },
+  crowdsec_delete_decision:  { severity: 65, type: 'security_policy', label: 'CrowdSec decision deleted' },
   // File system ops
-  write_file:             { severity: 40, type: 'file_write',         label: 'File written by agent' },
-  delete_file:            { severity: 65, type: 'file_delete',        label: 'File deleted by agent' },
+  write_file:                { severity: 40, type: 'file_write',      label: 'File written by agent' },
+  delete_file:               { severity: 65, type: 'file_delete',     label: 'File deleted by agent' },
 }
 
-/** Patterns in command args that bump severity. */
+/** Scan string values in args recursively for dangerous patterns. */
 const DANGEROUS_PATTERNS = [
-  /rm\s+-rf/i, /DROP\s+TABLE/i, /chmod\s+777/i,
-  /curl.*\|\s*bash/i, /wget.*\|\s*sh/i,
-  /base64\s+-d/i, /\/etc\/passwd/i, /\/etc\/shadow/i,
+  /rm\s+-[rf]{1,2}\b/i,
+  /DROP\s+TABLE/i,
+  /chmod\s+[0-7]*7[0-7]{2}/i,  // world-writable bits
+  /curl[^|]*\|\s*(ba)?sh/i,
+  /wget[^|]*\|\s*(ba)?sh/i,
+  /\/etc\/shadow\b/i,
 ]
 
-function scanArgsForDangerousPatterns(args: Record<string, unknown>): boolean {
-  const flat = JSON.stringify(args)
-  return DANGEROUS_PATTERNS.some(re => re.test(flat))
+function scanStringValues(val: unknown): boolean {
+  if (typeof val === 'string') return DANGEROUS_PATTERNS.some(re => re.test(val))
+  if (Array.isArray(val)) return val.some(scanStringValues)
+  if (val !== null && typeof val === 'object') return Object.values(val as object).some(scanStringValues)
+  return false
+}
+
+/** Throttle the sourceHealth heartbeat to once per 30s in-process. */
+let lastHeartbeatMs = 0
+function maybeHeartbeat() {
+  const now = Date.now()
+  if (now - lastHeartbeatMs < 30_000) return Promise.resolve()
+  lastHeartbeatMs = now
+  return prisma.sourceHealth.upsert({
+    where: { source: 'gateway_audit' },
+    update: { lastSeenAt: new Date(now) },
+    create: { source: 'gateway_audit', lastSeenAt: new Date(now), lastWatermark: null, staleAfterMs: 3_600_000 },
+  })
 }
 
 /**
@@ -55,53 +79,66 @@ function scanArgsForDangerousPatterns(args: Record<string, unknown>): boolean {
  * Fires and forgets — never throws, never blocks the caller.
  */
 export function auditToolCall(event: AuditEvent): void {
-  const risk = TOOL_RISK[event.toolName]
-  const hasDangerousArgs = scanArgsForDangerousPatterns(event.args)
+  let hasDangerousArgs = false
+  try {
+    hasDangerousArgs = scanStringValues(event.args)
+  } catch {
+    // Non-serializable args — treat as potentially dangerous
+    hasDangerousArgs = true
+  }
 
-  // Skip if low-risk tool and args are clean
+  const risk = TOOL_RISK[event.toolName]
   if (!risk && !hasDangerousArgs) return
 
   const severity = risk
     ? (hasDangerousArgs ? Math.min(100, risk.severity + 20) : risk.severity)
     : (hasDangerousArgs ? 70 : 40)
 
+  // Use the tool's natural type; only fall back to shell_execution for unknown tools
   const type = risk?.type ?? 'shell_execution'
-  const label = risk?.label ?? `Tool call: ${event.toolName}`
-  const agentLabel = event.agentName ? `agent:${event.agentName}` : `agent:${event.agentId.slice(0, 8)}`
+  const actionVerb = event.outcome === 'denied' ? '(denied)' : ''
+  const label = (risk?.label ?? `Tool call: ${event.toolName}`) + (actionVerb ? ` ${actionVerb}` : '')
+  const agentLabel = event.agentName ?? `agent:${event.agentId.slice(0, 8)}`
 
+  // Include a dangerous-args flag in the dedup key so a clean call and a dirty
+  // call in the same minute produce separate events (different severity/description)
+  const dangerFlag = hasDangerousArgs ? '1' : '0'
   const dedupKey = crypto.createHash('sha256')
-    .update(`${event.toolName}:${event.agentId}:${Math.floor(Date.now() / 60_000)}`)
+    .update(`${event.toolName}:${event.agentId}:${Math.floor(Date.now() / 60_000)}:${dangerFlag}`)
     .digest('hex')
 
   const now = new Date()
 
-  // Fire and forget — log errors but never surface them to the caller
-  prisma.securityEvent.findFirst({ where: { dedupKey }, select: { id: true } }).then(existing =>
-    existing
-      ? prisma.securityEvent.update({ where: { id: existing.id }, data: { lastSeen: now } })
-      : prisma.securityEvent.create({
-          data: {
-            environmentId: event.environmentId ?? null,
-            type,
-            source: 'gateway_audit',
-            severity,
-            title: `${label} by ${agentLabel}`,
-            description: hasDangerousArgs
-              ? `Dangerous pattern detected in args. Tool: ${event.toolName}`
-              : `High-risk tool called by ${agentLabel}`,
-            rawEvent: JSON.parse(JSON.stringify({ toolName: event.toolName, args: event.args, agentId: event.agentId })),
-            dedupKey,
-            firstSeen: now,
-            lastSeen: now,
-          },
-        })
-  ).then(() =>
-    prisma.sourceHealth.upsert({
-      where: { source: 'gateway_audit' },
-      update: { lastSeenAt: new Date() },
-      create: { source: 'gateway_audit', lastSeenAt: new Date(), lastWatermark: null, staleAfterMs: 3_600_000 },
+  let rawEvent: Prisma.InputJsonValue
+  try {
+    rawEvent = JSON.parse(JSON.stringify({ toolName: event.toolName, agentId: event.agentId, outcome: event.outcome }))
+  } catch {
+    rawEvent = { toolName: event.toolName, agentId: event.agentId, outcome: event.outcome }
+  }
+
+  // Fire and forget
+  prisma.securityEvent.findFirst({ where: { dedupKey }, select: { id: true } })
+    .then(existing => {
+      if (existing) {
+        return prisma.securityEvent.update({ where: { id: existing.id }, data: { lastSeen: now } })
+      }
+      return prisma.securityEvent.create({
+        data: {
+          environmentId: event.environmentId ?? null,
+          type,
+          source: 'gateway_audit',
+          severity,
+          title: `${label} by ${agentLabel}`,
+          description: hasDangerousArgs
+            ? `Dangerous pattern in args for tool '${event.toolName}' (outcome: ${event.outcome})`
+            : `High-risk tool by ${agentLabel} (outcome: ${event.outcome})`,
+          rawEvent,
+          dedupKey,
+          firstSeen: now,
+          lastSeen: now,
+        },
+      })
     })
-  ).catch(err => {
-    console.warn('[security-audit] failed to emit event:', err)
-  })
+    .then(() => { maybeHeartbeat().catch(() => {}) })
+    .catch(err => console.warn('[security-audit] failed to emit event:', err))
 }


### PR DESCRIPTION
## Summary

- **Fix pending approvals bug**: overview API was querying `status: 'denied'` instead of `status: 'pending'`, so the approvals count was always wrong
- **Real-time audit trail**: agent tool calls now emit `SecurityEvent` records automatically — `kubectl_exec`, `docker_exec`, `bash`, `kubectl_delete`, CrowdSec decisions, file deletes, and any tool whose args match dangerous patterns (`rm -rf`, `DROP TABLE`, `chmod 777`, pipe-to-shell, `/etc/shadow`)
- **Default correlation rules**: `POST /api/monitoring/security/seed-rules` seeds 8 rules (brute_force, port_scan, malware_detection, crowdsec_block, privilege_escalation, data_exfil, anomaly_cluster, k8s_warning_burst) — re-seeding restores defaults
- **Demo event injection**: `POST /api/monitoring/security/demo-events` injects a realistic attack scenario (brute-force sequence, port scan from single IP, malware signal, K8s warnings) in a single transaction so the correlator has something to work with end-to-end
- **Security Settings UI**: new Correlation Rules panel (shows loaded rules, seed button) and Demo Data section with inject button and proper `res.ok` error handling
- **Getting-started guide**: empty incidents tab now shows setup steps instead of just a blank state
- **Remove dead query**: `severityDist` groupBy in overview was computed but never returned

## How real data flows (no external services needed)

Every agent session that uses high-risk tools will now generate `SecurityEvent` rows visible in the Alerts feed. The correlator runs every 30s and groups events into incidents automatically.

For external sources (CrowdSec, Wazuh, Falco, ELK, ntopng), webhook endpoints already exist — point them at ORION with the shared secret.

## Test plan

- [ ] Security → Settings → "Seed default rules" — 8 rules appear in the panel
- [ ] Security → Settings → "Inject demo events" — success message; switch to Alerts tab and verify events appear
- [ ] Wait ~30s for correlator to run; check Incidents tab for brute_force and port_scan incidents
- [ ] Run an agent task that uses `kubectl` or `bash`; verify a `gateway_audit` SecurityEvent appears
- [ ] Sources tab shows `gateway_audit` as healthy after tool calls fire
- [ ] Approvals count on dashboard reflects actual pending (not denied) approvals

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_