### PR TITLE
fix(build): update all API route params to Promise<T> for Next.js 15

### DIFF
--- a/apps/web/src/app/api/admin/models/[id]/route.ts
+++ b/apps/web/src/app/api/admin/models/[id]/route.ts
@@ -11,7 +11,7 @@ function maskKey(key: string | null): string | null {
   return '••••' + key.slice(-4)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const admin = await requireAdmin()
   const result = await parseBodyOrError(req, UpdateExternalModelSchema)
   if ('error' in result) return result.error
@@ -37,19 +37,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (data.apiKey)              updateData.apiKey        = data.apiKey
 
   const model = await prisma.externalModel.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: updateData,
   })
 
   // If contextSize changed, drop the cached limit so the next agent turn re-reads the new value.
   // Cache is keyed by "ext:<id>" (model-level), not baseUrl, so two models at the same server don't bleed.
-  if ('contextSize' in data) clearContextLimitCache(`ext:${params.id}`)
+  if ('contextSize' in data) clearContextLimitCache(`ext:${(await params).id}`)
 
   // SOC2: [M-005] Log model update (non-blocking)
   logAudit({
     userId: admin.id,
     action: 'model_update',
-    target: `model:${params.id}`,
+    target: `model:${(await params).id}`,
     detail: { name: model.name, provider: model.provider },
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
@@ -58,19 +58,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json({ ...model, apiKey: maskKey(model.apiKey) })
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const admin = await requireAdmin()
   const model = await prisma.externalModel.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { name: true },
   })
-  await prisma.externalModel.delete({ where: { id: params.id } })
+  await prisma.externalModel.delete({ where: { id: (await params).id } })
 
   // SOC2: [M-005] Log model delete (non-blocking)
   logAudit({
     userId: admin.id,
     action: 'model_delete',
-    target: `model:${params.id}`,
+    target: `model:${(await params).id}`,
     detail: { name: model?.name },
     ipAddress: getClientIp(_req),
     userAgent: getUserAgent(_req.headers),

--- a/apps/web/src/app/api/admin/prompts/[key]/route.ts
+++ b/apps/web/src/app/api/admin/prompts/[key]/route.ts
@@ -9,10 +9,10 @@ import { parseBodyOrError, UpdateSystemPromptSchema } from '@/lib/validate'
 /** GET /api/admin/prompts/:key — get a single prompt's current content */
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { key: string } },
+  { params }: { params: Promise<{ key: string }> },
 ) {
   await requireAdmin()
-  const key = decodeURIComponent(params.key)
+  const key = decodeURIComponent((await params).key)
   const def = PROMPT_DEFAULTS.find(p => p.key === key)
   if (!def) return NextResponse.json({ error: 'Unknown prompt key' }, { status: 404 })
 
@@ -28,14 +28,14 @@ export async function GET(
 /** PUT /api/admin/prompts/:key — save edited prompt content */
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { key: string } },
+  { params }: { params: Promise<{ key: string }> },
 ) {
   await requireAdmin()
   const result = await parseBodyOrError(req, UpdateSystemPromptSchema)
   if ('error' in result) return result.error
   const { data } = result
 
-  const key = decodeURIComponent(params.key)
+  const key = decodeURIComponent((await params).key)
   const def = PROMPT_DEFAULTS.find(p => p.key === key)
   if (!def) {
     return NextResponse.json({ error: 'Unknown prompt key' }, { status: 404 })
@@ -62,10 +62,10 @@ export async function PUT(
 /** POST /api/admin/prompts/:key/reset — restore to default */
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { key: string } },
+  { params }: { params: Promise<{ key: string }> },
 ) {
   await requireAdmin()
-  const key = decodeURIComponent(params.key)
+  const key = decodeURIComponent((await params).key)
   const def = PROMPT_DEFAULTS.find(p => p.key === key)
   if (!def) return NextResponse.json({ error: 'Unknown prompt key' }, { status: 404 })
 

--- a/apps/web/src/app/api/admin/users/[id]/route.ts
+++ b/apps/web/src/app/api/admin/users/[id]/route.ts
@@ -5,7 +5,7 @@ import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { parseBodyOrError, UpdateUserSchema } from '@/lib/validate'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const admin = await requireAdmin()
   const result = await parseBodyOrError(req, UpdateUserSchema)
   if ('error' in result) return result.error
@@ -20,7 +20,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   if (data.name !== undefined) updateData.name = data.name
 
   const user = await prisma.user.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: updateData,
     select: {
       id: true, username: true, email: true, name: true,
@@ -37,7 +37,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   logAudit({
     userId: admin.id,
     action: data.role !== undefined ? 'user_role_change' : 'user_update',
-    target: `user:${params.id}`,
+    target: `user:${(await params).id}`,
     detail,
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
@@ -48,7 +48,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     logAudit({
       userId: admin.id,
       action: 'password_reset',
-      target: `user:${params.id}`,
+      target: `user:${(await params).id}`,
       detail: { resetBy: admin.id },
       ipAddress: getClientIp(req),
       userAgent: getUserAgent(req.headers),
@@ -58,37 +58,37 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(user)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const admin = await requireAdmin()
 
   // BLOCKER fix: prevent deleting the last admin or yourself, causing lockout.
-  if (params.id === admin.id) {
+  if ((await params).id === admin.id) {
     return NextResponse.json({ error: 'Cannot delete your own account' }, { status: 400 })
   }
   const adminCount = await prisma.user.count({ where: { role: 'admin', active: true } })
-  const targetUser = await prisma.user.findUnique({ where: { id: params.id }, select: { role: true, username: true } })
+  const targetUser = await prisma.user.findUnique({ where: { id: (await params).id }, select: { role: true, username: true } })
   if (adminCount <= 1 && targetUser?.role === 'admin') {
     return NextResponse.json({ error: 'Cannot delete the last admin account — this would lock out all admin access' }, { status: 400 })
   }
   const user = await prisma.user.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { username: true },
   })
-  await prisma.user.delete({ where: { id: params.id } })
+  await prisma.user.delete({ where: { id: (await params).id } })
 
   // GDPR: anonymize audit log entries referencing the deleted user
   await prisma.auditLog.updateMany({
-    where: { userId: params.id },
+    where: { userId: (await params).id },
     data: { userId: '[deleted]' },
   })
 
   // GDPR: anonymize ToolApprovalRequest entries referencing the deleted user
   await prisma.toolApprovalRequest.updateMany({
-    where: { userId: params.id },
+    where: { userId: (await params).id },
     data: { userId: '[deleted]' },
   })
   await prisma.toolApprovalRequest.updateMany({
-    where: { approvedBy: params.id },
+    where: { approvedBy: (await params).id },
     data: { approvedBy: '[deleted]' },
   })
 
@@ -96,7 +96,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: { id: stri
   logAudit({
     userId: admin.id,
     action: 'user_delete',
-    target: `user:${params.id}`,
+    target: `user:${(await params).id}`,
     detail: { username: user?.username },
     ipAddress: getClientIp(_req),
     userAgent: getUserAgent(_req.headers),

--- a/apps/web/src/app/api/agent-groups/[id]/members/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/members/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
   let parsed: unknown
   try { parsed = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
@@ -12,14 +12,14 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
   const agentExists = await prisma.agent.findUnique({ where: { id: agentId }, select: { id: true } })
   if (!agentExists) return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
-  await prisma.agentGroupMember.create({ data: { agentGroupId: params.id, agentId } })
+  await prisma.agentGroupMember.create({ data: { agentGroupId: (await params).id, agentId } })
   return NextResponse.json({ ok: true })
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
   const agentId = req.nextUrl.searchParams.get('agentId')
   if (!agentId) return NextResponse.json({ error: 'agentId required' }, { status: 400 })
-  await prisma.agentGroupMember.delete({ where: { agentGroupId_agentId: { agentGroupId: params.id, agentId } } })
+  await prisma.agentGroupMember.delete({ where: { agentGroupId_agentId: { agentGroupId: (await params).id, agentId } } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/agent-groups/[id]/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
   let body: Record<string, unknown>
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
@@ -11,7 +11,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     return NextResponse.json({ error: 'name must be a non-empty string' }, { status: 400 })
   }
   const g = await prisma.agentGroup.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(b.name        !== undefined && { name:        (b.name as string).trim() }),
       ...(b.description !== undefined && { description: b.description as string | null }),
@@ -21,8 +21,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(g)
 }
 
-export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
-  await prisma.agentGroup.delete({ where: { id: params.id } })
+  await prisma.agentGroup.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/agent-groups/[id]/tool-access/route.ts
+++ b/apps/web/src/app/api/agent-groups/[id]/tool-access/route.ts
@@ -2,20 +2,20 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
   let parsed: unknown
   try { parsed = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const { toolGroupId } = parsed as { toolGroupId?: string }
   if (!toolGroupId) return NextResponse.json({ error: 'toolGroupId required' }, { status: 400 })
-  await prisma.agentGroupToolAccess.create({ data: { agentGroupId: params.id, toolGroupId } })
+  await prisma.agentGroupToolAccess.create({ data: { agentGroupId: (await params).id, toolGroupId } })
   return NextResponse.json({ ok: true })
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireAdmin()
   const toolGroupId = req.nextUrl.searchParams.get('toolGroupId')
   if (!toolGroupId) return NextResponse.json({ error: 'toolGroupId required' }, { status: 400 })
-  await prisma.agentGroupToolAccess.delete({ where: { agentGroupId_toolGroupId: { agentGroupId: params.id, toolGroupId } } })
+  await prisma.agentGroupToolAccess.delete({ where: { agentGroupId_toolGroupId: { agentGroupId: (await params).id, toolGroupId } } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/agents/[id]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[id]/chat/route.ts
@@ -7,8 +7,8 @@ import { prisma } from '@/lib/db'
 // Find or create a "direct" ChatRoom between the current user and this agent.
 // Returns { roomId } so the caller can navigate to /messages?r=<roomId>.
 // The Conversation model is no longer used for new chats (SOC2: attribution via ChatRoomMember).
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const agent = await prisma.agent.findUnique({ where: { id: params.id } })
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const agent = await prisma.agent.findUnique({ where: { id: (await params).id } })
   if (!agent) return new NextResponse(null, { status: 404 })
 
   const session = await getServerSession(authOptions)

--- a/apps/web/src/app/api/agents/[id]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/route.ts
@@ -4,12 +4,12 @@ import { parseBodyOrError, UpdateAgentSchema } from '@/lib/validate'
 import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const agent = await prisma.agent.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       tasks: { orderBy: { updatedAt: 'desc' }, take: 20 },
       messages: { orderBy: { createdAt: 'desc' }, take: 10 },
@@ -19,7 +19,7 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   return NextResponse.json(agent)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Require admin — any authenticated user could otherwise overwrite any agent's
   // systemPrompt or contextConfig (privilege escalation).
   try { await requireAdmin() } catch {
@@ -39,31 +39,31 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (validatedData.tokenBudgetMonth !== undefined) data.tokenBudgetMonth = validatedData.tokenBudgetMonth
   if (validatedData.metadata !== undefined) {
     // Deep merge metadata so callers can update contextConfig without wiping systemPrompt
-    const existing = await prisma.agent.findUnique({ where: { id: params.id }, select: { metadata: true } })
+    const existing = await prisma.agent.findUnique({ where: { id: (await params).id }, select: { metadata: true } })
     const existingMeta = (existing?.metadata ?? {}) as Record<string, unknown>
     data.metadata = { ...existingMeta, ...validatedData.metadata }
   }
-  const agent = await prisma.agent.update({ where: { id: params.id }, data })
+  const agent = await prisma.agent.update({ where: { id: (await params).id }, data })
   return NextResponse.json(agent)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   let adminUser
   try { adminUser = await requireAdmin() } catch {
     return NextResponse.json({ error: 'Admin privileges required to delete agents' }, { status: 403 })
   }
 
-  const agent = await prisma.agent.findUnique({ where: { id: params.id }, select: { name: true } })
+  const agent = await prisma.agent.findUnique({ where: { id: (await params).id }, select: { name: true } })
 
   // Unassign tasks first to avoid FK violation
-  await prisma.task.updateMany({ where: { assignedAgent: params.id }, data: { assignedAgent: null } })
-  await prisma.agent.delete({ where: { id: params.id } })
+  await prisma.task.updateMany({ where: { assignedAgent: (await params).id }, data: { assignedAgent: null } })
+  await prisma.agent.delete({ where: { id: (await params).id } })
 
   // SOC2: audit agent deletion
   logAudit({
     userId: adminUser.id,
     action: 'agent_delete',
-    target: `agent:${params.id}`,
+    target: `agent:${(await params).id}`,
     detail: { name: agent?.name },
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),

--- a/apps/web/src/app/api/agents/[id]/token-usage/route.ts
+++ b/apps/web/src/app/api/agents/[id]/token-usage/route.ts
@@ -12,11 +12,11 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   await requireServiceAuth(req)
   const agent = await prisma.agent.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { tokenBudgetDay: true, tokenBudgetMonth: true },
   })
   if (!agent) return new NextResponse(null, { status: 404 })
@@ -31,15 +31,15 @@ export async function GET(
 
   const [dayAgg, monthAgg, weekRecords] = await Promise.all([
     prisma.agentTokenUsage.aggregate({
-      where: { agentId: params.id, recordedAt: { gte: dayStart } },
+      where: { agentId: (await params).id, recordedAt: { gte: dayStart } },
       _sum: { inputTokens: true, outputTokens: true },
     }),
     prisma.agentTokenUsage.aggregate({
-      where: { agentId: params.id, recordedAt: { gte: monthStart } },
+      where: { agentId: (await params).id, recordedAt: { gte: monthStart } },
       _sum: { inputTokens: true, outputTokens: true },
     }),
     prisma.agentTokenUsage.findMany({
-      where: { agentId: params.id, recordedAt: { gte: sevenDaysAgo } },
+      where: { agentId: (await params).id, recordedAt: { gte: sevenDaysAgo } },
       select: { inputTokens: true, outputTokens: true, recordedAt: true },
       orderBy: { recordedAt: 'asc' },
     }),

--- a/apps/web/src/app/api/bugs/[id]/route.ts
+++ b/apps/web/src/app/api/bugs/[id]/route.ts
@@ -3,17 +3,17 @@ import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 import { parseBodyOrError, UpdateBugSchema } from '@/lib/validate'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
   const bug = await prisma.bug.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } } },
   })
   if (!bug) return new NextResponse(null, { status: 404 })
   return NextResponse.json(bug)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
   const parsed = await parseBodyOrError(req, UpdateBugSchema)
   if ('error' in parsed) return parsed.error
@@ -36,15 +36,15 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   }
 
   const bug = await prisma.bug.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: updateData,
     include: { assignedUser: { select: { id: true, name: true, username: true, email: true, role: true } } },
   })
   return NextResponse.json(bug)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
-  await prisma.bug.delete({ where: { id: params.id } })
+  await prisma.bug.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/chat/conversations/[id]/memory/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/memory/route.ts
@@ -8,14 +8,14 @@ import { assertConversationOwner } from '@/lib/conversation-owner'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   // B2 fix: any user could inject/read memories in any conversation (no ownership check)
-  const check = await assertConversationOwner(req, params.id)
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
 
   const memories = await prisma.memory.findMany({
-    where: { conversationId: params.id },
+    where: { conversationId: (await params).id },
     orderBy: { createdAt: 'asc' },
   })
 
@@ -28,10 +28,10 @@ export async function GET(
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   // B2 fix: any user could inject/read memories in any conversation (no ownership check)
-  const check = await assertConversationOwner(req, params.id)
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
 
   const { key, value, context } = await req.json()
@@ -53,7 +53,7 @@ export async function POST(
   await prisma.memory.upsert({
     where: {
       conversationId_key: {
-        conversationId: params.id,
+        conversationId: (await params).id,
         key
       }
     },
@@ -63,7 +63,7 @@ export async function POST(
       updatedAt: new Date(),
     },
     create: {
-      conversationId: params.id,
+      conversationId: (await params).id,
       key,
       value,
       context: context || null,
@@ -79,9 +79,9 @@ export async function POST(
  */
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const check = await assertConversationOwner(req, params.id)
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
 
   const searchParams = req.nextUrl.searchParams
@@ -93,7 +93,7 @@ export async function DELETE(
 
   await prisma.memory.deleteMany({
     where: {
-      conversationId: params.id,
+      conversationId: (await params).id,
       key: key,
     },
   })

--- a/apps/web/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -4,13 +4,13 @@ import { assertConversationOwner } from '@/lib/conversation-owner'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // B1 fix: this route had no auth at all — any caller could read any conversation's messages
-  const check = await assertConversationOwner(req, params.id)
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
 
   const messages = await prisma.message.findMany({
-    where: { conversationId: params.id },
+    where: { conversationId: (await params).id },
     orderBy: { createdAt: 'asc' },
   })
   return NextResponse.json(messages)

--- a/apps/web/src/app/api/chat/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/route.ts
@@ -5,16 +5,16 @@ import { parseBodyOrError, UpdateConversationSchema } from '@/lib/validate'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  const check = await assertConversationOwner(req, params.id)
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
-  const convo = await prisma.conversation.findUnique({ where: { id: params.id } })
+  const convo = await prisma.conversation.findUnique({ where: { id: (await params).id } })
   if (!convo) return new NextResponse(null, { status: 404 })
   return NextResponse.json(convo)
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const check = await assertConversationOwner(req, params.id)
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
 
   // SOC2 [INPUT-001]: Validate request body with Zod schema
@@ -34,18 +34,18 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   }
 
   const convo = await prisma.conversation.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: updateData,
     include: { _count: { select: { messages: true } } },
   })
   return NextResponse.json(convo)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
-  const check = await assertConversationOwner(req, params.id)
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const check = await assertConversationOwner(req, (await params).id)
   if (check instanceof NextResponse) return check
   await prisma.conversation.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: { archivedAt: new Date() },
   })
   return new NextResponse(null, { status: 204 })

--- a/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
+++ b/apps/web/src/app/api/chat/conversations/[id]/stream/route.ts
@@ -13,7 +13,7 @@ export const dynamic = 'force-dynamic'
 // SOC2: [LOW-1] Maximum allowed request body size (1 MB)
 const MAX_BODY_BYTES = 1_048_576
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // SOC2: [LOW-1] Reject oversized bodies before reading them into memory.
   const contentLength = req.headers.get('content-length')
   if (contentLength && parseInt(contentLength, 10) > MAX_BODY_BYTES) {
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       return env ? `@${env.name} (environment_id: ${env.id})` : `@${name}`
     })
   }
-  const { id: conversationId } = params
+  const { id: conversationId } = await params
 
   // B3 fix: stream route had no ownership check — any user could read/write any conversation via streaming
   const ownerCheck = await assertConversationOwner(req, conversationId)

--- a/apps/web/src/app/api/conversations/[id]/traces/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/traces/route.ts
@@ -6,10 +6,10 @@ import { NextRequest } from 'next/server'
 export const dynamic = 'force-dynamic'
 
 // GET /api/conversations/[id]/traces — Get trace timeline for a conversation
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const traces = await prisma.agentTrace.findMany({
-    where: { conversationId: params.id },
+    where: { conversationId: (await params).id },
     orderBy: { step: 'asc' },
   })
   return NextResponse.json(traces)

--- a/apps/web/src/app/api/dns/nodehosts/[ip]/route.ts
+++ b/apps/web/src/app/api/dns/nodehosts/[ip]/route.ts
@@ -2,23 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { upsertNodeHost, deleteNodeHost } from '@/lib/dns'
 import { requireAdmin } from '@/lib/auth'
 
-export async function PUT(req: NextRequest, { params }: { params: { ip: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ ip: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const body = await req.json()
   if (!Array.isArray(body.hostnames) || body.hostnames.length === 0)
     return NextResponse.json({ error: 'hostnames required' }, { status: 400 })
   try {
-    await upsertNodeHost(params.ip, body.hostnames)
-    return NextResponse.json({ ip: params.ip, hostnames: body.hostnames })
+    await upsertNodeHost((await params).ip, body.hostnames)
+    return NextResponse.json({ ip: (await params).ip, hostnames: body.hostnames })
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { ip: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ ip: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   try {
-    const deleted = await deleteNodeHost(params.ip)
+    const deleted = await deleteNodeHost((await params).ip)
     if (!deleted) return NextResponse.json({ error: 'Not found' }, { status: 404 })
     return new NextResponse(null, { status: 204 })
   } catch (err) {

--- a/apps/web/src/app/api/dns/records/[ip]/route.ts
+++ b/apps/web/src/app/api/dns/records/[ip]/route.ts
@@ -13,10 +13,10 @@ function isValidHostname(h: string): boolean {
   return HOSTNAME_RE.test(h)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { ip: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ ip: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
-  if (!isValidIp(params.ip)) {
+  if (!isValidIp((await params).ip)) {
     return NextResponse.json({ error: 'Invalid IP address' }, { status: 400 })
   }
 
@@ -27,22 +27,22 @@ export async function PUT(req: NextRequest, { params }: { params: { ip: string }
   }
 
   try {
-    await upsertCustomRecord(params.ip, hostnames)
+    await upsertCustomRecord((await params).ip, hostnames)
     return NextResponse.json({ ip, hostnames })
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 })
   }
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { ip: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ ip: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
-  if (!isValidIp(params.ip)) {
+  if (!isValidIp((await params).ip)) {
     return NextResponse.json({ error: 'Invalid IP address' }, { status: 400 })
   }
 
   try {
-    const deleted = await deleteCustomRecord(params.ip)
+    const deleted = await deleteCustomRecord((await params).ip)
     if (!deleted) return NextResponse.json({ error: 'Not found' }, { status: 404 })
     return new NextResponse(null, { status: 204 })
   } catch (err) {

--- a/apps/web/src/app/api/environments/[id]/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/agents/[agentId]/route.ts
@@ -3,12 +3,12 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
 /** DELETE /api/environments/:id/agents/:agentId — unlink an agent from this environment */
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string; agentId: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string; agentId: string }> }) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   await prisma.agentEnvironment.deleteMany({
-    where: { agentId: params.agentId, environmentId: params.id },
+    where: { agentId: (await params).agentId, environmentId: (await params).id },
   })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/environments/[id]/agents/route.ts
+++ b/apps/web/src/app/api/environments/[id]/agents/route.ts
@@ -3,13 +3,13 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
 /** POST /api/environments/:id/agents — link an agent to this environment */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const body = await req.json().catch(() => ({}))
   if (!body.agentId) return NextResponse.json({ error: 'agentId is required' }, { status: 400 })
 
   const [env, agent] = await Promise.all([
-    prisma.environment.findUnique({ where: { id: params.id } }),
+    prisma.environment.findUnique({ where: { id: (await params).id } }),
     prisma.agent.findUnique({ where: { id: body.agentId } }),
   ])
   if (!env)   return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
@@ -17,12 +17,12 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   // Idempotent — ignore if already linked
   const existing = await prisma.agentEnvironment.findFirst({
-    where: { agentId: body.agentId, environmentId: params.id },
+    where: { agentId: body.agentId, environmentId: (await params).id },
   })
   if (existing) return NextResponse.json(existing, { status: 200 })
 
   const link = await prisma.agentEnvironment.create({
-    data: { agentId: body.agentId, environmentId: params.id },
+    data: { agentId: body.agentId, environmentId: (await params).id },
     include: { agent: true },
   })
   return NextResponse.json(link, { status: 201 })

--- a/apps/web/src/app/api/environments/[id]/bootstrap/route.ts
+++ b/apps/web/src/app/api/environments/[id]/bootstrap/route.ts
@@ -16,19 +16,19 @@ import { bootstrapCluster } from '@/lib/cluster-bootstrap'
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
 
   const jobId = await startJob(
     'cluster-bootstrap',
     `Bootstrap: ${env.name}`,
-    { environmentId: params.id },
+    { environmentId: (await params).id },
     async (log) => {
-      await bootstrapCluster(params.id, (event) => {
+      await bootstrapCluster((await params).id, (event) => {
         const prefix = event.type === 'step'  ? '▶' :
                        event.type === 'error' ? '✗' :
                        event.type === 'done'  ? '✓' : ' '

--- a/apps/web/src/app/api/environments/[id]/credentials/route.ts
+++ b/apps/web/src/app/api/environments/[id]/credentials/route.ts
@@ -15,11 +15,11 @@ import { prisma } from '@/lib/db'
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const body = await req.json() as {
@@ -43,6 +43,6 @@ export async function PATCH(
     data.kubeconfig = body.kubeconfig.trim() || null
   }
 
-  await prisma.environment.update({ where: { id: params.id }, data })
+  await prisma.environment.update({ where: { id: (await params).id }, data })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/environments/[id]/deploy-gateway/route.ts
+++ b/apps/web/src/app/api/environments/[id]/deploy-gateway/route.ts
@@ -14,7 +14,7 @@ import { bootstrapLocalEnvironment, type LocalBootstrapEvent } from '@/lib/local
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
@@ -28,7 +28,7 @@ export async function POST(
       }
 
       try {
-        await bootstrapLocalEnvironment(params.id, send)
+        await bootstrapLocalEnvironment((await params).id, send)
       } catch (err) {
         send({ type: 'error', message: err instanceof Error ? err.message : String(err) })
       } finally {

--- a/apps/web/src/app/api/environments/[id]/drift/[reportId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/drift/[reportId]/route.ts
@@ -7,18 +7,18 @@ import { prisma } from '@/lib/db'
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string; reportId: string } },
+  { params }: { params: Promise<{ id: string; reportId: string }> },
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 
   const report = await prisma.driftReport.findUnique({
-    where: { id: params.reportId },
+    where: { id: (await params).reportId },
   })
 
-  if (!report || report.environmentId !== params.id) {
+  if (!report || report.environmentId !== (await params).id) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 

--- a/apps/web/src/app/api/environments/[id]/drift/route.ts
+++ b/apps/web/src/app/api/environments/[id]/drift/route.ts
@@ -9,18 +9,18 @@ import { detectGitOpsDriftForEnv } from '@/jobs/gitops-drift'
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const reports = await prisma.driftReport.findMany({
-    where:   { environmentId: params.id },
+    where:   { environmentId: (await params).id },
     orderBy: { scannedAt: 'desc' },
     take:    10,
   })
@@ -39,18 +39,18 @@ export async function GET(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => {
     throw Object.assign(new Error('Unauthorized'), { status: 401 })
   })
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   try {
-    await detectGitOpsDriftForEnv(params.id)
+    await detectGitOpsDriftForEnv((await params).id)
   } catch (e) {
     console.error('[drift] Drift detection failed:', e)
     return NextResponse.json(
@@ -61,7 +61,7 @@ export async function POST(
 
   // Return the freshly-created report
   const latest = await prisma.driftReport.findFirst({
-    where:   { environmentId: params.id },
+    where:   { environmentId: (await params).id },
     orderBy: { scannedAt: 'desc' },
   })
   if (!latest) return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/aggregate/route.ts
@@ -6,10 +6,10 @@ export const dynamic = 'force-dynamic'
 // GET /api/environments/[id]/evals/aggregate
 // Chart data for eval dashboard.
 // Query params: type=conversation|task|skill|hook, window=7|30|90
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const envId = params.id
+  const envId = (await params).id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/rulesets/route.ts
@@ -7,8 +7,8 @@ export const dynamic = 'force-dynamic'
 // List all eval rulesets.
 // POST /api/environments/[id]/evals/rulesets
 // Create or update a ruleset (admin only).
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  const envId = params.id
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const envId = (await params).id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
@@ -30,8 +30,8 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(parsed)
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const envId = params.id
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const envId = (await params).id
 
   // Admin check
   try {

--- a/apps/web/src/app/api/environments/[id]/evals/run/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/run/route.ts
@@ -12,15 +12,15 @@ const RunEvalSchema = z.object({
 
 // POST /api/environments/[id]/evals/run
 // Auto-eval trigger — evaluates a conversation or task after completion.
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = params
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   try {
     await requireGatewayAuthForEnvironment(req, id)
   } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const envId = params.id
+  const envId = (await params).id
 
   // Verify environment exists
   const env = await prisma.environment.findUnique({ where: { id: envId } })

--- a/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/hook/[hookId]/route.ts
@@ -5,10 +5,10 @@ export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores/hook/[hookId]
 // Score for a specific hook NebulaInstance.
-export async function GET(_req: NextRequest, { params }: { params: { id: string; hookId: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string; hookId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const envId = params.id
+  const envId = (await params).id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
@@ -18,7 +18,7 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string;
     where: {
       environmentId_name: {
         environmentId: envId,
-        name: params.hookId,
+        name: (await params).hookId,
       },
       category: 'hook',
     },

--- a/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/route.ts
@@ -5,10 +5,10 @@ export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores
 // Score overview for all targets in an environment.
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const envId = params.id
+  const envId = (await params).id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/evals/scores/skill/[skillId]/route.ts
@@ -5,10 +5,10 @@ export const dynamic = 'force-dynamic'
 
 // GET /api/environments/[id]/evals/scores/skill/[skillId]
 // Score for a specific skill NebulaInstance.
-export async function GET(_req: NextRequest, { params }: { params: { id: string; skillId: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string; skillId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const envId = params.id
+  const envId = (await params).id
 
   const env = await prisma.environment.findUnique({ where: { id: envId } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
@@ -18,7 +18,7 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string;
     where: {
       environmentId_name: {
         environmentId: envId,
-        name: params.skillId,
+        name: (await params).skillId,
       },
       category: 'skill',
     },

--- a/apps/web/src/app/api/environments/[id]/gateway/route.ts
+++ b/apps/web/src/app/api/environments/[id]/gateway/route.ts
@@ -9,9 +9,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
   if (!env.gatewayUrl || !env.gatewayToken) {
     return NextResponse.json({ error: 'Gateway not connected' }, { status: 422 })

--- a/apps/web/src/app/api/environments/[id]/generate-join/route.ts
+++ b/apps/web/src/app/api/environments/[id]/generate-join/route.ts
@@ -12,7 +12,7 @@ function hashJoinToken(raw: string): string {
 // to prevent type confusion (e.g. forging localhost type to trigger Docker-socket paths)
 const ALLOWED_GATEWAY_TYPES = new Set(['cluster', 'docker', 'localhost'])
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // B3 fix: generate-join previously had no auth — BEARER_PATHS only checked that
   // the Authorization header started with 'Bearer', not that it was a valid token.
   // Any caller could mint a join token for any environment. Require admin session.
@@ -20,12 +20,12 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   // Burn any unused tokens for this environment first (only one active at a time)
   await prisma.environmentJoinToken.deleteMany({
-    where: { environmentId: params.id, usedAt: null },
+    where: { environmentId: (await params).id, usedAt: null },
   })
 
   const rawToken = 'mcg_' + randomBytes(24).toString('hex')
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   // admin and never persisted. Existing plaintext tokens in the DB still work
   // via the dual-lookup in the join/manifest routes (hash-first, plaintext fallback).
   await prisma.environmentJoinToken.create({
-    data: { token: hashJoinToken(rawToken), environmentId: params.id, expiresAt },
+    data: { token: hashJoinToken(rawToken), environmentId: (await params).id, expiresAt },
   })
 
   // Replace token reference with rawToken in the commands below

--- a/apps/web/src/app/api/environments/[id]/git-provider/route.ts
+++ b/apps/web/src/app/api/environments/[id]/git-provider/route.ts
@@ -15,11 +15,11 @@ import { getGitProviderConfig } from '@/lib/git-provider'
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   // Verify gateway token
   const auth = req.headers.get('authorization')
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const expectedToken = env.gatewayToken

--- a/apps/web/src/app/api/environments/[id]/infrastructure/route.ts
+++ b/apps/web/src/app/api/environments/[id]/infrastructure/route.ts
@@ -114,10 +114,10 @@ function parsePod(pod: any): CachedPod {
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
   if (!env.gatewayUrl || !env.gatewayToken) {
     const missing = []

--- a/apps/web/src/app/api/environments/[id]/ingress/sync/route.ts
+++ b/apps/web/src/app/api/environments/[id]/ingress/sync/route.ts
@@ -20,11 +20,11 @@ export interface K8sIngressRule {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   // Verify gateway token
   const auth = req.headers.get('authorization')
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const expectedToken = env.gatewayToken
@@ -59,14 +59,14 @@ export async function POST(
   const ingressPointByDomain = new Map<string, any>()
   for (const [domainSuffix] of parentDomainLookup) {
     let ip = await prisma.ingressPoint.findFirst({
-      where: { environmentId: params.id, type: 'traefik', domainId: parentDomainLookup.get(domainSuffix)!.id },
+      where: { environmentId: (await params).id, type: 'traefik', domainId: parentDomainLookup.get(domainSuffix)!.id },
     })
     if (!ip) {
       const d = parentDomainLookup.get(domainSuffix)!
       ip = await prisma.ingressPoint.create({
         data: {
           domainId:      d.id,
-          environmentId: params.id,
+          environmentId: (await params).id,
           name:          `${env.name} (${d.name})`,
           type:          'traefik',
           certManager:   true,

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/hook-logs/route.ts
@@ -10,13 +10,13 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const logs = await prisma.hookExecutionLog.findMany({
-    where: { nebula: { environmentId: params.id, name: params.name } },
+    where: { nebula: { environmentId: (await params).id, name: (await params).name } },
     orderBy: { startedAt: 'desc' },
     take: 50,
   })
@@ -29,14 +29,14 @@ export async function GET(
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const body = await req.json()
   const entry = await prisma.nebulaInstance.findFirst({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   if (!entry) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/install/route.ts
@@ -10,12 +10,12 @@ export const dynamic = 'force-dynamic'
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const tier = await prisma.environmentUserTier.findUnique({
-    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+    where: { userId_environmentId: { userId: user.id, environmentId: (await params).id } },
   })
   const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
   if (!['operator', 'admin'].includes(effectiveTier)) {
@@ -25,7 +25,7 @@ export async function POST(
     )
   }
   const def = await prisma.novaDefinition.findFirst({
-    where: { name: params.name },
+    where: { name: (await params).name },
   })
   if (!def) {
     return NextResponse.json(
@@ -34,7 +34,7 @@ export async function POST(
     )
   }
   const existing = await prisma.nebulaInstance.findFirst({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   if (existing) {
     return NextResponse.json(
@@ -44,7 +44,7 @@ export async function POST(
   }
   const entry = await prisma.nebulaInstance.create({
     data: {
-      environmentId: params.id,
+      environmentId: (await params).id,
       name: def.name,
       category: def.category,
       spec: def.spec,

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/route.ts
@@ -18,10 +18,10 @@ async function requireOperator(userId: string, envId: string, role: string) {
  */
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
   const entry = await prisma.nebulaInstance.findFirst({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   if (!entry) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -35,16 +35,16 @@ export async function GET(
  */
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  if (!(await requireOperator(user.id, params.id, user.role))) {
+  if (!(await requireOperator(user.id, (await params).id, user.role))) {
     return NextResponse.json({ error: 'Operator access required' }, { status: 403 })
   }
   const body = await req.json()
   const existing = await prisma.nebulaInstance.findFirst({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   if (!existing) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -71,15 +71,15 @@ export async function PUT(
  */
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  if (!(await requireOperator(user.id, params.id, user.role))) {
+  if (!(await requireOperator(user.id, (await params).id, user.role))) {
     return NextResponse.json({ error: 'Operator access required' }, { status: 403 })
   }
   await prisma.nebulaInstance.deleteMany({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/skill-logs/route.ts
@@ -11,13 +11,13 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const logs = await prisma.skillExecutionLog.findMany({
-    where: { nebula: { environmentId: params.id, name: params.name } },
+    where: { nebula: { environmentId: (await params).id, name: (await params).name } },
     orderBy: { createdAt: 'desc' },
     take: 50,
   })

--- a/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/[name]/test/route.ts
@@ -10,12 +10,12 @@ export const dynamic = 'force-dynamic'
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string; name: string } }
+  { params }: { params: Promise<{ id: string; name: string }> }
 ) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const tier = await prisma.environmentUserTier.findUnique({
-    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+    where: { userId_environmentId: { userId: user.id, environmentId: (await params).id } },
   })
   const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
   if (!['operator', 'admin'].includes(effectiveTier)) {
@@ -26,7 +26,7 @@ export async function POST(
   }
   const body = await req.json()
   const entry = await prisma.nebulaInstance.findFirst({
-    where: { environmentId: params.id, name: params.name },
+    where: { environmentId: (await params).id, name: (await params).name },
   })
   if (!entry) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/active/route.ts
@@ -10,13 +10,13 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const entries = await prisma.nebulaInstance.findMany({
-    where: { environmentId: params.id, isInstalled: true },
+    where: { environmentId: (await params).id, isInstalled: true },
     orderBy: { name: 'asc' },
   })
   return NextResponse.json(entries)

--- a/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/discovery/route.ts
@@ -10,16 +10,16 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const defaults = await prisma.novaDefinition.findMany({
     orderBy: { name: 'asc' },
   })
   const installed = await prisma.nebulaInstance.findMany({
-    where: { environmentId: params.id },
+    where: { environmentId: (await params).id },
     include: { novaDefinition: true },
     orderBy: { name: 'asc' },
   })

--- a/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/effectiveness/route.ts
@@ -10,13 +10,13 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const entries = await prisma.nebulaInstance.findMany({
-    where: { environmentId: params.id, isInstalled: true },
+    where: { environmentId: (await params).id, isInstalled: true },
     include: {
       hookLogs: { take: 1000, orderBy: { startedAt: 'desc' } },
       skillLogs: { take: 1000, orderBy: { createdAt: 'desc' } },
@@ -26,7 +26,7 @@ export async function GET(
   // AgentScore is on Environment, not NebulaInstance — fetch once per env
   const agentScores = await prisma.agentScore.findMany({
     where: {
-      environmentId: params.id,
+      environmentId: (await params).id,
       targetType: { in: ['skill', 'hook'] },
     },
   })

--- a/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/hook/report/route.ts
@@ -5,8 +5,8 @@ import { prisma } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
 /** POST /api/environments/[id]/nebula/hook/report — Report hook execution result */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = params
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
   const body = await req.json()
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   // Find the nebula instance
   const nebula = await prisma.nebulaInstance.findFirst({
-    where: { id: nebulaId, environmentId: params.id },
+    where: { id: nebulaId, environmentId: (await params).id },
   })
   if (!nebula) {
     return NextResponse.json({ error: 'NebulaInstance not found' }, { status: 404 })

--- a/apps/web/src/app/api/environments/[id]/nebula/route.ts
+++ b/apps/web/src/app/api/environments/[id]/nebula/route.ts
@@ -20,10 +20,10 @@ const CreateNebulaInstanceSchema = z.object({
  */
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const entries = await prisma.nebulaInstance.findMany({
-    where: { environmentId: params.id },
+    where: { environmentId: (await params).id },
     include: { novaDefinition: { select: { title: true, version: true } } },
     orderBy: { name: 'asc' },
   })
@@ -36,7 +36,7 @@ export async function GET(
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const user = await getCurrentUser()
   if (!user) {
@@ -44,7 +44,7 @@ export async function POST(
   }
   // Require operator or admin tier — check environment-level tier
   const tier = await prisma.environmentUserTier.findUnique({
-    where: { userId_environmentId: { userId: user.id, environmentId: params.id } },
+    where: { userId_environmentId: { userId: user.id, environmentId: (await params).id } },
   })
   const effectiveTier = user.role === 'admin' ? 'admin' : (tier?.tier ?? 'viewer')
   if (!['operator', 'admin'].includes(effectiveTier)) {
@@ -57,7 +57,7 @@ export async function POST(
   if ('error' in result) return result.error
   const { data: body } = result
   const entry = await prisma.nebulaInstance.create({
-    data: { ...body, environmentId: params.id, isForked: true },
+    data: { ...body, environmentId: (await params).id, isForked: true },
   })
   return NextResponse.json(entry)
 }

--- a/apps/web/src/app/api/environments/[id]/preflight/route.ts
+++ b/apps/web/src/app/api/environments/[id]/preflight/route.ts
@@ -146,10 +146,10 @@ async function gatewayExec(
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    await requireGatewayAuthForEnvironment(_req, params.id)
+    await requireGatewayAuthForEnvironment(_req, (await params).id)
   } catch {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } })
   }
@@ -166,7 +166,7 @@ export async function GET(
       const done  = (payload: Record<string, unknown>) => emit({ type: 'done', ...payload })
 
       try {
-        const env = await prisma.environment.findUnique({ where: { id: params.id } })
+        const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
         if (!env) { emit({ type: 'error', message: 'Environment not found' }); return }
         if (env.type !== 'cluster') { emit({ type: 'error', message: 'Preflight only applies to cluster environments' }); return }
 

--- a/apps/web/src/app/api/environments/[id]/rotate-token/route.ts
+++ b/apps/web/src/app/api/environments/[id]/rotate-token/route.ts
@@ -17,7 +17,7 @@ import { requireAdmin } from '@/lib/auth'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 import { randomBytes } from 'crypto'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Require admin auth — only admins can rotate environment gateway tokens
   let admin
   try {
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
 
   const env = await prisma.environment.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { id: true, name: true, gatewayToken: true },
   })
 
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const newToken = 'mcga_' + randomBytes(32).toString('hex')
 
   await prisma.environment.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: { gatewayToken: newToken },
   })
 
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   void logAudit({
     userId: admin.id,
     action: 'environment_update',
-    target: `environment:${params.id}`,
+    target: `environment:${(await params).id}`,
     detail: { event: 'gateway_token_rotated', environmentName: env.name },
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   // The caller must distribute it to the gateway immediately.
   return NextResponse.json({
     ok: true,
-    environmentId: params.id,
+    environmentId: (await params).id,
     gatewayToken: newToken,
     message: 'Gateway token rotated. Distribute the new token to your gateway immediately — it will not be shown again.',
   })

--- a/apps/web/src/app/api/environments/[id]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/route.ts
@@ -6,7 +6,7 @@ import { parseBodyOrError, CreateEnvironmentSchema } from '@/lib/validate'
 import { encrypt, decrypt } from '@/lib/encryption'
 import { timingSafeEqual } from 'crypto'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // BLOCKER fix: GET had no auth — any request with an arbitrary Bearer header
   // passes through BEARER_PATHS middleware without a session, exposing environment
   // config (gitOwner/Repo, gatewayUrl, tool list, policyConfig) to unauthenticated callers.
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   // in PUT or by the downstream operation. For GET, validate it matches this env.
   if (auth?.startsWith('Bearer ')) {
     const token = auth.slice(7)
-    const envCheck = await prisma.environment.findUnique({ where: { id: params.id }, select: { gatewayToken: true } })
+    const envCheck = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { gatewayToken: true } })
     if (!envCheck?.gatewayToken) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   }
 
   const env = await prisma.environment.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       tools:     { orderBy: { name: 'asc' } },
       agents:    { include: { agent: true } },
@@ -52,7 +52,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   })
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = req.headers.get('authorization')
 
   if (auth?.startsWith('Bearer ')) {
@@ -60,7 +60,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     // Validate the token against the stored gateway token for this environment.
     const body = await req.json()
     const env = await prisma.environment.findUnique({
-      where: { id: params.id },
+      where: { id: (await params).id },
       select: { gatewayToken: true, gatewayUrl: true },
     })
     if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -85,7 +85,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     if (body.gatewayVersion !== undefined) data.gatewayVersion = body.gatewayVersion || null
 
     const updated = await prisma.environment.update({
-      where: { id: params.id },
+      where: { id: (await params).id },
       data,
       include: {
         tools:     { orderBy: { name: 'asc' } },
@@ -98,7 +98,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       void logAudit({
         userId: 'gateway',
         action: 'environment_update',
-        target: `environment:${params.id}`,
+        target: `environment:${(await params).id}`,
         detail: { field: 'gatewayUrl', changed: true },
       })
     }
@@ -116,7 +116,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     const { data } = result
 
     const admin = await requireAdmin()
-    const existing = await prisma.environment.findUnique({ where: { id: params.id }, select: { gatewayUrl: true } })
+    const existing = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { gatewayUrl: true } })
     const updateData: Record<string, unknown> = {}
     if (data.name !== undefined) updateData.name = data.name.trim()
     if (data.type !== undefined) updateData.type = data.type
@@ -142,7 +142,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     if (data.hubUrl          !== undefined) updateData.hubUrl          = data.hubUrl          ?? null
 
     const env = await prisma.environment.update({
-      where: { id: params.id },
+      where: { id: (await params).id },
       data: updateData,
       include: {
         tools:     { orderBy: { name: 'asc' } },
@@ -155,7 +155,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
     logAudit({
       userId: admin.id,
       action: 'environment_update',
-      target: `environment:${params.id}`,
+      target: `environment:${(await params).id}`,
       detail: { name: data.name ?? env.name, changes: Object.keys(updateData) },
       ipAddress: getClientIp(req),
       userAgent: getUserAgent(req.headers),
@@ -165,7 +165,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
       void logAudit({
         userId: admin.id,
         action: 'environment_update',
-        target: `environment:${params.id}`,
+        target: `environment:${(await params).id}`,
         detail: { field: 'gatewayUrl', changed: true },
       })
     }
@@ -178,19 +178,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   }
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const admin = await requireAdmin()
   const env = await prisma.environment.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { name: true },
   })
-  await prisma.environment.delete({ where: { id: params.id } })
+  await prisma.environment.delete({ where: { id: (await params).id } })
 
   // SOC2: [M-005] Log environment deletion (non-blocking)
   logAudit({
     userId: admin.id,
     action: 'environment_delete',
-    target: `environment:${params.id}`,
+    target: `environment:${(await params).id}`,
     detail: { name: env?.name },
     ipAddress: getClientIp(_req),
     userAgent: getUserAgent(_req.headers),

--- a/apps/web/src/app/api/environments/[id]/status/route.ts
+++ b/apps/web/src/app/api/environments/[id]/status/route.ts
@@ -6,10 +6,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const env = await prisma.environment.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       _count: {
         select: { agents: true, tools: true },

--- a/apps/web/src/app/api/environments/[id]/storage-stats/route.ts
+++ b/apps/web/src/app/api/environments/[id]/storage-stats/route.ts
@@ -87,10 +87,10 @@ function cephStats(cluster: any): StorageStats {
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env)                          return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
   if (!env.gatewayUrl || !env.gatewayToken) {
     return NextResponse.json({ error: 'Gateway not connected' }, { status: 422 })

--- a/apps/web/src/app/api/environments/[id]/storage/route.ts
+++ b/apps/web/src/app/api/environments/[id]/storage/route.ts
@@ -24,11 +24,11 @@ async function gatewayExec(
   return data.result ?? ''
 }
 
-export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (!env.gatewayUrl || !env.gatewayToken) {
     return NextResponse.json({ error: 'Gateway not connected' }, { status: 422 })

--- a/apps/web/src/app/api/environments/[id]/sync-status/route.ts
+++ b/apps/web/src/app/api/environments/[id]/sync-status/route.ts
@@ -24,16 +24,16 @@ interface ArgoCDApp {
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params
+  const { id } = await params
   try {
     await requireGatewayAuthForEnvironment(req, id)
   } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const { applications } = (await req.json()) as { applications: ArgoCDApp[] }
@@ -55,7 +55,7 @@ export async function POST(
     },
   }))
   await prisma.environment.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       lastSeen: new Date(),
       status: 'connected',
@@ -74,7 +74,7 @@ export async function POST(
     // Best-effort: mark PRs as merged if they're still "open" and the app is now Synced.
     // (A more precise match would require storing the commit SHA at PR creation time.)
     const openPRs = await prisma.gitOpsPR.findMany({
-      where: { environmentId: params.id, status: 'open', decision: 'auto' },
+      where: { environmentId: (await params).id, status: 'open', decision: 'auto' },
     })
 
     for (const pr of openPRs) {
@@ -98,19 +98,19 @@ export async function POST(
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = params
+  const { id } = await params
   await requireGatewayAuthForEnvironment(req, id).catch(() => { throw Object.assign(new Error('Unauthorized'), {status:401}) })
 
-  const env = await prisma.environment.findUnique({ where: { id: params.id } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const meta = (env.metadata as Record<string, unknown>) ?? {}
   const argocd = (meta.argocd as Record<string, unknown>) ?? null
 
   return NextResponse.json({
-    environmentId: params.id,
+    environmentId: (await params).id,
     argocd,
   })
 }

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/approve/route.ts
@@ -5,15 +5,15 @@ import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 // POST /api/environments/[id]/tools/[toolId]/approve
 // Approves a pending tool proposal — activates it so the gateway picks it up on next heartbeat.
-export async function POST(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string; toolId: string }> }) {
   // SOC2: CR-001 — require admin to approve tools (prevents unauthorized tool activation)
   const user = await requireAdmin()
 
   // Verify env exists
-  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { id: true } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-  const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
+  const tool = await prisma.mcpTool.findFirst({ where: { id: (await params).toolId, environmentId: (await params).id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (tool.status !== 'pending') return NextResponse.json({ error: 'Tool is not pending' }, { status: 400 })
   // SOC2: separation of duties — prevent self-approval.
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string;
   const body = await req.json().catch(() => ({}))
 
   const updated = await prisma.mcpTool.update({
-    where: { id: params.toolId },
+    where: { id: (await params).toolId },
     data: {
       status:  'active',
       enabled: body.enabled !== false,
@@ -39,8 +39,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string;
   logAudit({
     userId: user.id,
     action: 'tool_approve',
-    target: `tool:${params.toolId}`,
-    detail: { environmentId: params.id, toolName: tool.name },
+    target: `tool:${(await params).toolId}`,
+    detail: { environmentId: (await params).id, toolName: tool.name },
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
   }).catch(() => {})

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/reject/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/reject/route.ts
@@ -4,16 +4,16 @@ import { prisma } from '@/lib/db'
 import { logAudit, getClientIp, getUserAgent } from '@/lib/audit'
 
 // POST /api/environments/[id]/tools/[toolId]/reject
-export async function POST(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string; toolId: string }> }) {
   let user: Awaited<ReturnType<typeof requireAdmin>>
   try { user = await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
-  const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
+  const tool = await prisma.mcpTool.findFirst({ where: { id: (await params).toolId, environmentId: (await params).id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (tool.status !== 'pending') return NextResponse.json({ error: 'Tool is not pending' }, { status: 400 })
 
   const updated = await prisma.mcpTool.update({
-    where: { id: params.toolId },
+    where: { id: (await params).toolId },
     data: { status: 'rejected', enabled: false },
   })
 
@@ -21,8 +21,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string;
   logAudit({
     userId: user.id,
     action: 'tool_revoke',
-    target: `tool:${params.toolId}`,
-    detail: { environmentId: params.id, toolName: tool.name },
+    target: `tool:${(await params).toolId}`,
+    detail: { environmentId: (await params).id, toolName: tool.name },
     ipAddress: getClientIp(req),
     userAgent: getUserAgent(req.headers),
   }).catch(() => {})

--- a/apps/web/src/app/api/environments/[id]/tools/[toolId]/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/[toolId]/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getCurrentUser } from '@/lib/auth'
 
-export async function GET(_: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string; toolId: string }> }) {
   // Support gateway Bearer token OR user session
   const auth = _.headers.get('authorization')
   if (auth?.startsWith('Bearer ')) {
     const env = await prisma.environment.findUnique({
-      where: { id: params.id },
+      where: { id: (await params).id },
       select: { gatewayToken: true },
     })
     if (!env?.gatewayToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -17,17 +17,17 @@ export async function GET(_: NextRequest, { params }: { params: { id: string; to
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const tool = await prisma.mcpTool.findFirst({ where: { id: params.toolId, environmentId: params.id } })
+  const tool = await prisma.mcpTool.findFirst({ where: { id: (await params).toolId, environmentId: (await params).id } })
   if (!tool) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(tool)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string; toolId: string }> }) {
   // SOC2: CR-001 — require authenticated user
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   // Verify env exists
-  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { id: true } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const body = await req.json()
@@ -41,16 +41,16 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string; 
   if (body.enabled     !== undefined) data.enabled     = body.enabled
 
   const tool = await prisma.mcpTool.update({
-    where: { id: params.toolId },
+    where: { id: (await params).toolId },
     data,
   })
   return NextResponse.json(tool)
 }
 
-export async function DELETE(_: NextRequest, { params }: { params: { id: string; toolId: string } }) {
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string; toolId: string }> }) {
   // SOC2: CR-001 — require authenticated user
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  await prisma.mcpTool.delete({ where: { id: params.toolId } })
+  await prisma.mcpTool.delete({ where: { id: (await params).toolId } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/environments/[id]/tools/route.ts
+++ b/apps/web/src/app/api/environments/[id]/tools/route.ts
@@ -2,13 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getCurrentUser, requireGatewayAuthForEnvironment } from '@/lib/auth'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Support gateway Bearer auth OR admin session auth
   const auth = req.headers.get('authorization')
   if (auth?.startsWith('Bearer ')) {
     // Gateway path: validate the token is scoped to this specific environment
     try {
-      await requireGatewayAuthForEnvironment(req, params.id)
+      await requireGatewayAuthForEnvironment(req, (await params).id)
     } catch {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   }
 
   // Verify environment exists
-  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { id: true } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const { searchParams } = new URL(req.url)
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
   const tools = await prisma.mcpTool.findMany({
     where: {
-      environmentId: params.id,
+      environmentId: (await params).id,
       ...(enabledOnly ? { enabled: true, status: 'active' } : {}),
     },
     orderBy: [{ builtIn: 'desc' }, { name: 'asc' }],
@@ -39,7 +39,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(tools)
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // SOC2 HIGH-6: require admin for session callers (consistent with other env sub-routes)
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
 
   // Verify env exists
-  const env = await prisma.environment.findUnique({ where: { id: params.id }, select: { id: true } })
+  const env = await prisma.environment.findUnique({ where: { id: (await params).id }, select: { id: true } })
   if (!env) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   const body = await req.json()
@@ -65,7 +65,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   const tool = await prisma.mcpTool.create({
     data: {
-      environmentId: params.id,
+      environmentId: (await params).id,
       name:          body.name.trim(),
       description:   body.description.trim(),
       inputSchema:   body.inputSchema,

--- a/apps/web/src/app/api/environments/[id]/user-tiers/route.ts
+++ b/apps/web/src/app/api/environments/[id]/user-tiers/route.ts
@@ -2,17 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
   const tiers = await prisma.environmentUserTier.findMany({
-    where: { environmentId: params.id },
+    where: { environmentId: (await params).id },
     include: { user: { select: { id: true, username: true, email: true, name: true, role: true } } },
   })
   return NextResponse.json(tiers)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
   const { userId, tier } = await req.json()
@@ -21,19 +21,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (!valid.includes(tier)) return NextResponse.json({ error: `tier must be one of: ${valid.join(', ')}` }, { status: 400 })
 
   const result = await prisma.environmentUserTier.upsert({
-    where: { userId_environmentId: { userId, environmentId: params.id } },
-    create: { userId, environmentId: params.id, tier },
+    where: { userId_environmentId: { userId, environmentId: (await params).id } },
+    create: { userId, environmentId: (await params).id, tier },
     update: { tier },
     include: { user: { select: { id: true, username: true, email: true, name: true, role: true } } },
   })
   return NextResponse.json(result)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
 
   const userId = req.nextUrl.searchParams.get('userId')
   if (!userId) return NextResponse.json({ error: 'userId required' }, { status: 400 })
-  await prisma.environmentUserTier.deleteMany({ where: { userId, environmentId: params.id } })
+  await prisma.environmentUserTier.deleteMany({ where: { userId, environmentId: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
+++ b/apps/web/src/app/api/environments/join/[token]/manifest/route.ts
@@ -12,17 +12,17 @@ function settingStr(setting: { value: unknown } | null, fallback: string): strin
   return typeof setting?.value === 'string' ? setting.value : fallback
 }
 
-export async function GET(req: NextRequest, { params }: { params: { token: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
   // Dual lookup: hash-first (new tokens stored as SHA-256), plaintext fallback
   // for tokens created before hashing was introduced. The raw token from the URL
   // is still embedded in the returned manifest (gateway needs it); hashing only
   // protects the at-rest DB copy.
-  const tokenHash = createHash('sha256').update(params.token).digest('hex')
+  const tokenHash = createHash('sha256').update((await params).token).digest('hex')
   const record = await prisma.environmentJoinToken.findUnique({
     where: { token: tokenHash },
     include: { environment: true },
   }) ?? await prisma.environmentJoinToken.findUnique({
-    where: { token: params.token },
+    where: { token: (await params).token },
     include: { environment: true },
   })
 
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest, { params }: { params: { token: strin
 # ORION Gateway — auto-generated manifest
 # Environment: ${record.environment.name}
 # Expires: ${record.expiresAt.toISOString()}
-# Apply with: kubectl apply -f <(curl -s '${orionUrl}/api/environments/join/${params.token}/manifest')
+# Apply with: kubectl apply -f <(curl -s '${orionUrl}/api/environments/join/${(await params).token}/manifest')
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -170,7 +170,7 @@ metadata:
     orion/environment-id: "${record.environmentId}"
     orion/expires-at: "${record.expiresAt.toISOString()}"
 stringData:
-  join-token: "${params.token}"
+  join-token: "${(await params).token}"
   orion-url: "${remoteOrionUrl}"
   environment-id: ""
   gateway-token: ""

--- a/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/epics/[id]/approve-plan/route.ts
@@ -11,12 +11,12 @@ import { computeWaves } from '@/lib/plan-waves'
  * approved. For each such feature it sets planApprovedAt/planApprovedBy and
  * computes execution waves for its tasks.
  */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   const epic = await prisma.epic.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       features: {
         include: { tasks: { select: { id: true, dependsOn: true } } },

--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -4,22 +4,22 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateEpicSchema } from '@/lib/validate'
 import { handlePlanPatch } from '@/lib/plan-patch'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
   const epic = await prisma.epic.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { features: { include: { _count: { select: { tasks: true } } } } },
   })
   if (!epic) return new NextResponse(null, { status: 404 })
   return NextResponse.json(epic)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.epic.findUnique({ where: { id: params.id } })
+  const existing = await prisma.epic.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
@@ -35,23 +35,23 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (validatedData.status          !== undefined) data.status          = validatedData.status
   if (validatedData.planApprovedBy  !== undefined) data.planApprovedBy  = validatedData.planApprovedBy
   if (validatedData.planApprovedAt  !== undefined) data.planApprovedAt  = validatedData.planApprovedAt ? new Date(validatedData.planApprovedAt) : null
-  const epic = await prisma.epic.update({ where: { id: params.id }, data })
+  const epic = await prisma.epic.update({ where: { id: (await params).id }, data })
   return NextResponse.json(epic)
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  return handlePlanPatch('epic', params.id, req)
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return handlePlanPatch('epic', (await params).id, req)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.epic.findUnique({ where: { id: params.id } })
+  const existing = await prisma.epic.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
-  await prisma.epic.delete({ where: { id: params.id } })
+  await prisma.epic.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/eval-runs/[id]/route.ts
+++ b/apps/web/src/app/api/eval-runs/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   const run = await prisma.evalRun.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       suite: { select: { id: true, name: true } },
       agent: { select: { id: true, name: true } },

--- a/apps/web/src/app/api/eval-runs/[id]/score/route.ts
+++ b/apps/web/src/app/api/eval-runs/[id]/score/route.ts
@@ -82,11 +82,11 @@ Does the response satisfy the expected behavior? Respond with JSON only:
   }
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   const run = await prisma.evalRun.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       results: {
         include: { case: true },
@@ -168,7 +168,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   // Check if all results are scored
   const allResults = await prisma.evalCaseResult.findMany({
-    where: { runId: params.id },
+    where: { runId: (await params).id },
   })
 
   type CaseResult = (typeof allResults)[number]
@@ -194,7 +194,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     const failCount = allResults.filter((r: CaseResult) => r.passed === false).length
 
     await prisma.evalRun.update({
-      where: { id: params.id },
+      where: { id: (await params).id },
       data: {
         status: 'completed',
         scoreTotal,

--- a/apps/web/src/app/api/eval-suites/[id]/cases/[caseId]/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/cases/[caseId]/route.ts
@@ -4,7 +4,7 @@ import { requireServiceAuth } from '@/lib/auth'
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string; caseId: string } }
+  { params }: { params: Promise<{ id: string; caseId: string }> }
 ) {
   await requireServiceAuth(req)
 
@@ -23,7 +23,7 @@ export async function PUT(
   }
 
   const evalCase = await prisma.evalCase.update({
-    where: { id: params.caseId },
+    where: { id: (await params).caseId },
     data: {
       ...(body.title !== undefined && { title: body.title }),
       ...(body.prompt !== undefined && { prompt: body.prompt }),
@@ -38,10 +38,10 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string; caseId: string } }
+  { params }: { params: Promise<{ id: string; caseId: string }> }
 ) {
   await requireServiceAuth(req)
 
-  await prisma.evalCase.delete({ where: { id: params.caseId } })
+  await prisma.evalCase.delete({ where: { id: (await params).caseId } })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/eval-suites/[id]/cases/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/cases/route.ts
@@ -2,18 +2,18 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   const cases = await prisma.evalCase.findMany({
-    where: { suiteId: params.id },
+    where: { suiteId: (await params).id },
     orderBy: { createdAt: 'asc' },
   })
 
   return NextResponse.json(cases)
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   let body: {
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   const evalCase = await prisma.evalCase.create({
     data: {
-      suiteId: params.id,
+      suiteId: (await params).id,
       title: body.title,
       prompt: body.prompt,
       expectedOutput: body.expectedOutput ?? null,

--- a/apps/web/src/app/api/eval-suites/[id]/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   const suite = await prisma.evalSuite.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       agent: { select: { id: true, name: true } },
       cases: { orderBy: { createdAt: 'asc' } },
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(suite)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   let body: { name?: string; description?: string; agentId?: string | null }
@@ -36,7 +36,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   }
 
   const suite = await prisma.evalSuite.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(body.name !== undefined && { name: body.name }),
       ...(body.description !== undefined && { description: body.description }),
@@ -47,9 +47,9 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(suite)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
-  await prisma.evalSuite.delete({ where: { id: params.id } })
+  await prisma.evalSuite.delete({ where: { id: (await params).id } })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/eval-suites/[id]/run/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/run/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
 
   let body: { agentId: string; modelId?: string }
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   // Load suite with cases
   const suite = await prisma.evalSuite.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { cases: true },
   })
   if (!suite) return NextResponse.json({ error: 'Suite not found' }, { status: 404 })
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   // Create EvalRun
   const run = await prisma.evalRun.create({
     data: {
-      suiteId: params.id,
+      suiteId: (await params).id,
       agentId: body.agentId,
       modelId,
       status: 'pending',

--- a/apps/web/src/app/api/eval-suites/[id]/runs/route.ts
+++ b/apps/web/src/app/api/eval-suites/[id]/runs/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireServiceAuth } from '@/lib/auth'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
 
   const runs = await prisma.evalRun.findMany({
-    where: { suiteId: params.id },
+    where: { suiteId: (await params).id },
     orderBy: { createdAt: 'desc' },
     include: {
       agent: { select: { id: true, name: true } },

--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -4,14 +4,14 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   let caller
   try { caller = await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const isService = caller === null
   try {
     const execution = await prisma.toolExecution.findUnique({
-      where: { id: params.id },
+      where: { id: (await params).id },
     })
 
     if (!execution) {
@@ -34,7 +34,7 @@ export async function GET(
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   let caller
   try { caller = await requireServiceAuth(req) } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
@@ -42,7 +42,7 @@ export async function PATCH(
   try {
     // Load execution first to verify ownership before mutation
     const existing = await prisma.toolExecution.findUnique({
-      where: { id: params.id },
+      where: { id: (await params).id },
     })
     if (!existing) {
       return NextResponse.json(
@@ -81,7 +81,7 @@ export async function PATCH(
     if (completedAt !== undefined) updateData.completedAt = completedAt
 
     const execution = await prisma.toolExecution.update({
-      where: { id: params.id },
+      where: { id: (await params).id },
       data: updateData,
     })
 

--- a/apps/web/src/app/api/features/[id]/approve-plan/route.ts
+++ b/apps/web/src/app/api/features/[id]/approve-plan/route.ts
@@ -11,12 +11,12 @@ import { computeWaves } from '@/lib/plan-waves'
  * execution wave for every task under the feature. The worker only picks up
  * tasks whose feature has planApprovedAt set.
  */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   const feature = await prisma.feature.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { tasks: { select: { id: true, dependsOn: true } } },
   })
   if (!feature) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/features/[id]/route.ts
+++ b/apps/web/src/app/api/features/[id]/route.ts
@@ -4,22 +4,22 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateFeatureSchema } from '@/lib/validate'
 import { handlePlanPatch } from '@/lib/plan-patch'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
   const feature = await prisma.feature.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { _count: { select: { tasks: true } } },
   })
   if (!feature) return new NextResponse(null, { status: 404 })
   return NextResponse.json(feature)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.feature.findUnique({ where: { id: params.id } })
+  const existing = await prisma.feature.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
@@ -36,23 +36,23 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (validatedData.epicId          !== undefined) data.epicId          = validatedData.epicId
   if (validatedData.planApprovedBy  !== undefined) data.planApprovedBy  = validatedData.planApprovedBy
   if (validatedData.planApprovedAt  !== undefined) data.planApprovedAt  = validatedData.planApprovedAt ? new Date(validatedData.planApprovedAt) : null
-  const feature = await prisma.feature.update({ where: { id: params.id }, data })
+  const feature = await prisma.feature.update({ where: { id: (await params).id }, data })
   return NextResponse.json(feature)
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  return handlePlanPatch('feature', params.id, req)
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return handlePlanPatch('feature', (await params).id, req)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.feature.findUnique({ where: { id: params.id } })
+  const existing = await prisma.feature.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
-  await prisma.feature.delete({ where: { id: params.id } })
+  await prisma.feature.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/federation/tasks/[id]/status/route.ts
+++ b/apps/web/src/app/api/federation/tasks/[id]/status/route.ts
@@ -21,13 +21,13 @@ async function validateFederationToken(req: NextRequest): Promise<boolean> {
   return env !== null
 }
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   if (!(await validateFederationToken(req))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const task = await prisma.task.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { id: true, status: true, updatedAt: true, metadata: true },
   })
 

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/bootstrap/route.ts
@@ -165,11 +165,11 @@ function buildDockerCorefile(domainName: string): string {
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const domain = await prisma.domain.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { coreDnsEnvironment: true, dnsRecords: { where: { enabled: true } } },
   })
   if (!domain) return new Response(JSON.stringify({ error: 'Domain not found' }), { status: 404 })
@@ -263,7 +263,7 @@ export async function POST(
         }
 
         await prisma.domain.update({
-          where: { id: params.id },
+          where: { id: (await params).id },
           data: { coreDnsStatus: 'bootstrapped', ...(assignedIp ? { coreDnsIp: assignedIp } : {}) },
         })
 
@@ -274,7 +274,7 @@ export async function POST(
         const msg = err instanceof Error ? err.message : String(err)
         log(ctrl, `Bootstrap failed: ${msg}`)
         sse(ctrl, { type: 'done', success: false, error: msg })
-        await prisma.domain.update({ where: { id: params.id }, data: { coreDnsStatus: 'error' } })
+        await prisma.domain.update({ where: { id: (await params).id }, data: { coreDnsStatus: 'error' } })
       } finally {
         ctrl.close()
       }

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/records/[recordId]/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/records/[recordId]/route.ts
@@ -26,11 +26,11 @@ async function maybeSync(domainId: string) {
   }
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string; recordId: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string; recordId: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const record = await prisma.dnsRecord.update({
-    where: { id: params.recordId },
+    where: { id: (await params).recordId },
     data: {
       ...(body.ip        !== undefined && { ip:        body.ip.trim() }),
       ...(body.hostnames !== undefined && { hostnames: body.hostnames.map((h: string) => h.trim().toLowerCase()) }),
@@ -38,13 +38,13 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
       ...(body.comment   !== undefined && { comment:   body.comment }),
     },
   })
-  await maybeSync(params.id)
+  await maybeSync((await params).id)
   return NextResponse.json(record)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string; recordId: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string; recordId: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  await prisma.dnsRecord.delete({ where: { id: params.recordId } })
-  await maybeSync(params.id)
+  await prisma.dnsRecord.delete({ where: { id: (await params).recordId } })
+  await maybeSync((await params).id)
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/records/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/records/route.ts
@@ -22,16 +22,16 @@ async function getGatewayExec(envId: string) {
   }
 }
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const records = await prisma.dnsRecord.findMany({
-    where: { domainId: params.id },
+    where: { domainId: (await params).id },
     orderBy: { ip: 'asc' },
   })
   return NextResponse.json(records)
 }
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   if (!body.ip || !Array.isArray(body.hostnames) || body.hostnames.length === 0) {
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   const record = await prisma.dnsRecord.create({
     data: {
-      domainId:  params.id,
+      domainId:  (await params).id,
       ip:        body.ip.trim(),
       hostnames: body.hostnames.map((h: string) => h.trim().toLowerCase()),
       comment:   body.comment ?? null,
@@ -49,12 +49,12 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   })
 
   // Sync to CoreDNS if environment is configured
-  const domain = await prisma.domain.findUnique({ where: { id: params.id } })
+  const domain = await prisma.domain.findUnique({ where: { id: (await params).id } })
   if (domain?.coreDnsEnvironmentId && domain.coreDnsStatus === 'bootstrapped') {
     const gw = await getGatewayExec(domain.coreDnsEnvironmentId)
     if (gw) {
       try {
-        await syncDomainDns(params.id, gw.exec, gw.envType)
+        await syncDomainDns((await params).id, gw.exec, gw.envType)
       } catch (err) {
         console.error('[dns-sync] Sync failed after record create:', err)
       }

--- a/apps/web/src/app/api/ingress/domains/[id]/dns/sync/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/dns/sync/route.ts
@@ -3,9 +3,9 @@ import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 import { syncDomainDns } from '@/lib/dns-sync'
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  const domain = await prisma.domain.findUnique({ where: { id: params.id } })
+  const domain = await prisma.domain.findUnique({ where: { id: (await params).id } })
   if (!domain) return NextResponse.json({ error: 'Domain not found' }, { status: 404 })
   if (!domain.coreDnsEnvironmentId || domain.coreDnsStatus !== 'bootstrapped') {
     return NextResponse.json({ error: 'CoreDNS not bootstrapped for this domain' }, { status: 422 })
@@ -29,7 +29,7 @@ export async function POST(_req: NextRequest, { params }: { params: { id: string
   }
 
   try {
-    await syncDomainDns(params.id, exec, env.type)
+    await syncDomainDns((await params).id, exec, env.type)
     return NextResponse.json({ ok: true })
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 })

--- a/apps/web/src/app/api/ingress/domains/[id]/points/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/points/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const point = await prisma.ingressPoint.create({
     data: {
-      domainId:      params.id,
+      domainId:      (await params).id,
       environmentId: body.environmentId ?? null,
       name:          body.name.trim(),
       type:          body.type          ?? 'traefik',

--- a/apps/web/src/app/api/ingress/domains/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/domains/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const DOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/
@@ -14,7 +14,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     body.name = name
   }
   const domain = await prisma.domain.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(body.name                 !== undefined && { name:                 body.name }),
       ...(body.type                 !== undefined && { type:                 body.type }),
@@ -35,8 +35,8 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(domain)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  await prisma.domain.delete({ where: { id: params.id } })
+  await prisma.domain.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/middlewares/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/middlewares/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const middleware = await prisma.ingressMiddleware.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(body.name    !== undefined && { name:    body.name.trim() }),
       ...(body.type    !== undefined && { type:    body.type }),
@@ -17,8 +17,8 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(middleware)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  await prisma.ingressMiddleware.delete({ where: { id: params.id } })
+  await prisma.ingressMiddleware.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/bootstrap-middleware/route.ts
@@ -33,14 +33,14 @@ interface MiddlewareNovaConfig {
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const point = await prisma.ingressPoint.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { environment: true },
   })
   if (!point) {

--- a/apps/web/src/app/api/ingress/points/[id]/bootstrap-sso/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/bootstrap-sso/route.ts
@@ -18,14 +18,14 @@ import { getProvider, renderProviderConfig, type ProviderConfig } from '@/lib/pr
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const point = await prisma.ingressPoint.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { environment: true },
   })
   if (!point) {

--- a/apps/web/src/app/api/ingress/points/[id]/bootstrap/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/bootstrap/route.ts
@@ -14,14 +14,14 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const point = await prisma.ingressPoint.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       domain:      true,
       environment: true,
@@ -78,10 +78,10 @@ export async function POST(
       if (useGateway) {
         await log(`Using gateway at ${gwUrl}`)
         const gc = new GatewayClient(gwUrl!, gwToken!)
-        await bootstrapIngressPointWith(log, (tool, args) => gc.executeTool(tool, args), point, env, isDocker, params.id)
+        await bootstrapIngressPointWith(log, (tool, args) => gc.executeTool(tool, args), point, env, isDocker, (await params).id)
       } else if (useLocal) {
         await log(`Using local kubectl (stored kubeconfig)`)
-        await bootstrapIngressPointWith(log, makeLocalGx(env.kubeconfig!), point, env, isDocker, params.id)
+        await bootstrapIngressPointWith(log, makeLocalGx(env.kubeconfig!), point, env, isDocker, (await params).id)
       }
     },
   )

--- a/apps/web/src/app/api/ingress/points/[id]/middlewares/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/middlewares/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const middleware = await prisma.ingressMiddleware.create({
     data: {
-      ingressPointId: params.id,
+      ingressPointId: (await params).id,
       name:           body.name.trim(),
       type:           body.type    ?? 'custom',
       config:         body.config  ?? {},

--- a/apps/web/src/app/api/ingress/points/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const point = await prisma.ingressPoint.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(body.name          !== undefined && { name:          body.name.trim() }),
       ...(body.type          !== undefined && { type:          body.type }),
@@ -26,8 +26,8 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(point)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  await prisma.ingressPoint.delete({ where: { id: params.id } })
+  await prisma.ingressPoint.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/points/[id]/routes/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/routes/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const route = await prisma.ingressRoute.create({
     data: {
-      ingressPointId: params.id,
+      ingressPointId: (await params).id,
       host:           body.host.trim().toLowerCase(),
       paths:          body.paths   ?? [],
       tls:            body.tls         ?? true,

--- a/apps/web/src/app/api/ingress/points/[id]/set-as-orion-proxy/route.ts
+++ b/apps/web/src/app/api/ingress/points/[id]/set-as-orion-proxy/route.ts
@@ -20,7 +20,7 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -36,7 +36,7 @@ export async function POST(
   }
 
   const point = await prisma.ingressPoint.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { domain: true },
   })
   if (!point) return NextResponse.json({ error: 'IngressPoint not found' }, { status: 404 })
@@ -47,7 +47,7 @@ export async function POST(
   const publicUrl = `https://${point.domain.name}`
 
   await upsert('reverse-proxy.public-url', publicUrl)
-  await upsert('reverse-proxy.ingress-point-id', params.id)
+  await upsert('reverse-proxy.ingress-point-id', (await params).id)
 
   return NextResponse.json({ ok: true, publicUrl })
 }

--- a/apps/web/src/app/api/ingress/routes/[id]/route.ts
+++ b/apps/web/src/app/api/ingress/routes/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireAdmin } from '@/lib/auth'
 import { prisma } from '@/lib/db'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const body = await req.json()
   const route = await prisma.ingressRoute.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(body.host    !== undefined && { host:    body.host.trim().toLowerCase() }),
       ...(body.paths   !== undefined && { paths:   body.paths }),
@@ -18,8 +18,8 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(route)
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
-  await prisma.ingressRoute.delete({ where: { id: params.id } })
+  await prisma.ingressRoute.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/ingress/routes/[id]/toggle/route.ts
+++ b/apps/web/src/app/api/ingress/routes/[id]/toggle/route.ts
@@ -4,15 +4,15 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { requireAdmin } from '@/lib/auth'
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return new Response(JSON.stringify({error:'Unauthorized'}),{status:401,headers:{'Content-Type':'application/json'}}) }
   const session = await getServerSession(authOptions)
 
-  const current = await prisma.ingressRoute.findUniqueOrThrow({ where: { id: params.id } })
+  const current = await prisma.ingressRoute.findUniqueOrThrow({ where: { id: (await params).id } })
   const nowEnabled = !current.enabled
 
   const route = await prisma.ingressRoute.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       enabled:    nowEnabled,
       disabledAt: nowEnabled ? null : new Date(),

--- a/apps/web/src/app/api/jobs/[id]/route.ts
+++ b/apps/web/src/app/api/jobs/[id]/route.ts
@@ -15,24 +15,24 @@ async function guard() {
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const deny = await guard(); if (deny) return deny
-  const job = await prisma.backgroundJob.findUnique({ where: { id: params.id } })
+  const job = await prisma.backgroundJob.findUnique({ where: { id: (await params).id } })
   if (!job) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(job)
 }
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const deny = await guard(); if (deny) return deny
   const parsed = await parseBodyOrError(req, PatchJobSchema)
   if ('error' in parsed) return parsed.error
   const { archived } = parsed.data
   const job = await prisma.backgroundJob.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       archivedAt: archived ? new Date() : null,
       updatedAt: new Date(),
@@ -43,9 +43,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const deny = await guard(); if (deny) return deny
-  await prisma.backgroundJob.delete({ where: { id: params.id } })
+  await prisma.backgroundJob.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
+++ b/apps/web/src/app/api/k8s/pods/[ns]/[pod]/logs/route.ts
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic'
 // SOC2: CR-003 — pod logs are admin-only (vault-namespace logs contain secrets/tokens)
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { ns: string; pod: string } }
+  { params }: { params: Promise<{ ns: string; pod: string }> }
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -18,7 +18,7 @@ export async function GET(
   // Validate namespace and pod name as DNS-1123 labels to prevent
   // path-based enumeration of the API server
   const DNS_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
-  if (!DNS_LABEL.test(params.ns) || !DNS_LABEL.test(params.pod)) {
+  if (!DNS_LABEL.test((await params).ns) || !DNS_LABEL.test((await params).pod)) {
     return NextResponse.json({ error: 'Invalid namespace or pod name' }, { status: 400 })
   }
 
@@ -27,8 +27,8 @@ export async function GET(
       try {
         // v0.22: readNamespacedPodLog(name, ns, container, follow, insecureSkipTLS, limitBytes, pretty, previous, sinceSeconds, sinceTime, tailLines, timestamps)
         const res = await coreApi.readNamespacedPodLog(
-          params.pod,
-          params.ns,
+          (await params).pod,
+          (await params).ns,
           undefined,   // container
           false,       // follow
           undefined,   // insecureSkipTLSVerifyBackend

--- a/apps/web/src/app/api/monitoring/security/alerts/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/[id]/route.ts
@@ -6,12 +6,12 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const event = await prisma.securityEvent.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: {
       id: true,
       type: true,

--- a/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/approvals/[id]/route.ts
@@ -22,7 +22,7 @@ const bodySchema = z.object({
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   let approver: { id: string; username: string }
   try {
@@ -40,7 +40,7 @@ export async function POST(
   }
 
   const { action, note } = parsed.data
-  const auditId = params.id
+  const auditId = (await params).id
 
   // Fetch audit row to get action details for execution
   const audit = await prisma.actionAudit.findUnique({

--- a/apps/web/src/app/api/monitoring/security/incidents/[id]/create-investigation/route.ts
+++ b/apps/web/src/app/api/monitoring/security/incidents/[id]/create-investigation/route.ts
@@ -12,7 +12,7 @@ import { extractFromEvents } from '@/lib/security/extract-observables'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request, { params }: { params: { id: string } }) {
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const incidentId = (await params).id

--- a/apps/web/src/app/api/monitoring/security/incidents/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/incidents/[id]/route.ts
@@ -12,11 +12,11 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
-  const incidentId = params.id
+  const incidentId = (await params).id
 
   const incident = await prisma.incident.findUnique({
     where: { id: incidentId },

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/audit/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/audit/route.ts
@@ -10,7 +10,7 @@ import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/auto-extract-observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/auto-extract-observables/route.ts
@@ -11,7 +11,7 @@ import { extractFromEvents } from '@/lib/security/extract-observables'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request, { params }: { params: { id: string } }) {
+export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/[incidentId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/[incidentId]/route.ts
@@ -11,7 +11,7 @@ import { recordAudit } from '../../../_utils'
 
 export const dynamic = 'force-dynamic'
 
-export async function DELETE(_req: Request, { params }: { params: { id: string; incidentId: string } }) {
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string; incidentId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, incidentId } = await params

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/link-incident/route.ts
@@ -16,7 +16,7 @@ const linkSchema = z.object({
   incidentId: z.string().uuid(),
 })
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/merge/route.ts
@@ -18,7 +18,7 @@ const mergeSchema = z.object({
   sourceId: z.string().uuid(),
 })
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const targetId = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/[noteId]/route.ts
@@ -16,7 +16,7 @@ const updateSchema = z.object({
   isDraft: z.boolean().optional(),
 })
 
-export async function PATCH(req: Request, { params }: { params: { id: string; noteId: string } }) {
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string; noteId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, noteId } = await params
@@ -53,7 +53,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string; no
   return NextResponse.json(updated)
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string; noteId: string } }) {
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string; noteId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, noteId } = await params

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/notes/route.ts
@@ -19,7 +19,7 @@ const createSchema = z.object({
   isDraft: z.boolean().default(false),
 })
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/[obsId]/route.ts
@@ -19,7 +19,7 @@ const updateSchema = z.object({
   role: z.enum(['ioc', 'artifact', 'infrastructure']).optional(),
 })
 
-export async function PATCH(req: Request, { params }: { params: { id: string; obsId: string } }) {
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string; obsId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, obsId } = await params
@@ -75,7 +75,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string; ob
   return NextResponse.json(updated)
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string; obsId: string } }) {
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string; obsId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, obsId } = await params

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/observables/route.ts
@@ -23,7 +23,7 @@ const createSchema = z.object({
   context: z.string().optional().nullable(),
 })
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/report/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/report/route.ts
@@ -10,7 +10,7 @@ import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/route.ts
@@ -44,7 +44,7 @@ function applyWardenConstraints(
   return clean
 }
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id
@@ -75,7 +75,7 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
   })
 }
 
-export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id
@@ -124,7 +124,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   return NextResponse.json(updated)
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/[entryId]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/[entryId]/route.ts
@@ -16,7 +16,7 @@ const updateSchema = z.object({
   description: z.string().optional().nullable(),
 })
 
-export async function PATCH(req: Request, { params }: { params: { id: string; entryId: string } }) {
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string; entryId: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const { id, entryId } = await params

--- a/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
+++ b/apps/web/src/app/api/monitoring/security/investigations/[id]/timeline/route.ts
@@ -22,7 +22,7 @@ const createSchema = z.object({
   payload: z.record(z.unknown()).optional().nullable(),
 })
 
-export async function POST(req: Request, { params }: { params: { id: string } }) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/monitoring/security/observables/[id]/route.ts
+++ b/apps/web/src/app/api/monitoring/security/observables/[id]/route.ts
@@ -10,7 +10,7 @@ import { prisma } from '@/lib/db'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const id = (await params).id

--- a/apps/web/src/app/api/nebulae/[id]/sync/route.ts
+++ b/apps/web/src/app/api/nebulae/[id]/sync/route.ts
@@ -5,13 +5,13 @@ import { syncNebula } from '@/lib/nebula-loader'
 /**
  * POST /api/nebulae/:id/sync — Trigger a manual sync for a Nebula
  */
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   try {
-    const result = await syncNebula(params.id)
+    const result = await syncNebula((await params).id)
     return NextResponse.json(result)
   } catch (err) {
     return NextResponse.json(

--- a/apps/web/src/app/api/notes/[id]/route.ts
+++ b/apps/web/src/app/api/notes/[id]/route.ts
@@ -4,22 +4,22 @@ import { embedNote, computeSemanticEdges } from '@/lib/embeddings'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateNoteSchema } from '@/lib/validate'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
-  const note = await prisma.note.findUnique({ where: { id: params.id } })
+  const note = await prisma.note.findUnique({ where: { id: (await params).id } })
   if (!note) return new NextResponse(null, { status: 404 })
   // Only the creator or admin/service can read notes
   await assertCanModify(caller, isService, note.createdBy ?? '')
   return NextResponse.json(note)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership before mutation
-  const existing = await prisma.note.findUnique({ where: { id: params.id } })
+  const existing = await prisma.note.findUnique({ where: { id: (await params).id } })
   if (!existing) return new NextResponse(null, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy ?? '')
 
@@ -39,12 +39,12 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (data.type    !== undefined) updateData.type    = data.type
   if (data.tags    !== undefined) updateData.tags    = data.tags || null
 
-  const note = await prisma.note.update({ where: { id: params.id }, data: updateData })
+  const note = await prisma.note.update({ where: { id: (await params).id }, data: updateData })
 
   // Re-embed if content or title changed
   if (isContentChange || isTitleChange) {
     // Re-fetch with fresh data (the update may have returned a truncated row)
-    const updated = await prisma.note.findUnique({ where: { id: params.id } })
+    const updated = await prisma.note.findUnique({ where: { id: (await params).id } })
     if (updated) {
       const ok = await embedNote(updated).catch(err => { console.error('[embed] failed for updated note:', err); return false })
       if (ok) computeSemanticEdges(updated.id).catch(() => {})
@@ -54,15 +54,15 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(note)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership before deletion
-  const existing = await prisma.note.findUnique({ where: { id: params.id } })
+  const existing = await prisma.note.findUnique({ where: { id: (await params).id } })
   if (!existing) return new NextResponse(null, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy ?? '')
 
-  await prisma.note.delete({ where: { id: params.id } })
+  await prisma.note.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/notification-channels/[id]/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/route.ts
@@ -4,17 +4,17 @@ import { requireAdmin } from '@/lib/auth'
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  const channel = await prisma.notificationChannel.findUnique({ where: { id: params.id } })
+  const channel = await prisma.notificationChannel.findUnique({ where: { id: (await params).id } })
   if (!channel) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(channel)
 }
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const body = await req.json() as Partial<{
@@ -27,7 +27,7 @@ export async function PUT(
   }>
 
   const channel = await prisma.notificationChannel.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: body,
   })
   return NextResponse.json(channel)
@@ -35,9 +35,9 @@ export async function PUT(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  await prisma.notificationChannel.delete({ where: { id: params.id } })
+  await prisma.notificationChannel.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/notification-channels/[id]/test/route.ts
+++ b/apps/web/src/app/api/notification-channels/[id]/test/route.ts
@@ -5,13 +5,13 @@ import { isPrivateUrl } from '@/lib/ssrf-guard'
 
 export async function POST(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
   }
 
-  const channel = await prisma.notificationChannel.findUnique({ where: { id: params.id } })
+  const channel = await prisma.notificationChannel.findUnique({ where: { id: (await params).id } })
   if (!channel) return NextResponse.json({ ok: false, error: 'Channel not found' }, { status: 404 })
 
   if (await isPrivateUrl(channel.webhookUrl)) {

--- a/apps/web/src/app/api/nova-definitions/[id]/route.ts
+++ b/apps/web/src/app/api/nova-definitions/[id]/route.ts
@@ -10,14 +10,14 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   // MAJOR fix: GET had no auth — any logged-in user could read nova definition specs
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const nova = await prisma.novaDefinition.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
   })
   if (!nova) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -31,7 +31,7 @@ export async function GET(
  */
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await requireAdmin()
@@ -57,7 +57,7 @@ export async function PUT(
   if (metadata !== undefined)    updateData.metadata = metadata
 
   const nova = await prisma.novaDefinition.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: updateData,
   })
   return NextResponse.json(nova)
@@ -69,7 +69,7 @@ export async function PUT(
  */
 export async function DELETE(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await requireAdmin()
@@ -78,7 +78,7 @@ export async function DELETE(
   }
   // Check for instances
   const instances = await prisma.nebulaInstance.findFirst({
-    where: { sourceNovaId: params.id },
+    where: { sourceNovaId: (await params).id },
   })
   if (instances) {
     return NextResponse.json(
@@ -86,6 +86,6 @@ export async function DELETE(
       { status: 409 }
     )
   }
-  await prisma.novaDefinition.delete({ where: { id: params.id } })
+  await prisma.novaDefinition.delete({ where: { id: (await params).id } })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/novas/[id]/import/route.ts
+++ b/apps/web/src/app/api/novas/[id]/import/route.ts
@@ -12,14 +12,14 @@ import { requireAdmin } from '@/lib/auth'
  */
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const body = await req.json()
   const nova = await prisma.nova.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
   })
 
   if (!nova) {

--- a/apps/web/src/app/api/novas/[id]/revisions/route.ts
+++ b/apps/web/src/app/api/novas/[id]/revisions/route.ts
@@ -7,12 +7,12 @@ import { prisma } from '@/lib/db'
  */
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
 
   const nova = await prisma.nova.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       revisions: {
         orderBy: { createdAt: 'desc' },

--- a/apps/web/src/app/api/novas/[id]/route.ts
+++ b/apps/web/src/app/api/novas/[id]/route.ts
@@ -7,13 +7,13 @@ import { requireAdmin } from '@/lib/auth'
  */
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const nova = await prisma.nova.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       revisions: { orderBy: { createdAt: 'desc' }, take: 10 },
       deployments: { orderBy: { deployedAt: 'desc' }, take: 20 },
@@ -36,7 +36,7 @@ export async function GET(
  */
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -45,7 +45,7 @@ export async function PUT(
   try { bodyRaw = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const body = bodyRaw as { name?: string; displayName?: string; description?: string | null; category?: string; version?: string; config?: unknown; tags?: unknown; reasoning?: string }
   const nova = await prisma.nova.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
   })
 
   if (!nova) {
@@ -67,7 +67,7 @@ export async function PUT(
   const newConfig = data.config || prevConfig
 
   const updatedNova = await prisma.nova.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data,
   })
 
@@ -91,13 +91,13 @@ export async function PUT(
  */
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try { await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const nova = await prisma.nova.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { _count: { select: { deployments: true } } },
   })
 
@@ -113,7 +113,7 @@ export async function DELETE(
   }
 
   await prisma.nova.delete({
-    where: { id: params.id },
+    where: { id: (await params).id },
   })
 
   return new NextResponse(null, { status: 204 })

--- a/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
@@ -3,12 +3,12 @@ import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseCron, nextRun } from '@/lib/cron'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   const task = await prisma.scheduledTask.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { agent: { select: { id: true, name: true } } },
   })
 
@@ -17,11 +17,11 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(task)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
-  const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
+  const existing = await prisma.scheduledTask.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
@@ -43,7 +43,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   const newNextRunAt = cronChanged ? nextRun(newCronExpr) : existing.nextRunAt
 
   const updated = await prisma.scheduledTask.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(typeof name === 'string' && { name }),
       ...(typeof cronExpr === 'string' && { cronExpr }),
@@ -58,14 +58,14 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(updated)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
-  const existing = await prisma.scheduledTask.findUnique({ where: { id: params.id } })
+  const existing = await prisma.scheduledTask.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
-  await prisma.scheduledTask.delete({ where: { id: params.id } })
+  await prisma.scheduledTask.delete({ where: { id: (await params).id } })
   return NextResponse.json({ ok: true })
 }

--- a/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
@@ -3,12 +3,12 @@ import { prisma } from '@/lib/db'
 import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { nextRun } from '@/lib/cron'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   const schedule = await prisma.scheduledTask.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { agent: { select: { createdBy: true } } },
   })
   if (!schedule) return NextResponse.json({ error: 'Not found' }, { status: 404 })

--- a/apps/web/src/app/api/system-settings/[key]/route.ts
+++ b/apps/web/src/app/api/system-settings/[key]/route.ts
@@ -15,10 +15,10 @@ const PUBLIC_SETTING_KEYS = new Set([
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { key: string } }
+  { params }: { params: Promise<{ key: string }> }
 ) {
   try {
-    if (!PUBLIC_SETTING_KEYS.has(params.key)) {
+    if (!PUBLIC_SETTING_KEYS.has((await params).key)) {
       // MINOR fix: any logged-in user could read any SystemSetting key, including
       // vault.unsealKeys (encrypted) and other sensitive config. Admin-gate all
       // non-public keys.
@@ -28,7 +28,7 @@ export async function GET(
     }
 
     const setting = await prisma.systemSetting.findUnique({
-      where: { key: params.key },
+      where: { key: (await params).key },
     })
 
     if (!setting) {

--- a/apps/web/src/app/api/tasks/[id]/cancel/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/cancel/route.ts
@@ -8,11 +8,11 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
  * Cancels a task — used to reject a plan that paused for approval, or to stop a
  * task before it runs. Marks the task 'failed' and records a TaskEvent.
  */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
-  const task = await prisma.task.findUnique({ where: { id: params.id } })
+  const task = await prisma.task.findUnique({ where: { id: (await params).id } })
   if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, task.createdBy)
 

--- a/apps/web/src/app/api/tasks/[id]/chat/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/chat/route.ts
@@ -10,13 +10,13 @@ import { requireServiceAuth } from '@/lib/auth'
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   // B3 fix: route had no auth — any caller could read any task's chat room contents
   await requireServiceAuth(req).catch(() => { throw Object.assign(new Error('Unauthorized'), { status: 401 }) })
 
   const task = await prisma.task.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     select: { feature: { select: { id: true } } },
   })
 

--- a/apps/web/src/app/api/tasks/[id]/events/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/events/route.ts
@@ -7,17 +7,17 @@ const VALID_TASK_STATUSES = new Set([
 ])
 
 // GET /api/tasks/:id/events — fetch all events for a task
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   await requireServiceAuth(req)
   const events = await prisma.taskEvent.findMany({
-    where: { taskId: params.id },
+    where: { taskId: (await params).id },
     orderBy: { createdAt: 'asc' },
   })
   return NextResponse.json(events)
 }
 
 // POST /api/tasks/:id/events — add a comment/status event to a task
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
 
   // M4 fix: previously no validation — malformed JSON threw 500; content/eventType were
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   const event = await prisma.taskEvent.create({
     data: {
-      taskId:    params.id,
+      taskId:    (await params).id,
       eventType: (body.eventType as string) ?? 'comment',
       content:   (body.content as string) ?? null,
       agentId:   typeof (caller as any)?.agentId === 'string' ? (caller as any).agentId : null,
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   })
 
   if (body.status) {
-    await prisma.task.update({ where: { id: params.id }, data: { status: body.status } })
+    await prisma.task.update({ where: { id: (await params).id }, data: { status: body.status } })
   }
 
   return NextResponse.json(event, { status: 201 })

--- a/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/resume-plan/route.ts
@@ -15,11 +15,11 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
  *     When provided, the worker injects a note telling the agent to skip these
  *     steps before executing the rest of the approved plan.
  */
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
-  const task = await prisma.task.findUnique({ where: { id: params.id } })
+  const task = await prisma.task.findUnique({ where: { id: (await params).id } })
   if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, task.createdBy)
 

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -4,11 +4,11 @@ import { requireServiceAuth, assertCanModify } from '@/lib/auth'
 import { parseBodyOrError, UpdateTaskSchema } from '@/lib/validate'
 import { handlePlanPatch } from '@/lib/plan-patch'
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
   const task = await prisma.task.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: {
       agent:        true,
       assignedUser: true,
@@ -22,12 +22,12 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(task)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.task.findUnique({ where: { id: params.id } })
+  const existing = await prisma.task.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
@@ -57,7 +57,7 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   if (data.dependsOn       !== undefined) dbData.dependsOn       = data.dependsOn
   if (data.wave            !== undefined) dbData.wave            = data.wave
   const task = await prisma.task.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: dbData,
     include: { agent: true, assignedUser: true },
   })
@@ -80,19 +80,19 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(task)
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  return handlePlanPatch('task', params.id, req)
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return handlePlanPatch('task', (await params).id, req)
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await requireServiceAuth(req)
   const isService = caller === null
 
   // Check ownership
-  const existing = await prisma.task.findUnique({ where: { id: params.id } })
+  const existing = await prisma.task.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   await assertCanModify(caller, isService, existing.createdBy)
 
-  await prisma.task.delete({ where: { id: params.id } })
+  await prisma.task.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/tasks/[id]/stream/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/stream/route.ts
@@ -23,7 +23,7 @@ const TERMINAL_STATES  = new Set(['done', 'failed', 'cancelled', 'completed'])
  */
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   // B4 fix: route had no auth — any caller could stream any task's events
   let caller: Awaited<ReturnType<typeof requireServiceAuth>>
@@ -34,7 +34,7 @@ export async function GET(
   }
   const isService = caller === null
 
-  const taskId = params.id
+  const taskId = (await params).id
   const afterParam = req.nextUrl.searchParams.get('after') ?? undefined
 
   // Verify the task exists before opening the stream

--- a/apps/web/src/app/api/tool-approvals/[id]/route.ts
+++ b/apps/web/src/app/api/tool-approvals/[id]/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
 // POST /api/tool-approvals/[id]  body: { action: 'approve'|'deny', adminNote?: string, approvedBy?: string }
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   let admin
   try { admin = await requireAdmin() } catch {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const { action, adminNote } = body as { action: 'approve' | 'deny'; adminNote?: string }
 
-  const request = await prisma.toolApprovalRequest.findUnique({ where: { id: params.id } })
+  const request = await prisma.toolApprovalRequest.findUnique({ where: { id: (await params).id } })
   if (!request) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (request.status !== 'pending') return NextResponse.json({ error: 'Already resolved' }, { status: 400 })
   if (request.userId === admin.id) {
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
 
   const updated = await prisma.toolApprovalRequest.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       status:     action === 'approve' ? 'approved' : 'denied',
       approvedBy: resolvedApprovedBy,

--- a/apps/web/src/app/api/tool-groups/[id]/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/route.ts
@@ -2,23 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
-export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const g = await prisma.toolGroup.findUnique({
-    where: { id: params.id },
+    where: { id: (await params).id },
     include: { tools: { include: { tool: true } }, agentAccess: { include: { agentGroup: true } } },
   })
   if (!g) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return NextResponse.json(g)
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   let body: Record<string, unknown>
   try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) }
   const b = body as { name?: string; description?: string | null; minimumTier?: string }
   const g = await prisma.toolGroup.update({
-    where: { id: params.id },
+    where: { id: (await params).id },
     data: {
       ...(b.name        !== undefined && { name:        b.name.trim() }),
       ...(b.description !== undefined && { description: b.description }),
@@ -29,8 +29,8 @@ export async function PUT(req: NextRequest, { params }: { params: { id: string }
   return NextResponse.json(g)
 }
 
-export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
-  await prisma.toolGroup.delete({ where: { id: params.id } })
+  await prisma.toolGroup.delete({ where: { id: (await params).id } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
+++ b/apps/web/src/app/api/tool-groups/[id]/tools/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/db'
 import { requireAdmin } from '@/lib/auth'
 
 // POST — add a tool to the group
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const { toolId } = await req.json()
   if (!toolId || typeof toolId !== 'string' || !toolId.trim()) {
@@ -11,15 +11,15 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
   const toolExists = await prisma.mcpTool.findUnique({ where: { id: toolId }, select: { id: true } })
   if (!toolExists) return NextResponse.json({ error: 'Tool not found' }, { status: 404 })
-  await prisma.toolGroupTool.create({ data: { toolGroupId: params.id, toolId } })
+  await prisma.toolGroupTool.create({ data: { toolGroupId: (await params).id, toolId } })
   return NextResponse.json({ ok: true })
 }
 
 // DELETE — remove a tool from the group (?toolId=xxx)
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
   const toolId = req.nextUrl.searchParams.get('toolId')
   if (!toolId) return NextResponse.json({ error: 'toolId required' }, { status: 400 })
-  await prisma.toolGroupTool.delete({ where: { toolGroupId_toolId: { toolGroupId: params.id, toolId } } })
+  await prisma.toolGroupTool.delete({ where: { toolGroupId_toolId: { toolGroupId: (await params).id, toolId } } })
   return new NextResponse(null, { status: 204 })
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -395,7 +395,7 @@ export async function getCurrentUser(): Promise<AppUser | null> {
   // Optional SSO fallback: header-based (only if OIDCProvider.headerMode is enabled)
   try {
     const { headers } = await import('next/headers')
-    const h = headers()
+    const h = await headers()
     // SOC2 [LOW-2]: Only accept the signed x-authentik-username header.
     // x-forwarded-user is not included in the HMAC canonical string and must
     // not be used as a fallback — accepting it would bypass signature validation.


### PR DESCRIPTION
## Summary

Next.js 15 requires all dynamic route handler `params` to be typed as `Promise<T>` and awaited. This fixes the remaining 127 API route files that still had the old synchronous params signature.

**Pattern fixed across all files:**
```ts
// Before
export async function GET(req, { params }: { params: { id: string } }) {
  const { id } = params

// After  
export async function GET(req, { params }: { params: Promise<{ id: string }> }) {
  const { id } = await params
```

## Test plan
- [ ] `Build ORION Web` GitHub Action passes
- [ ] All dynamic API routes (`/api/agents/[id]`, `/api/environments/[id]`, etc.) respond correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_