### PR TITLE
fix(webhook): add delivery ID deduplication to prevent replay attacks

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -1833,6 +1833,20 @@ model WebhookTrigger {
   @@index([agentId])
 }
 
+// ── Webhook Delivery Deduplication ────────────────────────────────────────────
+// Stores seen delivery IDs to prevent replay attacks.
+// Records are pruned after 24h by a cleanup job.
+
+model WebhookDelivery {
+  id          String   @id @default(cuid())
+  triggerId   String
+  deliveryId  String   // X-GitHub-Delivery UUID or SHA256(triggerId+rawBody)
+  receivedAt  DateTime @default(now())
+
+  @@unique([triggerId, deliveryId])
+  @@index([receivedAt])
+}
+
 // ── Job Run History ────────────────────────────────────────────────────────────
 // Records every execution of a ScheduledTask, WebhookTrigger, or system job.
 

--- a/apps/web/src/app/api/webhooks/[triggerId]/route.ts
+++ b/apps/web/src/app/api/webhooks/[triggerId]/route.ts
@@ -125,6 +125,25 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ tri
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
   }
 
+  // Replay protection: compute a delivery ID from X-GitHub-Delivery or body hash
+  const deliveryHeader = req.headers.get('x-github-delivery') ?? req.headers.get('x-gitea-delivery')
+  const { createHash } = await import('crypto')
+  const deliveryId = deliveryHeader ?? createHash('sha256').update(`${triggerId}:${rawBody}`).digest('hex').slice(0, 32)
+
+  // Check/store delivery ID atomically — unique constraint prevents duplicates
+  try {
+    await prisma.webhookDelivery.create({
+      data: { triggerId, deliveryId },
+    })
+  } catch (e: unknown) {
+    // Unique constraint violation = duplicate delivery
+    const isPrismaUniqueError = (e as { code?: string }).code === 'P2002'
+    if (isPrismaUniqueError) {
+      return NextResponse.json({ ok: true, duplicate: true }, { status: 200 })
+    }
+    throw e
+  }
+
   // Parse payload
   let parsedBody: unknown = {}
   try {


### PR DESCRIPTION
## Summary

- **prisma/schema.prisma**: Add `WebhookDelivery` model with `@@unique([triggerId, deliveryId])` and `@@index([receivedAt])`. Records are intended to be pruned after 24h by a cleanup job.
- **webhooks/[triggerId]/route.ts**: After signature verification, compute a `deliveryId` from `X-GitHub-Delivery` / `X-Gitea-Delivery` header (falling back to `SHA256(triggerId:rawBody).slice(0,32)`). Attempt `prisma.webhookDelivery.create` — a P2002 unique constraint violation means duplicate delivery, returns `200 { ok: true, duplicate: true }` without creating a Task or JobRun.

**Impact**: Without this fix, an attacker with a captured valid webhook (e.g. from a GitHub delivery log) can replay it repeatedly to spam the agent task queue.

## Test plan
- [ ] First delivery with a given `X-GitHub-Delivery` header creates a task normally
- [ ] Replayed delivery with the same header returns `200 { ok: true, duplicate: true }` and creates no new task
- [ ] Delivery without the header falls back to body hash deduplication
- [ ] Migration applies cleanly (prisma db push / migrate deploy)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_