### PR TITLE
fix: validation schemas, bug/webhook Zod migration, health display

### DIFF
--- a/apps/web/src/app/api/bugs/[id]/route.ts
+++ b/apps/web/src/app/api/bugs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
+import { parseBodyOrError, UpdateBugSchema } from '@/lib/validate'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
@@ -12,38 +13,31 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(bug)
 }
 
-const VALID_BUG_STATUSES = new Set(['open', 'triaged', 'in_progress', 'resolved', 'wont_fix', 'closed'])
-
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
   await requireServiceAuth(req)
-  const body = await req.json()
-  const data: Record<string, unknown> = {}
-  if (body.title          !== undefined) data.title          = body.title
-  if (body.description    !== undefined) data.description    = body.description
-  if (body.severity       !== undefined) data.severity       = body.severity
-  if (body.status !== undefined) {
-    const s = String(body.status)
-    if (!VALID_BUG_STATUSES.has(s)) {
-      return NextResponse.json(
-        { error: `Invalid status '${s}'. Must be one of: ${[...VALID_BUG_STATUSES].join(', ')}` },
-        { status: 400 }
-      )
-    }
-    data.status = s
-  }
-  if (body.area !== undefined) data.area = body.area || null
-  if (body.assignedUserId !== undefined) {
-    const uid = body.assignedUserId || null
+  const parsed = await parseBodyOrError(req, UpdateBugSchema)
+  if ('error' in parsed) return parsed.error
+  const { data } = parsed
+
+  const updateData: Record<string, unknown> = {}
+  if (data.title          !== undefined) updateData.title          = data.title
+  if (data.description    !== undefined) updateData.description    = data.description
+  if (data.severity       !== undefined) updateData.severity       = data.severity
+  if (data.status         !== undefined) updateData.status         = data.status
+  if ('area'              in data)       updateData.area           = data.area ?? null
+  if ('assignedUserId'    in data) {
+    const uid = data.assignedUserId ?? null
     if (uid) {
-      // MAJOR fix: invalid assignedUserId caused uncaught Prisma P2003 FK error → HTTP 500.
+      // Validate FK before Prisma throws a P2003
       const userExists = await prisma.user.findUnique({ where: { id: uid }, select: { id: true } })
       if (!userExists) return NextResponse.json({ error: 'assignedUserId not found' }, { status: 400 })
     }
-    data.assignedUserId = uid
+    updateData.assignedUserId = uid
   }
+
   const bug = await prisma.bug.update({
     where: { id: params.id },
-    data,
+    data: updateData,
     include: { assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } } },
   })
   return NextResponse.json(bug)

--- a/apps/web/src/app/api/webhook-triggers/[id]/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
+import { parseBodyOrError, UpdateWebhookTriggerSchema } from '@/lib/validate'
 
 async function guard() {
   try { await requireAdmin() } catch {
@@ -30,32 +31,23 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const deny = await guard(); if (deny) return deny
   const { id } = await params
-  let body: {
-    name?: string
-    taskTitle?: string
-    taskDesc?: string
-    enabled?: boolean
-    source?: string
-  }
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await parseBodyOrError(req, UpdateWebhookTriggerSchema)
+  if ('error' in parsed) return parsed.error
+  const { data } = parsed
 
   const existing = await prisma.webhookTrigger.findUnique({ where: { id } })
   if (!existing) return new NextResponse(null, { status: 404 })
 
-  const data: Record<string, unknown> = {}
-  if (body.name      !== undefined) data.name      = body.name
-  if (body.taskTitle !== undefined) data.taskTitle = body.taskTitle
-  if (body.taskDesc  !== undefined) data.taskDesc  = body.taskDesc
-  if (body.enabled   !== undefined) data.enabled   = body.enabled
-  if (body.source    !== undefined) data.source    = body.source
+  const updateData: Record<string, unknown> = {}
+  if (data.name      !== undefined) updateData.name      = data.name
+  if (data.taskTitle !== undefined) updateData.taskTitle = data.taskTitle
+  if ('taskDesc'     in data)       updateData.taskDesc  = data.taskDesc ?? null
+  if (data.enabled   !== undefined) updateData.enabled   = data.enabled
+  if (data.source    !== undefined) updateData.source    = data.source
 
   const trigger = await prisma.webhookTrigger.update({
     where: { id },
-    data,
+    data: updateData,
     include: { agent: { select: { id: true, name: true } } },
   })
   return NextResponse.json({ ...trigger, secret: '••••••••', webhookUrl: `/api/webhooks/${id}` })

--- a/apps/web/src/app/api/webhook-triggers/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { randomBytes } from 'crypto'
 import { requireAdmin } from '@/lib/auth'
+import { parseBodyOrError, CreateWebhookTriggerSchema } from '@/lib/validate'
 
 async function guard() {
   try { await requireAdmin() } catch {
@@ -21,42 +22,22 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   const deny = await guard(); if (deny) return deny
-  let body: {
-    name: string
-    agentId: string
-    source?: string
-    taskTitle: string
-    taskDesc?: string
-    enabled?: boolean
-  }
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
-  }
+  const parsed = await parseBodyOrError(req, CreateWebhookTriggerSchema)
+  if ('error' in parsed) return parsed.error
+  const { data } = parsed
 
-  if (!body.name || !body.agentId || !body.taskTitle) {
-    return NextResponse.json(
-      { error: 'name, agentId, and taskTitle are required' },
-      { status: 400 }
-    )
-  }
-
-  const agent = await prisma.agent.findUnique({ where: { id: body.agentId } })
-  if (!agent) {
-    return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
-  }
+  const agent = await prisma.agent.findUnique({ where: { id: data.agentId }, select: { id: true } })
+  if (!agent) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
 
   const secret = randomBytes(32).toString('hex')
-
   const trigger = await prisma.webhookTrigger.create({
     data: {
-      name:      body.name,
-      agentId:   body.agentId,
-      source:    body.source ?? 'custom',
-      taskTitle: body.taskTitle,
-      taskDesc:  body.taskDesc ?? null,
-      enabled:   body.enabled ?? true,
+      name:      data.name,
+      agentId:   data.agentId,
+      source:    data.source,
+      taskTitle: data.taskTitle,
+      taskDesc:  data.taskDesc ?? null,
+      enabled:   data.enabled,
       secret,
     },
     include: { agent: { select: { id: true, name: true } } },

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -220,7 +220,7 @@ export const UpdateTaskSchema = z.object({
   description: z.string().max(5000).optional(),
   plan: z.string().max(10000).nullable().optional(),
   priority: z.enum(['low', 'medium', 'high', 'urgent']).optional(),
-  status: z.enum(['pending', 'running', 'done', 'failed']).optional(),
+  status: z.enum(['pending', 'in_progress', 'pending_validation', 'done', 'failed', 'blocked']).optional(),
   assignedAgentId: z.string().optional(),
   assignedUserId: z.string().optional(),
   planProgress: z.number().int().nullable().optional(),
@@ -357,6 +357,15 @@ export const CreateBugSchema = z.object({
   assignedUserId: z.string().max(100).optional(),
 })
 
+export const UpdateBugSchema = z.object({
+  title:          z.string().min(1).max(500).optional(),
+  description:    z.string().max(10000).optional(),
+  severity:       z.enum(['low', 'medium', 'high', 'critical']).optional(),
+  status:         z.enum(['open', 'triaged', 'in_progress', 'resolved', 'wont_fix', 'closed']).optional(),
+  area:           z.string().max(100).nullable().optional(),
+  assignedUserId: z.string().max(100).nullable().optional(),
+})
+
 // ── API Key Schemas ─────────────────────────────────────────────────────────────
 
 export const CreateApiKeySchema = z.object({
@@ -446,6 +455,23 @@ export const CreateExternalModelSchema = z.object({
   minP:          z.number().min(0).max(1).optional().nullable(),
   repeatPenalty: z.number().min(0).max(5).optional().nullable(),
   seed:          z.number().int().optional().nullable(),
+})
+
+export const CreateWebhookTriggerSchema = z.object({
+  name:      z.string().min(1).max(200),
+  agentId:   z.string().min(1),
+  taskTitle: z.string().min(1).max(500),
+  taskDesc:  z.string().max(5000).optional(),
+  source:    z.string().max(100).default('custom'),
+  enabled:   z.boolean().default(true),
+})
+
+export const UpdateWebhookTriggerSchema = z.object({
+  name:      z.string().min(1).max(200).optional(),
+  taskTitle: z.string().min(1).max(500).optional(),
+  taskDesc:  z.string().max(5000).nullable().optional(),
+  source:    z.string().max(100).optional(),
+  enabled:   z.boolean().optional(),
 })
 
 export const UpdateExternalModelSchema = z.object({


### PR DESCRIPTION
## Summary

- **Fix `UpdateTaskSchema` status enum** — was `['pending', 'running', 'done', 'failed']`; `'running'` is never a real DB status and `'in_progress'`, `'pending_validation'`, `'blocked'` were missing, causing PATCH /api/tasks/[id] to silently reject valid status transitions
- **Add Zod schemas** for `UpdateBugSchema`, `CreateWebhookTriggerSchema`, `UpdateWebhookTriggerSchema` and migrate the corresponding routes off raw `req.json()` to `parseBodyOrError()`
- **Health display** — external model health keys changed from raw CUIDs (`ext:abc123`) to human-readable `"Name (provider)"` strings; health page no longer needs `.replace('ext:', '')` workaround

## Test plan

- [ ] PATCH /api/tasks/[id] with `status: "in_progress"` or `"pending_validation"` now succeeds instead of returning 400
- [ ] PUT /api/bugs/[id] with invalid severity/status returns 400 with Zod error details
- [ ] POST /api/webhook-triggers with missing required fields returns 400
- [ ] Admin health page shows external model names like "Llama 3 (ollama)" instead of raw IDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_