### PR TITLE
fix(falco): raise memlock ulimit to fix modern_ebpf scap_init failure

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -599,6 +599,12 @@ services:
     restart: unless-stopped
     privileged: true
     pid: host
+    # modern_ebpf ring buffers need locked memory beyond the Docker default (8 MB).
+    # Without this, scap_init fails even in a privileged container.
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock:ro
       - /dev:/host/dev:ro


### PR DESCRIPTION
## Summary

Falco has been crash-looping with `Error: Initialization issues during scap_init` since switching to `modern_ebpf` (CO-RE) in #658.

**Root cause:** Docker's default `RLIMIT_MEMLOCK` is **8 MB**, even for `privileged: true` containers. Falco's modern_ebpf driver allocates per-CPU BPF ring buffers for event capture — on a multi-core system these easily exceed 8 MB total, causing `scap_init` to fail when it can't lock the memory.

The host itself has ~4 GB of lockable memory (`ulimit -l` = 4097608 KB); the container just wasn't inheriting it.

**Fix:** Add `ulimits.memlock: soft=-1, hard=-1` to the Falco service so BPF ring-buffer allocation succeeds.

## Test plan

- [ ] After deploy, `docker logs deploy-falco-1 --tail 20` shows Falco running (no `scap_init` error, no restart loop)
- [ ] Falcosidekick connects and forwards alerts to Orion

🤖 Generated with [Claude Code](https://claude.com/claude-code)