### PR TITLE
fix(build): check agent environment via AgentEnvironment relation

### DIFF
--- a/apps/web/src/app/api/federation/tasks/route.ts
+++ b/apps/web/src/app/api/federation/tasks/route.ts
@@ -85,7 +85,13 @@ export async function POST(req: NextRequest) {
   if (body.agentId) {
     const agent = await prisma.agent.findUnique({
       where: { id: body.agentId },
-      select: { id: true, environmentId: true },
+      select: {
+        id: true,
+        environments: {
+          where: { environmentId: body.environmentId },
+          select: { id: true },
+        },
+      },
     })
     if (!agent) {
       return NextResponse.json(
@@ -93,7 +99,7 @@ export async function POST(req: NextRequest) {
         { status: 422 },
       )
     }
-    if (agent.environmentId !== body.environmentId) {
+    if (agent.environments.length === 0) {
       return NextResponse.json(
         { error: `Agent ${body.agentId} does not belong to the federated environment` },
         { status: 403 },


### PR DESCRIPTION
The federation tasks route selected a nonexistent scalar `environmentId` on the Agent model, breaking the type-check step:

`./src/app/api/federation/tasks/route.ts:88` — `'environmentId' does not exist in type 'AgentSelect'`.

The Agent model has no scalar `environmentId`; environment membership is a many-to-many relation via `AgentEnvironment`. This fixes the query to verify the agent belongs to the target environment by filtering the `environments` relation, preserving the original MEDIUM-1 cross-environment guard.

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_