### PR TITLE
fix(build): drop nonexistent createdBy on ScheduledTask/Agent in scheduled-tasks routes

### DIFF
--- a/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   })
 
   if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  await assertCanModify(caller, isService, task.createdBy)
+  await assertCanModify(caller, isService, '')
   return NextResponse.json(task)
 }
 
@@ -23,7 +23,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
   const existing = await prisma.scheduledTask.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  await assertCanModify(caller, isService, existing.createdBy)
+  await assertCanModify(caller, isService, '')
 
   let body: unknown
   try {
@@ -64,7 +64,7 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
 
   const existing = await prisma.scheduledTask.findUnique({ where: { id: (await params).id } })
   if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
-  await assertCanModify(caller, isService, existing.createdBy)
+  await assertCanModify(caller, isService, '')
 
   await prisma.scheduledTask.delete({ where: { id: (await params).id } })
   return NextResponse.json({ ok: true })

--- a/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
+++ b/apps/web/src/app/api/scheduled-tasks/[id]/trigger/route.ts
@@ -9,14 +9,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   const schedule = await prisma.scheduledTask.findUnique({
     where: { id: (await params).id },
-    include: { agent: { select: { createdBy: true } } },
+    include: { agent: { select: { id: true } } },
   })
   if (!schedule) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
   // SOC2 [PRIV-003]: Verify caller owns (or is admin/service for) the target agent
   if (schedule.agent) {
     try {
-      await assertCanModify(caller, isService, schedule.agent.createdBy)
+      await assertCanModify(caller, isService, '')
     } catch {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }


### PR DESCRIPTION
Type-check failed at `scheduled-tasks/[id]/route.ts` (`task.createdBy`/`existing.createdBy`) and `scheduled-tasks/[id]/trigger/route.ts` (`agent.createdBy`). Neither the `ScheduledTask` nor the `Agent` Prisma model has a `createdBy` column.

Verified against the schema that only ScheduledTask and Agent lack `createdBy` (Task, Feature, Epic, ChatRoom all have it, so their routes are fine). These routes now pass `''` to `assertCanModify` — service tokens and admins retain access, other users are forbidden — and the trigger route selects `agent.id` instead of the nonexistent `agent.createdBy`.

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_