### PR TITLE
SOC2 #627: Fix user record exposure, setup token logging, and missing audit events

### DIFF
--- a/apps/web/src/app/api/admin/users/[id]/route.ts
+++ b/apps/web/src/app/api/admin/users/[id]/route.ts
@@ -22,6 +22,12 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   const user = await prisma.user.update({
     where: { id: params.id },
     data: updateData,
+    select: {
+      id: true, username: true, email: true, name: true,
+      role: true, active: true, createdAt: true, lastSeen: true,
+      totpEnabled: true,
+      // explicitly exclude: passwordHash, totpSecret, totpSecretEncrypted, totpRecoveryCodes, totpRecoveryCodesEncrypted
+    },
   })
 
   // SOC2: [M-005] Log user update (non-blocking)
@@ -36,6 +42,18 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
   }).catch(() => {})
+
+  // SOC2: log password resets specifically
+  if (data.password !== undefined) {
+    logAudit({
+      userId: admin.id,
+      action: 'password_reset',
+      target: `user:${params.id}`,
+      detail: { resetBy: admin.id },
+      ipAddress: getClientIp(req),
+      userAgent: getUserAgent(req.headers),
+    }).catch(() => {})
+  }
 
   return NextResponse.json(user)
 }

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { parseBodyOrError, UpdateAgentSchema } from '@/lib/validate'
 import { requireAdmin } from '@/lib/auth'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
   const agent = await prisma.agent.findUnique({
@@ -44,12 +45,26 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
-  try { await requireAdmin() } catch {
+  let adminUser
+  try { adminUser = await requireAdmin() } catch {
     return NextResponse.json({ error: 'Admin privileges required to delete agents' }, { status: 403 })
   }
+
+  const agent = await prisma.agent.findUnique({ where: { id: params.id }, select: { name: true } })
 
   // Unassign tasks first to avoid FK violation
   await prisma.task.updateMany({ where: { assignedAgent: params.id }, data: { assignedAgent: null } })
   await prisma.agent.delete({ where: { id: params.id } })
+
+  // SOC2: audit agent deletion
+  logAudit({
+    userId: adminUser.id,
+    action: 'agent_delete',
+    target: `agent:${params.id}`,
+    detail: { name: agent?.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -1,6 +1,7 @@
 import { makeCrudRoutes } from '@/lib/crud-route-factory'
 import { CreateAgentSchema } from '@/lib/validate'
 import { RESERVED_AGENT_NAMES } from '@/lib/management-tools'
+import { logAudit } from '@/lib/audit'
 
 // SOC2 [INPUT-001]: Extended validation with reserved name check
 const CreateAgentWithReservedCheck = CreateAgentSchema.refine(
@@ -19,4 +20,13 @@ export const { GET, POST } = makeCrudRoutes({
     role:     data.role ?? null,
     ...(data.metadata ? { metadata: data.metadata } : {}),
   }),
+  afterCreate: async (record: any, caller: any) => {
+    // SOC2: audit agent creation
+    logAudit({
+      userId: caller?.id ?? 'unknown',
+      action: 'agent_create',
+      target: `agent:${record.id}`,
+      detail: { name: record.name },
+    }).catch(() => {})
+  },
 })

--- a/apps/web/src/app/api/internal/encryption/rotate/route.ts
+++ b/apps/web/src/app/api/internal/encryption/rotate/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { timingSafeEqual } from 'crypto'
 import { prisma } from '@/lib/db'
 import { encrypt, decrypt, encryptWithKey } from '@/lib/encryption'
+import { logAudit } from '@/lib/audit'
 
 export async function POST(req: NextRequest) {
   // MAJOR fix: previously authenticated with ORION_ENCRYPTION_KEY itself.
@@ -153,6 +154,14 @@ export async function POST(req: NextRequest) {
       errors.push({ model: 'SystemSetting', id: setting.key, field: 'value', error: 'Key rotation failed' })
     }
   }
+
+  // SOC2: audit key rotation
+  logAudit({
+    userId: 'system',
+    action: 'encryption_key_rotation',
+    target: 'system:encryption',
+    detail: { migrated, failed: errors.length },
+  }).catch(() => {})
 
   return NextResponse.json({
     migrated,

--- a/apps/web/src/app/api/webhook-triggers/[id]/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, UpdateWebhookTriggerSchema } from '@/lib/validate'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 async function guard() {
   try { await requireAdmin() } catch {
@@ -53,11 +54,25 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   return NextResponse.json({ ...trigger, secret: '••••••••', webhookUrl: `/api/webhooks/${id}` })
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const deny = await guard(); if (deny) return deny
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let adminUser
+  try { adminUser = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const { id } = await params
   const existing = await prisma.webhookTrigger.findUnique({ where: { id } })
   if (!existing) return new NextResponse(null, { status: 404 })
   await prisma.webhookTrigger.delete({ where: { id } })
+
+  // SOC2: audit webhook trigger deletion
+  logAudit({
+    userId: adminUser.id,
+    action: 'webhook_trigger_delete',
+    target: `webhook_trigger:${id}`,
+    detail: { name: existing.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/webhook-triggers/route.ts
+++ b/apps/web/src/app/api/webhook-triggers/route.ts
@@ -4,16 +4,12 @@ import { randomBytes } from 'crypto'
 import { requireAdmin } from '@/lib/auth'
 import { parseBodyOrError, CreateWebhookTriggerSchema } from '@/lib/validate'
 import { encrypt } from '@/lib/encryption'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
-async function guard() {
+export async function GET() {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  return null
-}
-
-export async function GET() {
-  const deny = await guard(); if (deny) return deny
   const triggers = await prisma.webhookTrigger.findMany({
     orderBy: { createdAt: 'desc' },
     include: { agent: { select: { id: true, name: true } } },
@@ -22,7 +18,10 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const deny = await guard(); if (deny) return deny
+  let adminUser
+  try { adminUser = await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const parsed = await parseBodyOrError(req, CreateWebhookTriggerSchema)
   if ('error' in parsed) return parsed.error
   const { data } = parsed
@@ -44,6 +43,16 @@ export async function POST(req: NextRequest) {
     },
     include: { agent: { select: { id: true, name: true } } },
   })
+
+  // SOC2: audit webhook trigger creation
+  logAudit({
+    userId: adminUser.id,
+    action: 'webhook_trigger_create',
+    target: `webhook_trigger:${trigger.id}`,
+    detail: { name: trigger.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
 
   // Return the secret in the creation response — this is the only time the full secret is shown
   return NextResponse.json({ ...trigger, secret }, { status: 201 })

--- a/apps/web/src/lib/setup-token.ts
+++ b/apps/web/src/lib/setup-token.ts
@@ -28,7 +28,10 @@ export async function ensureSetupToken(): Promise<void> {
   })
 
   // bootstrap.sh greps for this exact line
-  console.log(`SETUP_TOKEN: ${token}`)
+  if (!process.env.CI && !process.env.SETUP_TOKEN_SUPPRESS_LOG) {
+    console.log(`SETUP_TOKEN: ${token}`)
+    console.warn('[security] SETUP_TOKEN logged above — clear application logs after completing setup or set SETUP_TOKEN_SUPPRESS_LOG=true')
+  }
   console.log('[orion] Visit http://<management-ip>:3000/setup to complete first-run setup.')
 }
 


### PR DESCRIPTION
## Summary

Fixes 2 secret-in-logs findings and closes 4 audit trail gaps identified by Fable security review.

### Secrets in Logs

**HIGH — `admin/users/[id]/route.ts`**: Admin PATCH returned the full `prisma.user.update()` result with no select clause — `passwordHash`, `totpSecret`, `totpSecretEncrypted`, and recovery codes were included in the API response. Added explicit `select` returning only safe fields (`id`, `username`, `email`, `name`, `role`, `active`, `createdAt`, `lastSeen`, `totpEnabled`).

**HIGH — `setup-token.ts`**: `SETUP_TOKEN` logged to stdout indefinitely — persisted in Docker/journald logs after setup completes. Wrapped in `if (!process.env.CI && !process.env.SETUP_TOKEN_SUPPRESS_LOG)` guard and added a `console.warn` security reminder to clear logs after setup.

### Audit Trail Gaps

**MED — Agent create/delete**: No audit events existed. Added `logAudit` with `agent_create` (POST) and `agent_delete` (DELETE) in `agents/route.ts` and `agents/[id]/route.ts`.

**MED — Webhook trigger create/delete**: No audit events existed. Added `logAudit` with `webhook_trigger_create` and `webhook_trigger_delete` in `webhook-triggers/route.ts` and `webhook-triggers/[id]/route.ts`.

**MED — Encryption key rotation**: Master key rotation left no audit record. Added `logAudit` with `encryption_key_rotation` and `{ migrated, failed }` detail in `internal/encryption/rotate/route.ts`.

**LOW — Password change**: Previously logged only as generic `user_update`. Added a secondary `logAudit` with action `password_reset` when `data.password` is present in the PATCH body.

## SOC2 Controls
CC4.1 (audit trail completeness), C1.1 (sensitive data not in logs), CC6.1 (credential protection), CC7.2 (privileged action logging)

## Test plan
- [ ] Admin PATCH user → response contains no `passwordHash` or `totpSecret`
- [ ] Set `SETUP_TOKEN_SUPPRESS_LOG=true` → token not printed to stdout
- [ ] Create/delete agent → audit log entry with `agent_create`/`agent_delete`
- [ ] Run key rotation → audit log entry with `encryption_key_rotation`
- [ ] Admin password reset → audit log entry with `password_reset`

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_