### PR TITLE
feat: health dashboard, task dep editor, model cost tracking, auth+audit for tool ACLs

### DIFF
--- a/apps/web/prisma/migrations/10_agent_token_usage_model_id/migration.sql
+++ b/apps/web/prisma/migrations/10_agent_token_usage_model_id/migration.sql
@@ -1,0 +1,3 @@
+-- Add modelId to AgentTokenUsage for per-model cost breakdown
+ALTER TABLE "AgentTokenUsage" ADD COLUMN "modelId" TEXT;
+CREATE INDEX "AgentTokenUsage_modelId_idx" ON "AgentTokenUsage"("modelId");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -97,12 +97,14 @@ model AgentTokenUsage {
   agentId      String
   agent        Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
   taskId       String?
+  modelId      String?  // e.g. "claude-sonnet-4-6", "gpt-4o", "llama3" — null for legacy rows
   inputTokens  Int      @default(0)
   outputTokens Int      @default(0)
   recordedAt   DateTime @default(now())
 
   @@index([agentId, recordedAt])
   @@index([taskId])
+  @@index([modelId])
 }
 
 model Environment {

--- a/apps/web/src/app/(app)/admin/health/page.tsx
+++ b/apps/web/src/app/(app)/admin/health/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+import { useState, useEffect, useCallback } from 'react'
+import { CheckCircle2, XCircle, RefreshCw, Activity, Database, Cloud, Bot, Cpu, Clock, type LucideIcon } from 'lucide-react'
+
+interface WorkerHealth {
+  running: number
+  queued: number
+  lastActivityAt: string | null
+  active: boolean
+}
+
+interface HealthData {
+  k8s: boolean
+  db: boolean
+  claude: boolean
+  externalModels: Record<string, boolean>
+  worker: WorkerHealth
+}
+
+function StatusDot({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      {ok
+        ? <CheckCircle2 size={14} className="text-emerald-400 flex-shrink-0" />
+        : <XCircle size={14} className="text-red-400 flex-shrink-0" />
+      }
+      <span className={`text-sm ${ok ? 'text-text-primary' : 'text-red-400'}`}>{label}</span>
+    </div>
+  )
+}
+
+function Card({ title, icon: Icon, children }: { title: string; icon: LucideIcon; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border-subtle bg-bg-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-border-subtle flex items-center gap-2">
+        <Icon size={14} className="text-accent" />
+        <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+      </div>
+      <div className="px-4 py-4 space-y-2.5">{children}</div>
+    </div>
+  )
+}
+
+export default function SystemHealthPage() {
+  const [data, setData] = useState<HealthData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [lastChecked, setLastChecked] = useState<Date | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/health')
+      const json = await res.json() as HealthData
+      setData(json)
+      setLastChecked(new Date())
+    } catch {
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const t = setInterval(refresh, 30_000)
+    return () => clearInterval(t)
+  }, [refresh])
+
+  const extEntries = Object.entries(data?.externalModels ?? {})
+
+  return (
+    <div className="p-6 space-y-5 max-w-3xl">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary flex items-center gap-2">
+            <Activity size={18} className="text-accent" /> System Health
+          </h1>
+          <p className="text-sm text-text-muted mt-0.5">Live status of all ORION subsystems. Auto-refreshes every 30 s.</p>
+        </div>
+        <button
+          onClick={refresh}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded border border-border-subtle text-text-muted hover:text-text-primary hover:border-border-visible transition-colors disabled:opacity-50"
+        >
+          <RefreshCw size={11} className={loading ? 'animate-spin' : ''} /> Refresh
+        </button>
+      </div>
+
+      {lastChecked && (
+        <p className="text-[11px] text-text-muted flex items-center gap-1">
+          <Clock size={10} /> Last checked: {lastChecked.toLocaleTimeString()}
+        </p>
+      )}
+
+      {loading && !data && (
+        <div className="text-sm text-text-muted">Checking health…</div>
+      )}
+
+      {data && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* Core services */}
+          <Card title="Core Services" icon={Database}>
+            <StatusDot ok={data.db} label="Database (PostgreSQL)" />
+            <StatusDot ok={data.k8s} label="Kubernetes API" />
+            <StatusDot ok={data.claude} label="Claude credentials" />
+          </Card>
+
+          {/* Worker */}
+          <Card title="Worker" icon={Bot}>
+            <StatusDot ok={data.worker.active} label={data.worker.active ? 'Worker active' : 'Worker idle / no recent activity'} />
+            <div className="grid grid-cols-2 gap-3 mt-1">
+              <div className="rounded bg-bg-raised border border-border-subtle px-3 py-2 text-center">
+                <p className="text-2xl font-bold text-text-primary">{data.worker.running}</p>
+                <p className="text-[10px] text-text-muted mt-0.5">Running</p>
+              </div>
+              <div className="rounded bg-bg-raised border border-border-subtle px-3 py-2 text-center">
+                <p className="text-2xl font-bold text-text-primary">{data.worker.queued}</p>
+                <p className="text-[10px] text-text-muted mt-0.5">Queued</p>
+              </div>
+            </div>
+            {data.worker.lastActivityAt && (
+              <p className="text-[10px] text-text-muted flex items-center gap-1 mt-1">
+                <Clock size={9} /> Last activity: {new Date(data.worker.lastActivityAt).toLocaleString()}
+              </p>
+            )}
+          </Card>
+
+          {/* External models */}
+          <Card title="External Models" icon={Cpu}>
+            {extEntries.length === 0 ? (
+              <p className="text-xs text-text-muted">No external models configured.</p>
+            ) : (
+              extEntries.map(([id, ok]) => (
+                <StatusDot key={id} ok={ok} label={id.replace('ext:', '')} />
+              ))
+            )}
+          </Card>
+
+          {/* K8s + cloud summary */}
+          <Card title="Infrastructure" icon={Cloud}>
+            <StatusDot ok={data.k8s} label={data.k8s ? 'Kubernetes reachable' : 'Kubernetes unavailable (Docker-only mode)'} />
+            <p className="text-[10px] text-text-muted mt-1">
+              K8s is optional — ORION functions without it in Docker-only deployments.
+            </p>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(app)/admin/layout.tsx
+++ b/apps/web/src/app/(app)/admin/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare, KeyRound, Shield } from 'lucide-react'
+import { LayoutDashboard, Settings, Cpu, Users, ShieldCheck, ScrollText, Layers, ShieldAlert, UsersRound, MessageSquare, KeyRound, Shield, Activity } from 'lucide-react'
 import { usePendingTools } from '@/hooks/usePendingTools'
 
 const adminNav = [
@@ -16,6 +16,7 @@ const adminNav = [
   { href: '/admin/prompts',        icon: MessageSquare,   label: 'Prompts'       },
   { href: '/admin/claude',         icon: KeyRound,        label: 'Claude OAuth'  },
   { href: '/admin/tool-permissions', icon: Shield,        label: 'Tool ACLs'     },
+  { href: '/admin/health',        icon: Activity,        label: 'Health'        },
   { href: '/admin/audit',         icon: ScrollText,      label: 'Audit Log'     },
 ]
 

--- a/apps/web/src/app/(app)/cost/page.tsx
+++ b/apps/web/src/app/(app)/cost/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { BarChart2, Coins, RefreshCw, TrendingUp, Zap, Calendar, Activity } from 'lucide-react'
+import { BarChart2, Coins, RefreshCw, TrendingUp, Zap, Calendar, Activity, Cpu } from 'lucide-react'
 
 type Days = 7 | 30 | 90
 
@@ -18,11 +18,18 @@ interface DayRow {
   outputTokens: number
 }
 
+interface ModelRow {
+  modelId: string
+  inputTokens: number
+  outputTokens: number
+}
+
 interface Summary {
   totalInputTokens: number
   totalOutputTokens: number
   totalTasks: number
   byAgent: AgentRow[]
+  byModel: ModelRow[]
   byDay: DayRow[]
 }
 
@@ -250,6 +257,35 @@ export default function CostPage() {
                           </tr>
                         )
                       })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {summary.byModel.length > 0 && (
+              <div className="rounded-lg border border-border-subtle bg-bg-surface overflow-hidden">
+                <div className="px-4 py-3 border-b border-border-subtle flex items-center gap-2">
+                  <Cpu size={13} className="text-accent" />
+                  <h2 className="text-sm font-semibold text-text-primary">By Model</h2>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead><tr className="bg-bg-raised border-b border-border-subtle">
+                      <th className="px-4 py-2.5 text-left text-xs font-medium text-text-secondary">Model</th>
+                      <th className="px-4 py-2.5 text-right text-xs font-medium text-text-secondary">Input</th>
+                      <th className="px-4 py-2.5 text-right text-xs font-medium text-text-secondary">Output</th>
+                      <th className="px-4 py-2.5 text-right text-xs font-medium text-text-secondary">Total</th>
+                    </tr></thead>
+                    <tbody className="divide-y divide-border-subtle">
+                      {summary.byModel.map(m => (
+                        <tr key={m.modelId} className="hover:bg-bg-raised/50 transition-colors">
+                          <td className="px-4 py-2.5 font-mono text-xs text-text-primary">{m.modelId}</td>
+                          <td className="px-4 py-2.5 text-right text-xs text-text-secondary">{fmt(m.inputTokens)}</td>
+                          <td className="px-4 py-2.5 text-right text-xs text-text-secondary">{fmt(m.outputTokens)}</td>
+                          <td className="px-4 py-2.5 text-right text-xs font-medium text-text-primary">{fmt(m.inputTokens + m.outputTokens)}</td>
+                        </tr>
+                      ))}
                     </tbody>
                   </table>
                 </div>

--- a/apps/web/src/app/api/admin/tools/route.ts
+++ b/apps/web/src/app/api/admin/tools/route.ts
@@ -2,9 +2,13 @@ export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { logAudit } from '@/lib/audit'
 
 // GET /api/admin/tools — list all MCP tools with environment and agent restriction info
 export async function GET() {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const tools = await prisma.mcpTool.findMany({
     orderBy: [{ environmentId: 'asc' }, { name: 'asc' }],
     include: {
@@ -19,6 +23,9 @@ export async function GET() {
 
 // PATCH /api/admin/tools — update a tool's enabled/status
 export async function PATCH(req: NextRequest) {
+  let admin
+  try { admin = await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
   const body = await req.json() as { id: string; enabled?: boolean; status?: string }
   if (!body.id) return NextResponse.json({ error: 'id required' }, { status: 400 })
 
@@ -27,5 +34,22 @@ export async function PATCH(req: NextRequest) {
   if (body.status === 'active' || body.status === 'rejected') update.status = body.status
 
   const tool = await prisma.mcpTool.update({ where: { id: body.id }, data: update })
+
+  // Map operation to nearest AuditAction — detail.operation captures the specifics
+  const auditAction = body.status === 'rejected' ? 'tool_revoke' as const : 'tool_approve' as const
+  const operation = body.status === 'active' ? 'approve'
+    : body.status === 'rejected' ? 'reject'
+    : body.enabled === false ? 'disable'
+    : 'enable'
+
+  await logAudit({
+    userId: admin.id,
+    action: auditAction,
+    target: `mcpTool:${tool.id}`,
+    detail: { toolName: tool.name, operation, enabled: tool.enabled, status: tool.status },
+    ipAddress: req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip'),
+    userAgent: req.headers.get('user-agent'),
+  })
+
   return NextResponse.json(tool)
 }

--- a/apps/web/src/app/api/cost/summary/route.ts
+++ b/apps/web/src/app/api/cost/summary/route.ts
@@ -29,6 +29,8 @@ export async function GET(req: NextRequest) {
     tasks: Set<string>
   }>()
 
+  const modelMap = new Map<string, { modelId: string; inputTokens: number; outputTokens: number }>()
+
   const dayMap = new Map<string, { inputTokens: number; outputTokens: number }>()
 
   for (const r of records) {
@@ -46,6 +48,14 @@ export async function GET(req: NextRequest) {
     ag.inputTokens += r.inputTokens
     ag.outputTokens += r.outputTokens
     if (r.taskId) ag.tasks.add(r.taskId as string)
+
+    const mId = (r as any).modelId as string | null
+    if (mId) {
+      if (!modelMap.has(mId)) modelMap.set(mId, { modelId: mId, inputTokens: 0, outputTokens: 0 })
+      const m = modelMap.get(mId)!
+      m.inputTokens += r.inputTokens
+      m.outputTokens += r.outputTokens
+    }
 
     const dateKey = r.recordedAt.toISOString().slice(0, 10)
     if (!dayMap.has(dateKey)) dayMap.set(dateKey, { inputTokens: 0, outputTokens: 0 })
@@ -72,11 +82,15 @@ export async function GET(req: NextRequest) {
     tasks: a.tasks.size,
   })).sort((a, b) => (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens))
 
+  const byModel = Array.from(modelMap.values())
+    .sort((a, b) => (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens))
+
   return NextResponse.json({
     totalInputTokens,
     totalOutputTokens,
     totalTasks: taskSet.size,
     byAgent,
+    byModel,
     byDay,
   })
 }

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -44,6 +44,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (data.planProgress    !== undefined) dbData.planProgress    = data.planProgress
   if (data.planApprovedBy  !== undefined) dbData.planApprovedBy  = data.planApprovedBy
   if (data.planApprovedAt  !== undefined) dbData.planApprovedAt  = data.planApprovedAt ? new Date(data.planApprovedAt) : null
+  if (data.dependsOn       !== undefined) dbData.dependsOn       = data.dependsOn
+  if (data.wave            !== undefined) dbData.wave            = data.wave
   const task = await prisma.task.update({
     where: { id: params.id },
     data: dbData,

--- a/apps/web/src/components/security/AlertFeed.tsx
+++ b/apps/web/src/components/security/AlertFeed.tsx
@@ -105,7 +105,14 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
 
   if (alerts.length === 0) {
     return (
-      <div className="p-8 text-center text-text-muted text-sm">No alerts.</div>
+      <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+        <Shield size={32} className="text-text-muted/40" />
+        <p className="text-sm font-medium text-text-secondary">No security alerts</p>
+        <p className="text-xs text-text-muted max-w-xs">
+          ORION is listening for events from CrowdSec, Falco, ntopng, and Wazuh.
+          Alerts will appear here in real time.
+        </p>
+      </div>
     )
   }
 

--- a/apps/web/src/components/tasks/TasksPage.tsx
+++ b/apps/web/src/components/tasks/TasksPage.tsx
@@ -145,6 +145,7 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
   const [editDesc, setEditDesc]         = useState('')
   const [editPlan, setEditPlan]         = useState('')
   const [editPriority, setEditPriority] = useState('medium')
+  const [depSearch, setDepSearch]       = useState('')
   const titleRef = useRef<HTMLInputElement>(null)
 
   // Task log tab
@@ -884,32 +885,73 @@ export function TasksPage({ initialTasks, initialEpics, initialAgents, initialUs
                       })}
                     </div>
                   </div>
-                  {((panel.task.dependsOn?.length ?? 0) > 0 || panel.task.wave != null) && (
-                    <div>
-                      <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block flex items-center gap-1">
-                        <Layers size={10} /> Dependencies
-                      </label>
-                      {panel.task.wave != null && (
-                        <p className="text-[10px] text-text-muted mb-1">Wave {panel.task.wave}</p>
-                      )}
-                      {(panel.task.dependsOn?.length ?? 0) > 0 && (
-                        <div className="space-y-1">
-                          {panel.task.dependsOn!.map(depId => {
-                            const dep = tasks.find(t => t.id === depId)
-                            return dep ? (
-                              <div key={depId} className="flex items-center gap-1.5 text-[10px] text-text-muted bg-bg-card rounded px-2 py-1">
-                                {dep.status === 'done' ? <CheckCircle2 size={10} className="text-emerald-400" /> : <Lock size={10} className="text-amber-400" />}
-                                <span className="flex-1 truncate">{dep.title}</span>
-                                <span className="text-text-muted/60">{dep.status}</span>
-                              </div>
-                            ) : (
-                              <div key={depId} className="text-[10px] text-text-muted/50 px-2 py-1">{depId}</div>
-                            )
-                          })}
+                  <div>
+                    <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block flex items-center gap-1">
+                      <Layers size={10} /> Dependencies
+                    </label>
+                    {/* Current deps */}
+                    {(panel.task.dependsOn?.length ?? 0) > 0 && (
+                      <div className="space-y-1 mb-2">
+                        {panel.task.dependsOn!.map(depId => {
+                          const dep = tasks.find(t => t.id === depId)
+                          return dep ? (
+                            <div key={depId} className="flex items-center gap-1.5 text-[10px] text-text-muted bg-bg-card rounded px-2 py-1">
+                              {dep.status === 'done' ? <CheckCircle2 size={10} className="text-emerald-400" /> : <Lock size={10} className="text-amber-400" />}
+                              <span className="flex-1 truncate">{dep.title}</span>
+                              <span className="text-text-muted/60 mr-1">{dep.status}</span>
+                              <button
+                                onClick={() => {
+                                  const next = (panel.task.dependsOn ?? []).filter(d => d !== depId)
+                                  updateTask(panel.task.id, { dependsOn: next } as any)
+                                }}
+                                className="text-text-muted/40 hover:text-red-400 transition-colors"
+                                title="Remove dependency"
+                              >
+                                <X size={9} />
+                              </button>
+                            </div>
+                          ) : null
+                        })}
+                      </div>
+                    )}
+                    {/* Add dep search */}
+                    <input
+                      value={depSearch}
+                      onChange={e => setDepSearch(e.target.value)}
+                      placeholder="Search tasks to add as dependency…"
+                      className="w-full px-2.5 py-1.5 text-xs rounded border border-border-visible bg-bg-raised text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+                    />
+                    {depSearch.trim().length > 1 && (() => {
+                      const q = depSearch.toLowerCase()
+                      const candidates = tasks.filter(t =>
+                        t.id !== panel.task.id &&
+                        !(panel.task.dependsOn ?? []).includes(t.id) &&
+                        t.title.toLowerCase().includes(q)
+                      ).slice(0, 5)
+                      return candidates.length > 0 ? (
+                        <div className="border border-border-subtle rounded mt-1 overflow-hidden">
+                          {candidates.map(t => (
+                            <button
+                              key={t.id}
+                              onClick={() => {
+                                const next = [...(panel.task.dependsOn ?? []), t.id]
+                                updateTask(panel.task.id, { dependsOn: next } as any)
+                                setDepSearch('')
+                              }}
+                              className="w-full text-left px-2.5 py-1.5 text-xs text-text-secondary hover:bg-accent/10 hover:text-text-primary flex items-center gap-2 transition-colors"
+                            >
+                              <Plus size={9} className="text-accent flex-shrink-0" />
+                              <span className="truncate">{t.title}</span>
+                            </button>
+                          ))}
                         </div>
-                      )}
-                    </div>
-                  )}
+                      ) : null
+                    })()}
+                    {/* Wave */}
+                    {panel.task.wave != null && (
+                      <p className="text-[10px] text-text-muted mt-1.5">Execution wave: {panel.task.wave}</p>
+                    )}
+                  </div>
                   <div>
                     <label className="text-[10px] text-text-muted uppercase tracking-wide mb-1 block">Your Description</label>
                     <textarea value={editDesc} onChange={e => setEditDesc(e.target.value)} onBlur={saveTaskDetail} rows={4}

--- a/apps/web/src/lib/agent-runner/claude-runner.ts
+++ b/apps/web/src/lib/agent-runner/claude-runner.ts
@@ -26,12 +26,23 @@ export const claudeRunner: AgentRunner = {
       taskPlan:        ctx.taskPlan ? `\nImplementation plan:\n${ctx.taskPlan}` : '',
     })
 
+    // Inject completed checkpoint steps into the prompt so the sidecar (Claude Code CLI)
+    // doesn't re-execute tool calls that already succeeded in a prior run.
+    let fullPrompt = taskPrompt
+    if (ctx.checkpoints && ctx.checkpoints.size > 0) {
+      const steps = Array.from(ctx.checkpoints.entries())
+        .sort(([a], [b]) => a - b)
+        .map(([step, cp]) => `Step ${step} [${cp.toolName}]: ${cp.result}`)
+        .join('\n')
+      fullPrompt += `\n\n---\nThe following tool steps were already completed in a previous run. Do not repeat them:\n${steps}\n---`
+    }
+
     try {
       const res = await fetch(`${CLAUDE_URL}/run/collect`, {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          prompt:       taskPrompt,
+          prompt:       fullPrompt,
           systemPrompt: ctx.systemPrompt,
           model:        modelName,
           agentId:      ctx.agentId,

--- a/apps/web/src/lib/token-budget.ts
+++ b/apps/web/src/lib/token-budget.ts
@@ -79,9 +79,10 @@ export async function recordTokenUsage(
   taskId: string | null,
   inputTokens: number,
   outputTokens: number,
+  modelId?: string,
 ): Promise<void> {
   if (inputTokens === 0 && outputTokens === 0) return
   await prisma.agentTokenUsage.create({
-    data: { agentId, taskId, inputTokens, outputTokens },
+    data: { agentId, taskId, inputTokens, outputTokens, ...(modelId ? { modelId } : {}) },
   })
 }

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -226,6 +226,8 @@ export const UpdateTaskSchema = z.object({
   planProgress: z.number().int().nullable().optional(),
   planApprovedBy: z.string().max(200).nullable().optional(),
   planApprovedAt: z.string().datetime().nullable().optional(),
+  dependsOn: z.array(z.string()).optional(),
+  wave: z.number().int().min(0).nullable().optional(),
 })
 
 // ── Feature & Epic Schemas ─────────────────────────────────────────────────────

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -761,7 +761,7 @@ async function runTask(taskId: string): Promise<void> {
         agent.id,
       ).catch(() => {})
       // Record token spend for budget tracking
-      await recordTokenUsage(agent.id, taskId, totalInputTokens, totalOutputTokens).catch(() => {})
+      await recordTokenUsage(agent.id, taskId, totalInputTokens, totalOutputTokens, modelId).catch(() => {})
     }
 
     // Auto-write the task outcome to the knowledge base so future agents learn


### PR DESCRIPTION
- /admin/health: new System Health page showing db/k8s/claude/worker/ext-model
  status with auto-refresh every 30s; added to admin nav
- Task dependency editor: inline add/remove deps from task detail panel with
  typeahead search; depends-on + wave fields now editable via PUT /api/tasks/:id
- UpdateTaskSchema: added dependsOn (string[]) and wave (int) to validation schema
- Tool ACL route: requireAdmin() auth guard + logAudit() on every approve/reject/
  enable/disable action; maps to tool_approve / tool_revoke AuditAction
- Claude runner: inject completed checkpoint steps into prompt context so the
  orion-claude sidecar doesn't re-execute already-completed tool calls on retry
- AgentTokenUsage.modelId: optional field for per-model cost tracking; migration
  10_agent_token_usage_model_id; worker passes modelId to recordTokenUsage()
- Cost summary API: returns byModel array (modelId, inputTokens, outputTokens)
  alongside existing byAgent/byDay; cost page renders a "By Model" table
- Security AlertFeed: richer empty state with icon, headline, and source list
- recordTokenUsage(): accepts optional modelId param (backwards-compatible)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV