### PR TITLE
feat: audit log UX, federation staleness, auth guards, tasks API limit

### DIFF
--- a/apps/web/prisma/migrations/11_federated_dispatch_fail_tracking/migration.sql
+++ b/apps/web/prisma/migrations/11_federated_dispatch_fail_tracking/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "FederatedDispatch" ADD COLUMN "lastPolledAt" TIMESTAMP(3);
+ALTER TABLE "FederatedDispatch" ADD COLUMN "failCount" INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX "FederatedDispatch_status_idx" ON "FederatedDispatch"("status");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -318,8 +318,11 @@ model FederatedDispatch {
   dispatchedAt   DateTime  @default(now())
   acknowledgedAt DateTime?
   completedAt    DateTime?
+  lastPolledAt   DateTime?
+  failCount      Int       @default(0)
 
   @@index([targetEnvId])
+  @@index([status])
 }
 
 model TaskEvent {

--- a/apps/web/src/app/(app)/admin/audit/page.tsx
+++ b/apps/web/src/app/(app)/admin/audit/page.tsx
@@ -1,31 +1,131 @@
 export const dynamic = 'force-dynamic'
 
 import { prisma } from '@/lib/db'
+import Link from 'next/link'
 
-export default async function AuditLogPage() {
+const ACTION_LABELS: Record<string, string> = {
+  login:           'Login',
+  logout:          'Logout',
+  login_failed:    'Login failed',
+  user_create:     'User created',
+  user_update:     'User updated',
+  user_delete:     'User deleted',
+  model_create:    'Model created',
+  model_update:    'Model updated',
+  model_delete:    'Model deleted',
+  tool_approve:    'Tool approved',
+  tool_revoke:     'Tool revoked',
+  settings_update: 'Settings updated',
+  prompt_update:   'Prompt updated',
+  api_key_create:  'API key created',
+  api_key_revoke:  'API key revoked',
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  login:           'bg-emerald-500/10 text-emerald-400',
+  logout:          'bg-bg-raised text-text-muted',
+  login_failed:    'bg-red-500/10 text-red-400',
+  user_delete:     'bg-red-500/10 text-red-400',
+  model_delete:    'bg-red-500/10 text-red-400',
+  api_key_revoke:  'bg-red-500/10 text-red-400',
+  tool_revoke:     'bg-orange-500/10 text-orange-400',
+  tool_approve:    'bg-emerald-500/10 text-emerald-400',
+  settings_update: 'bg-blue-500/10 text-blue-400',
+}
+
+function actionColor(action: string): string {
+  return ACTION_COLORS[action] ?? 'bg-status-warning/10 text-status-warning'
+}
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams: { action?: string; user?: string }
+}) {
+  const actionFilter = searchParams.action || undefined
+  const userFilter   = searchParams.user   || undefined
+
+  // Fetch matching users if filtering by user substring
+  const userIds = userFilter
+    ? (await prisma.user.findMany({
+        where: { OR: [{ username: { contains: userFilter, mode: 'insensitive' } }, { email: { contains: userFilter, mode: 'insensitive' } }] },
+        select: { id: true },
+      })).map(u => u.id)
+    : undefined
+
   const entries = await prisma.auditLog.findMany({
+    where: {
+      ...(actionFilter ? { action: actionFilter } : {}),
+      ...(userIds      ? { userId: { in: userIds } } : {}),
+    },
     orderBy: { createdAt: 'desc' },
-    take: 100,
+    take: 200,
   })
 
+  // Resolve user IDs → usernames in one query
+  const uniqueUserIds = [...new Set(entries.map(e => e.userId).filter(Boolean) as string[])]
+  const users = await prisma.user.findMany({
+    where: { id: { in: uniqueUserIds } },
+    select: { id: true, username: true },
+  })
+  const userMap = Object.fromEntries(users.map(u => [u.id, u.username]))
+
+  // Available actions for the filter dropdown
+  const allActions = Object.keys(ACTION_LABELS)
+
+  const clearHref = '/admin/audit'
+
   return (
-    <div className="p-6 space-y-6 max-w-5xl">
-      <div>
-        <h1 className="text-lg font-semibold text-text-primary">Audit Log</h1>
-        <p className="text-sm text-text-muted mt-0.5">Last 100 recorded events</p>
+    <div className="p-6 space-y-5 max-w-6xl">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary">Audit Log</h1>
+          <p className="text-sm text-text-muted mt-0.5">Last 200 events — filtered by action or user</p>
+        </div>
+
+        {/* Filters */}
+        <form method="GET" className="flex items-center gap-2 flex-wrap">
+          <select
+            name="action"
+            defaultValue={actionFilter ?? ''}
+            className="text-xs px-2 py-1.5 rounded border border-border-subtle bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+          >
+            <option value="">All actions</option>
+            {allActions.map(a => (
+              <option key={a} value={a}>{ACTION_LABELS[a] ?? a}</option>
+            ))}
+          </select>
+          <input
+            name="user"
+            defaultValue={userFilter ?? ''}
+            placeholder="Username or email…"
+            className="text-xs px-2 py-1.5 rounded border border-border-subtle bg-bg-raised text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent w-44"
+          />
+          <button
+            type="submit"
+            className="text-xs px-3 py-1.5 rounded border border-border-subtle bg-bg-raised text-text-primary hover:border-accent hover:text-accent transition-colors"
+          >
+            Filter
+          </button>
+          {(actionFilter || userFilter) && (
+            <Link href={clearHref} className="text-xs text-text-muted hover:text-text-primary transition-colors">
+              Clear
+            </Link>
+          )}
+        </form>
       </div>
 
       {entries.length === 0 ? (
         <div className="rounded-lg border border-border-subtle bg-bg-card px-4 py-10 text-center text-sm text-text-muted">
-          No audit events recorded yet.
+          No audit events match the current filter.
         </div>
       ) : (
-        <div className="rounded-lg border border-border-subtle bg-bg-card overflow-hidden">
-          <table className="w-full text-sm">
+        <div className="rounded-lg border border-border-subtle bg-bg-card overflow-hidden overflow-x-auto">
+          <table className="w-full text-sm min-w-[700px]">
             <thead className="border-b border-border-subtle bg-bg-raised">
               <tr>
-                {['Time', 'User', 'Action', 'Target', 'Details'].map(h => (
-                  <th key={h} className="text-left px-4 py-2.5 text-xs font-semibold text-text-muted">{h}</th>
+                {['Time', 'User', 'Action', 'Target', 'IP', 'Details'].map(h => (
+                  <th key={h} className="text-left px-4 py-2.5 text-xs font-semibold text-text-muted whitespace-nowrap">{h}</th>
                 ))}
               </tr>
             </thead>
@@ -35,13 +135,16 @@ export default async function AuditLogPage() {
                   <td className="px-4 py-2.5 text-text-muted font-mono text-xs whitespace-nowrap">
                     {new Date(e.createdAt).toLocaleString()}
                   </td>
-                  <td className="px-4 py-2.5 text-accent text-xs font-mono">{e.userId}</td>
-                  <td className="px-4 py-2.5">
-                    <span className="text-xs px-2 py-0.5 rounded bg-status-warning/10 text-status-warning">
-                      {e.action}
+                  <td className="px-4 py-2.5 text-accent text-xs font-mono">
+                    {userMap[e.userId] ?? e.userId?.slice(0, 8) ?? '—'}
+                  </td>
+                  <td className="px-4 py-2.5 whitespace-nowrap">
+                    <span className={`text-xs px-2 py-0.5 rounded ${actionColor(e.action)}`}>
+                      {ACTION_LABELS[e.action] ?? e.action}
                     </span>
                   </td>
-                  <td className="px-4 py-2.5 text-text-secondary text-xs truncate max-w-[200px]">{e.target}</td>
+                  <td className="px-4 py-2.5 text-text-secondary text-xs truncate max-w-[180px]">{e.target ?? '—'}</td>
+                  <td className="px-4 py-2.5 text-text-muted text-xs font-mono whitespace-nowrap">{e.ipAddress ?? '—'}</td>
                   <td className="px-4 py-2.5 text-text-muted text-xs font-mono truncate max-w-[200px]">
                     {e.detail ? JSON.stringify(e.detail) : '—'}
                   </td>
@@ -51,6 +154,10 @@ export default async function AuditLogPage() {
           </table>
         </div>
       )}
+
+      <p className="text-[11px] text-text-muted">
+        Showing up to 200 most recent events. Full export available via <span className="font-mono text-accent">/admin/audit-export</span>.
+      </p>
     </div>
   )
 }

--- a/apps/web/src/app/(app)/admin/page.tsx
+++ b/apps/web/src/app/(app)/admin/page.tsx
@@ -14,11 +14,15 @@ async function getOverviewData() {
     prisma.oIDCProvider.findFirst(),
   ])
 
-  return { userCount, modelCount, recentAudit, oidcProvider }
+  const uniqueIds = [...new Set(recentAudit.map((e: any) => e.userId).filter(Boolean) as string[])]
+  const users = await prisma.user.findMany({ where: { id: { in: uniqueIds } }, select: { id: true, username: true } })
+  const userMap = Object.fromEntries(users.map(u => [u.id, u.username]))
+
+  return { userCount, modelCount, recentAudit, oidcProvider, userMap }
 }
 
 export default async function AdminOverviewPage() {
-  const { userCount, modelCount, recentAudit, oidcProvider } = await getOverviewData()
+  const { userCount, modelCount, recentAudit, oidcProvider, userMap } = await getOverviewData()
   const h = headers()
   const ssoActive = !!h.get('x-authentik-username')
 
@@ -58,7 +62,7 @@ export default async function AdminOverviewPage() {
                 <span className="text-text-muted font-mono text-xs w-40 flex-shrink-0">
                   {new Date(entry.createdAt).toLocaleString()}
                 </span>
-                <span className="text-accent text-xs w-28 flex-shrink-0 truncate">{entry.userId}</span>
+                <span className="text-accent text-xs w-28 flex-shrink-0 truncate">{userMap[entry.userId] ?? entry.userId?.slice(0, 8) ?? '—'}</span>
                 <span className="text-status-warning text-xs w-24 flex-shrink-0">{entry.action}</span>
                 <span className="text-text-secondary truncate">{entry.target}</span>
               </div>

--- a/apps/web/src/app/api/agents/[id]/token-usage/route.ts
+++ b/apps/web/src/app/api/agents/[id]/token-usage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,9 +11,10 @@ export const dynamic = 'force-dynamic'
  * calendar month, and a 7-day sparkline.
  */
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  await requireServiceAuth(req)
   const agent = await prisma.agent.findUnique({
     where: { id: params.id },
     select: { tokenBudgetDay: true, tokenBudgetMonth: true },

--- a/apps/web/src/app/api/k8s/events/route.ts
+++ b/apps/web/src/app/api/k8s/events/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { coreApi } from '@/lib/k8s'
+import { requireServiceAuth } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
   const { searchParams } = new URL(req.url)
   const type  = searchParams.get('type')   // e.g. "Warning"
   const limit = parseInt(searchParams.get('limit') ?? '100', 10)

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -10,6 +10,7 @@ export async function GET(req: NextRequest) {
   const featureId     = searchParams.get('featureId')
   const assignedAgent = searchParams.get('assignedAgent')
   const priority      = searchParams.get('priority')
+  const limit         = Math.min(parseInt(searchParams.get('limit') ?? '500', 10), 1000)
 
   const where: Record<string, unknown> = {}
   if (status)        where.status        = status
@@ -20,6 +21,7 @@ export async function GET(req: NextRequest) {
   const tasks = await prisma.task.findMany({
     where,
     orderBy: { updatedAt: 'desc' },
+    take: limit,
     include: { agent: true, feature: { include: { epic: true } } },
   })
   return NextResponse.json(tasks)
@@ -37,14 +39,14 @@ export async function POST(req: NextRequest) {
 
   const task = await prisma.task.create({
     data: {
-      title:       data.title,
-      description: data.description ?? null,
-      priority:    data.priority ?? 'medium',
-      featureId:   data.featureId ?? null,
-      ...(data.assignedAgentId && { assignedAgent: data.assignedAgentId }),
-      assignedUserId: data.assignedUserId ?? null,
-      createdBy:    caller?.id ?? 'gateway',
-    } as any,
+      title:          data.title,
+      description:    data.description   ?? null,
+      priority:       data.priority      ?? 'medium',
+      featureId:      data.featureId     ?? null,
+      assignedAgent:  data.assignedAgentId ?? null,
+      assignedUserId: data.assignedUserId  ?? null,
+      createdBy:      caller?.id           ?? 'gateway',
+    },
     include: { agent: true },
   })
   return NextResponse.json(task, { status: 201 })

--- a/apps/web/src/worker.ts
+++ b/apps/web/src/worker.ts
@@ -1459,23 +1459,45 @@ async function escalateStalePendingValidation(): Promise<void> {
  * Poll all in-flight federated tasks for completion.
  * Fetches status from each spoke and marks the local task done/failed to match.
  */
+const FED_POLL_MAX_FAILURES = 5          // give up after 5 consecutive failures
+const FED_POLL_MAX_AGE_MS   = 24 * 60 * 60 * 1000  // abandon dispatches older than 24h
+
 async function pollFederatedTasks(): Promise<void> {
+  const now = new Date()
+  const cutoff = new Date(now.getTime() - FED_POLL_MAX_AGE_MS)
+
   const dispatches = await prisma.federatedDispatch.findMany({
     where: { status: { in: ['dispatched', 'acknowledged'] } },
-    select: { id: true, taskId: true, spokeUrl: true, status: true },
+    select: { id: true, taskId: true, spokeUrl: true, status: true, failCount: true, dispatchedAt: true },
   })
   if (dispatches.length === 0) return
 
-  // Get the federation token from env (hub uses this to authenticate with spokes)
   const token = process.env.ORION_GATEWAY_TOKEN ?? ''
 
   await Promise.all(dispatches.map(async (dispatch) => {
+    // Abandon dispatches that are too old or have failed too many times
+    if (dispatch.dispatchedAt < cutoff || dispatch.failCount >= FED_POLL_MAX_FAILURES) {
+      await prisma.$transaction([
+        prisma.task.update({ where: { id: dispatch.taskId }, data: { status: 'failed' } }),
+        prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'failed' } }),
+      ])
+      err(`Federated task ${dispatch.taskId} abandoned — ${dispatch.failCount >= FED_POLL_MAX_FAILURES ? `${dispatch.failCount} consecutive failures` : 'dispatch age exceeded 24h'}`)
+      return
+    }
+
     try {
       const res = await fetch(`${dispatch.spokeUrl}/api/federation/tasks/${dispatch.taskId}/status`, {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(5_000),
       })
-      if (!res.ok) return
+
+      if (!res.ok) {
+        await prisma.federatedDispatch.update({
+          where: { id: dispatch.id },
+          data: { failCount: { increment: 1 }, lastPolledAt: now },
+        })
+        return
+      }
 
       const data = (await res.json()) as { status: string }
       const spokeStatus = data.status
@@ -1483,14 +1505,20 @@ async function pollFederatedTasks(): Promise<void> {
       if (spokeStatus === 'done' || spokeStatus === 'failed') {
         await prisma.$transaction([
           prisma.task.update({ where: { id: dispatch.taskId }, data: { status: spokeStatus } }),
-          prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'completed', completedAt: new Date() } }),
+          prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'completed', completedAt: now, failCount: 0, lastPolledAt: now } }),
         ])
         log(`Federated task ${dispatch.taskId} completed on spoke with status: ${spokeStatus}`)
       } else if (spokeStatus === 'in_progress' && dispatch.status === 'dispatched') {
-        await prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'acknowledged', acknowledgedAt: new Date() } })
+        await prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { status: 'acknowledged', acknowledgedAt: now, failCount: 0, lastPolledAt: now } })
+      } else {
+        await prisma.federatedDispatch.update({ where: { id: dispatch.id }, data: { failCount: 0, lastPolledAt: now } })
       }
     } catch (e) {
       err(`Failed to poll federated task ${dispatch.taskId} at ${dispatch.spokeUrl}: ${e instanceof Error ? e.message : String(e)}`)
+      await prisma.federatedDispatch.update({
+        where: { id: dispatch.id },
+        data: { failCount: { increment: 1 }, lastPolledAt: now },
+      }).catch(() => {})
     }
   }))
 }


### PR DESCRIPTION
## Summary

- **Audit log** (`/admin/audit`): resolves `userId` → username via a single join query; adds IP address column; adds action filter dropdown + username/email search via GET searchParams; color-codes action badges by severity; bumps row limit 100 → 200
- **Admin overview** (`/admin`): same username resolution for the 10-event recent audit feed
- **Federation dispatch staleness**: adds `failCount` + `lastPolledAt` fields to `FederatedDispatch` (migration 11); poller now increments `failCount` on error, resets to 0 on success, and marks dispatch + task as `failed` after 5 consecutive failures or 24h without completion — prevents indefinite polling of permanently-down spokes
- **`k8s/events` auth guard**: adds `requireServiceAuth()` — was publicly readable and exposed cluster events without session or service token
- **`agents/[id]/token-usage` auth guard**: same fix — token usage data now requires auth consistent with other agent endpoints
- **Tasks API limit**: adds `?limit` param (default 500, max 1000) to prevent unbounded full-table scans on large installations
- **Tasks POST `as any` fix**: removes cast — uses `assignedAgent` field name directly matching the Prisma schema

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` passes
- [x] Audit log filter works via GET querystring
- [x] Federation dispatch migration SQL verified against schema

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_