### PR TITLE
SOC2 hardening: audit logging, federation injection, webhook sanitization

### DIFF
--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, CreateUserSchema } from '@/lib/validate'
 import { hash } from 'bcryptjs'
+import { logAudit } from '@/lib/audit'
 
 // Fields safe to return — never include passwordHash, totpSecret, totpRecoveryCodes
 const SAFE_USER_SELECT = {
@@ -24,7 +25,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  await requireAdmin()
+  const admin = await requireAdmin()
   const result = await parseBodyOrError(req, CreateUserSchema)
   if ('error' in result) return result.error
   const { data } = result
@@ -34,6 +35,13 @@ export async function POST(req: NextRequest) {
   const user = await prisma.user.create({
     data: { username: data.username, email: data.email, passwordHash, name: data.name, role: data.role },
     select: SAFE_USER_SELECT,
+  })
+
+  await logAudit({
+    userId: admin.id,
+    action: 'user_create',
+    target: user.id,
+    detail: { username: user.username, role: user.role },
   })
 
   return NextResponse.json(user, { status: 201 })

--- a/apps/web/src/app/api/federation/tasks/route.ts
+++ b/apps/web/src/app/api/federation/tasks/route.ts
@@ -60,11 +60,15 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // Create or upsert the task — the taskId is supplied by the hub so it can
-  // correlate status lookups by the same ID.
-  const task = await prisma.task.upsert({
-    where: { id: body.taskId },
-    create: {
+  // Create-only — reject duplicate taskIds with 409 to prevent a compromised
+  // spoke from force-resetting an in-progress or completed task to 'pending'.
+  const existing = await prisma.task.findUnique({ where: { id: body.taskId }, select: { id: true } })
+  if (existing) {
+    return NextResponse.json({ error: 'Task already exists', taskId: body.taskId }, { status: 409 })
+  }
+
+  const task = await prisma.task.create({
+    data: {
       id: body.taskId,
       title: body.title,
       description: body.description ?? null,
@@ -75,9 +79,6 @@ export async function POST(req: NextRequest) {
         ...(body.metadata as object | null ?? {}),
         federatedFrom: 'hub',
       } as object,
-    },
-    update: {
-      status: 'pending',
     },
     select: { id: true, status: true },
   })

--- a/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/crowdsec/route.ts
@@ -109,7 +109,11 @@ export async function POST(req: NextRequest) {
   event.environmentId = envId || null
 
   // 7. Validate with Zod
-  const parsed = normalizedEventSchema.parse(event)
+  const parseResult = normalizedEventSchema.safeParse(event)
+  if (!parseResult.success) {
+    return NextResponse.json({ error: 'Event failed schema validation', issues: parseResult.error.issues }, { status: 400 })
+  }
+  const parsed = parseResult.data
 
   // 8. Idempotency check
   if (await wasAlreadyProcessed(parsed.dedupKey, 'crowdsec')) {

--- a/apps/web/src/app/api/webhooks/[triggerId]/route.ts
+++ b/apps/web/src/app/api/webhooks/[triggerId]/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { createHmac, timingSafeEqual } from 'crypto'
 
+const MAX_VAR_LENGTH = 200
+
 // ---------------------------------------------------------------------------
 // Template interpolation — replaces {{key}} with vars[key]
 // ---------------------------------------------------------------------------
 function interpolate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? `{{${key}}}`)
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+    const val = vars[key] ?? `{{${key}}}`
+    // Cap each substituted value to prevent prompt injection via webhook payloads
+    return val.length > MAX_VAR_LENGTH ? val.slice(0, MAX_VAR_LENGTH) + '[…]' : val
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/audit-export.ts
+++ b/apps/web/src/lib/audit-export.ts
@@ -181,29 +181,8 @@ async function exportLogsToFile(retentionDays: number): Promise<{
 
   // Create temporary gzipped file
   const tmpFile = join(tmpdir(), `audit-export-${randomBytes(8).toString('hex')}.json.gz`)
-  const writeStream = createWriteStream(tmpFile)
-  const gzip = createGzip()
 
-  await new Promise<void>((resolve, reject) => {
-    let isFirstLine = true
-    writeStream.write('[\n')
-
-    for (const log of logs) {
-      const line = JSON.stringify(log)
-      if (!isFirstLine) writeStream.write(',\n')
-      writeStream.write(line)
-      isFirstLine = false
-    }
-
-    writeStream.write('\n]')
-    writeStream.end()
-
-    const pipeStream = createReadStream(tmpFile.replace('.gz', '')).pipe(gzip).pipe(writeStream)
-    pipeStream.on('finish', resolve)
-    pipeStream.on('error', reject)
-  })
-
-  // Actually, let's write JSON then gzip it
+  // Write JSON then gzip it
   const jsonFile = tmpFile.replace('.gz', '')
   const jsonStream = createWriteStream(jsonFile)
 
@@ -349,6 +328,8 @@ export async function uploadToS3(
         ContentType: 'application/gzip',
         ContentEncoding: 'gzip',
         ServerSideEncryption: 'AES256',
+        ObjectLockMode: 'COMPLIANCE',
+        ObjectLockRetainUntilDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1-year retention
         Metadata: {
           'export-date': new Date().toISOString(),
           'export-type': 'audit-logs',

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -122,9 +122,9 @@ export async function logAudit(params: {
         previousHash: prevHash ?? undefined,
       },
     })
-  } catch {
+  } catch (e) {
     // Non-blocking — audit logging failures must not impact normal operations
-    // SOC2: If audit logging is consistently failing, this is an alerting condition
+    console.error('[audit] logAudit failed:', e)
   }
 }
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -89,7 +89,10 @@ export const authOptions: NextAuthOptions = {
         if (!user || !user.active || !user.passwordHash) return null
 
         const passwordValid = await compare(credentials.password, user.passwordHash)
-        if (!passwordValid) return null
+        if (!passwordValid) {
+          void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_password' } })
+          return null
+        }
 
         // SOC2: [M-002] Check MFA requirement
         if (user.totpEnabled) {
@@ -100,6 +103,7 @@ export const authOptions: NextAuthOptions = {
             const code = credentials.totpCode as string
             const hashedCodes: string[] = user.totpRecoveryCodes ? JSON.parse(user.totpRecoveryCodes) : []
             if (!code || !(await verifyRecoveryCode(code, hashedCodes))) {
+              void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_recovery_code' } })
               return { error: 'Invalid recovery code' }
             }
             // BLOCKER fix: consume the recovery code (single-use)
@@ -116,12 +120,14 @@ export const authOptions: NextAuthOptions = {
               return { mfaRequired: true, totpEnabled: true, username: user.username }
             }
             if (!(await verifyTOTP(user.totpSecret, code))) {
+              void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_totp' } })
               return { error: 'Invalid TOTP code' }
             }
           }
 
           // MFA verified — update lastSeen and return full user
           await prisma.user.update({ where: { id: user.id }, data: { lastSeen: new Date() } })
+          void logAudit({ userId: user.id, action: 'user_login', target: user.id, detail: { mfaVerified: true } })
           return {
             id: user.id,
             name: user.name,
@@ -137,6 +143,7 @@ export const authOptions: NextAuthOptions = {
           data: { lastSeen: new Date() },
         })
 
+        void logAudit({ userId: user.id, action: 'user_login', target: user.id, detail: { mfaVerified: false } })
         return {
           id: user.id,
           name: user.name,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

SOC2 auditor findings (CC7/CC4, CC9/C1, PI1) — first batch of fixes.

- **audit.ts**: `logAudit()` failures now surface via `console.error` instead of vanishing silently — persistent failures are now detectable
- **auth.ts**: All credential check paths (`invalid_password`, `invalid_totp`, `invalid_recovery_code`, success) now emit `user_login` / `user_login_failure` audit events
- **admin/users route**: `POST` emits a `user_create` audit event with the acting admin's userId
- **federation/tasks route**: Replace dangerous `upsert` (keyed on attacker-supplied `taskId`) with create-only; duplicate IDs return **409** — prevents a compromised spoke from force-resetting a completed task back to `pending`
- **webhooks/[triggerId]**: Interpolated webhook payload values capped at 200 chars to prevent prompt injection via malicious webhook bodies
- **crowdsec webhook**: `normalizedEventSchema.parse()` → `safeParse()` so schema validation failures return **400** instead of an unhandled 500
- **audit-export.ts**: Remove broken dead code block that caused the daily S3 export to fail silently on every run; add `ObjectLockMode: 'COMPLIANCE'` + `ObjectLockRetainUntilDate` to `PutObjectCommand` (documented in comments but never set in the command)

## Test plan

- [ ] Login with wrong password → `user_login_failure` appears in audit log
- [ ] Login with wrong TOTP → `user_login_failure` with `reason: invalid_totp`
- [ ] Successful login → `user_login` in audit log
- [ ] POST `/api/admin/users` → `user_create` audit entry
- [ ] POST `/api/federation/tasks` with existing `taskId` → 409, task not reset
- [ ] POST `/api/federation/tasks` with new `taskId` → 201, task created
- [ ] Webhook with a very long commit message → title/description truncated at 200 chars
- [ ] CrowdSec webhook with malformed normalized event → 400 (not 500)
- [ ] `exportAuditLogs()` completes without error and uploads to S3

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_