### PR TITLE
fix: auth guards, take limits, Zod schemas, health display

### DIFF
--- a/apps/web/src/app/(app)/admin/health/page.tsx
+++ b/apps/web/src/app/(app)/admin/health/page.tsx
@@ -131,7 +131,7 @@ export default function SystemHealthPage() {
               <p className="text-xs text-text-muted">No external models configured.</p>
             ) : (
               extEntries.map(([id, ok]) => (
-                <StatusDot key={id} ok={ok} label={id.replace('ext:', '')} />
+                <StatusDot key={id} ok={ok} label={id} />
               ))
             )}
           </Card>

--- a/apps/web/src/app/api/admin/models/default/route.ts
+++ b/apps/web/src/app/api/admin/models/default/route.ts
@@ -7,7 +7,9 @@ export async function PUT(req: NextRequest) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const { modelId } = await req.json()
+  let body: unknown
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }) }
+  const modelId = typeof (body as any)?.modelId === 'string' ? (body as any).modelId as string : null
 
   if (!modelId) {
     // Clear default

--- a/apps/web/src/app/api/admin/tools/route.ts
+++ b/apps/web/src/app/api/admin/tools/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { logAudit } from '@/lib/audit'
+import { parseBodyOrError, PatchAdminToolSchema } from '@/lib/validate'
 
 // GET /api/admin/tools — list all MCP tools with environment and agent restriction info
 export async function GET() {
@@ -26,12 +27,13 @@ export async function PATCH(req: NextRequest) {
   let admin
   try { admin = await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const body = await req.json() as { id: string; enabled?: boolean; status?: string }
-  if (!body.id) return NextResponse.json({ error: 'id required' }, { status: 400 })
+  const parsed = await parseBodyOrError(req, PatchAdminToolSchema)
+  if ('error' in parsed) return parsed.error
+  const body = parsed.data
 
   const update: Record<string, unknown> = {}
-  if (typeof body.enabled === 'boolean') update.enabled = body.enabled
-  if (body.status === 'active' || body.status === 'rejected') update.status = body.status
+  if (body.enabled !== undefined) update.enabled = body.enabled
+  if (body.status  !== undefined) update.status  = body.status
 
   const tool = await prisma.mcpTool.update({ where: { id: body.id }, data: update })
 

--- a/apps/web/src/app/api/admin/watchers/route.ts
+++ b/apps/web/src/app/api/admin/watchers/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
+import { parseBodyOrError, UpdateWatcherPauseSchema } from '@/lib/validate'
 
 export async function GET() {
   await requireAdmin()
@@ -10,7 +11,9 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   await requireAdmin()
-  const { paused } = await req.json() as { paused: boolean }
+  const parsed = await parseBodyOrError(req, UpdateWatcherPauseSchema)
+  if ('error' in parsed) return parsed.error
+  const { paused } = parsed.data
   await prisma.systemSetting.upsert({
     where:  { key: 'system.watchers.paused' },
     update: { value: paused },

--- a/apps/web/src/app/api/agent-groups/route.ts
+++ b/apps/web/src/app/api/agent-groups/route.ts
@@ -11,6 +11,7 @@ export async function GET() {
       toolAccess: { include: { toolGroup: { include: { environment: { select: { id: true, name: true } } } } } },
     },
     orderBy: { name: 'asc' },
+    take: 200,
   })
   return NextResponse.json(groups)
 }

--- a/apps/web/src/app/api/chatrooms/[id]/members/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/members/route.ts
@@ -28,10 +28,12 @@ export async function GET(
   const allUsers = await prisma.user.findMany({
     select: { id: true, username: true, name: true },
     orderBy: { username: 'asc' },
+    take: 500,
   })
   const allAgents = await prisma.agent.findMany({
     select: { id: true, name: true, type: true, metadata: true },
     orderBy: { name: 'asc' },
+    take: 500,
   })
 
   const memberUserIds = room.members.map((m: any) => m.userId).filter(Boolean) as string[]

--- a/apps/web/src/app/api/dns/nodehosts/[ip]/route.ts
+++ b/apps/web/src/app/api/dns/nodehosts/[ip]/route.ts
@@ -1,17 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { upsertNodeHost, deleteNodeHost } from '@/lib/dns'
+import { requireAdmin } from '@/lib/auth'
 
 export async function PUT(req: NextRequest, { params }: { params: { ip: string } }) {
-  const { ip, hostnames } = await req.json()
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  const body = await req.json()
+  if (!Array.isArray(body.hostnames) || body.hostnames.length === 0)
+    return NextResponse.json({ error: 'hostnames required' }, { status: 400 })
   try {
-    await upsertNodeHost(params.ip, hostnames)
-    return NextResponse.json({ ip, hostnames })
+    await upsertNodeHost(params.ip, body.hostnames)
+    return NextResponse.json({ ip: params.ip, hostnames: body.hostnames })
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: { ip: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
     const deleted = await deleteNodeHost(params.ip)
     if (!deleted) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -38,8 +38,8 @@ export async function GET() {
         headers: m.apiKey ? { Authorization: `Bearer ${m.apiKey}` } : {},
         signal: AbortSignal.timeout(3000),
       })
-      extHealth[`ext:${m.id}`] = res.ok
-    } catch { extHealth[`ext:${m.id}`] = false }
+      extHealth[`${m.name} (${m.provider})`] = res.ok
+    } catch { extHealth[`${m.name} (${m.provider})`] = false }
   }))
 
   // Worker health — inferred from task activity (worker has no direct health port)

--- a/apps/web/src/app/api/notification-channels/route.ts
+++ b/apps/web/src/app/api/notification-channels/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 function maskUrl(url: string): string {
   if (url.length <= 4) return '****'
@@ -7,8 +8,10 @@ function maskUrl(url: string): string {
 }
 
 export async function GET() {
+  await requireAdmin()
   const channels = await prisma.notificationChannel.findMany({
     orderBy: { createdAt: 'desc' },
+    take: 200,
   })
   return NextResponse.json(
     channels.map(c => ({ ...c, webhookUrl: maskUrl(c.webhookUrl) }))
@@ -16,6 +19,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  await requireAdmin()
   const body = await req.json() as {
     name: string
     type: string

--- a/apps/web/src/app/api/tool-approvals/route.ts
+++ b/apps/web/src/app/api/tool-approvals/route.ts
@@ -1,11 +1,14 @@
 export const dynamic = 'force-dynamic'
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET() {
+  await requireAdmin()
   const requests = await prisma.toolApprovalRequest.findMany({
     where: { status: 'pending' },
     orderBy: { createdAt: 'desc' },
+    take: 200,
   })
   return NextResponse.json(requests)
 }

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -474,6 +474,16 @@ export const UpdateWebhookTriggerSchema = z.object({
   enabled:   z.boolean().optional(),
 })
 
+export const UpdateWatcherPauseSchema = z.object({
+  paused: z.boolean(),
+})
+
+export const PatchAdminToolSchema = z.object({
+  id:      z.string().min(1),
+  enabled: z.boolean().optional(),
+  status:  z.enum(['active', 'rejected']).optional(),
+})
+
 export const UpdateExternalModelSchema = z.object({
   name:          z.string().min(1).max(200).optional(),
   provider:      z.string().min(1).max(50).regex(/^[a-z0-9_-]+$/).optional(),


### PR DESCRIPTION
## Summary

- **Auth guards** — `notification-channels` GET+POST and `tool-approvals` GET were publicly accessible; added `requireAdmin` to both
- **Critical: DNS node host routes** — `dns/nodehosts/[ip]` PUT and DELETE had no auth at all; anyone could modify or delete node host entries. Added `requireAdmin` to both handlers
- **Zod schemas** — `PatchAdminToolSchema` for `admin/tools` PATCH; `UpdateWatcherPauseSchema` for `admin/watchers` POST; migrated both routes to `parseBodyOrError()`
- **`take:` limits** — added caps to `chatrooms/[id]/members` user+agent queries (500), `agent-groups` (200), `tool-approvals` (200), `notification-channels` (200)
- **Health display** — external model keys changed from raw CUIDs to `"Name (provider)"` strings; health page no longer needs `.replace('ext:', '')` workaround

## Test plan

- [ ] GET /api/notification-channels without admin session → 401
- [ ] PUT /api/dns/nodehosts/1.2.3.4 without admin session → 401
- [ ] DELETE /api/dns/nodehosts/1.2.3.4 without admin session → 401
- [ ] PATCH /api/admin/tools with invalid status (e.g. `"pending"`) → 400
- [ ] POST /api/admin/watchers with `{"paused": "yes"}` (string not bool) → 400
- [ ] Admin health page shows e.g. "Llama 3 (ollama)" not raw CUID

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_