### PR TITLE
fix(siem): fix Vector 401 — move HMAC signature into body

### DIFF
--- a/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
@@ -55,12 +55,27 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  // 1. Read raw body (for HMAC verification)
+  // 1. Read body and parse outer envelope
+  //
+  // Vector's raw_message codec strips event fields before HTTP sink header
+  // templates are evaluated, so {{ x_signature }} was sent literally instead
+  // of interpolated. Signature is now embedded in the body as:
+  //   { "sig": "sha256=<hex>", "payload": "<json-string>" }
+  // HMAC is verified over `payload` (the exact string Vector signed) before
+  // parsing the inner batch — no re-serialisation, no ordering ambiguity.
   const bodyText = await req.text()
-  const signature = req.headers.get('X-Signature') || req.headers.get('x-host-agent-signature')
   const timestamp = req.headers.get('X-Timestamp') || req.headers.get('x-timestamp')
 
-  // 2. Verify HMAC signature
+  let outerEnvelope: { sig?: string; payload?: string } = {}
+  try {
+    outerEnvelope = JSON.parse(bodyText)
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { sig: signature, payload: payloadStr } = outerEnvelope
+
+  // 2. Verify HMAC over the raw payload string
   if (!process.env.HOST_AGENT_WEBHOOK_SECRET) {
     const refuse = warnMissingWebhookSecret('host_agent', 'HOST_AGENT_WEBHOOK_SECRET')
     if (refuse) {
@@ -74,10 +89,7 @@ export async function POST(req: NextRequest) {
     }
   } else {
     const secret = process.env.HOST_AGENT_WEBHOOK_SECRET
-    if (!verifyWebhookHmac(secret, bodyText, signature)) {
-      const computed = `sha256=${crypto.createHmac('sha256', secret).update(bodyText).digest('hex')}`
-      // eslint-disable-next-line no-console
-      console.error('[siem:hmac-debug] 401 body_len=%d body_tail=%s received=%s computed=%s', bodyText.length, JSON.stringify(bodyText.slice(-4)), signature, computed)
+    if (!payloadStr || !verifyWebhookHmac(secret, payloadStr, signature ?? null)) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
     }
   }
@@ -87,12 +99,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Request expired (replay window exceeded)' }, { status: 410 })
   }
 
-  // 4. Parse and validate batch
+  // 4. Parse inner payload and validate batch
   let batch: unknown
   try {
-    batch = JSON.parse(bodyText)
+    batch = JSON.parse(payloadStr ?? '')
   } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    return NextResponse.json({ error: 'Invalid payload JSON' }, { status: 400 })
   }
 
   let validatedBatch

--- a/deploy/host-agent/vector.toml
+++ b/deploy/host-agent/vector.toml
@@ -233,26 +233,35 @@ max_events = 100
 [transforms.batch_events.merge_strategies]
 events = "array"
 
-# Step 3: add envelope fields + compute HMAC
+# Step 3: build signed envelope
+#
+# Signature approach: the HMAC is embedded in the outer JSON body, NOT a header.
+# Vector's raw_message codec strips event fields before the HTTP sink evaluates
+# header templates, so {{ x_signature }} was sent literally (not interpolated).
+#
+# Instead we produce:
+#   { "sig": "sha256=<hex>", "payload": "<json-string>" }
+#
+# where `payload` is the JSON-serialised inner envelope and `sig` is
+# HMAC-SHA256 over those exact bytes. The server extracts `payload` as a
+# string (no re-serialisation, no ordering ambiguity) and verifies against `sig`.
 
 [transforms.build_envelope]
 type = "remap"
 inputs = ["batch_events"]
 source = """
   secret = get_env_var!("HOST_AGENT_WEBHOOK_SECRET")
-  envelope = {
+  inner = {
     "batch_id": uuid_v4(),
     "hostname": get_hostname!(),
     "events": .events
   }
-  body = encode_json(envelope)
-  sig = downcase(encode_base16(hmac(body, secret, algorithm: "sha-256")))
-  .x_signature = "sha256=" + sig
-  .message = body
+  payload_str = encode_json(inner)
+  sig = "sha256=" + downcase(encode_base16(hmac(payload_str, secret, algorithm: "sha-256")))
+  .message = encode_json({ "sig": sig, "payload": payload_str })
 """
 
 # ── Sink: HTTP → Orion host-agent webhook ───────────────────────────────────
-# Sends pre-built JSON body with HMAC signature header.
 
 [sinks.webhook]
 type = "http"
@@ -264,7 +273,6 @@ method = "post"
 codec = "raw_message"
 
 [sinks.webhook.request.headers]
-"X-Signature" = "{{ x_signature }}"
 "Content-Type" = "application/json"
 
 [sinks.webhook.request]


### PR DESCRIPTION
## Summary

- **Root cause:** Vector 0.39's `raw_message` codec strips all event fields before the HTTP sink evaluates `request.headers` templates. `{{ x_signature }}` was being sent as the literal string, not the computed HMAC — so every request got 401.

- **Fix:** Remove the `X-Signature` header entirely. Vector now produces a wrapper envelope:
  ```json
  { "sig": "sha256=<hex>", "payload": "<json-string>" }
  ```
  HMAC is computed over `payload` (the exact bytes Vector serialised). The server extracts `payload` as a string and verifies against `sig` — no re-serialisation, no JSON key ordering ambiguity.

- Also removes the temporary `[siem:hmac-debug]` console.error that was added to diagnose the 401.

## Files changed

- `deploy/host-agent/vector.toml` — `build_envelope` now produces `{sig, payload}` wrapper; `X-Signature` header removed from sink
- `apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts` — reads `sig`/`payload` from body, verifies HMAC over `payload` string, parses inner batch from `payload`

## Test plan

- [ ] After deploy, `docker logs deploy-orion-1 2>&1 | grep -c '401'` drops to 0
- [ ] Security events appear in the Orion SIEM dashboard from host-agent source
- [ ] `docker logs deploy-vector-1 2>&1 | grep -c 'Not retriable'` drops to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)