### PR TITLE
SOC2 hardening: MFA enforcement, SSO startup alarm, settings redaction

### DIFF
--- a/apps/web/src/app/api/admin/settings/route.ts
+++ b/apps/web/src/app/api/admin/settings/route.ts
@@ -4,12 +4,21 @@ import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, UpdateSettingsSchema } from '@/lib/validate'
 
+// Keys containing these substrings are redacted in GET responses.
+// They hold tokens, secrets, or keys that must not be returned to the browser.
+const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'key', 'credential']
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase()
+  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
+}
+
 export async function GET() {
   await requireAdmin()
   const rows = await prisma.systemSetting.findMany({ take: 500 })
   const result: Record<string, unknown> = {}
   for (const row of rows) {
-    result[row.key] = row.value
+    result[row.key] = isSensitiveKey(row.key) ? '••••' : row.value
   }
   return NextResponse.json(result)
 }

--- a/apps/web/src/app/api/setup/ai-provider/route.ts
+++ b/apps/web/src/app/api/setup/ai-provider/route.ts
@@ -1,22 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
-import { validateBody, SetupAiProviderSchema } from '@/lib/validate'
+import { parseBodyOrError, SetupAiProviderSchema } from '@/lib/validate'
+import { z } from 'zod'
+
+const SetupAiProviderWithSkipSchema = SetupAiProviderSchema.or(z.object({ skip: z.literal(true) }))
 
 export async function POST(req: NextRequest) {
   if (!await requireWizardSession(req)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = await req.json()
-  if (body.skip) {
+  const result = await parseBodyOrError(req, SetupAiProviderWithSkipSchema)
+  if ('error' in result) return result.error
+
+  if ('skip' in result.data && result.data.skip) {
     return NextResponse.json({ ok: true, skipped: true })
   }
 
-  const data = validateBody(body, SetupAiProviderSchema)
-  if (!data) {
-    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
-  }
+  const data = result.data as z.infer<typeof SetupAiProviderSchema>
 
   // Use provider default baseUrl if not provided
   const defaultBaseUrls: Record<string, string> = {

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -2,15 +2,31 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 import { parseBodyOrError, CreateTaskSchema } from '@/lib/validate'
+import { z } from 'zod'
+
+const TaskQuerySchema = z.object({
+  status:        z.enum(['pending', 'in_progress', 'pending_validation', 'done', 'failed', 'blocked']).optional(),
+  featureId:     z.string().max(100).optional(),
+  assignedAgent: z.string().max(100).optional(),
+  priority:      z.enum(['low', 'medium', 'high', 'urgent']).optional(),
+  limit:         z.coerce.number().int().min(1).max(1000).default(500),
+})
 
 export async function GET(req: NextRequest) {
   await requireServiceAuth(req)
   const { searchParams } = new URL(req.url)
-  const status        = searchParams.get('status')        // pending|in_progress|completed|blocked
-  const featureId     = searchParams.get('featureId')
-  const assignedAgent = searchParams.get('assignedAgent')
-  const priority      = searchParams.get('priority')
-  const limit         = Math.min(parseInt(searchParams.get('limit') ?? '500', 10), 1000)
+
+  const parsed = TaskQuerySchema.safeParse({
+    status:        searchParams.get('status') ?? undefined,
+    featureId:     searchParams.get('featureId') ?? undefined,
+    assignedAgent: searchParams.get('assignedAgent') ?? undefined,
+    priority:      searchParams.get('priority') ?? undefined,
+    limit:         searchParams.get('limit') ?? undefined,
+  })
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query parameters', issues: parsed.error.issues }, { status: 400 })
+  }
+  const { status, featureId, assignedAgent, priority, limit } = parsed.data
 
   const where: Record<string, unknown> = {}
   if (status)        where.status        = status

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -28,5 +28,16 @@ export async function register() {
 
     const { ensureSocConfig } = await import('./lib/seed-soc-config')
     await ensureSocConfig()
+
+    // SOC2 [SSO-001]: Warn at startup if unsigned SSO headers are permitted.
+    // SSO_ALLOW_UNSIGNED_SSO=true is only for rollout — must not persist in production.
+    if (process.env.SSO_ALLOW_UNSIGNED_SSO === 'true') {
+      console.warn(
+        '[SOC2][SSO-001] SECURITY WARNING: SSO_ALLOW_UNSIGNED_SSO=true — ' +
+        'SSO header authentication is running WITHOUT HMAC signature verification. ' +
+        'Any request can forge identity headers. Set SSO_HMAC_SECRET and remove ' +
+        'SSO_ALLOW_UNSIGNED_SSO before going to production.'
+      )
+    }
   }
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -14,6 +14,7 @@ export interface AppUser {
   role: string
   active: boolean
   totpEnabled?: boolean // SOC2: [M-002] whether this user has MFA enabled
+  mfaVerified?: boolean // SOC2: [M-002] whether MFA was verified in this session
 }
 
 /**
@@ -291,6 +292,7 @@ export async function getCurrentUser(): Promise<AppUser | null> {
   // Primary: NextAuth JWT session
   const session = await getServerSession(authOptions)
   if (session?.user) {
+    const sessionUser = session.user as AppUser & { mfaVerified?: boolean }
     return {
       id: session.user.id,
       username: session.user.username,
@@ -299,6 +301,7 @@ export async function getCurrentUser(): Promise<AppUser | null> {
       role: session.user.role,
       active: true,
       totpEnabled: (session.user as AppUser & { totpEnabled?: boolean }).totpEnabled,
+      mfaVerified: sessionUser.mfaVerified ?? false,
     }
   }
 
@@ -357,6 +360,10 @@ export async function requireAdmin(): Promise<AppUser> {
   const user = await getCurrentUser()
   if (!user || user.role !== 'admin') {
     throw new Error('Unauthorized')
+  }
+  // SOC2 [M-002]: If the user has MFA enabled, require it to be verified in this session.
+  if (user.totpEnabled && !user.mfaVerified) {
+    throw new Error('MFA verification required')
   }
   return user
 }

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -54,18 +54,15 @@ export async function parseBodyOrError<T extends z.ZodType>(
  * Returns null if invalid (caller must return 400).
  * Use parseBodyOrError() in new code instead.
  */
+/** @deprecated Use parseBodyOrError() instead — this returns null on failure with no details. */
 export function validateBody<T extends z.ZodType>(
   body: unknown,
   schema: T,
-  options?: { errorPrefix?: string },
 ): z.infer<T> | null {
   try {
-    const parsed = schema.parse(body)
-    return parsed
-  } catch (err) {
-    const zodErr = err as z.ZodError
-    const prefix = options?.errorPrefix ?? 'Invalid input'
-    return null // caller should return 400 with error details
+    return schema.parse(body)
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary

SOC2 auditor findings (CC6, CC2, CC5) — third batch, all remaining medium-severity items.

- **`requireAdmin()` MFA enforcement**: Admin users with `totpEnabled=true` whose session hasn't completed MFA (`mfaVerified=false`) are now rejected with "MFA verification required". Previously `requireAdmin()` only checked `role === 'admin'` — a stolen session cookie for an MFA-enabled admin bypassed all MFA protection on every admin API route.
- **SSO startup alarm**: `instrumentation.ts` now emits a `SECURITY WARNING` at server boot when `SSO_ALLOW_UNSIGNED_SSO=true`. Previously this was only logged at the moment an SSO request arrived — invisible during normal ops where header-mode SSO isn't used.
- **Admin settings redaction**: `GET /api/admin/settings` now returns `••••` for keys matching sensitive patterns (`token`, `secret`, `password`, `key`, `credential`). All ~500 SystemSettings were previously returned in plaintext to the browser.
- **Tasks query param validation**: `GET /api/tasks` now validates `status` and `priority` against their allowed enum values via Zod. Invalid values return 400 instead of passing raw strings to Prisma.
- **`validateBody()` cleanup**: Remove dead/unused variable; mark as `@deprecated`. Migrate the single caller (`setup/ai-provider`) to `parseBodyOrError()`.

## Test plan

- [ ] Admin with `totpEnabled=true` and `mfaVerified=false` → any admin route returns 401/403
- [ ] Admin with `totpEnabled=false` → admin routes work as before
- [ ] Server start with `SSO_ALLOW_UNSIGNED_SSO=true` → SECURITY WARNING appears in startup logs
- [ ] `GET /api/admin/settings` → keys like `audit.lastExportManifestHash` visible, but any key containing "token"/"secret"/"key" shows `••••`
- [ ] `GET /api/tasks?status=INVALID` → 400 with Zod issues
- [ ] `GET /api/tasks?priority=critical` → 400 (not a valid enum value)
- [ ] `GET /api/tasks?status=pending&priority=high` → 200 with filtered results
- [ ] `POST /api/setup/ai-provider` with `{ skip: true }` → `{ ok: true, skipped: true }`
- [ ] `POST /api/setup/ai-provider` with invalid body → structured 400 with Zod issues

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_