### PR TITLE
SOC2 #621: Per-environment gateway token scoping + encrypt federation/webhook secrets

### DIFF
--- a/apps/web/src/app/api/environments/[id]/drift/[reportId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/drift/[reportId]/route.ts
@@ -2,14 +2,15 @@
  * GET /api/environments/:id/drift/:reportId — full report with all findings
  */
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string; reportId: string } },
 ) {
-  await requireServiceAuth(req).catch(() => {
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 

--- a/apps/web/src/app/api/environments/[id]/drift/route.ts
+++ b/apps/web/src/app/api/environments/[id]/drift/route.ts
@@ -3,7 +3,7 @@
  * POST /api/environments/:id/drift      — manually trigger a drift scan
  */
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { detectGitOpsDriftForEnv } from '@/jobs/gitops-drift'
 
@@ -11,7 +11,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  await requireServiceAuth(req).catch(() => {
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 
@@ -40,7 +41,8 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  await requireServiceAuth(req).catch(() => {
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 

--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { parseBodyOrError } from '@/lib/validate'
 export const dynamic = 'force-dynamic'
 
@@ -13,8 +13,9 @@ const RunEvalSchema = z.object({
 // POST /api/environments/[id]/evals/run
 // Auto-eval trigger — evaluates a conversation or task after completion.
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const { id } = params
   try {
-    await requireServiceAuth(req)
+    await requireGatewayAuthForEnvironment(req, id)
   } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const logs = await prisma.hookExecutionLog.findMany({
     where: { nebula: { environmentId: params.id, name: params.name } },
@@ -30,7 +31,8 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const body = await req.json()
   const entry = await prisma.nebulaInstance.findFirst({

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server"
 import { NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
@@ -13,7 +13,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string; name: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const logs = await prisma.skillExecutionLog.findMany({
     where: { nebula: { environmentId: params.id, name: params.name } },

--- a/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const entries = await prisma.nebulaInstance.findMany({
     where: { environmentId: params.id, isInstalled: true },

--- a/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const defaults = await prisma.novaDefinition.findMany({
     orderBy: { name: 'asc' },

--- a/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const entries = await prisma.nebulaInstance.findMany({
     where: { environmentId: params.id, isInstalled: true },

--- a/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
 /** POST /api/environments/[id]/nebula/hook/report — Report hook execution result */
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const body = await req.json()
   const { nebulaId, triggerEvent, triggerData, actionType, status, output, startedAt, durationMs } = body

--- a/apps/web/src/app/api/environments/[id]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/route.ts
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, CreateEnvironmentSchema } from '@/lib/validate'
+import { encrypt, decrypt } from '@/lib/encryption'
+import { timingSafeEqual } from 'crypto'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   // BLOCKER fix: GET had no auth — any request with an arbitrary Bearer header
@@ -21,7 +23,15 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   if (auth?.startsWith('Bearer ')) {
     const token = auth.slice(7)
     const envCheck = await prisma.environment.findUnique({ where: { id: params.id }, select: { gatewayToken: true } })
-    if (!envCheck?.gatewayToken || token !== envCheck.gatewayToken) {
+    if (!envCheck?.gatewayToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    try {
+      const storedToken = decrypt(envCheck.gatewayToken)
+      if (storedToken.length !== token.length || !timingSafeEqual(Buffer.from(storedToken), Buffer.from(token))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+    } catch {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
   }
@@ -54,7 +64,17 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       select: { gatewayToken: true },
     })
     if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-    if (!env.gatewayToken || auth !== `Bearer ${env.gatewayToken}`) {
+    if (!env.gatewayToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    try {
+      const storedGatewayToken = decrypt(env.gatewayToken)
+      const bearerToken = auth.slice(7)
+      if (storedGatewayToken.length !== bearerToken.length ||
+          !timingSafeEqual(Buffer.from(storedGatewayToken), Buffer.from(bearerToken))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      }
+    } catch {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     // Gateways may only update heartbeat fields — not name, kubeconfig, policy, etc.
@@ -101,7 +121,12 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       updateData.kubeconfig = data.kubeconfig || null
     }
     if (data.federationRole  !== undefined) updateData.federationRole  = data.federationRole  === 'standalone' ? null : (data.federationRole ?? null)
-    if (data.federationToken !== undefined) updateData.federationToken = data.federationToken ?? null
+    if (data.federationToken !== undefined) {
+      const rawFedToken = data.federationToken ?? null
+      updateData.federationToken = rawFedToken && process.env.ORION_ENCRYPTION_KEY
+        ? encrypt(rawFedToken)
+        : rawFedToken
+    }
     if (data.spokeUrl        !== undefined) updateData.spokeUrl        = data.spokeUrl        ?? null
     if (data.hubUrl          !== undefined) updateData.hubUrl          = data.hubUrl          ?? null
 

--- a/apps/web/src/app/api/environments/[id]/sync-status/route.ts
+++ b/apps/web/src/app/api/environments/[id]/sync-status/route.ts
@@ -8,7 +8,7 @@
  * Auth: Bearer gatewayToken (same token used for heartbeats).
  */
 import { NextRequest, NextResponse } from 'next/server'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireGatewayAuthForEnvironment } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
 interface ArgoCDApp {
@@ -26,17 +26,15 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
-
-  // Verify gateway token
-  const auth = req.headers.get('authorization')
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
-  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-
-  const expectedToken = env.gatewayToken
-  if (expectedToken && auth !== `Bearer ${expectedToken}`) {
+  const { id } = params
+  try {
+    await requireGatewayAuthForEnvironment(req, id)
+  } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const { applications } = (await req.json()) as { applications: ArgoCDApp[] }
   if (!Array.isArray(applications)) {
@@ -102,7 +100,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
-  await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
+  const { id } = params
+  await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const env = await prisma.environment.findUnique({ where: { id: params.id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -6,6 +6,7 @@ import { seedNovaDefinitions } from '@/lib/default-novas'
 import { getCurrentUser, requireAdmin } from '@/lib/auth'
 import { CreateEnvironmentSchema } from '@/lib/validate'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
+import { encrypt } from '@/lib/encryption'
 
 export async function GET() {
   // SOC2: CR-002 — require authentication to list environments
@@ -40,18 +41,23 @@ export async function POST(req: NextRequest) {
     )
   }
 
+  const federationTokenToStore = parsed.data.federationToken && process.env.ORION_ENCRYPTION_KEY
+    ? encrypt(parsed.data.federationToken)
+    : (parsed.data.federationToken ?? null)
+
   const env = await prisma.environment.create({
     data: {
-      name:         parsed.data.name,
-      type:         parsed.data.type,
-      description:  parsed.data.description ?? null,
-      gatewayUrl:   parsed.data.gatewayUrl ?? null,
-      gatewayToken: parsed.data.gatewayToken ?? null,
-      gitOwner:     parsed.data.gitOwner ?? null,
-      gitRepo:      parsed.data.gitRepo ?? null,
-      policyConfig: (parsed.data.policyConfig ?? undefined) as any,
-      kubeconfig:   parsed.data.kubeconfig ?? null,
-      metadata:     (parsed.data.metadata ?? undefined) as any,
+      name:           parsed.data.name,
+      type:           parsed.data.type,
+      description:    parsed.data.description ?? null,
+      gatewayUrl:     parsed.data.gatewayUrl ?? null,
+      gatewayToken:   parsed.data.gatewayToken ?? null,
+      gitOwner:       parsed.data.gitOwner ?? null,
+      gitRepo:        parsed.data.gitRepo ?? null,
+      policyConfig:   (parsed.data.policyConfig ?? undefined) as any,
+      kubeconfig:     parsed.data.kubeconfig ?? null,
+      metadata:       (parsed.data.metadata ?? undefined) as any,
+      federationToken: federationTokenToStore,
     },
     include: { tools: true, agents: { include: { agent: true } } },
   })

--- a/apps/web/src/app/api/federation/tasks/route.ts
+++ b/apps/web/src/app/api/federation/tasks/route.ts
@@ -10,17 +10,28 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { decrypt } from '@/lib/encryption'
+import { timingSafeEqual } from 'crypto'
 
 async function validateFederationToken(req: NextRequest): Promise<boolean> {
   const auth = req.headers.get('authorization')
   if (!auth?.startsWith('Bearer ')) return false
   const token = auth.slice(7)
 
-  const env = await prisma.environment.findFirst({
-    where: { federationToken: token },
-    select: { id: true },
+  const envs = await prisma.environment.findMany({
+    where: { federationToken: { not: null } },
+    select: { id: true, federationToken: true },
   })
-  return env !== null
+  for (const env of envs) {
+    try {
+      const stored = decrypt(env.federationToken!)  // handles enc:v1: prefix and plaintext passthrough
+      if (stored.length === token.length &&
+          timingSafeEqual(Buffer.from(stored), Buffer.from(token))) {
+        return true
+      }
+    } catch { continue }
+  }
+  return false
 }
 
 export async function POST(req: NextRequest) {

--- a/apps/web/src/app/api/webhook-triggers/[id]/regenerate-secret/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/[id]/regenerate-secret/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { randomBytes } from 'crypto'
 import { requireAdmin } from '@/lib/auth'
+import { encrypt } from '@/lib/encryption'
 
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch {
@@ -12,8 +13,9 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   if (!existing) return new NextResponse(null, { status: 404 })
 
   const secret = randomBytes(32).toString('hex')
-  await prisma.webhookTrigger.update({ where: { id }, data: { secret } })
+  const secretToStore = process.env.ORION_ENCRYPTION_KEY ? encrypt(secret) : secret
+  await prisma.webhookTrigger.update({ where: { id }, data: { secret: secretToStore } })
 
-  // Return the new secret — this is the only time it is shown in full
+  // Return the plaintext secret — this is the only time it is shown in full
   return NextResponse.json({ secret })
 }

--- a/apps/web/src/app/api/webhook-triggers/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { randomBytes } from 'crypto'
 import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, CreateWebhookTriggerSchema } from '@/lib/validate'
+import { encrypt } from '@/lib/encryption'
 
 async function guard() {
   try { await requireAdmin() } catch {
@@ -30,6 +31,7 @@ export async function POST(req: NextRequest) {
   if (!agent) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
 
   const secret = randomBytes(32).toString('hex')
+  const secretToStore = process.env.ORION_ENCRYPTION_KEY ? encrypt(secret) : secret
   const trigger = await prisma.webhookTrigger.create({
     data: {
       name:      data.name,
@@ -38,7 +40,7 @@ export async function POST(req: NextRequest) {
       taskTitle: data.taskTitle,
       taskDesc:  data.taskDesc ?? null,
       enabled:   data.enabled,
-      secret,
+      secret:    secretToStore,
     },
     include: { agent: { select: { id: true, name: true } } },
   })

--- a/apps/web/src/app/api/webhooks/[triggerId]/route.ts
+++ b/apps/web/src/app/api/webhooks/[triggerId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { createHmac, timingSafeEqual } from 'crypto'
+import { decrypt } from '@/lib/encryption'
 
 const MAX_VAR_LENGTH = 200
 
@@ -102,19 +103,22 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tri
   // Read raw body for HMAC computation
   const rawBody = await req.text()
 
+  // Decrypt the stored secret (handles enc:v1: prefix and plaintext passthrough for legacy)
+  const triggerSecret = decrypt(trigger.secret)
+
   // Verify signature based on source
   let verified = false
   const source = trigger.source
 
   if (source === 'github') {
-    verified = verifyGitHub(rawBody, trigger.secret, req.headers.get('x-hub-signature-256'))
+    verified = verifyGitHub(rawBody, triggerSecret, req.headers.get('x-hub-signature-256'))
   } else if (source === 'prometheus' || source === 'alertmanager') {
-    verified = verifySecretHeader(trigger.secret, req.headers.get('x-webhook-secret'))
+    verified = verifySecretHeader(triggerSecret, req.headers.get('x-webhook-secret'))
   } else {
     // custom: accept X-Webhook-Secret or Authorization: Bearer <secret>
     verified =
-      verifySecretHeader(trigger.secret, req.headers.get('x-webhook-secret')) ||
-      verifyBearerToken(trigger.secret, req.headers.get('authorization'))
+      verifySecretHeader(triggerSecret, req.headers.get('x-webhook-secret')) ||
+      verifyBearerToken(triggerSecret, req.headers.get('authorization'))
   }
 
   if (!verified) {

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { prisma } from './db'
 import { verifyTOTP, verifyRecoveryCode, consumeRecoveryCode } from './totp'
 import { createHmac, timingSafeEqual } from 'crypto'
 import { logAudit } from './audit'
+import { decrypt } from './encryption'
 
 export interface AppUser {
   id: string
@@ -426,4 +427,36 @@ export async function assertCanModify(
   if (user.role === 'admin') return
   if (user.id === recordCreatedBy) return
   throw new Error('Forbidden')
+}
+
+/**
+ * SOC2: Per-environment gateway token scoping.
+ *
+ * Validates that the Bearer token in the request matches the gateway token
+ * for the specified environment. Prevents a token for env A from being used
+ * to access env B's resources.
+ *
+ * Throws 'Unauthorized' if validation fails.
+ */
+export async function requireGatewayAuthForEnvironment(
+  req: { headers: Headers },
+  environmentId: string,
+): Promise<void> {
+  const auth = req.headers.get('authorization')
+  if (!auth?.startsWith('Bearer ')) throw new Error('Unauthorized')
+  const bearerToken = auth.slice(7)
+
+  const env = await prisma.environment.findUnique({
+    where: { id: environmentId },
+    select: { gatewayToken: true },
+  })
+  if (!env?.gatewayToken) throw new Error('Unauthorized')
+
+  const storedToken = decrypt(env.gatewayToken)
+  if (
+    storedToken.length !== bearerToken.length ||
+    !timingSafeEqual(Buffer.from(storedToken), Buffer.from(bearerToken))
+  ) {
+    throw new Error('Unauthorized')
+  }
 }


### PR DESCRIPTION
## Summary

**Encrypt secrets at rest:**
- `environments/route.ts` (POST): encrypts `federationToken` before DB write
- `environments/[id]/route.ts`: GET Bearer auth and PUT gateway heartbeat auth decrypt stored `gatewayToken` and use `timingSafeEqual`; PUT admin path encrypts `federationToken` on update
- `federation/tasks/route.ts`: `validateFederationToken` now decrypts each stored token via `decrypt()` (passthrough for legacy plaintext) and compares with `timingSafeEqual`
- `webhook-triggers/route.ts` (POST) and `[id]/regenerate-secret/route.ts`: encrypt secret before DB write, return plaintext once to caller
- `webhooks/[triggerId]/route.ts`: decrypts `trigger.secret` before HMAC verification

**Per-environment gateway token scoping:**
- `lib/auth.ts`: new `requireGatewayAuthForEnvironment(req, environmentId)` — looks up environment's `gatewayToken`, decrypts, timing-safe compares against Bearer token
- 10 routes under `environments/[id]/`: all replaced generic `requireServiceAuth` with `requireGatewayAuthForEnvironment(req, id)` — a token for environment A can no longer authenticate requests for environment B

## SOC2 Controls
C1.1 (secrets encrypted at rest), CC6.1 (token scoping/least privilege), CC6.3 (service-to-service authentication), CC9.2 (key management)

## Test plan
- [ ] Gateway token for env A cannot access env B's routes
- [ ] `federationToken` stored with `enc:v1:` prefix in DB
- [ ] Federation validation works with both encrypted and legacy plaintext tokens
- [ ] Webhook HMAC verification works with encrypted-at-rest secret

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_