### PR TITLE
SOC2 #626: Fix race conditions — atomic lockout, recovery code, gateway join, federation taskId, SSO audit

### DIFF
--- a/apps/web/src/app/api/environments/join/route.ts
+++ b/apps/web/src/app/api/environments/join/route.ts
@@ -99,9 +99,9 @@ export async function POST(req: NextRequest) {
   const apiToken    = 'mcga_' + randomBytes(32).toString('hex')
   const fingerprint = machineId ? hashFingerprint(machineId) : null
 
-  const [, env] = await prisma.$transaction([
-    prisma.environmentJoinToken.update({
-      where: { id: record.id },
+  const [tokenUpdate, env] = await prisma.$transaction([
+    prisma.environmentJoinToken.updateMany({
+      where: { id: record.id, usedAt: null },  // conditional: only if not yet used
       data: { usedAt: new Date(), fingerprint },
     }),
     prisma.environment.update({
@@ -115,6 +115,10 @@ export async function POST(req: NextRequest) {
       },
     }),
   ])
+  if (tokenUpdate.count === 0) {
+    // Another concurrent request already consumed this token
+    return NextResponse.json({ error: 'Join token already used' }, { status: 409 })
+  }
 
   console.log(`[join] Gateway registered for environment "${env.name}" (${env.id})${fingerprint ? ' with fingerprint' : ' (no fingerprint)'}`)
 

--- a/apps/web/src/app/api/federation/tasks/route.ts
+++ b/apps/web/src/app/api/federation/tasks/route.ts
@@ -80,26 +80,31 @@ export async function POST(req: NextRequest) {
 
   // Create-only — reject duplicate taskIds with 409 to prevent a compromised
   // spoke from force-resetting an in-progress or completed task to 'pending'.
-  const existing = await prisma.task.findUnique({ where: { id: body.taskId }, select: { id: true } })
-  if (existing) {
-    return NextResponse.json({ error: 'Task already exists', taskId: body.taskId }, { status: 409 })
+  // Use try/catch on P2002 instead of a pre-check findUnique to avoid a
+  // TOCTOU race where concurrent creates both pass the check before either commits.
+  let task: { id: string; status: string }
+  try {
+    task = await prisma.task.create({
+      data: {
+        id: body.taskId,
+        title: body.title,
+        description: body.description ?? null,
+        assignedAgent: body.agentId ?? null,
+        createdBy: 'federation',
+        status: 'pending',
+        metadata: {
+          ...(body.metadata as object | null ?? {}),
+          federatedFrom: 'hub',
+        } as object,
+      },
+      select: { id: true, status: true },
+    })
+  } catch (e: unknown) {
+    if (e instanceof Error && 'code' in e && (e as any).code === 'P2002') {
+      return NextResponse.json({ error: 'Task already exists', taskId: body.taskId }, { status: 409 })
+    }
+    throw e
   }
-
-  const task = await prisma.task.create({
-    data: {
-      id: body.taskId,
-      title: body.title,
-      description: body.description ?? null,
-      assignedAgent: body.agentId ?? null,
-      createdBy: 'federation',
-      status: 'pending',
-      metadata: {
-        ...(body.metadata as object | null ?? {}),
-        federatedFrom: 'hub',
-      } as object,
-    },
-    select: { id: true, status: true },
-  })
 
   // Acknowledge the dispatch if a FederatedDispatch record exists for this task
   await prisma.federatedDispatch

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -38,13 +38,17 @@ const IS_SECURE = process.env.NODE_ENV === 'production' || process.env.HEADER_X_
  * Increments the counter; locks the account for 15 minutes after 5 failures.
  */
 async function recordFailedLogin(userId: string): Promise<void> {
-  const user = await prisma.user.findUnique({ where: { id: userId }, select: { failedLoginAttempts: true } })
-  const attempts = (user?.failedLoginAttempts ?? 0) + 1
-  const lockedUntil = attempts >= 5 ? new Date(Date.now() + 15 * 60 * 1000) : null
-  await prisma.user.update({
+  const updated = await prisma.user.update({
     where: { id: userId },
-    data: { failedLoginAttempts: attempts, ...(lockedUntil ? { lockedUntil } : {}) },
+    data: { failedLoginAttempts: { increment: 1 } },
+    select: { failedLoginAttempts: true },
   })
+  if (updated.failedLoginAttempts >= 5) {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { lockedUntil: new Date(Date.now() + 15 * 60 * 1000) },
+    })
+  }
 }
 
 export const authOptions: NextAuthOptions = {
@@ -138,17 +142,25 @@ export const authOptions: NextAuthOptions = {
               await recordFailedLogin(user.id)
               return null
             }
-            // BLOCKER fix: consume the recovery code (single-use)
-            const updatedCodes = await consumeRecoveryCode(code, hashedCodes)
-            if (updatedCodes) {
-              const newCodesJson = JSON.stringify(updatedCodes)
-              const { encrypt: encryptFn } = await import('./encryption')
-              const encryptedUpdate: Record<string, unknown> = { totpRecoveryCodes: newCodesJson }
-              if (process.env.ORION_ENCRYPTION_KEY) {
-                encryptedUpdate.totpRecoveryCodesEncrypted = encryptFn(newCodesJson)
+            // BLOCKER fix: consume the recovery code atomically inside a transaction
+            // to prevent concurrent requests from both consuming the same code.
+            const { encrypt: encryptFn } = await import('./encryption')
+            const consumed = await prisma.$transaction(async (tx) => {
+              const fresh = await tx.user.findUnique({
+                where: { id: user.id },
+                select: { totpRecoveryCodes: true, totpRecoveryCodesEncrypted: true },
+              })
+              const freshCodes: string[] = fresh?.totpRecoveryCodes ? JSON.parse(fresh.totpRecoveryCodes) : []
+              const updatedCodes = await consumeRecoveryCode(code, freshCodes)
+              if (!updatedCodes) return false  // code already consumed by concurrent request
+              const writeData: Record<string, unknown> = { totpRecoveryCodes: JSON.stringify(updatedCodes) }
+              if (process.env.ORION_ENCRYPTION_KEY && fresh?.totpRecoveryCodesEncrypted) {
+                writeData.totpRecoveryCodesEncrypted = encryptFn(JSON.stringify(updatedCodes))
               }
-              await prisma.user.update({ where: { id: user.id }, data: encryptedUpdate })
-            }
+              await tx.user.update({ where: { id: user.id }, data: writeData })
+              return true
+            })
+            if (!consumed) return null  // concurrent request already used this code
           } else {
             // TOTP code login
             const code = credentials.totpCode as string
@@ -380,10 +392,10 @@ export async function getCurrentUser(): Promise<AppUser | null> {
           return null
         }
 
-        const existingUser = await prisma.user.findUnique({ where: { username } })
+        const now = new Date()
         const user = await prisma.user.upsert({
           where: { username },
-          update: { lastSeen: new Date() },
+          update: { lastSeen: now },
           create: {
             username,
             email: h.get('x-authentik-email') ?? `${username}@sso`,
@@ -391,9 +403,15 @@ export async function getCurrentUser(): Promise<AppUser | null> {
             externalId: h.get('x-authentik-uid'),
             role: 'user',
             provider: 'authentik',
+            lastSeen: now,
           },
         })
-        const isNewUser = !existingUser
+        // Derive new-vs-existing from the upsert result rather than a separate
+        // pre-read findUnique — avoids a race where two concurrent first-time SSO
+        // logins both read existingUser=null before either upsert commits.
+        // A new user has createdAt === lastSeen (both just set); an existing user
+        // has lastSeen updated but createdAt older.
+        const isNewUser = Math.abs(user.createdAt.getTime() - user.lastSeen.getTime()) < 2000
         if (isNewUser) {
           void logAudit({
             userId: user.id,


### PR DESCRIPTION
## Summary

Fixes 5 race condition / TOCTOU findings from Fable security review.

### HIGH — `auth.ts`: Atomic lockout counter
`recordFailedLogin` was a read-modify-write race — concurrent wrong-password requests all read the same counter value, computed the same `+1`, and wrote it back, allowing an attacker scripting parallel requests to pin the counter and never trigger the 15-minute lockout.

**Fix**: Replaced with `{ increment: 1 }` (atomic DB-side increment). `lockedUntil` is set in a follow-up write only when the returned count reaches 5.

### HIGH — `auth.ts`: Single-use recovery code consumed atomically
Recovery code consumption (read → verify → write filtered list) was three separate awaited steps. Two concurrent requests with the same code both passed verification before either consumed it, granting two sessions from one single-use code.

**Fix**: Wrapped consume logic in `prisma.$transaction`. Re-reads codes fresh inside the transaction, returns `null` immediately if the code is already gone (concurrent request consumed it first).

### MED — `environments/join/route.ts`: First-join conditional update
`usedAt === null` check was outside the transaction. Two concurrent first-join requests both saw `null`, both minted different gateway tokens, second overwrites first — locking out the legitimate gateway.

**Fix**: Changed to `updateMany({ where: { id, usedAt: null } })` inside the transaction. Returns 409 if `count === 0` (token already consumed concurrently).

### MED — `federation/tasks/route.ts`: taskId P2002 → 409
`findUnique` + `create` for taskId dedup wasn't atomic. Concurrent creates threw an unhandled Prisma P2002 as a 500 instead of the intended 409.

**Fix**: Removed pre-check. `create` is wrapped in try/catch; P2002 returns 409.

### MED — `auth.ts`: SSO audit event fires exactly once
Two concurrent first-time SSO logins both read `existingUser = null` before the upsert, both emitting `user_create` audit events for the same account (corrupting the audit trail).

**Fix**: Removed separate `findUnique` pre-read. `isNewUser` derived from upsert result by comparing `createdAt` vs `lastSeen` timestamps.

## SOC2 Controls
CC6.1 (brute force protection integrity), CC6.6 (account lockout correctness), CC4.1 (audit trail integrity), CC7.2 (concurrency safety)

## Test plan
- [ ] Concurrent wrong-password requests → lockout triggers correctly at attempt 5
- [ ] Two simultaneous recovery code submissions → only one succeeds, second gets 401
- [ ] Two simultaneous first-join requests → one succeeds, second gets 409
- [ ] Two concurrent federation task creates with same taskId → second gets 409, not 500

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_