### PR TITLE
make all CREATE TABLE statements idempotent with IF NOT EXISTS

### DIFF
--- a/apps/web/prisma/migrations/0_baseline/migration.sql
+++ b/apps/web/prisma/migrations/0_baseline/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "Conversation" (
+CREATE TABLE IF NOT EXISTS "Conversation" (
     "id" TEXT NOT NULL,
     "title" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -11,7 +11,7 @@ CREATE TABLE "Conversation" (
 );
 
 -- CreateTable
-CREATE TABLE "Message" (
+CREATE TABLE IF NOT EXISTS "Message" (
     "id" TEXT NOT NULL,
     "conversationId" TEXT NOT NULL,
     "role" TEXT NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE "Message" (
 );
 
 -- CreateTable
-CREATE TABLE "ClaudeInvocation" (
+CREATE TABLE IF NOT EXISTS "ClaudeInvocation" (
     "id" TEXT NOT NULL,
     "conversationId" TEXT NOT NULL,
     "prompt" TEXT NOT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE "ClaudeInvocation" (
 );
 
 -- CreateTable
-CREATE TABLE "Memory" (
+CREATE TABLE IF NOT EXISTS "Memory" (
     "id" TEXT NOT NULL,
     "conversationId" TEXT NOT NULL,
     "key" TEXT NOT NULL,
@@ -53,7 +53,7 @@ CREATE TABLE "Memory" (
 );
 
 -- CreateTable
-CREATE TABLE "Agent" (
+CREATE TABLE IF NOT EXISTS "Agent" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "type" TEXT NOT NULL DEFAULT 'human',
@@ -68,7 +68,7 @@ CREATE TABLE "Agent" (
 );
 
 -- CreateTable
-CREATE TABLE "Environment" (
+CREATE TABLE IF NOT EXISTS "Environment" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "type" TEXT NOT NULL DEFAULT 'cluster',
@@ -92,7 +92,7 @@ CREATE TABLE "Environment" (
 );
 
 -- CreateTable
-CREATE TABLE "GitOpsPR" (
+CREATE TABLE IF NOT EXISTS "GitOpsPR" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "prNumber" INTEGER NOT NULL,
@@ -111,7 +111,7 @@ CREATE TABLE "GitOpsPR" (
 );
 
 -- CreateTable
-CREATE TABLE "McpTool" (
+CREATE TABLE IF NOT EXISTS "McpTool" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -131,7 +131,7 @@ CREATE TABLE "McpTool" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentEnvironment" (
+CREATE TABLE IF NOT EXISTS "AgentEnvironment" (
     "id" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
@@ -141,7 +141,7 @@ CREATE TABLE "AgentEnvironment" (
 );
 
 -- CreateTable
-CREATE TABLE "EnvironmentJoinToken" (
+CREATE TABLE IF NOT EXISTS "EnvironmentJoinToken" (
     "id" TEXT NOT NULL,
     "token" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
@@ -154,7 +154,7 @@ CREATE TABLE "EnvironmentJoinToken" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentMessage" (
+CREATE TABLE IF NOT EXISTS "AgentMessage" (
     "id" TEXT NOT NULL,
     "agentId" TEXT,
     "channel" TEXT NOT NULL DEFAULT 'general',
@@ -168,7 +168,7 @@ CREATE TABLE "AgentMessage" (
 );
 
 -- CreateTable
-CREATE TABLE "Epic" (
+CREATE TABLE IF NOT EXISTS "Epic" (
     "id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "description" TEXT,
@@ -182,7 +182,7 @@ CREATE TABLE "Epic" (
 );
 
 -- CreateTable
-CREATE TABLE "Feature" (
+CREATE TABLE IF NOT EXISTS "Feature" (
     "id" TEXT NOT NULL,
     "epicId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -197,7 +197,7 @@ CREATE TABLE "Feature" (
 );
 
 -- CreateTable
-CREATE TABLE "Task" (
+CREATE TABLE IF NOT EXISTS "Task" (
     "id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "description" TEXT,
@@ -216,7 +216,7 @@ CREATE TABLE "Task" (
 );
 
 -- CreateTable
-CREATE TABLE "TaskEvent" (
+CREATE TABLE IF NOT EXISTS "TaskEvent" (
     "id" TEXT NOT NULL,
     "taskId" TEXT NOT NULL,
     "eventType" TEXT NOT NULL,
@@ -228,7 +228,7 @@ CREATE TABLE "TaskEvent" (
 );
 
 -- CreateTable
-CREATE TABLE "AuditLog" (
+CREATE TABLE IF NOT EXISTS "AuditLog" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "action" TEXT NOT NULL,
@@ -243,7 +243,7 @@ CREATE TABLE "AuditLog" (
 );
 
 -- CreateTable
-CREATE TABLE "SavedView" (
+CREATE TABLE IF NOT EXISTS "SavedView" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "page" TEXT NOT NULL,
@@ -254,7 +254,7 @@ CREATE TABLE "SavedView" (
 );
 
 -- CreateTable
-CREATE TABLE "SystemSetting" (
+CREATE TABLE IF NOT EXISTS "SystemSetting" (
     "key" TEXT NOT NULL,
     "value" JSONB NOT NULL,
     "updatedAt" TIMESTAMP(3) NOT NULL,
@@ -263,7 +263,7 @@ CREATE TABLE "SystemSetting" (
 );
 
 -- CreateTable
-CREATE TABLE "SystemPrompt" (
+CREATE TABLE IF NOT EXISTS "SystemPrompt" (
     "key" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
@@ -276,7 +276,7 @@ CREATE TABLE "SystemPrompt" (
 );
 
 -- CreateTable
-CREATE TABLE "Note" (
+CREATE TABLE IF NOT EXISTS "Note" (
     "id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "content" TEXT NOT NULL DEFAULT '',
@@ -291,7 +291,7 @@ CREATE TABLE "Note" (
 );
 
 -- CreateTable
-CREATE TABLE "note_embeddings" (
+CREATE TABLE IF NOT EXISTS "note_embeddings" (
     "noteId" TEXT NOT NULL,
     "embedding" TEXT NOT NULL,
     "dimension" INTEGER NOT NULL,
@@ -304,7 +304,7 @@ CREATE TABLE "note_embeddings" (
 );
 
 -- CreateTable
-CREATE TABLE "semantic_connections" (
+CREATE TABLE IF NOT EXISTS "semantic_connections" (
     "sourceNoteId" TEXT NOT NULL,
     "targetNoteId" TEXT NOT NULL,
     "score" DOUBLE PRECISION NOT NULL,
@@ -315,7 +315,7 @@ CREATE TABLE "semantic_connections" (
 );
 
 -- CreateTable
-CREATE TABLE "User" (
+CREATE TABLE IF NOT EXISTS "User" (
     "id" TEXT NOT NULL,
     "username" TEXT NOT NULL,
     "email" TEXT NOT NULL,
@@ -337,7 +337,7 @@ CREATE TABLE "User" (
 );
 
 -- CreateTable
-CREATE TABLE "api_keys" (
+CREATE TABLE IF NOT EXISTS "api_keys" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "hash" TEXT NOT NULL,
@@ -353,7 +353,7 @@ CREATE TABLE "api_keys" (
 );
 
 -- CreateTable
-CREATE TABLE "Session" (
+CREATE TABLE IF NOT EXISTS "Session" (
     "id" TEXT NOT NULL,
     "sessionToken" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
@@ -363,14 +363,14 @@ CREATE TABLE "Session" (
 );
 
 -- CreateTable
-CREATE TABLE "VerificationToken" (
+CREATE TABLE IF NOT EXISTS "VerificationToken" (
     "identifier" TEXT NOT NULL,
     "token" TEXT NOT NULL,
     "expires" TIMESTAMP(3) NOT NULL
 );
 
 -- CreateTable
-CREATE TABLE "Bug" (
+CREATE TABLE IF NOT EXISTS "Bug" (
     "id" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "description" TEXT,
@@ -386,7 +386,7 @@ CREATE TABLE "Bug" (
 );
 
 -- CreateTable
-CREATE TABLE "ExternalModel" (
+CREATE TABLE IF NOT EXISTS "ExternalModel" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "provider" TEXT NOT NULL,
@@ -402,7 +402,7 @@ CREATE TABLE "ExternalModel" (
 );
 
 -- CreateTable
-CREATE TABLE "OIDCProvider" (
+CREATE TABLE IF NOT EXISTS "OIDCProvider" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL DEFAULT 'Authentik',
     "enabled" BOOLEAN NOT NULL DEFAULT true,
@@ -415,7 +415,7 @@ CREATE TABLE "OIDCProvider" (
 );
 
 -- CreateTable
-CREATE TABLE "ToolGroup" (
+CREATE TABLE IF NOT EXISTS "ToolGroup" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
@@ -428,7 +428,7 @@ CREATE TABLE "ToolGroup" (
 );
 
 -- CreateTable
-CREATE TABLE "ToolGroupTool" (
+CREATE TABLE IF NOT EXISTS "ToolGroupTool" (
     "toolGroupId" TEXT NOT NULL,
     "toolId" TEXT NOT NULL,
 
@@ -436,7 +436,7 @@ CREATE TABLE "ToolGroupTool" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentGroup" (
+CREATE TABLE IF NOT EXISTS "AgentGroup" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
@@ -446,7 +446,7 @@ CREATE TABLE "AgentGroup" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentGroupMember" (
+CREATE TABLE IF NOT EXISTS "AgentGroupMember" (
     "agentGroupId" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
 
@@ -454,7 +454,7 @@ CREATE TABLE "AgentGroupMember" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentGroupToolAccess" (
+CREATE TABLE IF NOT EXISTS "AgentGroupToolAccess" (
     "agentGroupId" TEXT NOT NULL,
     "toolGroupId" TEXT NOT NULL,
 
@@ -462,7 +462,7 @@ CREATE TABLE "AgentGroupToolAccess" (
 );
 
 -- CreateTable
-CREATE TABLE "ToolAgentRestriction" (
+CREATE TABLE IF NOT EXISTS "ToolAgentRestriction" (
     "toolId" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
 
@@ -470,7 +470,7 @@ CREATE TABLE "ToolAgentRestriction" (
 );
 
 -- CreateTable
-CREATE TABLE "EnvironmentUserTier" (
+CREATE TABLE IF NOT EXISTS "EnvironmentUserTier" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
@@ -480,7 +480,7 @@ CREATE TABLE "EnvironmentUserTier" (
 );
 
 -- CreateTable
-CREATE TABLE "ToolApprovalRequest" (
+CREATE TABLE IF NOT EXISTS "ToolApprovalRequest" (
     "id" TEXT NOT NULL,
     "conversationId" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
@@ -498,7 +498,7 @@ CREATE TABLE "ToolApprovalRequest" (
 );
 
 -- CreateTable
-CREATE TABLE "ToolExecutionGrant" (
+CREATE TABLE IF NOT EXISTS "ToolExecutionGrant" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
@@ -511,7 +511,7 @@ CREATE TABLE "ToolExecutionGrant" (
 );
 
 -- CreateTable
-CREATE TABLE "Domain" (
+CREATE TABLE IF NOT EXISTS "Domain" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "type" TEXT NOT NULL DEFAULT 'public',
@@ -526,7 +526,7 @@ CREATE TABLE "Domain" (
 );
 
 -- CreateTable
-CREATE TABLE "DnsRecord" (
+CREATE TABLE IF NOT EXISTS "DnsRecord" (
     "id" TEXT NOT NULL,
     "domainId" TEXT NOT NULL,
     "ip" TEXT NOT NULL,
@@ -540,7 +540,7 @@ CREATE TABLE "DnsRecord" (
 );
 
 -- CreateTable
-CREATE TABLE "IngressPoint" (
+CREATE TABLE IF NOT EXISTS "IngressPoint" (
     "id" TEXT NOT NULL,
     "domainId" TEXT NOT NULL,
     "environmentId" TEXT,
@@ -559,7 +559,7 @@ CREATE TABLE "IngressPoint" (
 );
 
 -- CreateTable
-CREATE TABLE "IngressRoute" (
+CREATE TABLE IF NOT EXISTS "IngressRoute" (
     "id" TEXT NOT NULL,
     "ingressPointId" TEXT NOT NULL,
     "host" TEXT NOT NULL,
@@ -577,7 +577,7 @@ CREATE TABLE "IngressRoute" (
 );
 
 -- CreateTable
-CREATE TABLE "BackgroundJob" (
+CREATE TABLE IF NOT EXISTS "BackgroundJob" (
     "id" TEXT NOT NULL,
     "type" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -594,7 +594,7 @@ CREATE TABLE "BackgroundJob" (
 );
 
 -- CreateTable
-CREATE TABLE "IngressMiddleware" (
+CREATE TABLE IF NOT EXISTS "IngressMiddleware" (
     "id" TEXT NOT NULL,
     "ingressPointId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -608,7 +608,7 @@ CREATE TABLE "IngressMiddleware" (
 );
 
 -- CreateTable
-CREATE TABLE "nova" (
+CREATE TABLE IF NOT EXISTS "nova" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "displayName" TEXT NOT NULL,
@@ -625,7 +625,7 @@ CREATE TABLE "nova" (
 );
 
 -- CreateTable
-CREATE TABLE "NovaDeployment" (
+CREATE TABLE IF NOT EXISTS "NovaDeployment" (
     "id" TEXT NOT NULL,
     "novaId" TEXT NOT NULL,
     "environmentId" TEXT,
@@ -641,7 +641,7 @@ CREATE TABLE "NovaDeployment" (
 );
 
 -- CreateTable
-CREATE TABLE "NovaRevision" (
+CREATE TABLE IF NOT EXISTS "NovaRevision" (
     "id" TEXT NOT NULL,
     "novaId" TEXT NOT NULL,
     "version" TEXT NOT NULL,
@@ -654,7 +654,7 @@ CREATE TABLE "NovaRevision" (
 );
 
 -- CreateTable
-CREATE TABLE "chat_rooms" (
+CREATE TABLE IF NOT EXISTS "chat_rooms" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
@@ -668,7 +668,7 @@ CREATE TABLE "chat_rooms" (
 );
 
 -- CreateTable
-CREATE TABLE "chat_room_members" (
+CREATE TABLE IF NOT EXISTS "chat_room_members" (
     "id" TEXT NOT NULL,
     "roomId" TEXT NOT NULL,
     "agentId" TEXT,
@@ -681,7 +681,7 @@ CREATE TABLE "chat_room_members" (
 );
 
 -- CreateTable
-CREATE TABLE "chat_messages" (
+CREATE TABLE IF NOT EXISTS "chat_messages" (
     "id" TEXT NOT NULL,
     "roomId" TEXT NOT NULL,
     "agentId" TEXT,

--- a/apps/web/prisma/migrations/10_room_goals/migration.sql
+++ b/apps/web/prisma/migrations/10_room_goals/migration.sql
@@ -1,7 +1,7 @@
 -- Add RoomGoal model: tracks goals set in chat rooms with full history,
 -- status, completion summary, and who set them.
 
-CREATE TABLE "room_goals" (
+CREATE TABLE IF NOT EXISTS "room_goals" (
     "id" TEXT NOT NULL,
     "roomId" TEXT NOT NULL,
     "text" TEXT NOT NULL,

--- a/apps/web/prisma/migrations/10_soc_case_management/migration.sql
+++ b/apps/web/prisma/migrations/10_soc_case_management/migration.sql
@@ -13,7 +13,7 @@ CREATE TYPE "ObservableRole" AS ENUM ('ioc', 'artifact', 'infrastructure');
 
 -- ── Investigation table ────────────────────────────────────────────────────────
 
-CREATE TABLE "Investigation" (
+CREATE TABLE IF NOT EXISTS "Investigation" (
   "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "name" TEXT NOT NULL,
   "status" "InvestigationStatus" NOT NULL DEFAULT 'open',
@@ -50,7 +50,7 @@ CREATE INDEX "Investigation_externalId" ON "Investigation"("externalId");
 
 -- ── InvestigationNote table ────────────────────────────────────────────────────
 
-CREATE TABLE "InvestigationNote" (
+CREATE TABLE IF NOT EXISTS "InvestigationNote" (
   "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "investigationId" UUID NOT NULL,
   "content" TEXT NOT NULL,
@@ -73,7 +73,7 @@ CREATE INDEX "InvestigationNote_searchVector_idx" ON "InvestigationNote" USING g
 
 -- ── InvestigationObservable table ──────────────────────────────────────────────
 
-CREATE TABLE "InvestigationObservable" (
+CREATE TABLE IF NOT EXISTS "InvestigationObservable" (
   "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "investigationId" UUID NOT NULL,
   "value" TEXT NOT NULL,
@@ -106,7 +106,7 @@ CREATE INDEX "InvestigationObservable_verdict" ON "InvestigationObservable"("ver
 
 -- ── InvestigationTimeline table ────────────────────────────────────────────────
 
-CREATE TABLE "InvestigationTimeline" (
+CREATE TABLE IF NOT EXISTS "InvestigationTimeline" (
   "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "investigationId" UUID NOT NULL,
   "eventTime" TIMESTAMPTZ(3) NOT NULL,
@@ -127,7 +127,7 @@ CREATE INDEX "InvestigationTimeline_investigationId_eventType" ON "Investigation
 
 -- ── InvestigationAudit table ───────────────────────────────────────────────────
 
-CREATE TABLE "InvestigationAudit" (
+CREATE TABLE IF NOT EXISTS "InvestigationAudit" (
   "id" UUID NOT NULL DEFAULT gen_random_uuid(),
   "investigationId" UUID NOT NULL,
   "actorId" TEXT NOT NULL,

--- a/apps/web/prisma/migrations/11_job_run_history/migration.sql
+++ b/apps/web/prisma/migrations/11_job_run_history/migration.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "JobRun" (
+CREATE TABLE IF NOT EXISTS "JobRun" (
   "id"           TEXT NOT NULL,
   "source"       TEXT NOT NULL,
   "sourceId"     TEXT NOT NULL,

--- a/apps/web/prisma/migrations/12_siem_foundation_schema/migration.sql
+++ b/apps/web/prisma/migrations/12_siem_foundation_schema/migration.sql
@@ -4,7 +4,7 @@ ALTER TABLE "SecurityEvent" ADD COLUMN "firstSeen" TIMESTAMP(3);
 ALTER TABLE "SecurityEvent" ADD COLUMN "lastSeen" TIMESTAMP(3);
 
 -- CreateTable: Incident
-CREATE TABLE "Incident" (
+CREATE TABLE IF NOT EXISTS "Incident" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "status" TEXT NOT NULL DEFAULT 'open',
@@ -19,7 +19,7 @@ CREATE TABLE "Incident" (
 );
 
 -- CreateTable: ActionAudit
-CREATE TABLE "ActionAudit" (
+CREATE TABLE IF NOT EXISTS "ActionAudit" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "incidentId" TEXT,
@@ -39,7 +39,7 @@ CREATE TABLE "ActionAudit" (
 );
 
 -- CreateTable: ActionPolicy
-CREATE TABLE "ActionPolicy" (
+CREATE TABLE IF NOT EXISTS "ActionPolicy" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "actionType" TEXT NOT NULL,
@@ -53,7 +53,7 @@ CREATE TABLE "ActionPolicy" (
 );
 
 -- CreateTable: CorrelationRule
-CREATE TABLE "CorrelationRule" (
+CREATE TABLE IF NOT EXISTS "CorrelationRule" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "name" TEXT NOT NULL,
@@ -69,7 +69,7 @@ CREATE TABLE "CorrelationRule" (
 );
 
 -- CreateTable: SourceHealth
-CREATE TABLE "SourceHealth" (
+CREATE TABLE IF NOT EXISTS "SourceHealth" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "source" TEXT NOT NULL,
@@ -83,7 +83,7 @@ CREATE TABLE "SourceHealth" (
 );
 
 -- CreateTable: Suppression
-CREATE TABLE "Suppression" (
+CREATE TABLE IF NOT EXISTS "Suppression" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "matchPattern" JSONB NOT NULL,

--- a/apps/web/prisma/migrations/16_environment_source_health/migration.sql
+++ b/apps/web/prisma/migrations/16_environment_source_health/migration.sql
@@ -5,7 +5,7 @@
 -- (environmentId, source) so each managed environment tracks its own Falco
 -- and K8s-events ingestion health independently.
 
-CREATE TABLE "EnvironmentSourceHealth" (
+CREATE TABLE IF NOT EXISTS "EnvironmentSourceHealth" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "source" TEXT NOT NULL,

--- a/apps/web/prisma/migrations/17_vulnerability_finding/migration.sql
+++ b/apps/web/prisma/migrations/17_vulnerability_finding/migration.sql
@@ -2,7 +2,7 @@
 
 CREATE TYPE "VulnStatus" AS ENUM ('open', 'fixed', 'accepted', 'false_positive');
 
-CREATE TABLE "VulnerabilityFinding" (
+CREATE TABLE IF NOT EXISTS "VulnerabilityFinding" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
 

--- a/apps/web/prisma/migrations/19_add_tool_execution/migration.sql
+++ b/apps/web/prisma/migrations/19_add_tool_execution/migration.sql
@@ -1,7 +1,7 @@
 -- Add ToolExecution table for tracking executor tool calls
 -- Tracks shell_exec, file_read, and system_info execution with Warden approval gating
 
-CREATE TABLE "ToolExecution" (
+CREATE TABLE IF NOT EXISTS "ToolExecution" (
   "id" TEXT NOT NULL,
   "executionId" TEXT NOT NULL,
   "environmentId" TEXT,

--- a/apps/web/prisma/migrations/21_add_task_checkpoints/migration.sql
+++ b/apps/web/prisma/migrations/21_add_task_checkpoints/migration.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "TaskCheckpoint" (
+CREATE TABLE IF NOT EXISTS "TaskCheckpoint" (
     "id" TEXT NOT NULL,
     "taskId" TEXT NOT NULL,
     "stepIndex" INTEGER NOT NULL,

--- a/apps/web/prisma/migrations/22_add_eval_benchmark/migration.sql
+++ b/apps/web/prisma/migrations/22_add_eval_benchmark/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "EvalSuite" (
+CREATE TABLE IF NOT EXISTS "EvalSuite" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT,
@@ -11,7 +11,7 @@ CREATE TABLE "EvalSuite" (
 );
 
 -- CreateTable
-CREATE TABLE "EvalCase" (
+CREATE TABLE IF NOT EXISTS "EvalCase" (
     "id" TEXT NOT NULL,
     "suiteId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -25,7 +25,7 @@ CREATE TABLE "EvalCase" (
 );
 
 -- CreateTable
-CREATE TABLE "EvalRun" (
+CREATE TABLE IF NOT EXISTS "EvalRun" (
     "id" TEXT NOT NULL,
     "suiteId" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
@@ -42,7 +42,7 @@ CREATE TABLE "EvalRun" (
 );
 
 -- CreateTable
-CREATE TABLE "EvalCaseResult" (
+CREATE TABLE IF NOT EXISTS "EvalCaseResult" (
     "id" TEXT NOT NULL,
     "runId" TEXT NOT NULL,
     "caseId" TEXT NOT NULL,

--- a/apps/web/prisma/migrations/23_add_drift_reports/migration.sql
+++ b/apps/web/prisma/migrations/23_add_drift_reports/migration.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "DriftReport" (
+CREATE TABLE IF NOT EXISTS "DriftReport" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "status" TEXT NOT NULL DEFAULT 'clean',

--- a/apps/web/prisma/migrations/23_add_token_budget/migration.sql
+++ b/apps/web/prisma/migrations/23_add_token_budget/migration.sql
@@ -3,7 +3,7 @@ ALTER TABLE "Agent" ADD COLUMN "tokenBudgetDay"   INTEGER;
 ALTER TABLE "Agent" ADD COLUMN "tokenBudgetMonth" INTEGER;
 
 -- Create AgentTokenUsage table
-CREATE TABLE "AgentTokenUsage" (
+CREATE TABLE IF NOT EXISTS "AgentTokenUsage" (
   "id"           TEXT NOT NULL,
   "agentId"      TEXT NOT NULL,
   "taskId"       TEXT NOT NULL,

--- a/apps/web/prisma/migrations/24_add_notification_channels/migration.sql
+++ b/apps/web/prisma/migrations/24_add_notification_channels/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "NotificationChannel" (
+CREATE TABLE IF NOT EXISTS "NotificationChannel" (
     "id"          TEXT NOT NULL,
     "name"        TEXT NOT NULL,
     "type"        TEXT NOT NULL,

--- a/apps/web/prisma/migrations/24_add_scheduled_tasks/migration.sql
+++ b/apps/web/prisma/migrations/24_add_scheduled_tasks/migration.sql
@@ -1,6 +1,6 @@
 -- Add ScheduledTask table for cron-style recurring task scheduling
 
-CREATE TABLE "ScheduledTask" (
+CREATE TABLE IF NOT EXISTS "ScheduledTask" (
   "id" TEXT NOT NULL,
   "name" TEXT NOT NULL,
   "description" TEXT,

--- a/apps/web/prisma/migrations/24_add_webhook_triggers/migration.sql
+++ b/apps/web/prisma/migrations/24_add_webhook_triggers/migration.sql
@@ -1,7 +1,7 @@
 -- Migration: 24_add_webhook_triggers
 -- Adds inbound webhook triggers that create tasks from external events.
 
-CREATE TABLE "WebhookTrigger" (
+CREATE TABLE IF NOT EXISTS "WebhookTrigger" (
     "id"          TEXT NOT NULL,
     "name"        TEXT NOT NULL,
     "agentId"     TEXT NOT NULL,

--- a/apps/web/prisma/migrations/26_add_webhook_delivery/migration.sql
+++ b/apps/web/prisma/migrations/26_add_webhook_delivery/migration.sql
@@ -1,7 +1,7 @@
 -- Migration: 26_add_webhook_delivery
 -- Tracks delivered webhook payloads for idempotency (deduplication by delivery ID).
 
-CREATE TABLE "WebhookDelivery" (
+CREATE TABLE IF NOT EXISTS "WebhookDelivery" (
     "id"         TEXT NOT NULL,
     "triggerId"  TEXT NOT NULL,
     "deliveryId" TEXT NOT NULL,

--- a/apps/web/prisma/migrations/5_ring_leader_hooks_evals/migration.sql
+++ b/apps/web/prisma/migrations/5_ring_leader_hooks_evals/migration.sql
@@ -2,7 +2,7 @@
 ALTER TABLE "managed_secrets" ALTER COLUMN "updatedAt" DROP DEFAULT;
 
 -- CreateTable
-CREATE TABLE "SecurityEvent" (
+CREATE TABLE IF NOT EXISTS "SecurityEvent" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "type" TEXT NOT NULL,
@@ -22,7 +22,7 @@ CREATE TABLE "SecurityEvent" (
 );
 
 -- CreateTable
-CREATE TABLE "SecurityConfig" (
+CREATE TABLE IF NOT EXISTS "SecurityConfig" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT,
     "key" TEXT NOT NULL,
@@ -34,7 +34,7 @@ CREATE TABLE "SecurityConfig" (
 );
 
 -- CreateTable
-CREATE TABLE "agent_profiles" (
+CREATE TABLE IF NOT EXISTS "agent_profiles" (
     "id" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
     "domain" TEXT NOT NULL,
@@ -50,7 +50,7 @@ CREATE TABLE "agent_profiles" (
 );
 
 -- CreateTable
-CREATE TABLE "room_knowledge" (
+CREATE TABLE IF NOT EXISTS "room_knowledge" (
     "id" TEXT NOT NULL,
     "roomId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -64,7 +64,7 @@ CREATE TABLE "room_knowledge" (
 );
 
 -- CreateTable
-CREATE TABLE "agent_knowledge" (
+CREATE TABLE IF NOT EXISTS "agent_knowledge" (
     "id" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -78,7 +78,7 @@ CREATE TABLE "agent_knowledge" (
 );
 
 -- CreateTable
-CREATE TABLE "NovaDefinition" (
+CREATE TABLE IF NOT EXISTS "NovaDefinition" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "category" TEXT NOT NULL,
@@ -94,7 +94,7 @@ CREATE TABLE "NovaDefinition" (
 );
 
 -- CreateTable
-CREATE TABLE "NebulaInstance" (
+CREATE TABLE IF NOT EXISTS "NebulaInstance" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "sourceNovaId" TEXT,
@@ -111,7 +111,7 @@ CREATE TABLE "NebulaInstance" (
 );
 
 -- CreateTable
-CREATE TABLE "HookExecutionLog" (
+CREATE TABLE IF NOT EXISTS "HookExecutionLog" (
     "id" TEXT NOT NULL,
     "nebulaId" TEXT NOT NULL,
     "triggerEvent" TEXT NOT NULL,
@@ -127,7 +127,7 @@ CREATE TABLE "HookExecutionLog" (
 );
 
 -- CreateTable
-CREATE TABLE "SkillExecutionLog" (
+CREATE TABLE IF NOT EXISTS "SkillExecutionLog" (
     "id" TEXT NOT NULL,
     "nebulaId" TEXT NOT NULL,
     "source" TEXT NOT NULL,
@@ -139,7 +139,7 @@ CREATE TABLE "SkillExecutionLog" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentTrace" (
+CREATE TABLE IF NOT EXISTS "AgentTrace" (
     "id" TEXT NOT NULL,
     "conversationId" TEXT,
     "taskId" TEXT,
@@ -163,7 +163,7 @@ CREATE TABLE "AgentTrace" (
 );
 
 -- CreateTable
-CREATE TABLE "Eval" (
+CREATE TABLE IF NOT EXISTS "Eval" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "targetType" TEXT NOT NULL,
@@ -182,7 +182,7 @@ CREATE TABLE "Eval" (
 );
 
 -- CreateTable
-CREATE TABLE "Ruleset" (
+CREATE TABLE IF NOT EXISTS "Ruleset" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "description" TEXT NOT NULL,
@@ -194,7 +194,7 @@ CREATE TABLE "Ruleset" (
 );
 
 -- CreateTable
-CREATE TABLE "AgentScore" (
+CREATE TABLE IF NOT EXISTS "AgentScore" (
     "id" TEXT NOT NULL,
     "environmentId" TEXT NOT NULL,
     "targetType" TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- Adds `IF NOT EXISTS` to all `CREATE TABLE` statements across 17 migration files
- Prevents migration failures when a table already exists in the target database
- Establishes this as the standard for all future migrations

## Test plan

- [ ] Apply migrations against a DB where tables already exist — confirm no errors
- [ ] Apply migrations against a fresh DB — confirm normal behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)