### PR TITLE
SOC2 #617: Audit logging — gateway joins, gatewayUrl changes, setup wizard, CI health check exit code

### DIFF
--- a/apps/web/src/app/api/environments/[id]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/route.ts
@@ -51,7 +51,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     const body = await req.json()
     const env = await prisma.environment.findUnique({
       where: { id: params.id },
-      select: { gatewayToken: true },
+      select: { gatewayToken: true, gatewayUrl: true },
     })
     if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
     if (!env.gatewayToken || auth !== `Bearer ${env.gatewayToken}`) {
@@ -73,6 +73,16 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
         gitOpsPRs: { orderBy: { createdAt: 'desc' }, take: 50 },
       },
     })
+
+    if (body.gatewayUrl !== undefined && body.gatewayUrl !== env.gatewayUrl) {
+      void logAudit({
+        userId: 'gateway',
+        action: 'environment_update',
+        target: `environment:${params.id}`,
+        detail: { field: 'gatewayUrl', changed: true },
+      })
+    }
+
     return NextResponse.json({
       ...updated,
       gatewayToken: updated.gatewayToken ? '••••' : null,
@@ -86,6 +96,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     const { data } = result
 
     const admin = await requireAdmin()
+    const existing = await prisma.environment.findUnique({ where: { id: params.id }, select: { gatewayUrl: true } })
     const updateData: Record<string, unknown> = {}
     if (data.name !== undefined) updateData.name = data.name.trim()
     if (data.type !== undefined) updateData.type = data.type
@@ -124,6 +135,15 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       ipAddress: getClientIp(req),
       userAgent: getUserAgent(req.headers),
     }).catch(() => {})
+
+    if (data.gatewayUrl !== undefined && data.gatewayUrl !== existing?.gatewayUrl) {
+      void logAudit({
+        userId: admin.id,
+        action: 'environment_update',
+        target: `environment:${params.id}`,
+        detail: { field: 'gatewayUrl', changed: true },
+      })
+    }
 
     return NextResponse.json({
       ...env,

--- a/apps/web/src/app/api/environments/join/route.ts
+++ b/apps/web/src/app/api/environments/join/route.ts
@@ -14,6 +14,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/db'
 import { randomBytes, createHash } from 'crypto'
+import { logAudit } from '@/lib/audit'
 
 function hashFingerprint(machineId: string): string {
   return createHash('sha256').update(machineId).digest('hex')
@@ -85,6 +86,12 @@ export async function POST(req: NextRequest) {
       where: { id: env.id },
       data: { status: 'connected', lastSeen: new Date(), gatewayUrl: gatewayUrl ?? env.gatewayUrl },
     })
+    void logAudit({
+      userId: 'system',
+      action: 'environment_update',
+      target: `environment:${env.id}`,
+      detail: { event: 'gateway_joined', environmentId: env.id, gatewayType: body.gatewayType ?? 'unknown' },
+    })
     return NextResponse.json({ environmentId: env.id, apiToken: env.gatewayToken, environmentName: env.name })
   }
 
@@ -110,6 +117,13 @@ export async function POST(req: NextRequest) {
   ])
 
   console.log(`[join] Gateway registered for environment "${env.name}" (${env.id})${fingerprint ? ' with fingerprint' : ' (no fingerprint)'}`)
+
+  void logAudit({
+    userId: 'system',
+    action: 'environment_update',
+    target: `environment:${env.id}`,
+    detail: { event: 'gateway_joined', environmentId: env.id, gatewayType: body.gatewayType ?? 'unknown' },
+  })
 
   return NextResponse.json({
     environmentId: env.id,

--- a/apps/web/src/app/api/setup/admin/route.ts
+++ b/apps/web/src/app/api/setup/admin/route.ts
@@ -3,6 +3,7 @@ import { hash } from 'bcryptjs'
 import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
 import { parseBodyOrError, SetupAdminSchema } from '@/lib/validate'
+import { logAudit } from '@/lib/audit'
 
 export async function POST(req: NextRequest) {
   if (!await requireWizardSession(req)) {
@@ -30,7 +31,7 @@ export async function POST(req: NextRequest) {
 
   const passwordHash = await hash(password, 14)
 
-  await prisma.user.create({
+  const createdUser = await prisma.user.create({
     data: {
       username,
       email: `${username}@local`,
@@ -39,6 +40,13 @@ export async function POST(req: NextRequest) {
       provider: 'local',
       active: true,
     },
+  })
+
+  void logAudit({
+    userId: createdUser.id,
+    action: 'user_create',
+    target: createdUser.id,
+    detail: { source: 'setup_wizard', role: 'admin' },
   })
 
   return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/setup/ai-provider/route.ts
+++ b/apps/web/src/app/api/setup/ai-provider/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { requireWizardSession } from '@/lib/setup-guard'
 import { parseBodyOrError, SetupAiProviderSchema } from '@/lib/validate'
 import { z } from 'zod'
+import { logAudit } from '@/lib/audit'
 
 const SetupAiProviderWithSkipSchema = SetupAiProviderSchema.or(z.object({ skip: z.literal(true) }))
 
@@ -62,6 +63,13 @@ export async function POST(req: NextRequest) {
     where:  { key: 'model.default' },
     update: { value: `ext:${created.id}` },
     create: { key: 'model.default', value: `ext:${created.id}` },
+  })
+
+  void logAudit({
+    userId: 'system',
+    action: 'admin_action',
+    target: `external_model:${created.id}`,
+    detail: { source: 'setup_wizard', provider: data.provider, modelId: data.modelId },
   })
 
   return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/setup/git-provider/route.ts
+++ b/apps/web/src/app/api/setup/git-provider/route.ts
@@ -26,6 +26,7 @@ import { GiteaGitProvider } from '@/lib/git-provider/gitea-provider'
 import { encryptJson } from '@/lib/encryption'
 import { randomBytes } from 'crypto'
 import { seedSystemNebula } from '@/lib/seed-system-nebula'
+import { logAudit } from '@/lib/audit'
 
 function isPrivateHost(hostname: string): boolean {
   if (hostname === 'localhost') return true
@@ -154,6 +155,13 @@ export async function POST(req: NextRequest) {
 
   // Seed system Nebula in background (don't block the response)
   seedSystemNebula().catch(err => console.error('[Nebula] System nebula seed failed:', err))
+
+  void logAudit({
+    userId: 'system',
+    action: 'admin_action',
+    target: 'git_provider_config',
+    detail: { source: 'setup_wizard', providerType: type, org },
+  })
 
   return NextResponse.json({ ok: true })
 }

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -38,12 +38,14 @@ docker compose up -d --remove-orphans || {
 
 echo "Waiting for ORION to become healthy..."
 for i in $(seq 1 30); do
-  if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+  if curl -sf --max-time 10 http://localhost:3000/api/health > /dev/null 2>&1; then
     echo "ORION is healthy!"
     exit 0
   fi
   sleep 2
 done
 
-echo "WARNING: ORION health check timed out (may still be starting)"
-exit 0
+if ! curl -sf --max-time 10 http://localhost:3000/api/health 2>/dev/null; then
+  echo "ERROR: ORION health check failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `environments/join/route.ts`: emits `environment_update / gateway_joined` audit event on both first-join and idempotent re-join paths
- `environments/[id]/route.ts`: detects `gatewayUrl` changes and emits targeted audit event (both gateway Bearer path and admin UI path)
- `setup/admin/route.ts`: emits `user_create` audit event after admin user creation during setup wizard
- `setup/git-provider/route.ts`: emits `admin_action` audit event with provider type and org
- `setup/ai-provider/route.ts`: emits `admin_action` audit event with provider and model ID
- `deploy/deploy.sh`: health check now exits `1` on timeout instead of silently succeeding; added `--max-time 10` to curl

## SOC2 Controls
CC4.1 (audit trail completeness), CC7.2 (change detection), CC5.2 (configuration change logging), A1.3 (deployment reliability)

## Test plan
- [ ] Gateway join → audit log shows `gateway_joined` event
- [ ] Update environment's `gatewayUrl` → audit log shows `gatewayUrl changed`
- [ ] Run setup wizard → `user_create` and `admin_action` entries in audit log
- [ ] Deploy with unhealthy app → `deploy.sh` exits non-zero and CI fails

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_