### PR TITLE
security: fix critical/high auth gaps and SSRF in production notification delivery

### DIFF
--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -11,7 +11,7 @@ const CreateAgentWithReservedCheck = CreateAgentSchema.refine(
 export const { GET, POST } = makeCrudRoutes({
   model:        'agent',
   createSchema: CreateAgentWithReservedCheck,
-  requireAuth:  false,
+  requireAuth:  true,
   orderBy:      { name: 'asc' },
   transformData: (data) => ({
     name:     data.name,

--- a/apps/web/src/app/api/environments/[id]/agents/route.ts
+++ b/apps/web/src/app/api/environments/[id]/agents/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 /** POST /api/environments/:id/agents — link an agent to this environment */
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const body = await req.json().catch(() => ({}))
   if (!body.agentId) return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
 

--- a/apps/web/src/app/api/environments/[id]/gateway/route.ts
+++ b/apps/web/src/app/api/environments/[id]/gateway/route.ts
@@ -7,8 +7,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const env = await prisma.environment.findUnique({ where: { id: params.id } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
   if (!env.gatewayUrl || !env.gatewayToken) {

--- a/apps/web/src/app/api/notification-channels/[id]/test/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/test/route.ts
@@ -1,35 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { promises as dns } from 'dns'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
-
-const PRIVATE_IP_PATTERNS = [
-  /^127\./, /^10\./, /^192\.168\./,
-  /^172\.(1[6-9]|2\d|3[01])\./,
-  /^169\.254\./,
-  /^::1$/, /^::ffff:/i, /^fc00:/i, /^fe80:/i,
-  /^0\.0\.0\.0$/,
-]
-
-function isPrivateIp(ip: string): boolean {
-  return PRIVATE_IP_PATTERNS.some(p => p.test(ip))
-}
-
-async function isPrivateUrl(url: string): Promise<boolean> {
-  try {
-    const parsed = new URL(url)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true
-    const { hostname } = parsed
-    if (hostname === 'localhost' || hostname === '0.0.0.0') return true
-    if (isPrivateIp(hostname)) return true
-    // Resolve DNS and check all returned addresses to block encoded IPs and pre-DNS-rebinding
-    const [v4, v6] = await Promise.all([
-      dns.resolve4(hostname).catch(() => [] as string[]),
-      dns.resolve6(hostname).catch(() => [] as string[]),
-    ])
-    return [...v4, ...v6].some(isPrivateIp)
-  } catch { return true }
-}
+import { isPrivateUrl } from '@/lib/ssrf-guard'
 
 export async function POST(
   _req: NextRequest,

--- a/apps/web/src/app/api/setup/bootstrap-config/route.ts
+++ b/apps/web/src/app/api/setup/bootstrap-config/route.ts
@@ -1,11 +1,15 @@
 export const dynamic = 'force-dynamic'
 
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireWizardSession } from '@/lib/setup-guard'
 
 // Returns server-side env vars needed by the setup wizard UI.
 // (NEXT_PUBLIC_ vars are baked at build time so we expose them server-side instead.)
-export async function GET() {
+export async function GET(req: NextRequest) {
+  if (!await requireWizardSession(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   // Only expose Gitea credentials during setup — after completion they're
   // stored encrypted in the database and this endpoint should not leak them.
   const setting = await prisma.systemSetting.findUnique({ where: { key: 'setup.completed' } })

--- a/apps/web/src/app/api/tool-groups/[id]/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const g = await prisma.toolGroup.findUnique({
     where: { id: params.id },
     include: { tools: { include: { tool: true } }, agentAccess: { include: { agentGroup: true } } },
@@ -11,6 +13,7 @@ export async function GET(_: NextRequest, { params }: { params: { id: string } }
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   let body: Record<string, unknown>
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const b = body as { name?: string; description?: string | null; minimumTier?: string }
@@ -27,6 +30,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   await prisma.toolGroup.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 // POST — add a tool to the group
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const { toolId } = await req.json()
   if (!toolId || typeof toolId !== 'string' || !toolId.trim()) {
     return NextResponse.json({ error: 'toolId is required' }, { status: 400 })
@@ -15,6 +17,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
 // DELETE — remove a tool from the group (?toolId=xxx)
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const toolId = req.nextUrl.searchParams.get('toolId')
   if (!toolId) return NextResponse.json({ error: 'toolId required' }, { status: 400 })
   await prisma.toolGroupTool.delete({ where: { toolGroupId_toolId: { toolGroupId: params.id, toolId } } })

--- a/apps/web/src/app/api/tool-groups/route.ts
+++ b/apps/web/src/app/api/tool-groups/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
 
 export async function GET(req: NextRequest) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const envId = req.nextUrl.searchParams.get('environmentId')
   const groups = await prisma.toolGroup.findMany({
     where: envId ? { environmentId: envId } : undefined,
@@ -15,6 +17,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   let body: Record<string, unknown>
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const b = body as { name?: string; description?: string | null; environmentId?: string; minimumTier?: string }

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -4,6 +4,7 @@
  */
 
 import { prisma } from './db'
+import { isPrivateUrl } from './ssrf-guard'
 
 export type NotificationEvent =
   | { type: 'task_completed'; taskId: string; taskTitle: string; agentId: string; agentName: string; durationMs?: number }
@@ -141,12 +142,18 @@ export async function notify(event: NotificationEvent): Promise<void> {
         payload = formatWebhook(event)
       }
 
-      fetch(channel.webhookUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      }).catch((e: unknown) => {
-        console.error(`[notifications] Failed to POST to channel "${channel.name}" (${channel.id}):`, e)
+      isPrivateUrl(channel.webhookUrl).then(blocked => {
+        if (blocked) {
+          console.warn(`[notifications] Blocked delivery to private/internal URL for channel "${channel.name}" (${channel.id})`)
+          return
+        }
+        fetch(channel.webhookUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }).catch((e: unknown) => {
+          console.error(`[notifications] Failed to POST to channel "${channel.name}" (${channel.id}):`, e)
+        })
       })
     }
   } catch (e) {

--- a/apps/web/src/lib/ssrf-guard.ts
+++ b/apps/web/src/lib/ssrf-guard.ts
@@ -1,0 +1,32 @@
+import { promises as dns } from 'dns'
+
+const PRIVATE_IP_PATTERNS = [
+  /^127\./, /^10\./, /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^169\.254\./,
+  /^::1$/, /^::ffff:/i, /^fc00:/i, /^fe80:/i,
+  /^0\.0\.0\.0$/,
+]
+
+export function isPrivateIp(ip: string): boolean {
+  return PRIVATE_IP_PATTERNS.some(p => p.test(ip))
+}
+
+/**
+ * Returns true if the URL should be blocked: non-http/https scheme,
+ * hostname resolves to a private/internal IP, or DNS lookup fails.
+ */
+export async function isPrivateUrl(url: string): Promise<boolean> {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true
+    const { hostname } = parsed
+    if (hostname === 'localhost' || hostname === '0.0.0.0') return true
+    if (isPrivateIp(hostname)) return true
+    const [v4, v6] = await Promise.all([
+      dns.resolve4(hostname).catch(() => [] as string[]),
+      dns.resolve6(hostname).catch(() => [] as string[]),
+    ])
+    return [...v4, ...v6].some(isPrivateIp)
+  } catch { return true }
+}


### PR DESCRIPTION
## Summary

Fable adversarial review pass 2 — 6 critical/high findings fixed.

**CRITICAL**
- `setup/bootstrap-config` GET: added `requireWizardSession` guard — previously returned `GITEA_ADMIN_TOKEN`, `GITEA_ADMIN_USER`, `GITEA_ADMIN_PASSWORD` in plaintext to any unauthenticated caller on a partially-set-up or reset instance
- `tool-groups` (all 3 route files): added `requireAdmin` to every handler (GET, POST, PUT, DELETE, tools POST/DELETE) — the entire API was unauthenticated, allowing anonymous callers to lower `minimumTier` on privileged tool groups (privilege escalation → RCE foothold)

**HIGH**
- `environments/[id]/agents` POST: added `requireAdmin` — unauthenticated agent linking to any environment
- `environments/[id]/gateway` POST: added `requireAdmin` — unauthenticated forced gateway restart/redeploy
- `agents/route` CRUD factory: changed `requireAuth: false` → `true` — anonymous agent creation fed the tool-execution pipeline
- `lib/notifications.ts` production delivery: SSRF guard was only on the test endpoint; actual event dispatch now also checks `isPrivateUrl` before firing webhook

**Refactor**
- Extracted `isPrivateUrl`/`isPrivateIp` into `lib/ssrf-guard.ts` — shared between the test endpoint and production delivery, no more duplication

## Test plan

- [ ] `GET /api/setup/bootstrap-config` without wizard session token → 401
- [ ] `POST /api/tool-groups` without admin session → 401
- [ ] `PUT /api/tool-groups/[id]` without admin session → 401
- [ ] `POST /api/environments/[id]/agents` without admin session → 401
- [ ] `POST /api/environments/[id]/gateway` without admin session → 401
- [ ] `GET /api/agents` without session → 401
- [ ] Notification channel with `webhookUrl: http://192.168.1.1` — production delivery logs a warning and skips fetch

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_