### PR TITLE
fix(idor): add ownership checks to notes, scheduled-tasks, executions, tasks, agents, novas

### DIFF
--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -5,6 +5,9 @@ import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const agent = await prisma.agent.findUnique({
     where: { id: params.id },
     include: {

--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  let caller
+  try { caller = await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  const isService = caller === null
   try {
     const execution = await prisma.toolExecution.findUnique({
       where: { id: params.id },
@@ -19,6 +21,7 @@ export async function GET(
       )
     }
 
+    await assertCanModify(caller, isService, execution.createdBy ?? '')
     return NextResponse.json(execution)
   } catch (error) {
     console.error('Error getting execution:', error)
@@ -33,8 +36,22 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  let caller
+  try { caller = await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  const isService = caller === null
   try {
+    // Load execution first to verify ownership before mutation
+    const existing = await prisma.toolExecution.findUnique({
+      where: { id: params.id },
+    })
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'Execution not found' },
+        { status: 404 }
+      )
+    }
+    await assertCanModify(caller, isService, existing.createdBy ?? '')
+
     const body = await req.json()
 
     const {

--- a/apps/web/src/app/api/notes/[id]/route.ts
+++ b/apps/web/src/app/api/notes/[id]/route.ts
@@ -1,18 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { embedNote, computeSemanticEdges } from '@/lib/embeddings'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateNoteSchema } from '@/lib/validate'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
   const note = await prisma.note.findUnique({ where: { id: params.id } })
-  if (!note) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (!note) return new NextResponse(null, { status: 404 })
+  // Only the creator or admin/service can read notes
+  await assertCanModify(caller, isService, note.createdBy ?? '')
   return NextResponse.json(note)
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  // Check ownership before mutation
+  const existing = await prisma.note.findUnique({ where: { id: params.id } })
+  if (!existing) return new NextResponse(null, { status: 404 })
+  await assertCanModify(caller, isService, existing.createdBy ?? '')
+
   // SOC2 [INPUT-001]: Validate request body with Zod schema
   const result = await parseBodyOrError(req, UpdateNoteSchema)
   if ('error' in result) return result.error
@@ -45,7 +55,14 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
+
+  // Check ownership before deletion
+  const existing = await prisma.note.findUnique({ where: { id: params.id } })
+  if (!existing) return new NextResponse(null, { status: 404 })
+  await assertCanModify(caller, isService, existing.createdBy ?? '')
+
   await prisma.note.delete({ where: { id: params.id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -9,6 +9,9 @@ export async function GET(
   _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
+  try { await requireAdmin() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   const nova = await prisma.nova.findUnique({
     where: { id: params.id },
     include: {

--- a/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { requireServiceAuth } from '@/lib/auth'
+import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseCron, nextRun } from '@/lib/cron'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
 
   const task = await prisma.scheduledTask.findUnique({
     where: { id: params.id },
@@ -12,14 +13,17 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   })
 
   if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, task.createdBy)
   return NextResponse.json(task)
 }
 
 export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
 
   const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, existing.createdBy)
 
   let body: unknown
   try {
@@ -55,10 +59,12 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
 
   const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  await assertCanModify(caller, isService, existing.createdBy)
 
   await prisma.scheduledTask.delete({ where: { id: params.id } })
   return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -5,7 +5,8 @@ import { parseBodyOrError, UpdateTaskSchema } from '@/lib/validate'
 import { handlePlanPatch } from '@/lib/plan-patch'
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  await requireServiceAuth(req)
+  const caller = await requireServiceAuth(req)
+  const isService = caller === null
   const task = await prisma.task.findUnique({
     where: { id: params.id },
     include: {
@@ -16,6 +17,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     },
   })
   if (!task) return new NextResponse(null, { status: 404 })
+  // Scope GET to task creator or admin/service (consistent with PUT/DELETE)
+  await assertCanModify(caller, isService, task.createdBy)
   return NextResponse.json(task)
 }
 


### PR DESCRIPTION
## Summary

Six IDOR (Insecure Direct Object Reference) fixes across API routes that accepted any authenticated request without scoping to the resource owner:

- **notes/[id]**: GET/PUT/DELETE now call `assertCanModify(caller, isService, note.createdBy)` — any user could previously read/overwrite/delete any other user's notes
- **scheduled-tasks/[id]**: GET/PUT/DELETE now call `assertCanModify` against `task.createdBy`
- **executions/[id]**: GET/PATCH now call `assertCanModify` against `execution.createdBy`; PATCH fetches record before mutating to enable the check
- **tasks/[id] GET**: Already had ownership checks on PUT/DELETE; GET was missing them — adds `assertCanModify` after the 404 guard
- **agents/[id] GET**: Had **no auth call at all** — any authenticated user could read any agent's `systemPrompt`, `contextConfig`, recent tasks and messages. Added `requireAdmin()` consistent with PUT/DELETE
- **novas/[id] GET**: Same — no auth, added `requireAdmin()` matching PUT/DELETE

## Test plan
- [ ] Non-owner user receives 403 on GET/PUT/DELETE for another user's notes
- [ ] Non-owner user receives 403 on GET/PUT/DELETE for another user's scheduled tasks
- [ ] Non-admin user receives 401 on GET /api/agents/[id] and /api/novas/[id]
- [ ] Service token (null caller / isService=true) still has full access

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_