### PR TITLE
fix(build): remove duplicate SENSITIVE_KEY_PATTERNS in admin settings route

### DIFF
--- a/apps/web/src/app/api/admin/settings/route.ts
+++ b/apps/web/src/app/api/admin/settings/route.ts
@@ -5,21 +5,11 @@ import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, UpdateSettingsSchema } from '@/lib/validate'
 import { encrypt } from '@/lib/encryption'
 
-// Keys containing these substrings are sensitive and must be encrypted at rest.
-const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'credential']
-
-function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase()
-  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
-}
-
-// Keys containing these substrings are redacted in GET responses.
-// They hold tokens, secrets, or keys that must not be returned to the browser.
+// Keys matching these substrings are sensitive: encrypted at rest and redacted in GET responses.
 const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'key', 'credential']
 
 function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase()
-  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
+  return SENSITIVE_KEY_PATTERNS.some(p => key.toLowerCase().includes(p))
 }
 
 export async function GET() {


### PR DESCRIPTION
## Summary

- A prior SOC2 hardening agent accidentally introduced duplicate `const SENSITIVE_KEY_PATTERNS` and `function isSensitiveKey` declarations in `apps/web/src/app/api/admin/settings/route.ts`
- This caused a webpack "duplicate identifier" error that broke the `Build ORION Web` Docker build action (run #27473239096)
- Merged the two definitions into one, keeping the wider pattern list (`'key'` added) so both GET redaction and PATCH encryption use the same set

## Test plan

- [ ] `Build ORION Web` GitHub Action passes on merge to main
- [ ] GET `/api/admin/settings` redacts keys matching sensitive patterns with `••••`
- [ ] PATCH `/api/admin/settings` encrypts sensitive values before storage

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_