### PR TITLE
fix(build): fix Edge Runtime error — extract SESSION_COOKIE_NAME from next-auth import chain

### DIFF
--- a/apps/web/src/lib/auth-constants.ts
+++ b/apps/web/src/lib/auth-constants.ts
@@ -1,0 +1,3 @@
+// Edge-safe auth constants — no next-auth import, safe for middleware.ts
+const IS_SECURE = process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
+export const SESSION_COOKIE_NAME = IS_SECURE ? '__Secure-next-auth.session-token' : 'next-auth.session-token'

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -26,11 +26,10 @@ export type MfaLoginResult =
   | { status: 'success'; user: AppUser }
   | { status: 'error'; message: string }
 
-// SOC2: [M-002] Use __Secure- cookie prefix in production so the browser enforces
-// HTTPS transport independent of the Set-Cookie secure flag (defence in depth).
-// Must stay in sync with the cookieName passed to getToken() in middleware.ts.
+import { SESSION_COOKIE_NAME } from './auth-constants'
+export { SESSION_COOKIE_NAME }
+
 const IS_SECURE = process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
-export const SESSION_COOKIE_NAME = IS_SECURE ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
 
 export const authOptions: NextAuthOptions = {
   session: { strategy: 'jwt' },

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,7 +12,7 @@ wrapConsoleLog()
 
 import { rateLimitRedis } from './lib/rate-limit-redis'
 import { isIpBlocked } from './lib/security/crowdsec-bouncer'
-import { SESSION_COOKIE_NAME } from './lib/auth'
+import { SESSION_COOKIE_NAME } from './lib/auth-constants'
 
 function getRateLimitKey(req: NextRequest): string {
   // X-Forwarded-For is intentionally NOT used: the leftmost IP is client-supplied


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `middleware.ts` imported `SESSION_COOKIE_NAME` from `lib/auth.ts`, which transitively imports `next-auth`. next-auth uses dynamic code evaluation (`eval`/`new Function`) which is forbidden in the Edge Runtime — causing the Docker build to fail with "Dynamic Code Evaluation not allowed in Edge Runtime".
- Fix: extracted `SESSION_COOKIE_NAME` and `IS_SECURE` into a new `lib/auth-constants.ts` file that has zero dependencies. `middleware.ts` now imports from there. `auth.ts` re-exports from `auth-constants` so all existing callers are unchanged.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [x] `npx next build` completes successfully — Edge Runtime error gone
- [x] No changes to runtime behaviour — same cookie name logic, same auth flow

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_