### PR TITLE
fix(build): resolve two webpack errors breaking the Docker build

### DIFF
--- a/apps/web/src/app/(app)/notes/graph/page.tsx
+++ b/apps/web/src/app/(app)/notes/graph/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { ComponentType } from 'react'
 import nextDynamic from 'next/dynamic'
 
@@ -16,10 +18,6 @@ const GraphViewClient = nextDynamic<{ }>(
     ),
   },
 )
-
-// Force dynamic rendering — prevents Next.js from prerendering
-// which crashes on react-force-graph-2d's window access
-export const dynamic = 'force-dynamic'
 
 export default function GraphPage() {
   return <GraphViewClient />

--- a/apps/web/src/app/api/admin/settings/route.ts
+++ b/apps/web/src/app/api/admin/settings/route.ts
@@ -5,21 +5,11 @@ import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, UpdateSettingsSchema } from '@/lib/validate'
 import { encrypt } from '@/lib/encryption'
 
-// Keys containing these substrings are sensitive and must be encrypted at rest.
-const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'credential']
-
-function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase()
-  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
-}
-
-// Keys containing these substrings are redacted in GET responses.
-// They hold tokens, secrets, or keys that must not be returned to the browser.
+// Keys matching these substrings are sensitive: encrypted at rest and redacted in GET responses.
 const SENSITIVE_KEY_PATTERNS = ['token', 'secret', 'password', 'apikey', 'api_key', 'key', 'credential']
 
 function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase()
-  return SENSITIVE_KEY_PATTERNS.some(p => lower.includes(p))
+  return SENSITIVE_KEY_PATTERNS.some(p => key.toLowerCase().includes(p))
 }
 
 export async function GET() {


### PR DESCRIPTION
## Summary

Two separate webpack errors were breaking the `Build ORION Web` action:

1. **Duplicate declaration** — `apps/web/src/app/api/admin/settings/route.ts` had `SENSITIVE_KEY_PATTERNS` and `isSensitiveKey` declared twice (from a prior SOC2 fix agent). Merged into a single declaration with the wider pattern list.

2. **`ssr: false` in Server Component** — `apps/web/src/app/(app)/notes/graph/page.tsx` used `next/dynamic` with `ssr: false` but was a Server Component. Next.js 15 rejects this. Added `'use client'` and removed the now-invalid `export const dynamic = 'force-dynamic'` server export.

## Test plan

- [ ] `Build ORION Web` GitHub Action passes
- [ ] Notes graph page loads in browser (Three.js / react-force-graph renders client-side)
- [ ] GET `/api/admin/settings` redacts sensitive keys with `••••`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_