### PR TITLE
add WebhookDelivery migration

### DIFF
--- a/apps/web/prisma/migrations/26_add_webhook_delivery/migration.sql
+++ b/apps/web/prisma/migrations/26_add_webhook_delivery/migration.sql
@@ -1,0 +1,14 @@
+-- Migration: 26_add_webhook_delivery
+-- Tracks delivered webhook payloads for idempotency (deduplication by delivery ID).
+
+CREATE TABLE "WebhookDelivery" (
+    "id"         TEXT NOT NULL,
+    "triggerId"  TEXT NOT NULL,
+    "deliveryId" TEXT NOT NULL,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "WebhookDelivery_triggerId_deliveryId_key" ON "WebhookDelivery"("triggerId", "deliveryId");
+CREATE INDEX "WebhookDelivery_receivedAt_idx" ON "WebhookDelivery"("receivedAt");


### PR DESCRIPTION
## Summary

- `WebhookDelivery` table was defined in `schema.prisma` but had no migration file
- Every inbound webhook POST was failing with Prisma `P2021` (table not found)
- Adds `26_add_webhook_delivery/migration.sql` to create the table with its unique index (deduplication by `triggerId` + `deliveryId`) and a `receivedAt` index

## Test plan

- [ ] Apply migration on staging and verify `WebhookDelivery` table exists
- [ ] Fire a test webhook — confirm `{"ok":true}` response and no P2021 error
- [ ] Fire the same webhook twice with the same delivery ID — confirm second call is deduplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)