### PR TITLE
fix(build): use actorId instead of nonexistent createdBy on ToolExecution

### DIFF
--- a/apps/web/src/app/api/executions/[id]/route.ts
+++ b/apps/web/src/app/api/executions/[id]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
       )
     }
 
-    await assertCanModify(caller, isService, execution.createdBy ?? '')
+    await assertCanModify(caller, isService, execution.actorId ?? '')
     return NextResponse.json(execution)
   } catch (error) {
     console.error('Error getting execution:', error)
@@ -50,7 +50,7 @@ export async function PATCH(
         { status: 404 }
       )
     }
-    await assertCanModify(caller, isService, existing.createdBy ?? '')
+    await assertCanModify(caller, isService, existing.actorId ?? '')
 
     const body = await req.json()
 


### PR DESCRIPTION
Fixes TypeScript build error in `apps/web/src/app/api/executions/[id]/route.ts`. The `ToolExecution` model has no `createdBy` field; the ownership field is `actorId`. Updated both GET and PATCH handlers.

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_