### PR TITLE
SOC2 #619: Backup and restore scripts for PostgreSQL, Vault, and MinIO

### DIFF
--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DEPLOY_DIR/.env" 2>/dev/null || true
+GIT_PROVIDER="${GIT_PROVIDER:-gitea-bundled}"
+PROFILE_FLAGS=""
+if [[ "$GIT_PROVIDER" == "gitea-bundled" ]]; then
+  PROFILE_FLAGS="--profile gitea"
+fi
+COMPOSE="docker compose -f $DEPLOY_DIR/docker-compose.yml --env-file $DEPLOY_DIR/.env $PROFILE_FLAGS"
+
+BACKUP_DIR="${BACKUP_DIR:-$DEPLOY_DIR/backups}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+mkdir -p "$BACKUP_DIR"
+
+echo "ORION Backup — $TIMESTAMP"
+echo "================================"
+
+# 1. PostgreSQL
+echo "Backing up PostgreSQL..."
+$COMPOSE exec -T postgres pg_dump \
+  -U "${POSTGRES_USER:-orion}" \
+  "${POSTGRES_DB:-orion}" \
+  | gzip > "$BACKUP_DIR/postgres_${TIMESTAMP}.sql.gz"
+echo "  ✓ PostgreSQL: $BACKUP_DIR/postgres_${TIMESTAMP}.sql.gz"
+
+# 2. Vault raft snapshot (if unsealed)
+echo "Backing up Vault..."
+if [[ -n "${VAULT_TOKEN:-}" ]]; then
+  $COMPOSE exec -T vault sh -c "vault operator raft snapshot save /tmp/vault-snap.snap" 2>/dev/null && \
+  $COMPOSE cp vault:/tmp/vault-snap.snap "$BACKUP_DIR/vault_${TIMESTAMP}.snap" 2>/dev/null && \
+  echo "  ✓ Vault: $BACKUP_DIR/vault_${TIMESTAMP}.snap" || \
+  echo "  NOTE: Vault snapshot skipped (not unsealed or not using raft storage)"
+else
+  echo "  NOTE: Vault backup skipped — VAULT_TOKEN not set"
+fi
+
+# 3. MinIO (requires mc client)
+echo "Backing up MinIO..."
+if command -v mc &>/dev/null; then
+  mc alias set orion-bkp "http://localhost:${MINIO_PORT:-9000}" \
+    "${MINIO_ROOT_USER:-}" "${MINIO_ROOT_PASSWORD:-}" --insecure 2>/dev/null && \
+  mc mirror --overwrite orion-bkp/ "$BACKUP_DIR/minio_${TIMESTAMP}/" 2>/dev/null && \
+  echo "  ✓ MinIO: $BACKUP_DIR/minio_${TIMESTAMP}/" || \
+  echo "  NOTE: MinIO mirror failed — check mc configuration"
+else
+  echo "  NOTE: MinIO backup skipped — install mc: https://min.io/docs/minio/linux/reference/minio-mc.html"
+fi
+
+# 4. Prune backups older than 30 days
+find "$BACKUP_DIR" -name "postgres_*.sql.gz" -mtime +30 -delete 2>/dev/null || true
+find "$BACKUP_DIR" -name "vault_*.snap" -mtime +30 -delete 2>/dev/null || true
+
+echo ""
+echo "Backup complete — files in: $BACKUP_DIR"
+echo "RPO target: run daily via cron:"
+echo "  0 2 * * * $DEPLOY_DIR/backup.sh >> /var/log/orion-backup.log 2>&1"

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -396,3 +396,8 @@ else
   echo "Stack started. Visit http://$(hostname -I | awk '{print $1}'):3000 to complete setup."
   echo "(If setup is already done, your ORION is ready to use.)"
 fi
+
+echo ""
+echo "IMPORTANT [SOC2]: No automated backup is configured."
+echo "  Schedule backups: crontab -e"
+echo "  Add: 0 2 * * * $DEPLOY_DIR/backup.sh >> /var/log/orion-backup.log 2>&1"

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DEPLOY_DIR/.env" 2>/dev/null || true
+GIT_PROVIDER="${GIT_PROVIDER:-gitea-bundled}"
+PROFILE_FLAGS=""
+if [[ "$GIT_PROVIDER" == "gitea-bundled" ]]; then
+  PROFILE_FLAGS="--profile gitea"
+fi
+COMPOSE="docker compose -f $DEPLOY_DIR/docker-compose.yml --env-file $DEPLOY_DIR/.env $PROFILE_FLAGS"
+
+BACKUP_DIR="${BACKUP_DIR:-$DEPLOY_DIR/backups}"
+
+usage() {
+  echo "Usage: restore.sh <timestamp>"
+  echo "       restore.sh --list"
+  echo ""
+  echo "  <timestamp>   Backup timestamp to restore (e.g. 20250612_020000)"
+  echo "  --list        List available backups"
+  exit 1
+}
+
+if [[ "${1:-}" == "--list" ]]; then
+  echo "Available backups in $BACKUP_DIR:"
+  ls "$BACKUP_DIR"/postgres_*.sql.gz 2>/dev/null | sed 's/.*postgres_//;s/\.sql\.gz//' || echo "  (none)"
+  exit 0
+fi
+
+TIMESTAMP="${1:-}"
+[[ -z "$TIMESTAMP" ]] && usage
+
+POSTGRES_BACKUP="$BACKUP_DIR/postgres_${TIMESTAMP}.sql.gz"
+VAULT_BACKUP="$BACKUP_DIR/vault_${TIMESTAMP}.snap"
+
+if [[ ! -f "$POSTGRES_BACKUP" ]]; then
+  echo "ERROR: PostgreSQL backup not found: $POSTGRES_BACKUP" >&2
+  exit 1
+fi
+
+echo "ORION Restore — $TIMESTAMP"
+echo "================================"
+echo "WARNING: This will overwrite the current database."
+read -r -p "Are you sure? Type 'yes' to continue: " confirm
+[[ "$confirm" != "yes" ]] && echo "Aborted." && exit 1
+
+# Restore PostgreSQL
+echo "Restoring PostgreSQL..."
+$COMPOSE exec -T postgres psql -U "${POSTGRES_USER:-orion}" -c "DROP DATABASE IF EXISTS ${POSTGRES_DB:-orion};" postgres
+$COMPOSE exec -T postgres psql -U "${POSTGRES_USER:-orion}" -c "CREATE DATABASE ${POSTGRES_DB:-orion};" postgres
+zcat "$POSTGRES_BACKUP" | $COMPOSE exec -T postgres psql -U "${POSTGRES_USER:-orion}" "${POSTGRES_DB:-orion}"
+echo "  ✓ PostgreSQL restored"
+
+# Restore Vault snapshot
+if [[ -f "$VAULT_BACKUP" ]]; then
+  echo "Restoring Vault snapshot..."
+  $COMPOSE cp "$VAULT_BACKUP" vault:/tmp/vault-restore.snap
+  $COMPOSE exec -T vault vault operator raft snapshot restore -force /tmp/vault-restore.snap 2>/dev/null && \
+  echo "  ✓ Vault restored" || \
+  echo "  NOTE: Vault restore skipped — restore manually if needed"
+else
+  echo "  NOTE: No Vault backup found for this timestamp — skipping"
+fi
+
+echo ""
+echo "Restore complete. Restart ORION: $DEPLOY_DIR/bootstrap.sh"


### PR DESCRIPTION
## Summary

- `deploy/backup.sh`: pg_dump + gzip for PostgreSQL, Vault raft snapshot (if `VAULT_TOKEN` set), MinIO mirror via `mc`. Prunes backups older than 30 days.
- `deploy/restore.sh`: `--list` shows available timestamps; prompts for confirmation; restores PostgreSQL (drop/create/restore) and Vault snapshot if present.
- `deploy/bootstrap.sh`: SOC2 cron notice added at the end reminding operators to schedule `backup.sh` at 02:00 daily.

## SOC2 Controls
A1.2 (recovery point objective), CC9.1 (backup procedures), A1.3 (recovery time objective)

## Test plan
- [ ] Run `backup.sh` → creates timestamped backup directory with postgres dump
- [ ] Run `restore.sh --list` → shows available backups
- [ ] Run `restore.sh <timestamp>` → restores DB from backup after confirmation

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_