### PR TITLE
feat: task deps visualization, tool ACL admin, fed polling, empty states, risk hints

### DIFF
--- a/apps/web/src/app/(app)/admin/layout.tsx
+++ b/apps/web/src/app/(app)/admin/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare, KeyRound } from 'lucide-react'
+import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare, KeyRound, Shield } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 
 const adminNav = [
@@ -15,6 +15,7 @@ const adminNav = [
   { href: '/admin/sso',           icon: ShieldCheck,     label: 'SSO'           },
   { href: '/admin/prompts',        icon: MessageSquare,   label: 'Prompts'       },
   { href: '/admin/claude',         icon: KeyRound,        label: 'Claude OAuth'  },
+  { href: '/admin/tool-permissions', icon: Shield,        label: 'Tool ACLs'     },
   { href: '/admin/audit',         icon: ScrollText,      label: 'Audit Log'     },
 ]
 

--- a/apps/web/src/app/(app)/admin/tool-permissions/page.tsx
+++ b/apps/web/src/app/(app)/admin/tool-permissions/page.tsx
@@ -1,0 +1,220 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { Shield, Eye, EyeOff, Check, X, RefreshCw, ChevronDown, ChevronUp, Lock } from 'lucide-react'
+
+interface AgentRestriction {
+  agentId: string
+  agent: { id: string; name: string }
+}
+
+interface Tool {
+  id: string
+  name: string
+  description: string
+  execType: string
+  enabled: boolean
+  builtIn: boolean
+  status: string
+  proposedAt: string | null
+  environment: { id: string; name: string }
+  agentRestrictions: AgentRestriction[]
+}
+
+export default function ToolPermissionsPage() {
+  const [tools, setTools] = useState<Tool[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [envFilter, setEnvFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await fetch('/api/admin/tools').then(r => r.json()) as Tool[]
+      setTools(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  async function patch(id: string, update: { enabled?: boolean; status?: string }) {
+    setSaving(id)
+    try {
+      const updated = await fetch('/api/admin/tools', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, ...update }),
+      }).then(r => r.json()) as Tool
+      setTools(prev => prev.map(t => t.id === id ? { ...t, ...updated } : t))
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const environments = Array.from(new Set(tools.map(t => t.environment.name))).sort()
+
+  const filtered = tools.filter(t => {
+    if (envFilter !== 'all' && t.environment.name !== envFilter) return false
+    if (statusFilter === 'pending' && t.status !== 'pending') return false
+    if (statusFilter === 'disabled' && t.enabled) return false
+    if (statusFilter === 'restricted' && t.agentRestrictions.length === 0) return false
+    return true
+  })
+
+  const pendingCount = tools.filter(t => t.status === 'pending').length
+
+  return (
+    <div className="p-6 space-y-5 max-w-5xl">
+      <div>
+        <h1 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+          <Shield size={18} className="text-accent" /> Tool Permissions
+        </h1>
+        <p className="text-sm text-text-muted mt-0.5">
+          Review, enable, disable, and approve MCP tools across all environments.
+        </p>
+      </div>
+
+      {pendingCount > 0 && (
+        <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-400">
+          <Lock size={14} />
+          <span>{pendingCount} tool{pendingCount !== 1 ? 's' : ''} pending approval — review below.</span>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <select
+          value={envFilter}
+          onChange={e => setEnvFilter(e.target.value)}
+          className="px-2.5 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="all">All environments</option>
+          {environments.map(env => <option key={env} value={env}>{env}</option>)}
+        </select>
+        <select
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value)}
+          className="px-2.5 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+        >
+          <option value="all">All statuses</option>
+          <option value="pending">Pending approval</option>
+          <option value="disabled">Disabled</option>
+          <option value="restricted">Agent-restricted</option>
+        </select>
+        <button onClick={load} disabled={loading} className="ml-auto flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded border border-border-subtle text-text-muted hover:text-text-primary hover:border-border-visible transition-colors">
+          <RefreshCw size={11} className={loading ? 'animate-spin' : ''} /> Refresh
+        </button>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <div className="text-sm text-text-muted">Loading tools…</div>
+      ) : filtered.length === 0 ? (
+        <div className="flex flex-col items-center py-16 text-center gap-3">
+          <Shield size={32} className="text-text-muted/40" />
+          <p className="text-sm text-text-secondary">No tools match the current filter.</p>
+        </div>
+      ) : (
+        <div className="border border-border-subtle rounded-lg overflow-hidden divide-y divide-border-subtle">
+          {filtered.map(tool => {
+            const isExpanded = expanded.has(tool.id)
+            const isSaving = saving === tool.id
+            return (
+              <div key={tool.id} className="bg-bg-surface">
+                <div className="flex items-center gap-3 px-4 py-3">
+                  {/* Expand toggle */}
+                  <button
+                    onClick={() => setExpanded(prev => {
+                      const next = new Set(prev)
+                      next.has(tool.id) ? next.delete(tool.id) : next.add(tool.id)
+                      return next
+                    })}
+                    className="text-text-muted hover:text-text-primary flex-shrink-0"
+                  >
+                    {isExpanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                  </button>
+
+                  {/* Name + env */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-text-primary truncate">{tool.name}</span>
+                      {tool.builtIn && <span className="text-[10px] text-text-muted border border-border-subtle rounded px-1">built-in</span>}
+                      {tool.status === 'pending' && (
+                        <span className="text-[10px] text-amber-400 border border-amber-400/30 bg-amber-400/10 rounded px-1">pending</span>
+                      )}
+                      {tool.agentRestrictions.length > 0 && (
+                        <span className="text-[10px] text-blue-400 border border-blue-400/30 bg-blue-400/10 rounded px-1 flex items-center gap-0.5">
+                          <Lock size={8} />{tool.agentRestrictions.length} agent{tool.agentRestrictions.length !== 1 ? 's' : ''}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className="text-[10px] text-text-muted">{tool.environment.name}</span>
+                      <span className="text-[10px] text-text-muted/50">·</span>
+                      <span className="text-[10px] text-text-muted">{tool.execType}</span>
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {tool.status === 'pending' && (
+                      <>
+                        <button
+                          onClick={() => patch(tool.id, { status: 'active', enabled: true })}
+                          disabled={isSaving}
+                          className="flex items-center gap-1 px-2 py-1 text-[11px] rounded border border-emerald-500/40 text-emerald-400 hover:bg-emerald-500/10 transition-colors disabled:opacity-50"
+                        >
+                          <Check size={10} /> Approve
+                        </button>
+                        <button
+                          onClick={() => patch(tool.id, { status: 'rejected', enabled: false })}
+                          disabled={isSaving}
+                          className="flex items-center gap-1 px-2 py-1 text-[11px] rounded border border-red-500/40 text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                        >
+                          <X size={10} /> Reject
+                        </button>
+                      </>
+                    )}
+                    <button
+                      onClick={() => patch(tool.id, { enabled: !tool.enabled })}
+                      disabled={isSaving || tool.status === 'pending'}
+                      title={tool.enabled ? 'Disable tool' : 'Enable tool'}
+                      className={`flex items-center gap-1 px-2 py-1 text-[11px] rounded border transition-colors disabled:opacity-40 ${
+                        tool.enabled
+                          ? 'border-border-subtle text-text-muted hover:border-red-500/40 hover:text-red-400'
+                          : 'border-border-subtle text-text-muted hover:border-emerald-500/40 hover:text-emerald-400'
+                      }`}
+                    >
+                      {tool.enabled ? <><Eye size={10} /> Enabled</> : <><EyeOff size={10} /> Disabled</>}
+                    </button>
+                  </div>
+                </div>
+
+                {isExpanded && (
+                  <div className="px-10 pb-3 space-y-2">
+                    <p className="text-xs text-text-muted">{tool.description}</p>
+                    {tool.agentRestrictions.length > 0 && (
+                      <div>
+                        <p className="text-[10px] text-text-muted uppercase tracking-wide mb-1">Restricted to agents</p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {tool.agentRestrictions.map(r => (
+                            <span key={r.agentId} className="text-[10px] px-2 py-0.5 bg-bg-card border border-border-subtle rounded text-text-secondary">
+                              {r.agent.name}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/cost/page.tsx
+++ b/apps/web/src/app/(app)/cost/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { BarChart2, Coins, RefreshCw, TrendingUp, Zap, Calendar } from 'lucide-react'
+import { BarChart2, Coins, RefreshCw, TrendingUp, Zap, Calendar, Activity } from 'lucide-react'
 
 type Days = 7 | 30 | 90
 
@@ -257,8 +257,10 @@ export default function CostPage() {
             )}
 
             {summary.byAgent.length === 0 && (
-              <div className="rounded-lg border border-border-subtle bg-bg-surface p-8 text-center text-text-muted text-sm">
-                No token usage data for this period.
+              <div className="flex flex-col items-center justify-center rounded-lg border border-border-subtle bg-bg-surface py-16 text-center gap-3">
+                <Activity size={32} className="text-text-muted/40" />
+                <p className="text-sm font-medium text-text-secondary">No token usage recorded yet</p>
+                <p className="text-xs text-text-muted max-w-xs">Token usage will appear here once agents start completing tasks. Try running a task to see cost data.</p>
               </div>
             )}
           </>

--- a/apps/web/src/app/api/admin/tools/route.ts
+++ b/apps/web/src/app/api/admin/tools/route.ts
@@ -1,0 +1,31 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+// GET /api/admin/tools — list all MCP tools with environment and agent restriction info
+export async function GET() {
+  const tools = await prisma.mcpTool.findMany({
+    orderBy: [{ environmentId: 'asc' }, { name: 'asc' }],
+    include: {
+      environment: { select: { id: true, name: true } },
+      agentRestrictions: {
+        include: { agent: { select: { id: true, name: true } } },
+      },
+    },
+  })
+  return NextResponse.json(tools)
+}
+
+// PATCH /api/admin/tools — update a tool's enabled/status
+export async function PATCH(req: NextRequest) {
+  const body = await req.json() as { id: string; enabled?: boolean; status?: string }
+  if (!body.id) return NextResponse.json({ error: 'id required' }, { status: 400 })
+
+  const update: Record<string, unknown> = {}
+  if (typeof body.enabled === 'boolean') update.enabled = body.enabled
+  if (body.status === 'active' || body.status === 'rejected') update.status = body.status
+
+  const tool = await prisma.mcpTool.update({ where: { id: body.id }, data: update })
+  return NextResponse.json(tool)
+}

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -42,6 +42,28 @@ export async function GET() {
     } catch { extHealth[`ext:${m.id}`] = false }
   }))
 
+  // Worker health — inferred from task activity (worker has no direct health port)
+  const [runningTasks, queuedTasks, lastActivity] = await Promise.all([
+    prisma.task.count({ where: { status: 'in_progress' } }),
+    prisma.task.count({ where: { status: 'pending' } }),
+    prisma.task.findFirst({
+      where: { status: 'in_progress' },
+      orderBy: { updatedAt: 'desc' },
+      select: { updatedAt: true },
+    }),
+  ])
+  const workerActive = lastActivity
+    ? (Date.now() - lastActivity.updatedAt.getTime()) < 5 * 60 * 1000
+    : false
+
   const healthy = db  // k8s optional — not available in Docker-only deployments
-  return NextResponse.json({ k8s, db, claude, externalModels: extHealth }, { status: healthy ? 200 : 503 })
+  return NextResponse.json({
+    k8s, db, claude, externalModels: extHealth,
+    worker: {
+      running: runningTasks,
+      queued: queuedTasks,
+      lastActivityAt: lastActivity?.updatedAt.toISOString() ?? null,
+      active: workerActive,
+    },
+  }, { status: healthy ? 200 : 503 })
 }

--- a/apps/web/src/components/jobs/JobsPage.tsx
+++ b/apps/web/src/components/jobs/JobsPage.tsx
@@ -5,7 +5,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import {
   Plus, Trash2, Play, Clock, Check, X,
   Webhook, RefreshCw, Copy, ChevronDown, ChevronUp,
-  Zap, Activity, Settings,
+  Zap, Activity, Settings, CalendarClock,
 } from 'lucide-react'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -361,7 +361,11 @@ function SchedulesTab() {
       )}
 
       {loading ? <div className="text-sm text-text-secondary">Loading...</div> : schedules.length === 0 ? (
-        <div className="text-sm text-text-secondary py-8 text-center">No scheduled tasks yet.</div>
+        <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+          <CalendarClock size={32} className="text-text-muted/40" />
+          <p className="text-sm font-medium text-text-secondary">No scheduled tasks yet</p>
+          <p className="text-xs text-text-muted max-w-xs">Schedule recurring tasks using cron expressions. Click <strong>+ New Schedule</strong> to get started.</p>
+        </div>
       ) : (
         <div className="border border-border-subtle rounded-lg overflow-hidden">
           <table className="w-full text-sm">
@@ -496,9 +500,10 @@ function WebhooksTab() {
       )}
 
       {loading ? <p className="text-sm text-text-muted">Loading…</p> : triggers.length === 0 ? (
-        <div className="rounded-lg border border-border-subtle p-8 text-center">
-          <Webhook size={32} className="mx-auto mb-2 text-text-muted opacity-40" />
-          <p className="text-sm text-text-muted">No webhook triggers yet.</p>
+        <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+          <Webhook size={32} className="text-text-muted/40" />
+          <p className="text-sm font-medium text-text-secondary">No webhook triggers yet</p>
+          <p className="text-xs text-text-muted max-w-xs">Connect external systems to kick off agents automatically. Click <strong>+ New Trigger</strong> to create one.</p>
         </div>
       ) : (
         <div className="rounded-lg border border-border-subtle overflow-hidden">

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -2,7 +2,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import { Plus, X, Trash2, ChevronRight, Flag, Menu, Terminal, CheckCircle2, XCircle, Play, MessageSquare, ChevronDown, ChevronUp, Send, Loader2, User } from 'lucide-react'
+import { Plus, X, Trash2, ChevronRight, Flag, Menu, Terminal, CheckCircle2, XCircle, Play, MessageSquare, ChevronDown, ChevronUp, Send, Loader2, User, Lock, AlertTriangle, Layers } from 'lucide-react'
 import type { Agent, Task, Feature, Epic, SelectionState, PlanTarget, Bug } from '@/types/tasks'
 import { BugManager } from './BugManager'
 import { KanbanBoard } from '../ui/KanbanBoard'
@@ -62,6 +62,18 @@ type RightPanel =
   | { kind: 'feature'; feature: Feature; epic: Epic }
 
 interface CreateTaskForm { title: string; description: string; priority: string }
+
+const RISK_KEYWORDS: { pattern: RegExp; hint: string }[] = [
+  { pattern: /\b(delete|drop|truncate|destroy|wipe|purge)\b/i, hint: 'Destructive operation — make sure a backup or rollback plan exists.' },
+  { pattern: /\b(production|prod|live)\b/i, hint: 'Targets production — verify with a staging environment first.' },
+  { pattern: /\b(password|secret|token|credential|api.?key)\b/i, hint: 'Involves credentials — avoid hard-coding; use env vars or secrets manager.' },
+  { pattern: /\b(migrate|migration|schema change|alter table)\b/i, hint: 'Database migration — check for zero-downtime path and rollback script.' },
+  { pattern: /\b(public|expose|open|unauthenticated)\b/i, hint: 'May expose data publicly — confirm auth requirements.' },
+]
+
+function getRiskHints(text: string): string[] {
+  return RISK_KEYWORDS.filter(r => r.pattern.test(text)).map(r => r.hint)
+}
 interface CreateEpicForm { title: string; description: string }
 interface CreateFeatureForm { title: string; description: string; epicId: string; epicTitle: string }
 
@@ -682,6 +694,14 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                       <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${p.dot}`} />
                       <span className={`text-[10px] ${p.color}`}>{p.label}</span>
                       <div className="ml-auto flex items-center gap-1">
+                        {task.wave != null && task.wave > 0 && (
+                          <span className="text-[10px] text-text-muted" title={`Wave ${task.wave}`}>W{task.wave}</span>
+                        )}
+                        {(task.dependsOn?.length ?? 0) > 0 && task.status === 'pending' && (
+                          <span className="flex items-center gap-0.5 text-[10px] text-amber-400" title={`Blocked by ${task.dependsOn!.length} task(s)`}>
+                            <Lock size={9} />{task.dependsOn!.length}
+                          </span>
+                        )}
                         {task.plan && <span className="text-[10px] text-accent">has plan</span>}
                         {task.agent && (() => {
                           const idx = agents.findIndex(a => a.id === task.agent!.id)
@@ -864,6 +884,32 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                       })}
                     </div>
                   </div>
+                  {((panel.task.dependsOn?.length ?? 0) > 0 || panel.task.wave != null) && (
+                    <div>
+                      <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block flex items-center gap-1">
+                        <Layers size={10} /> Dependencies
+                      </label>
+                      {panel.task.wave != null && (
+                        <p className="text-[10px] text-text-muted mb-1">Wave {panel.task.wave}</p>
+                      )}
+                      {(panel.task.dependsOn?.length ?? 0) > 0 && (
+                        <div className="space-y-1">
+                          {panel.task.dependsOn!.map(depId => {
+                            const dep = tasks.find(t => t.id === depId)
+                            return dep ? (
+                              <div key={depId} className="flex items-center gap-1.5 text-[10px] text-text-muted bg-bg-card rounded px-2 py-1">
+                                {dep.status === 'done' ? <CheckCircle2 size={10} className="text-emerald-400" /> : <Lock size={10} className="text-amber-400" />}
+                                <span className="flex-1 truncate">{dep.title}</span>
+                                <span className="text-text-muted/60">{dep.status}</span>
+                              </div>
+                            ) : (
+                              <div key={depId} className="text-[10px] text-text-muted/50 px-2 py-1">{depId}</div>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  )}
                   <div>
                     <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
                     <textarea value={editDesc} onChange={e => setEditDesc(e.target.value)} onBlur={saveTaskDetail} rows={4}
@@ -945,6 +991,11 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
               onKeyDown={e => e.key === 'Enter' && !e.shiftKey && createTask()}
               placeholder="What needs to be done?"
               className="w-full px-3 py-2 text-sm rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent" />
+            {getRiskHints(`${taskForm.title} ${taskForm.description}`).map((hint, i) => (
+              <div key={i} className="flex items-start gap-1.5 mt-1.5 text-[10px] text-amber-400 bg-amber-400/10 rounded px-2 py-1.5">
+                <AlertTriangle size={10} className="flex-shrink-0 mt-0.5" />{hint}
+              </div>
+            ))}
           </div>
           <div>
             <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>

--- a/apps/web/src/types/tasks.ts
+++ b/apps/web/src/types/tasks.ts
@@ -30,6 +30,9 @@ export interface Task {
   assignedUser: TaskUser | null
   createdAt: string
   updatedAt: string
+  dependsOn?: string[]
+  wave?: number | null
+  metadata?: Record<string, unknown> | null
 }
 
 export interface Feature {

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -191,6 +191,7 @@ let runningNtopngPoller = false
 let runningVulnScan = false
 let runningDriftDetector = false
 let runningScheduler = false
+let runningFedPoller = false
 
 const TASK_TIMEOUT_MS = 60 * 60 * 1000 // 60 minutes
 
@@ -1454,6 +1455,46 @@ async function escalateStalePendingValidation(): Promise<void> {
   }
 }
 
+/**
+ * Poll all in-flight federated tasks for completion.
+ * Fetches status from each spoke and marks the local task done/failed to match.
+ */
+async function pollFederatedTasks(): Promise<void> {
+  const dispatches = await prisma.federatedDispatch.findMany({
+    where: { status: { in: ['dispatched', 'acknowledged'] } },
+    select: { id: true, taskId: true, spokeUrl: true, status: true },
+  })
+  if (dispatches.length === 0) return
+
+  // Get the federation token from env (hub uses this to authenticate with spokes)
+  const token = process.env.ORION_GATEWAY_TOKEN ?? ''
+
+  await Promise.all(dispatches.map(async (dispatch) => {
+    try {
+      const res = await fetch(`${dispatch.spokeUrl}/api/federation/tasks/${dispatch.taskId}/status`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      })
+      if (!res.ok) return
+
+      const data = (await res.json()) as { status: string }
+      const spokeStatus = data.status
+
+      if (spokeStatus === 'done' || spokeStatus === 'failed') {
+        await prisma.$transaction([
+          prisma.task.update({ where: { id: dispatch.taskId }, data: { status: spokeStatus } }),
+          prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'completed', completedAt: new Date() } }),
+        ])
+        log(`Federated task ${dispatch.taskId} completed on spoke with status: ${spokeStatus}`)
+      } else if (spokeStatus === 'in_progress' && dispatch.status === 'dispatched') {
+        await prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'acknowledged', acknowledgedAt: new Date() } })
+      }
+    } catch (e) {
+      err(`Failed to poll federated task ${dispatch.taskId} at ${dispatch.spokeUrl}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }))
+}
+
 async function pollOnce() {
   if (runningTasks.size >= MAX_CONCURRENT) return
 
@@ -1663,6 +1704,13 @@ async function main() {
     runningDriftDetector = true
     detectGitOpsDrift().catch(e => err(`GitOps drift detection failed: ${e}`)).finally(() => { runningDriftDetector = false })
   }, 5 * 60_000)
+
+  // Federation spoke polling — every 60s, check in-flight federated tasks for completion.
+  setInterval(() => {
+    if (runningFedPoller) return
+    runningFedPoller = true
+    pollFederatedTasks().catch(e => err(`Federation spoke polling failed: ${e}`)).finally(() => { runningFedPoller = false })
+  }, 60_000)
 
 }
 


### PR DESCRIPTION
- TasksPage: show wave badge + dependency lock badge on Kanban cards; show
  dependency section (with done/blocked icons) in task detail panel
- TasksPage: pre-flight risk hints in task creation form — highlights destructive,
  prod-targeting, credential-handling, migration, and exposure keywords
- worker.ts: pollFederatedTasks() polls spokes every 60s for in-flight federated
  task completion and syncs local task status + FederatedDispatch.status
- /api/admin/tools route: GET all McpTools with env + agent restriction info,
  PATCH to toggle enabled/status
- /admin/tool-permissions page: review, approve/reject, enable/disable tools per
  environment with agent-restriction details; added to admin nav as "Tool ACLs"
- JobsPage: richer empty states with icon + CTA copy for schedules and triggers
- Cost page: richer empty state with icon + onboarding copy when no usage data
- types/tasks.ts: added dependsOn, wave, metadata fields to Task interface
- /api/health: worker health stats (running, queued, lastActivityAt, active)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV