### PR TITLE
SOC2 hardening: audit cleanup safety, secrets exposure, tool registry

### DIFF
--- a/apps/web/src/app/api/admin/audit-retention/cleanup/route.ts
+++ b/apps/web/src/app/api/admin/audit-retention/cleanup/route.ts
@@ -130,10 +130,12 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // Delete expired logs
-  const result = await prisma.auditLog.deleteMany({
-    where: { createdAt: { lt: cutoff } },
-  })
+  // exportAuditLogs already deletes by the exact IDs it exported. A second
+  // deleteMany by time-window would delete records that arrived after the
+  // export query ran but before this point — creating an audit gap.
+  // When hasRecentExport is true, the prior export already removed eligible
+  // records; we only report that cleanup has been handled.
+  const deletedCount = hasRecentExport ? 0 : 0  // deletion is handled inside exportAuditLogs
 
   // Log the cleanup action
   await logAudit({
@@ -142,7 +144,7 @@ export async function POST(req: NextRequest) {
     target: 'audit_log_cleanup',
     detail: {
       action: 'logs_deleted',
-      deletedCount: result.count,
+      deletedCount,
       retentionDays,
       cutoff: cutoff.toISOString(),
     },
@@ -150,7 +152,7 @@ export async function POST(req: NextRequest) {
 
   return NextResponse.json({
     ok: true,
-    deleted: result.count,
+    deleted: deletedCount,
     retentionDays,
     cutoff: cutoff.toISOString(),
     exportedBefore: hasRecentExport,

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
     take: 200,
   })
   // Mask sensitive fields
-  return NextResponse.json(environments.map((e: any) => ({ ...e, gatewayToken: e.gatewayToken ? '••••' : null, kubeconfig: e.kubeconfig ? '••••' : null })))
+  return NextResponse.json(environments.map((e: any) => ({ ...e, gatewayToken: e.gatewayToken ? '••••' : null, kubeconfig: e.kubeconfig ? '••••' : null, federationToken: e.federationToken ? '••••' : null })))
 }
 
 export async function POST(req: NextRequest) {

--- a/apps/web/src/lib/encryption.ts
+++ b/apps/web/src/lib/encryption.ts
@@ -33,7 +33,10 @@ export function encrypt(plaintext: string): string {
 }
 
 export function decrypt(value: string): string {
-  if (!value.startsWith(PREFIX)) return value   // plaintext passthrough (legacy values)
+  if (!value.startsWith(PREFIX)) {
+    console.warn('[encryption] decrypt() called on unencrypted value — plaintext passthrough (legacy). Migrate this value to encrypted format.')
+    return value
+  }
   const key    = getKey()
   const packed = Buffer.from(value.slice(PREFIX.length), 'base64')
   const iv         = packed.subarray(0, IV_BYTES)

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -107,7 +107,7 @@ export async function executeRegisteredTool(
   context: ToolExecutionContext,
 ): Promise<string> {
   const def = _registry.get(name)
-  if (!def) return `Error: unknown tool "${name}"`
+  if (!def) throw new Error(`Unknown tool: "${name}" — execution denied`)
   try {
     return await def.handler(args, context)
   } catch (e) {
@@ -122,7 +122,7 @@ export function validateToolArgs(
   args: unknown,
 ): { valid: boolean; errors: string[] } {
   const def = _registry.get(toolName)
-  if (!def) return { valid: true, errors: [] }  // unknown tools pass through
+  if (!def) return { valid: false, errors: [`Unknown tool: "${toolName}"`] }
 
   const schema = def.inputSchema as {
     required?: string[]

--- a/apps/web/src/lib/worker-tasks.ts
+++ b/apps/web/src/lib/worker-tasks.ts
@@ -44,6 +44,17 @@ export async function cleanupAuditLogs(): Promise<{ deleted: number; durationMs:
       return { deleted: 0, durationMs: Date.now() - startTime }
     }
 
+    // Require a successful export within the last 25 hours before deleting.
+    // This prevents the worker from permanently destroying audit records that
+    // have never been exported to S3.
+    const lastExportRow = await prisma.systemSetting.findUnique({ where: { key: 'audit.lastExportTime' } })
+    const lastExportMs = lastExportRow ? parseInt(String(lastExportRow.value), 10) : NaN
+    const exportAge = Date.now() - lastExportMs
+    if (isNaN(exportAge) || exportAge > 25 * 60 * 60 * 1000) {
+      console.warn(`[audit-cleanup] Skipping deletion — no successful export in the last 25h. Run exportAuditLogs() first.`)
+      return { deleted: 0, durationMs: Date.now() - startTime }
+    }
+
     // Delete in batches to avoid long transactions
     const BATCH_SIZE = 1000
     let deleted = 0

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -376,12 +376,20 @@ echo "Starting Vector host telemetry shipper..."
 $COMPOSE up -d --force-recreate vector 2>/dev/null || echo "NOTE: Vector service failed to start (check compose logs)."
 
 if [[ -n "${SETUP_TOKEN:-}" ]]; then
+  # In CI environments, write the setup token to a file rather than stdout
+  # to prevent it appearing in build logs.
+  if [[ -n "${CI:-}" ]]; then
+    TOKEN_FILE="${RUNNER_TEMP:-/tmp}/orion-setup-token"
+    echo "$SETUP_TOKEN" > "$TOKEN_FILE"
+    chmod 600 "$TOKEN_FILE"
+    echo "Setup token written to $TOKEN_FILE (suppressed from CI logs)."
+  fi
   echo ""
   echo "========================================"
   echo "  ORION is ready for first-run setup"
   echo "  Visit: http://$(hostname -I | awk '{print $1}'):3000"
   echo "  Or:    https://${ORION_DOMAIN:-orion.khalis.corp}"
-  echo "  Setup token: $SETUP_TOKEN"
+  if [[ -z "${CI:-}" ]]; then echo "  Setup token: $SETUP_TOKEN"; fi
   echo "========================================"
 else
   echo ""


### PR DESCRIPTION
## Summary

SOC2 auditor findings (CC6, CC7, A1, CC5) — second batch of fixes.

- **audit-retention/cleanup route**: Removed time-window `deleteMany` after export — `exportAuditLogs()` already deletes by exact exported IDs; a second pass by time window would delete records that arrived after the export query but before deletion (permanent audit gap)
- **worker-tasks**: Automated daily cleanup now checks for a successful export within the last 25h before deleting; previously the worker silently destroyed audit logs that had never been exported to S3
- **environments API**: `federationToken` now masked (`••••`) in GET response alongside `gatewayToken` and `kubeconfig` — was being sent to the browser in plaintext
- **encryption.ts**: `decrypt()` plaintext passthrough now emits a `console.warn` — silent passthrough was hiding misconfigured/unmigrated values
- **tool-registry**: `executeRegisteredTool` throws on unknown tool names instead of returning a soft error string; `validateToolArgs` returns `invalid` for unknown tools instead of passing them through (fail-closed)
- **deploy/bootstrap.sh**: `SETUP_TOKEN` suppressed from stdout in CI environments (`$CI` set); written to `$RUNNER_TEMP/orion-setup-token` (mode 600) instead to prevent token appearing in build logs

## Test plan

- [ ] POST `/api/admin/audit-retention/cleanup` with recent export → returns `deleted: 0`, no second DB delete
- [ ] Worker `cleanupAuditLogs()` with no export in last 25h → logs warning, returns `deleted: 0`
- [ ] GET `/api/environments` → `federationToken` field is `••••` not plaintext
- [ ] Call `decrypt()` on a non-prefixed string → `console.warn` emitted
- [ ] `executeRegisteredTool('nonexistent', ...)` → throws rather than returning error string
- [ ] `bootstrap.sh` run with `CI=true` → token not printed to stdout, written to file

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_