### PR TITLE
SOC2 #616: Infrastructure secrets — MinIO/Redis credentials, startup validation, HTTPS enforcement

### DIFF
--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -39,5 +39,23 @@ export async function register() {
         'SSO_ALLOW_UNSIGNED_SSO before going to production.'
       )
     }
+
+    // SOC2 CC5: validate critical security environment variables at startup
+    const REQUIRED_SECURITY_VARS = ['NEXTAUTH_SECRET', 'ORION_ENCRYPTION_KEY']
+    const WARN_IF_DEFAULT: Array<[string, string]> = [
+      ['MINIO_ROOT_PASSWORD', 'change-me'],
+      ['REDIS_PASSWORD', 'change-me'],
+      ['POSTGRES_PASSWORD', 'change-me'],
+    ]
+    for (const v of REQUIRED_SECURITY_VARS) {
+      if (!process.env[v]) {
+        console.error(`[SOC2][startup] MISSING REQUIRED ENV VAR: ${v} — server security may be compromised`)
+      }
+    }
+    for (const [v, def] of WARN_IF_DEFAULT) {
+      if (!process.env[v] || process.env[v] === def) {
+        console.warn(`[SOC2][startup] SECURITY WARNING: ${v} is unset or using placeholder value`)
+      }
+    }
   }
 }

--- a/apps/web/src/lib/federation.ts
+++ b/apps/web/src/lib/federation.ts
@@ -152,6 +152,12 @@ export async function dispatchToSpoke(
   })
   const targetEnvId = spokeEnv?.id ?? 'unknown'
 
+  if (process.env.NODE_ENV === 'production') {
+    if (spokeUrl.startsWith('http://')) {
+      throw new Error(`Federation URL must use HTTPS in production: ${spokeUrl}`)
+    }
+  }
+
   try {
     const res = await fetch(`${spokeUrl}/api/federation/tasks`, {
       method: 'POST',

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -111,7 +111,10 @@ UPSTASH_REDIS_URL=
 REDIS_SENTINEL_MASTER=
 REDIS_SENTINEL_NODES=
 REDIS_SENTINEL_PASSWORD=
-REDIS_PASSWORD=
+REDIS_PASSWORD=change-me-redis-password
+
+MINIO_ROOT_USER=change-me-minio-user
+MINIO_ROOT_PASSWORD=change-me-minio-password-min-16-chars
 
 # ── Audit Log Archival (S3 Export) — SOC2 [L-001] ────────────────────────────────
 # Multi-backend S3 storage: supports AWS S3, MinIO, DigitalOcean Spaces, Wasabi, custom

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -152,6 +152,27 @@ if grep -q "^NEXTAUTH_SECRET=change-me" "$DEPLOY_DIR/.env"; then
   echo "Generated NEXTAUTH_SECRET."
 fi
 
+# ── Auto-generate MinIO credentials if missing ────────────────────────────────
+if ! grep -q "^MINIO_ROOT_USER=" "$DEPLOY_DIR/.env" || grep -q "^MINIO_ROOT_USER=change-me" "$DEPLOY_DIR/.env" || grep -q "^MINIO_ROOT_USER=$" "$DEPLOY_DIR/.env"; then
+  sed -i '/^MINIO_ROOT_USER=/d' "$DEPLOY_DIR/.env"
+  echo "MINIO_ROOT_USER=orion-minio-$(openssl rand -hex 8)" >> "$DEPLOY_DIR/.env"
+  echo "Generated MINIO_ROOT_USER."
+fi
+if ! grep -q "^MINIO_ROOT_PASSWORD=" "$DEPLOY_DIR/.env" || grep -q "^MINIO_ROOT_PASSWORD=change-me" "$DEPLOY_DIR/.env" || grep -q "^MINIO_ROOT_PASSWORD=$" "$DEPLOY_DIR/.env"; then
+  MINIO_PASS=$(openssl rand -hex 24)
+  sed -i '/^MINIO_ROOT_PASSWORD=/d' "$DEPLOY_DIR/.env"
+  echo "MINIO_ROOT_PASSWORD=${MINIO_PASS}" >> "$DEPLOY_DIR/.env"
+  echo "Generated MINIO_ROOT_PASSWORD."
+fi
+
+# ── Auto-generate Redis password if missing ───────────────────────────────────
+if ! grep -q "^REDIS_PASSWORD=" "$DEPLOY_DIR/.env" || grep -q "^REDIS_PASSWORD=change-me" "$DEPLOY_DIR/.env" || grep -q "^REDIS_PASSWORD=$" "$DEPLOY_DIR/.env"; then
+  REDIS_PASS=$(openssl rand -hex 32)
+  sed -i '/^REDIS_PASSWORD=/d' "$DEPLOY_DIR/.env"
+  echo "REDIS_PASSWORD=${REDIS_PASS}" >> "$DEPLOY_DIR/.env"
+  echo "Generated REDIS_PASSWORD."
+fi
+
 # ── Auto-generate bundled Gitea admin credentials ─────────────────────────────
 if [[ "${GIT_PROVIDER:-gitea-bundled}" == "gitea-bundled" ]]; then
   if ! grep -q "^GITEA_ADMIN_USER=" "$DEPLOY_DIR/.env" || \
@@ -374,6 +395,13 @@ chown -R 1000:1000 "$DEPLOY_DIR/vector-data" 2>/dev/null || true
 
 echo "Starting Vector host telemetry shipper..."
 $COMPOSE up -d --force-recreate vector 2>/dev/null || echo "NOTE: Vector service failed to start (check compose logs)."
+
+# Warn about unpinned image tags (SOC2 LOW finding)
+if grep -qE ":(latest|[^@\"']+)\"" "$DEPLOY_DIR/docker-compose.yml" 2>/dev/null; then
+  echo ""
+  echo "NOTE [SOC2-LOW]: Some services use mutable image tags. For production,"
+  echo "  pin images to specific digests (e.g. image@sha256:...) in docker-compose.yml."
+fi
 
 if [[ -n "${SETUP_TOKEN:-}" ]]; then
   # In CI environments, write the setup token to a file rather than stdout

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -397,8 +397,8 @@ services:
     image: minio/minio:latest
     restart: unless-stopped
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-}
     command: server /data --console-address ":9001"
     volumes:
       - minio-data:/data
@@ -439,11 +439,11 @@ services:
   redis-master:
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --appendonly yes --dir /data
+    command: redis-server --appendonly yes --dir /data --requirepass ${REDIS_PASSWORD:-}
     volumes:
       - redis-master-data:/data
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary

- `docker-compose.yml`: removed hardcoded `minioadmin` defaults; MinIO and Redis now require credentials from env vars; Redis port bound to `127.0.0.1`
- `deploy/.env.example`: added `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `REDIS_PASSWORD` with `change-me-*` placeholders
- `deploy/bootstrap.sh`: auto-generates MinIO user, MinIO password (48-char hex), and Redis password (64-char hex) if missing/placeholder; adds image digest pinning notice
- `apps/web/src/instrumentation.ts`: startup validation errors for missing `NEXTAUTH_SECRET`/`ORION_ENCRYPTION_KEY`; warnings for default `change-me` infrastructure passwords
- `apps/web/src/lib/federation.ts`: HTTPS enforcement in `dispatchToSpoke` — throws in production if spoke URL uses `http://`

## SOC2 Controls
CC6.1 (credential hygiene), A1.2 (infrastructure hardening), CC5.2 (configuration management), C1.2 (data in transit)

## Test plan
- [ ] `bootstrap.sh` generates unique MinIO and Redis credentials on first run
- [ ] Starting app with missing `ORION_ENCRYPTION_KEY` logs startup error
- [ ] Federation dispatch to `http://` URL throws in production
- [ ] Redis requires password auth after compose up

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_