### PR TITLE
fix(build): update page props to Promise types for Next.js 15

### DIFF
--- a/apps/web/src/app/(app)/admin/audit/page.tsx
+++ b/apps/web/src/app/(app)/admin/audit/page.tsx
@@ -40,10 +40,11 @@ function actionColor(action: string): string {
 export default async function AuditLogPage({
   searchParams,
 }: {
-  searchParams: { action?: string; user?: string }
+  searchParams: Promise<{ action?: string; user?: string }>
 }) {
-  const actionFilter = searchParams.action || undefined
-  const userFilter   = searchParams.user   || undefined
+  const { action, user } = await searchParams
+  const actionFilter = action || undefined
+  const userFilter   = user   || undefined
 
   // Fetch matching users if filtering by user substring
   const userIds = userFilter

--- a/apps/web/src/app/(app)/security/[id]/page.tsx
+++ b/apps/web/src/app/(app)/security/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 
-export default function SecurityDetailPage({ params }: { params: { id: string } }) {
-  // Placeholder for future alert detail page
+export default async function SecurityDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  await params
   return notFound()
 }


### PR DESCRIPTION
## Summary

Next.js 15 changed `searchParams` and `params` in Server Component pages from plain objects to `Promise<T>`. The type-checker now rejects the old signatures causing the build to fail.

**Files fixed:**
- `src/app/(app)/admin/audit/page.tsx` — `searchParams: { action?, user? }` → `Promise<{ action?, user? }>`, awaited before use
- `src/app/(app)/security/[id]/page.tsx` — `params: { id }` → `Promise<{ id }>`, awaited

## Test plan

- [ ] `Build ORION Web` GitHub Action passes
- [ ] `/admin/audit` page filters by `?action=` and `?user=` query params correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_