### PR TITLE
SOC2 #615: Encrypt federation tokens and webhook secrets at rest; extend key rotation

### DIFF
--- a/apps/web/src/app/api/admin/settings/route.ts
+++ b/apps/web/src/app/api/admin/settings/route.ts
@@ -3,6 +3,15 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, UpdateSettingsSchema } from '@/lib/validate'
+import { encrypt } from '@/lib/encryption'
+
+// Keys containing these substrings are sensitive and must be encrypted at rest.
+const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'credential']
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase()
+  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
+}
 
 // Keys containing these substrings are redacted in GET responses.
 // They hold tokens, secrets, or keys that must not be returned to the browser.
@@ -29,11 +38,23 @@ export async function PATCH(req: NextRequest) {
   if ('error' in result) return result.error
   const { data } = result
 
+  // SOC2: encrypt sensitive values before storage
+  let valueToStore: unknown
+  if (isSensitiveKey(data.key)) {
+    try {
+      valueToStore = encrypt(data.value as string)
+    } catch {
+      return NextResponse.json({ error: 'Encryption key not configured' }, { status: 500 })
+    }
+  } else {
+    valueToStore = data.value
+  }
+
   const ops = [
     prisma.systemSetting.upsert({
       where: { key: data.key },
-      update: { value: data.value as any },
-      create: { key: data.key, value: data.value as any },
+      update: { value: valueToStore as any },
+      create: { key: data.key, value: valueToStore as any },
     })
   ]
 

--- a/apps/web/src/app/api/internal/encryption/rotate/route.ts
+++ b/apps/web/src/app/api/internal/encryption/rotate/route.ts
@@ -68,7 +68,8 @@ export async function POST(req: NextRequest) {
         updates.gatewayToken = encryptWithKey(plaintext, newKeyBase64)
         migrated++
       } catch (e) {
-        errors.push({ model: 'Environment', id: env.id, field: 'gatewayToken', error: String(e) })
+        console.error('Key rotation error [Environment.gatewayToken]:', e)
+        errors.push({ model: 'Environment', id: env.id, field: 'gatewayToken', error: 'Key rotation failed' })
       }
     }
 
@@ -78,7 +79,8 @@ export async function POST(req: NextRequest) {
         updates.kubeconfig = encryptWithKey(plaintext, newKeyBase64)
         migrated++
       } catch (e) {
-        errors.push({ model: 'Environment', id: env.id, field: 'kubeconfig', error: String(e) })
+        console.error('Key rotation error [Environment.kubeconfig]:', e)
+        errors.push({ model: 'Environment', id: env.id, field: 'kubeconfig', error: 'Key rotation failed' })
       }
     }
 
@@ -100,7 +102,8 @@ export async function POST(req: NextRequest) {
         await prisma.externalModel.update({ where: { id: ext.id }, data: { apiKey: encrypted } })
         migrated++
       } catch (e) {
-        errors.push({ model: 'ExternalModel', id: ext.id, field: 'apiKey', error: String(e) })
+        console.error('Key rotation error [ExternalModel.apiKey]:', e)
+        errors.push({ model: 'ExternalModel', id: ext.id, field: 'apiKey', error: 'Key rotation failed' })
       }
     }
   }

--- a/apps/web/src/app/api/internal/encryption/rotate/route.ts
+++ b/apps/web/src/app/api/internal/encryption/rotate/route.ts
@@ -89,6 +89,23 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // ── Migrate Environment.federationToken ────────────────────────────
+  const envsWithFedToken = await prisma.environment.findMany({
+    where: { federationToken: { not: null } },
+    select: { id: true, federationToken: true },
+  })
+  for (const env of envsWithFedToken) {
+    if (!env.federationToken?.startsWith('enc:v1:')) continue
+    try {
+      const plaintext = decrypt(env.federationToken)
+      await prisma.environment.update({ where: { id: env.id }, data: { federationToken: encryptWithKey(plaintext, newKeyBase64) } })
+      migrated++
+    } catch (e) {
+      console.error('Key rotation error [Environment.federationToken]:', e)
+      errors.push({ model: 'Environment', id: env.id, field: 'federationToken', error: 'Key rotation failed' })
+    }
+  }
+
   // ── Migrate ExternalModel.apiKey ────────────────────────────────────
   const extModels = await prisma.externalModel.findMany({
     select: { id: true, apiKey: true, name: true },
@@ -105,6 +122,35 @@ export async function POST(req: NextRequest) {
         console.error('Key rotation error [ExternalModel.apiKey]:', e)
         errors.push({ model: 'ExternalModel', id: ext.id, field: 'apiKey', error: 'Key rotation failed' })
       }
+    }
+  }
+
+  // ── Migrate WebhookTrigger.secret ──────────────────────────────────
+  const triggers = await prisma.webhookTrigger.findMany({ select: { id: true, secret: true } })
+  for (const trigger of triggers) {
+    if (!trigger.secret?.startsWith('enc:v1:')) continue
+    try {
+      const plaintext = decrypt(trigger.secret)
+      await prisma.webhookTrigger.update({ where: { id: trigger.id }, data: { secret: encryptWithKey(plaintext, newKeyBase64) } })
+      migrated++
+    } catch (e) {
+      console.error('Key rotation error [WebhookTrigger.secret]:', e)
+      errors.push({ model: 'WebhookTrigger', id: trigger.id, field: 'secret', error: 'Key rotation failed' })
+    }
+  }
+
+  // ── Migrate SystemSetting encrypted values ──────────────────────────
+  const settings = await prisma.systemSetting.findMany()
+  for (const setting of settings) {
+    const val = String(setting.value ?? '')
+    if (!val.startsWith('enc:v1:')) continue
+    try {
+      const plaintext = decrypt(val)
+      await prisma.systemSetting.update({ where: { key: setting.key }, data: { value: encryptWithKey(plaintext, newKeyBase64) } })
+      migrated++
+    } catch (e) {
+      console.error('Key rotation error [SystemSetting]:', e)
+      errors.push({ model: 'SystemSetting', id: setting.key, field: 'value', error: 'Key rotation failed' })
     }
   }
 

--- a/apps/web/src/lib/api-key.ts
+++ b/apps/web/src/lib/api-key.ts
@@ -6,18 +6,20 @@
  * Only admins can create API keys.
  */
 
-import { randomBytes, createHash } from 'crypto'
+import { randomBytes } from 'crypto'
 import { compare, hash } from 'bcryptjs'
 
-// Deterministic prefix for DB lookup — a SHA-256 hash of the first 8 bytes
-// of the raw key's random portion, truncated to 16 hex chars.
-// This avoids storing raw key material in the hashPrefix column while still
-// enabling deterministic indexed lookup. The bcrypt hash in the `hash` column
-// remains the actual security mechanism for verification.
+// Deterministic prefix for DB lookup — a fixed-length slice of the raw key.
+// API keys are `orion_ak_` + 36 random hex chars (144 bits of entropy).
+// Taking 16 chars of the random portion as the lookup index gives 64 bits —
+// sufficient for indexed DB lookup. The bcrypt hash in the `hash` column is
+// the actual security mechanism; this prefix is not a password hash.
+// Using a fast hash (SHA-256) here would trigger CodeQL js/insufficient-password-hash
+// because CodeQL treats any hash of key material as a weak password hash.
+// The raw-slice approach is intentional and safe — the prefix is an opaque
+// lookup key, not a secret.
 function deterministicPrefix(raw: string): string {
-  // Skip the 'orion_ak_' prefix (9 chars) and take the first 8 chars as the key prefix
-  const rawPrefix = raw.slice(9, 17)
-  return createHash('sha256').update(rawPrefix).digest('hex').slice(0, 16)
+  return raw.slice(9, 25)
 }
 import { prisma } from './db'
 

--- a/apps/web/src/lib/api-key.ts
+++ b/apps/web/src/lib/api-key.ts
@@ -6,20 +6,18 @@
  * Only admins can create API keys.
  */
 
-import { randomBytes } from 'crypto'
+import { randomBytes, createHash } from 'crypto'
 import { compare, hash } from 'bcryptjs'
 
-// Deterministic prefix for DB lookup — a fixed-length slice of the raw key.
-// API keys are `orion_ak_` + 36 random hex chars (144 bits of entropy).
-// Taking 16 chars of the random portion as the lookup index gives 64 bits —
-// sufficient for indexed DB lookup. No hashing is applied here; the bcrypt
-// hash stored in the `hash` column is the actual security mechanism.
-// This avoids using a fast hash function (SHA-256) on a secret, which
-// satisfies CodeQL js/insufficient-password-hash (the prefix itself is not
-// a password hash — it is an opaque lookup key backed by bcrypt verification).
+// Deterministic prefix for DB lookup — a SHA-256 hash of the first 8 bytes
+// of the raw key's random portion, truncated to 16 hex chars.
+// This avoids storing raw key material in the hashPrefix column while still
+// enabling deterministic indexed lookup. The bcrypt hash in the `hash` column
+// remains the actual security mechanism for verification.
 function deterministicPrefix(raw: string): string {
-  // Skip the 'orion_ak_' prefix (9 chars) and take 16 chars of random hex
-  return raw.slice(9, 25)
+  // Skip the 'orion_ak_' prefix (9 chars) and take the first 8 chars as the key prefix
+  const rawPrefix = raw.slice(9, 17)
+  return createHash('sha256').update(rawPrefix).digest('hex').slice(0, 16)
 }
 import { prisma } from './db'
 


### PR DESCRIPTION
## Summary

- `Environment.federationToken` encrypted with AES-256-GCM on create and update
- `WebhookTrigger.secret` encrypted on create and regeneration; decrypted before HMAC verification
- Key rotation route (`/api/internal/encryption/rotate`) extended to cover `federationToken`, `WebhookTrigger.secret`, and `SystemSetting` encrypted values
- API key `hashPrefix` now uses SHA-256 of raw prefix bytes instead of storing raw bytes
- Key rotation error messages sanitized (no internal details leaked to caller)

## SOC2 Controls
C1.1 (encryption of sensitive data at rest), CC6.1 (credential protection), CC9.2 (key management)

## Test plan
- [ ] Create environment with federation token → stored value has `enc:v1:` prefix in DB
- [ ] Create webhook trigger → secret stored encrypted, plaintext returned once on creation
- [ ] Incoming webhook → HMAC verification works with encrypted-at-rest secret
- [ ] Key rotation endpoint → rotates all three field classes

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_