### PR TITLE
SOC2 #614: Auth hardening — session expiry, authorize() errors, password policy, SSO audit

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -33,7 +33,7 @@ export { SESSION_COOKIE_NAME }
 const IS_SECURE = process.env.NODE_ENV === 'production' || process.env.HEADER_X_FORWARDED_PROTO === 'https'
 
 export const authOptions: NextAuthOptions = {
-  session: { strategy: 'jwt' },
+  session: { strategy: 'jwt', maxAge: 8 * 60 * 60 },
   secret: process.env.NEXTAUTH_SECRET,
   cookies: {
     sessionToken: {
@@ -105,7 +105,7 @@ export const authOptions: NextAuthOptions = {
             const hashedCodes: string[] = user.totpRecoveryCodes ? JSON.parse(user.totpRecoveryCodes) : []
             if (!code || !(await verifyRecoveryCode(code, hashedCodes))) {
               void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_recovery_code' } })
-              return { error: 'Invalid recovery code' }
+              return null
             }
             // BLOCKER fix: consume the recovery code (single-use)
             const updatedCodes = await consumeRecoveryCode(code, hashedCodes)
@@ -115,14 +115,14 @@ export const authOptions: NextAuthOptions = {
           } else {
             // TOTP code login
             const code = credentials.totpCode as string
-            if (!user.totpSecret) return { error: 'MFA not configured' }
+            if (!user.totpSecret) return null
             if (!code || typeof code !== 'string') {
               // No TOTP code provided — signal MFA required
               return { mfaRequired: true, totpEnabled: true, username: user.username }
             }
             if (!(await verifyTOTP(user.totpSecret, code))) {
               void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_totp' } })
-              return { error: 'Invalid TOTP code' }
+              return null
             }
           }
 
@@ -340,6 +340,7 @@ export async function getCurrentUser(): Promise<AppUser | null> {
           return null
         }
 
+        const existingUser = await prisma.user.findUnique({ where: { username } })
         const user = await prisma.user.upsert({
           where: { username },
           update: { lastSeen: new Date() },
@@ -352,6 +353,15 @@ export async function getCurrentUser(): Promise<AppUser | null> {
             provider: 'authentik',
           },
         })
+        const isNewUser = !existingUser
+        if (isNewUser) {
+          void logAudit({
+            userId: user.id,
+            action: 'user_create',
+            target: user.id,
+            detail: { provider: 'sso', username, source: 'auto-provision' },
+          })
+        }
         if (!user.active) return null
         return user
       }

--- a/apps/web/src/lib/validate.ts
+++ b/apps/web/src/lib/validate.ts
@@ -154,7 +154,7 @@ export const TOTPLoginSchema = z.object({
 export const CreateUserSchema = z.object({
   username: z.string().min(3).max(100).regex(/^[a-zA-Z0-9_-]+$/, 'Invalid username'),
   email: z.string().email('Invalid email'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  password: z.string().min(12, 'Password must be at least 12 characters'),
   name: z.string().max(200).optional(),
   role: z.enum(['admin', 'user', 'readonly']).default('user'),
 })
@@ -280,7 +280,7 @@ export const UpdateConversationSchema = z.object({
 
 export const SetupAdminSchema = z.object({
   username: z.string().min(3).max(100).regex(/^[a-zA-Z0-9_-]+$/, 'Username must be alphanumeric (hyphens/underscores allowed)'),
-  password: z.string().min(10, 'Password must be at least 10 characters'),
+  password: z.string().min(12, 'Password must be at least 12 characters'),
 })
 
 export const SetupAiProviderSchema = z.object({


### PR DESCRIPTION
## Summary

- `authorize()` returns `null` on all failure paths (previously returned truthy `{ error }` objects, bypassing NextAuth's failure detection)
- JWT session `maxAge` set to 8 hours (was unlimited)
- Password minimum raised to 12 characters in `CreateUserSchema` and `SetupAdminSchema`
- SSO auto-provisioning emits `user_create` audit event for new users

## SOC2 Controls
CC6.1 (authentication controls), CC6.2 (session management), CC6.3 (password policy), CC4.1 (audit trail completeness)

## Test plan
- [ ] Login with wrong password → `authorize()` returns `null`, session not created
- [ ] Login success → session expires after 8h
- [ ] Create user with 11-char password → rejected with validation error
- [ ] SSO new user provisioning → audit log entry created

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_