### PR TITLE
fix(build): proactive scan — all remaining TypeScript errors

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -442,7 +442,7 @@ export async function getCurrentUser(): Promise<AppUser | null> {
         // logins both read existingUser=null before either upsert commits.
         // A new user has createdAt === lastSeen (both just set); an existing user
         // has lastSeen updated but createdAt older.
-        const isNewUser = Math.abs(user.createdAt.getTime() - user.lastSeen.getTime()) < 2000
+        const isNewUser = user.lastSeen != null && Math.abs(user.createdAt.getTime() - user.lastSeen.getTime()) < 2000
         if (isNewUser) {
           void logAudit({
             userId: user.id,

--- a/apps/web/src/lib/rate-limit-examples.ts
+++ b/apps/web/src/lib/rate-limit-examples.ts
@@ -209,7 +209,7 @@ function getClientIp(req: NextRequest): string {
   if (forwarded) {
     return forwarded.split(',')[0].trim()
   }
-  return req.ip || ((null as any).remoteAddress) || 'unknown'
+  return req.headers.get('x-real-ip')?.trim() || 'unknown'
 }
 
 // ─── Usage Patterns ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Proactive scan of the Next.js 15 codebase (`apps/web`) for TypeScript errors that would fail `next build`. Ran `npx tsc --noEmit`, found and fixed 2 genuine errors. Tree is now clean (tsc exits 0).

## Errors found and fixed

1. **`src/lib/auth.ts:445`** — `TS18047: 'user.lastSeen' is possibly 'null'`. The `isNewUser` derivation called `user.lastSeen.getTime()` but the field is nullable. Added a null guard: `user.lastSeen != null && Math.abs(...)`.

2. **`src/lib/rate-limit-examples.ts:212`** — `TS2339: Property 'ip' does not exist on type 'NextRequest'`. `req.ip` was removed in Next.js 15. Replaced the `req.ip || (null as any).remoteAddress` fallback with a header-based lookup: `req.headers.get('x-real-ip')?.trim() || 'unknown'`.

## Verification

`npx tsc --noEmit` in `apps/web` now exits 0.

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_