### PR TITLE
security: auth guards, SQL injection fix, SSRF guard, role escalation fixes

### DIFF
--- a/apps/web/src/app/api/chatrooms/[id]/goals/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/goals/route.ts
@@ -38,8 +38,16 @@ export async function POST(
   const text = typeof body.text === 'string' ? body.text.trim() : ''
   if (!text) return NextResponse.json({ error: 'text is required' }, { status: 400 })
 
-  const room = await prisma.chatRoom.findUnique({ where: { id }, select: { id: true } })
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    select: { id: true, members: { select: { userId: true } } },
+  })
   if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
+
+  if (userId && !room.members.some((m: any) => m.userId === userId)) {
+    return NextResponse.json({ error: 'You are not a member of this room' }, { status: 403 })
+  }
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   // Abandon any existing active goal
   await prisma.roomGoal.updateMany({

--- a/apps/web/src/app/api/chatrooms/[id]/join/route.ts
+++ b/apps/web/src/app/api/chatrooms/[id]/join/route.ts
@@ -25,9 +25,8 @@ export async function POST(
   const room = await prisma.chatRoom.findUnique({ where: { id } })
   if (!room) return NextResponse.json({ error: 'Chat room not found' }, { status: 404 })
 
-  const role = body.role ? String(body.role) : 'member'
   await prisma.chatRoomMember.create({
-    data: { roomId: id, userId, agentId, role },
+    data: { roomId: id, userId, agentId, role: 'member' },
   })
 
   const name = agentId ? `Agent ${agentId}` : session?.user?.username ?? userId

--- a/apps/web/src/app/api/conversations/[id]/traces/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/traces/route.ts
@@ -1,10 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
+import { NextRequest } from 'next/server'
 
 export const dynamic = 'force-dynamic'
 
 // GET /api/conversations/[id]/traces — Get trace timeline for a conversation
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  await requireServiceAuth(req)
   const traces = await prisma.agentTrace.findMany({
     where: { conversationId: params.id },
     orderBy: { step: 'asc' },

--- a/apps/web/src/app/api/environments/[id]/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/agents/[agentId]/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 /** DELETE /api/environments/:id/agents/:agentId — unlink an agent from this environment */
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string; agentId: string } }) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   await prisma.agentEnvironment.deleteMany({
     where: { agentId: params.agentId, environmentId: params.id },
   })

--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  await requireServiceAuth(req)
   try {
     const execution = await prisma.toolExecution.findUnique({
       where: { id: params.id },
@@ -31,6 +33,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  await requireServiceAuth(req)
   try {
     const body = await req.json()
 

--- a/apps/web/src/app/api/executions/route.ts
+++ b/apps/web/src/app/api/executions/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 
 export async function POST(req: NextRequest) {
+  await requireServiceAuth(req)
   try {
     const body = await req.json()
 
@@ -58,6 +60,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
   try {
     const { searchParams } = new URL(req.url)
     const actorId = searchParams.get('actorId')

--- a/apps/web/src/app/api/job-runs/route.ts
+++ b/apps/web/src/app/api/job-runs/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireServiceAuth } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
+  await requireServiceAuth(req)
   const { searchParams } = new URL(req.url)
   const limit  = Math.min(parseInt(searchParams.get('limit') ?? '200', 10), 500)
   const source = searchParams.get('source') ?? undefined

--- a/apps/web/src/app/api/notification-channels/[id]/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const channel = await prisma.notificationChannel.findUnique({ where: { id: params.id } })
   if (!channel) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(channel)
@@ -14,6 +16,7 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const body = await req.json() as Partial<{
     name: string
     type: string
@@ -34,6 +37,7 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   await prisma.notificationChannel.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/notification-channels/[id]/test/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/test/route.ts
@@ -1,12 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+
+function isPrivateUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    if (hostname === 'localhost') return true
+    const privatePatterns = [/^127\./, /^10\./, /^192\.168\./, /^172\.(1[6-9]|2\d|3[01])\./, /^169\.254\./, /^::1$/, /^fc00:/i, /^fe80:/i]
+    return privatePatterns.some(p => p.test(hostname))
+  } catch { return true }
+}
 
 export async function POST(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
   const channel = await prisma.notificationChannel.findUnique({ where: { id: params.id } })
   if (!channel) return NextResponse.json({ ok: false, error: 'Channel not found' }, { status: 404 })
+
+  if (isPrivateUrl(channel.webhookUrl)) {
+    return NextResponse.json({ ok: false, error: 'Webhook URL targets a private/internal address' }, { status: 400 })
+  }
 
   let payload: object
 

--- a/apps/web/src/app/api/tool-approvals/[id]/route.ts
+++ b/apps/web/src/app/api/tool-approvals/[id]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 // POST /api/tool-approvals/[id]  body: { action: 'approve'|'deny', adminNote?: string, approvedBy?: string }
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const admin = await requireAdmin()
+  // Override approvedBy with the authenticated admin's username
+  const resolvedApprovedBy = admin?.username ?? admin?.email ?? 'admin'
   let body: unknown
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
-  const { action, adminNote, approvedBy } = body as { action: 'approve' | 'deny'; adminNote?: string; approvedBy?: string }
+  const { action, adminNote } = body as { action: 'approve' | 'deny'; adminNote?: string }
 
   const request = await prisma.toolApprovalRequest.findUnique({ where: { id: params.id } })
   if (!request) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -15,7 +19,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     where: { id: params.id },
     data: {
       status:     action === 'approve' ? 'approved' : 'denied',
-      approvedBy: approvedBy ?? null,
+      approvedBy: resolvedApprovedBy,
       adminNote:  adminNote ?? null,
       resolvedAt: new Date(),
     },

--- a/apps/web/src/app/api/tools/pending/route.ts
+++ b/apps/web/src/app/api/tools/pending/route.ts
@@ -2,9 +2,11 @@ export const dynamic = 'force-dynamic'
 
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 // GET /api/tools/pending — all pending tool proposals across all environments
 export async function GET() {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const tools = await prisma.mcpTool.findMany({
     where: { status: 'pending' },
     include: { environment: { select: { id: true, name: true } } },

--- a/apps/web/src/components/environments/EnvironmentsPage.tsx
+++ b/apps/web/src/components/environments/EnvironmentsPage.tsx
@@ -474,7 +474,8 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
 
   const loadToolGroups = useCallback(async () => {
     if (!selected) return
-    const data = await fetch(`/api/tool-groups?environmentId=${selected.id}`).then(r => r.json())
+    const r = await fetch(`/api/tool-groups?environmentId=${selected.id}`)
+    const data = r.ok ? await r.json() : []
     setToolGroups(data)
     setToolGroupsLoaded(true)
   }, [selected])
@@ -528,7 +529,8 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
 
   const loadAllAgents = useCallback(async () => {
     if (agentsLoaded) return
-    const data: AllAgent[] = await fetch('/api/agents').then(r => r.json())
+    const r = await fetch('/api/agents')
+    const data: AllAgent[] = r.ok ? await r.json() : []
     setAllAgents(data)
     setAgentsLoaded(true)
   }, [agentsLoaded])
@@ -562,10 +564,14 @@ export function EnvironmentsPage({ initialEnvironments }: { initialEnvironments:
 
   const loadUserTiers = useCallback(async () => {
     if (!selected) return
-    const [tiersData, usersData] = await Promise.all([
-      fetch(`/api/environments/${selected.id}/user-tiers`).then(r => r.json()),
-      fetch('/api/admin/users').then(r => r.json()),
+    const [tiersRes, usersRes] = await Promise.all([
+      fetch(`/api/environments/${selected.id}/user-tiers`),
+      fetch('/api/admin/users'),
     ])
+    const [tiersData, usersData] = [
+      tiersRes.ok ? await tiersRes.json() : [],
+      usersRes.ok ? await usersRes.json() : [],
+    ]
     setUserTiers(tiersData)
     setAllUsers(usersData)
     setTiersLoaded(true)

--- a/apps/web/src/components/tasks/BugManager.tsx
+++ b/apps/web/src/components/tasks/BugManager.tsx
@@ -112,6 +112,7 @@ export function BugManager({ initialBugs, users }: Props) {
         reportedBy:  'admin',
       }),
     })
+    if (!r.ok) { setSaving(false); return }
     const bug: Bug = await r.json()
     setBugs(prev => [bug, ...prev])
     setForm({ title: '', description: '', severity: 'medium', area: '' })

--- a/apps/web/src/hooks/usePendingTools.ts
+++ b/apps/web/src/hooks/usePendingTools.ts
@@ -33,8 +33,8 @@ export function usePendingTools(intervalMs = 30_000) {
   const fetch_ = useCallback(async () => {
     try {
       const [toolData, approvalData] = await Promise.all([
-        fetch('/api/tools/pending').then(r => r.json()) as Promise<PendingTool[]>,
-        fetch('/api/tool-approvals').then(r => r.json()) as Promise<ApprovalRequest[]>,
+        fetch('/api/tools/pending').then(r => r.ok ? r.json() : []) as Promise<PendingTool[]>,
+        fetch('/api/tool-approvals').then(r => r.ok ? r.json() : []) as Promise<ApprovalRequest[]>,
       ])
       setTools(toolData)
       setApprovals(approvalData)

--- a/apps/web/src/lib/local-exec.ts
+++ b/apps/web/src/lib/local-exec.ts
@@ -4,11 +4,12 @@
 import { mkdirSync, writeFileSync, rmSync } from 'fs'
 import { execFile, type ExecFileOptions } from 'child_process'
 import { promisify } from 'util'
+import { randomBytes } from 'crypto'
 
 const execFileAsync = promisify(execFile)
 
 export function makeLocalGx(kubeconfig: string) {
-  const tmpDir = `/tmp/orion-kubectl-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const tmpDir = `/tmp/orion-kubectl-${Date.now()}-${randomBytes(8).toString('hex')}`
 
   try {
     mkdirSync(tmpDir, { recursive: true })

--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -602,6 +602,10 @@ async function runVolumeSumRule(
 
   // Build a safe JSON path for Postgres: "rawEvent"->'field' or "rawEvent"->'parent'->>'child'
   const pathParts = params.jsonPath.split('.')
+  // Validate each path segment to prevent SQL injection via $queryRawUnsafe
+  if (pathParts.some(p => !/^[a-zA-Z0-9_]+$/.test(p))) {
+    throw new Error('Invalid jsonPath: segments must be alphanumeric/underscore only')
+  }
   let jsonExtract: string
   if (pathParts.length === 1) {
     jsonExtract = `("rawEvent"->>'${pathParts[0]}')`


### PR DESCRIPTION
## Summary

Fable-model comprehensive security review findings — batch 5.

- **SQL injection** (`rule-engine.ts`): validate each `jsonPath` segment matches `[a-zA-Z0-9_]` before interpolating into `$queryRawUnsafe`; malformed paths would have allowed arbitrary SQL
- **Unauthenticated endpoints**: added `requireServiceAuth` to `executions`, `job-runs`, and `conversations/[id]/traces`; added `requireAdmin` to `tool-approvals/[id]`, `tools/pending`, `notification-channels/[id]`, and `environments/[id]/agents/[agentId]`
- **Role escalation** (`chatrooms/[id]/join`): hardcode `role: 'member'` — caller was able to supply any role including `moderator`/`admin`
- **Privilege escalation** (`tool-approvals/[id]`): derive `approvedBy` from the authenticated admin session, not a caller-supplied field
- **SSRF** (`notification-channels/[id]/test`): block webhook test requests targeting localhost/private IP ranges
- **Unauthorized data access** (`chatrooms/[id]/goals`): verify requesting user is a room member before returning goals
- **Weak randomness** (`local-exec.ts`): replace `Math.random()` with `crypto.randomBytes` for temp dir names
- **Missing `res.ok` guards**: `BugManager`, `EnvironmentsPage`, `usePendingTools`

## Test plan

- [ ] POST `/api/tool-approvals/[id]` without admin session → 401
- [ ] POST `/api/chatrooms/[id]/join` with `role: 'admin'` in body → role stored as `member`
- [ ] POST `/api/notification-channels/[id]/test` with a `127.0.0.1` webhook URL → 400 error
- [ ] GET `/api/conversations/[id]/traces` without auth → 401
- [ ] GET `/api/executions` and `/api/job-runs` without service token → 401
- [ ] Security rule with `jsonPath` containing SQL characters → throws validation error, not query executed

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_