### PR TITLE
fix(siem): unblock monitoring deploy and security event pipeline

### DIFF
--- a/apps/web/src/app/api/environments/[id]/monitoring/deploy/route.ts
+++ b/apps/web/src/app/api/environments/[id]/monitoring/deploy/route.ts
@@ -29,7 +29,7 @@ export async function POST(
 
   const env = await prisma.environment.findUnique({ where: { id } })
   if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
-  if (env.type !== 'kubernetes') {
+  if (env.type !== 'cluster') {
     return NextResponse.json({ error: 'Monitoring deployment is only supported for Kubernetes environments' }, { status: 400 })
   }
   if (!env.kubeconfig) {

--- a/apps/web/src/components/security/SecuritySettings.tsx
+++ b/apps/web/src/components/security/SecuritySettings.tsx
@@ -50,7 +50,7 @@ export default function SecuritySettings() {
         const rulesData = await rulesRes.json()
         setRules(rulesData.rules ?? [])
         const envData = await envRes.json() as K8sEnv[]
-        const k8s = (Array.isArray(envData) ? envData : envData).filter((e: any) => e.type === 'kubernetes')
+        const k8s = (Array.isArray(envData) ? envData : envData).filter((e: any) => e.type === 'cluster')
         setK8sEnvs(k8s)
         if (k8s.length > 0) setSelectedEnvId(k8s[0].id)
       } catch {}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -589,18 +589,19 @@ services:
   # attempts. Falco's coverage is strictly larger than `docker events` (which
   # vector's docker_lifecycle source already provides).
   #
-  # Uses falco-no-driver image (eBPF-based, no kernel module install needed).
+  # Uses full falco image (includes falcoctl) which downloads the eBPF probe
+  # for the running kernel at startup. falco-no-driver was previously used
+  # here but lacks the driver loader — it crashed with "need to provide a
+  # path to the bpf object file" because probe: "" in falco.yaml is unset.
+  # modern_ebpf segfaults on kernel 6.8; legacy ebpf probe is downloaded by
+  # falcoctl automatically via the full image's entrypoint.
   # privileged: true is currently required for Falco's syscall capture even
   # with eBPF — see https://falco.org/docs/getting-started/running/#docker.
   falco:
-    image: falcosecurity/falco-no-driver:0.38.2
+    image: falcosecurity/falco:0.38.2
     restart: unless-stopped
     privileged: true
     pid: host
-    # engine.kind is set to "ebpf" (legacy) in host-agent/falco/falco.yaml.
-    # modern_ebpf (default) segfaults (SIGSEGV) on this kernel build (6.8).
-    # falco-no-driver uses the config file for engine selection — the --driver
-    # CLI flag does not exist in this image and causes a crash-loop.
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock:ro
       - /dev:/host/dev:ro

--- a/deploy/host-agent/vector.toml
+++ b/deploy/host-agent/vector.toml
@@ -244,7 +244,7 @@ source = """
     "events": .events
   }
   body = encode_json(envelope)
-  sig = encode_base16(hmac(body, secret, algorithm: "sha-256"))
+  sig = downcase(encode_base16(hmac(body, secret, algorithm: "sha-256")))
   .x_signature = "sha256=" + sig
   .message = body
 """


### PR DESCRIPTION
## Summary

- **Deploy Monitoring Stack broken**: `SecuritySettings.tsx` and the `monitoring/deploy` API route both filtered/checked `env.type === 'kubernetes'` — but the schema stores `'cluster'` for K8s environments. Result: the Deploy section showed "No Kubernetes environments found" even though Talos Cluster exists with a kubeconfig.

- **Vector dropping all host-agent events (401)**: VRL's `encode_base16()` outputs uppercase hex; Node's `digest('hex')` produces lowercase. Every batch from Vector got rejected as an invalid signature. Added `downcase()` to the `build_envelope` VRL transform so the HMAC hex matches.

- **Falco crash-looping**: `falco-no-driver:0.38.2` has no `falcoctl`/driver-loader. The `probe: ""` in `falco.yaml` is an empty path and the image cannot download the BPF object file itself. Switched to `falcosecurity/falco:0.38.2` which runs `falcoctl driver install --type ebpf` at startup and fetches the right probe for the running kernel (6.8, legacy eBPF).

## After merge

1. Merge this PR → CI builds new image + bootstrap.sh redeploys
2. Vector will start shipping journald/Docker/Vault events into SecurityEvents immediately
3. Falco will start up and stream syscall alerts via Falcosidekick → `/webhooks/falco`
4. The "Deploy Monitoring Stack" button in `/security` Settings will show Talos Cluster and let you deploy VictoriaMetrics + ntopng

## Test plan

- [ ] Go to `/security` → Settings → "Deploy Monitoring Stack" section now shows Talos Cluster in the picker
- [ ] Click Deploy → 202 returned, job progress logs shown
- [ ] `docker logs deploy-vector-1` shows no more 401 errors after redeploy
- [ ] `docker logs deploy-falco-1` shows Falco starting cleanly and detecting events

🤖 Generated with [Claude Code](https://claude.com/claude-code)