### PR TITLE
fix(siem): remove replay-window check from host-agent route

### DIFF
--- a/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
+++ b/apps/web/src/app/api/monitoring/security/webhooks/host-agent/route.ts
@@ -23,7 +23,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import {
   verifyWebhookHmac,
-  isWithinReplayWindow,
   wasAlreadyProcessed,
   shouldAcceptUnauthenticated,
   warnMissingWebhookSecret,
@@ -64,7 +63,6 @@ export async function POST(req: NextRequest) {
   // HMAC is verified over `payload` (the exact string Vector signed) before
   // parsing the inner batch — no re-serialisation, no ordering ambiguity.
   const bodyText = await req.text()
-  const timestamp = req.headers.get('X-Timestamp') || req.headers.get('x-timestamp')
 
   let outerEnvelope: { sig?: string; payload?: string } = {}
   try {
@@ -94,12 +92,10 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // 3. Check replay window
-  if (!isWithinReplayWindow(timestamp)) {
-    return NextResponse.json({ error: 'Request expired (replay window exceeded)' }, { status: 410 })
-  }
-
-  // 4. Parse inner payload and validate batch
+  // 3. Parse inner payload and validate batch
+  // Note: no replay-window check here — Vector cannot send a dynamic X-Timestamp
+  // header (HTTP sink templates are not evaluated for raw_message codec). Replay
+  // protection is provided by the 24h dedupKey idempotency check below.
   let batch: unknown
   try {
     batch = JSON.parse(payloadStr ?? '')


### PR DESCRIPTION
## Summary

Vector's HTTP sink cannot send dynamic `X-Timestamp` headers — the `raw_message` codec strips all event fields before header templates are evaluated (same root cause as #659). `isWithinReplayWindow()` returns `false` in production when the header is absent, so every batch was returning 410.

The 24h dedupKey idempotency check already provides stronger replay protection than the 5-minute window, making the check redundant for this route.

## Test plan

- [ ] After deploy, `docker logs deploy-vector-1 --tail 20 2>&1 | grep -E 'error|Error'` shows no 410s
- [ ] Security events appear in the SIEM dashboard from `host_agent` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)