### PR TITLE
SOC2: Business logic — budget TOCTOU lock, TOTP rate limit, task cap, cron min interval

### DIFF
--- a/apps/web/src/lib/token-budget.ts
+++ b/apps/web/src/lib/token-budget.ts
@@ -1,5 +1,59 @@
 import { prisma } from './db'
 
+// ─── Redis budget lock helpers ────────────────────────────────────────────────
+// SOC2: [H-TOCTOU] Per-agent mutex prevents concurrent tasks from all reading
+// the same "current usage" before any of them records spend.
+
+let _budgetRedisClient: any = null
+
+async function getBudgetRedis(): Promise<any | null> {
+  if (_budgetRedisClient) return _budgetRedisClient
+  try {
+    const ioredis = await import('ioredis')
+    const Redis = ioredis.default || ioredis
+    const url =
+      process.env.REDIS_URL || process.env.UPSTASH_REDIS_URL || 'redis://localhost:6379/0'
+    const client = new Redis(url)
+    await client.ping()
+    _budgetRedisClient = client
+    return _budgetRedisClient
+  } catch {
+    return null
+  }
+}
+
+/**
+ * SOC2: [H-TOCTOU] Acquire a per-agent budget lock using SET NX EX.
+ * Returns the lock token string if acquired, or null if the lock is already held.
+ * Returns 'no-redis' when Redis is unavailable (fail-open — allow the task to proceed).
+ */
+export async function acquireBudgetLock(agentId: string): Promise<string | null> {
+  const redis = await getBudgetRedis()
+  if (!redis) return 'no-redis' // fail open when Redis is unavailable
+  const token = `${Date.now()}-${Math.random()}`
+  const key = `agent:${agentId}:budget:lock`
+  const result = await redis.set(key, token, 'NX', 'EX', 30)
+  return result === 'OK' ? token : null
+}
+
+/**
+ * SOC2: [H-TOCTOU] Release the per-agent budget lock using a Lua check-and-delete
+ * so we only release the lock we own (guards against expiry races).
+ */
+export async function releaseBudgetLock(agentId: string, token: string): Promise<void> {
+  if (token === 'no-redis') return
+  const redis = await getBudgetRedis()
+  if (!redis) return
+  const key = `agent:${agentId}:budget:lock`
+  const lua = `
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      return redis.call('DEL', KEYS[1])
+    end
+    return 0
+  `
+  await redis.eval(lua, 1, key, token)
+}
+
 /**
  * Check whether an agent is within its token budget (daily and monthly).
  *
@@ -8,6 +62,10 @@ import { prisma } from './db'
  *
  * Returns { allowed: true } when under budget or no budget is set.
  * Returns { allowed: false, reason: '...' } when a limit is exceeded.
+ *
+ * SOC2: [H-TOCTOU] Callers MUST hold the per-agent budget lock before calling
+ * this function to prevent concurrent tasks reading the same stale usage total.
+ * Use acquireBudgetLock / releaseBudgetLock in the caller (e.g. worker.ts).
  */
 export async function checkAgentBudget(
   agentId: string,


### PR DESCRIPTION
## Summary

**HIGH** `token-budget.ts` + `worker.ts`: Redis `SET NX EX 30` per-agent budget lock — concurrent tasks now queue behind a lock before calling `checkAgentBudget`, preventing the TOCTOU race where N tasks all pass the budget check before any records usage

**MEDIUM** `totp-login/route.ts`: TOTP rate limiter was imported but never called — added IP-keyed rate limit (10 req/15 min) as the first operation in the POST handler, before body parsing or DB access; closes online brute-force of TOTP codes

**MEDIUM** `tasks/route.ts`: Pending task cap — returns 429 if pending task count for the agent reaches `MAX_PENDING_TASKS_PER_AGENT` (env var, default 50); prevents unbounded queue growth

**MEDIUM** `cron.ts` + `scheduled-tasks/route.ts`: Minimum cron interval — `minCronIntervalSeconds()` samples 3 consecutive fire times; schedules with interval < 5 minutes rejected with 400; prevents `* * * * *` minutely drain

## Test plan
- [ ] Two concurrent task submissions for an agent with tight budget — only one proceeds, other re-queues
- [ ] POST `/api/auth/totp-login` 11 times rapidly → 429 on 11th
- [ ] POST `/api/tasks` until 50 pending → 429
- [ ] POST `/api/scheduled-tasks` with `* * * * *` → 400

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_