### PR TITLE
fix(xss): replace Tabs.tsx innerHTML with safe DOM cloning; set MermaidBlock securityLevel to strict

### DIFF
--- a/apps/web/src/components/notes/MermaidBlock.tsx
+++ b/apps/web/src/components/notes/MermaidBlock.tsx
@@ -6,7 +6,8 @@ let initialized = false
 
 // ── SVG sanitizer for XSS prevention ─────────────────────────────────────────
 // Parses SVG string and removes dangerous elements/attributes before rendering.
-// Prevents XSS when mermaid uses securityLevel: 'loose' (needed for interactivity).
+// Now redundant with securityLevel: 'strict' (which disables HTML labels and click
+// handlers in Mermaid diagrams), but kept as defense-in-depth.
 function sanitizeSvg(svgString: string): Element | null {
   const parser = new DOMParser()
   const doc = parser.parseFromString(svgString, 'image/svg+xml')
@@ -57,7 +58,7 @@ export function MermaidBlock({ code }: { code: string }) {
 
   useEffect(() => {
     if (!initialized) {
-      mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' })
+      mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' })
       initialized = true
     }
 

--- a/apps/web/src/components/notes/Tabs.tsx
+++ b/apps/web/src/components/notes/Tabs.tsx
@@ -63,7 +63,10 @@ export function Tabs({ children }: { children: React.ReactNode }) {
         const panel = document.createElement('div')
         panel.className = 'note-tab-panel'
         panel.style.display = i === activeIdx ? '' : 'none'
-        panel.innerHTML = div.innerHTML
+        // Use cloneNode instead of innerHTML to avoid XSS via injected HTML
+        Array.from(div.childNodes).forEach(node => {
+          panel.appendChild(node.cloneNode(true))
+        })
         contentWrapper.appendChild(panel)
       })
 


### PR DESCRIPTION
## Summary

- **Tabs.tsx**: Replace `panel.innerHTML = div.innerHTML` (line 66) with `Array.from(div.childNodes).forEach(node => panel.appendChild(node.cloneNode(true)))`. Eliminates the innerHTML sink that would execute injected scripts if raw HTML ever enters the markdown pipeline (e.g. if `rehype-raw` is added).
- **MermaidBlock.tsx**: Change `securityLevel: 'loose'` → `'strict'`. Disables HTML labels and `click` handler injection in Mermaid diagrams. The existing `sanitizeSvg` function is preserved as defense-in-depth with an updated comment.

## Test plan
- [ ] Notes with tab syntax render correctly (tab bar appears, switching works)
- [ ] Mermaid diagrams still render (flowchart, sequence, etc.)
- [ ] `<img onerror=alert(1)>` injected via a tab div does not execute
- [ ] Mermaid diagram with HTML node label does not render HTML (strict mode)

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_