### PR TITLE
security: fix 401 vs 500 on auth failure, SSRF scheme bypass, IPv4-mapped IPv6

### DIFF
--- a/apps/web/src/app/api/conversations/[id]/traces/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/traces/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic'
 
 // GET /api/conversations/[id]/traces — Get trace timeline for a conversation
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const traces = await prisma.agentTrace.findMany({
     where: { conversationId: params.id },
     orderBy: { step: 'asc' },

--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
     const execution = await prisma.toolExecution.findUnique({
       where: { id: params.id },
@@ -33,7 +33,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
     const body = await req.json()
 

--- a/apps/web/src/app/api/executions/route.ts
+++ b/apps/web/src/app/api/executions/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
 export async function POST(req: NextRequest) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
     const body = await req.json()
 
@@ -60,7 +60,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET(req: NextRequest) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
     const { searchParams } = new URL(req.url)
     const actorId = searchParams.get('actorId')

--- a/apps/web/src/app/api/job-runs/route.ts
+++ b/apps/web/src/app/api/job-runs/route.ts
@@ -5,7 +5,7 @@ import { requireServiceAuth } from '@/lib/auth'
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: NextRequest) {
-  await requireServiceAuth(req)
+  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const { searchParams } = new URL(req.url)
   const limit  = Math.min(parseInt(searchParams.get('limit') ?? '200', 10), 500)
   const source = searchParams.get('source') ?? undefined

--- a/apps/web/src/app/api/notification-channels/[id]/test/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/test/route.ts
@@ -4,9 +4,16 @@ import { requireAdmin } from '@/lib/auth'
 
 function isPrivateUrl(url: string): boolean {
   try {
-    const { hostname } = new URL(url)
-    if (hostname === 'localhost') return true
-    const privatePatterns = [/^127\./, /^10\./, /^192\.168\./, /^172\.(1[6-9]|2\d|3[01])\./, /^169\.254\./, /^::1$/, /^fc00:/i, /^fe80:/i]
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true
+    const { hostname } = parsed
+    if (hostname === 'localhost' || hostname === '0.0.0.0') return true
+    const privatePatterns = [
+      /^127\./, /^10\./, /^192\.168\./,
+      /^172\.(1[6-9]|2\d|3[01])\./,
+      /^169\.254\./,
+      /^::1$/, /^::ffff:/i, /^fc00:/i, /^fe80:/i,
+    ]
     return privatePatterns.some(p => p.test(hostname))
   } catch { return true }
 }

--- a/apps/web/src/app/api/tool-approvals/[id]/route.ts
+++ b/apps/web/src/app/api/tool-approvals/[id]/route.ts
@@ -4,9 +4,11 @@ import { requireAdmin } from '@/lib/auth'
 
 // POST /api/tool-approvals/[id]  body: { action: 'approve'|'deny', adminNote?: string, approvedBy?: string }
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const admin = await requireAdmin()
-  // Override approvedBy with the authenticated admin's username
-  const resolvedApprovedBy = admin?.username ?? admin?.email ?? 'admin'
+  let admin
+  try { admin = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const resolvedApprovedBy = admin.username ?? admin.email ?? 'admin'
   let body: unknown
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const { action, adminNote } = body as { action: 'approve' | 'deny'; adminNote?: string }


### PR DESCRIPTION
## Summary

Follow-up fixes from Fable adversarial review of PR #605.

- **Auth throws return 500 not 401**: all `requireAdmin`/`requireServiceAuth` calls now wrapped in try/catch — unauthenticated requests get a proper 401 instead of an unhandled exception causing a 500 (`executions`, `executions/[id]`, `job-runs`, `conversations/[id]/traces`, `tool-approvals/[id]`)
- **SSRF scheme bypass**: `isPrivateUrl` now rejects any non-`http:`/`https:` scheme — `file://`, `gopher://`, etc. previously returned `false` (allowed) because their hostname was empty/unmatched
- **IPv4-mapped IPv6 bypass**: added `::ffff:` pattern to block `::ffff:127.0.0.1` style addresses that bypassed the previous regex set
- **`0.0.0.0` bypass**: added explicit check for `0.0.0.0` which routes to localhost on most systems

## Test plan

- [ ] Unauthenticated request to `GET /api/executions` → 401 (not 500)
- [ ] Unauthenticated request to `POST /api/tool-approvals/[id]` → 401 (not 500)
- [ ] Webhook test with `file:///etc/passwd` URL → blocked (400)
- [ ] Webhook test with `gopher://internal-host` → blocked (400)
- [ ] Webhook test with `http://::ffff:127.0.0.1/` → blocked (400)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_