### PR TITLE
fix(siem): stop Warden token burn from Docker event storm

### DIFF
--- a/apps/web/src/lib/security/rule-engine.ts
+++ b/apps/web/src/lib/security/rule-engine.ts
@@ -29,15 +29,15 @@ function envIdFilter(envId: string): string | null {
  * Rule parameter types supported by the correlation engine.
  */
 export type RuleParams =
-  | { type: 'threshold'; field: string; op: 'gte' | 'lte' | 'eq'; value: number; window: number; groupBy: string[]; maxEvents?: number; sourceFilter?: string[] }
-  | { type: 'pattern'; regex: string; field: string; window: number; sourceFilter?: string[]; minSeverity?: number }
+  | { type: 'threshold'; field: string; op: 'gte' | 'lte' | 'eq'; value: number; window: number; groupBy: string[]; maxEvents?: number; sourceFilter?: string[]; typeFilter?: string[] }
+  | { type: 'pattern'; regex: string; field: string; window: number; sourceFilter?: string[]; typeFilter?: string[]; minSeverity?: number }
   | { type: 'malware'; ruleLevel: number; field: string }
   | { type: 'process'; commandPattern: string; window: number }
   | { type: 'composite'; rules: RuleParams[]; combine: 'all' | 'any'; window: number }
   // volume_sum: aggregates a numeric JSON field from rawEvent across all matching
   // events in the window. Fires when the total exceeds `thresholdBytes`.
   // Designed for high-egress / large-transfer detection from ntopng flows.
-  | { type: 'volume_sum'; jsonPath: string; thresholdBytes: number; window: number; sourceFilter?: string[]; groupBy?: string[] }
+  | { type: 'volume_sum'; jsonPath: string; thresholdBytes: number; window: number; sourceFilter?: string[]; typeFilter?: string[]; groupBy?: string[] }
 
 // ── Correlation ───────────────────────────────────────────────────────────────
 
@@ -338,6 +338,7 @@ async function runThresholdRule(
       environmentId: envIdFilter(envId),
       createdAt: { gte: effectiveSince },
       ...(params.sourceFilter?.length ? { source: { in: params.sourceFilter } } : {}),
+      ...(params.typeFilter?.length ? { type: { in: params.typeFilter } } : {}),
     },
     orderBy: { createdAt: 'desc' },
   })
@@ -367,8 +368,12 @@ async function runThresholdRule(
 
     // Calculate severity as max of group events
     const maxSeverity = Math.max(...group.map(e => e.severity))
+    // Only apply the count-based boost when there's a known attacker — infrastructure
+    // events that group under 'unknown' (Docker restarts, stale sources) should not
+    // be artificially boosted to 100 just because the rule sees many of them.
+    const hasKnownAttacker = key !== 'unknown' && key !== ''
     const severity = params.op === 'gte'
-      ? Math.min(100, maxSeverity + (count - params.value) * 5)
+      ? Math.min(100, maxSeverity + (hasKnownAttacker ? (count - params.value) * 5 : 0))
       : maxSeverity
 
     if (!bestGroup || severity > bestGroup.severity) {
@@ -407,6 +412,7 @@ async function runPatternRule(
       environmentId: envIdFilter(envId),
       createdAt: { gte: since },
       ...(params.sourceFilter?.length ? { source: { in: params.sourceFilter } } : {}),
+      ...(params.typeFilter?.length ? { type: { in: params.typeFilter } } : {}),
       ...(params.minSeverity != null ? { severity: { gte: params.minSeverity } } : {}),
     },
     orderBy: { createdAt: 'desc' },

--- a/apps/web/src/lib/seed-correlation-rules.ts
+++ b/apps/web/src/lib/seed-correlation-rules.ts
@@ -19,17 +19,20 @@ const DEFAULT_RULES = [
       type: 'threshold',
       // Plan: "≥5 failed logins, same IP, 5min". Group by the virtual
       // `attackerKey` extractor so the rule fires uniformly across CrowdSec,
-      // Wazuh, ELK, and ntopng — each source surfaces the attacker IP at a
-      // different JSON path. The previous seed hard-coded `rawEvent.srcip`
-      // which silently missed CrowdSec (where the attacker IP lives at
-      // `rawEvent.payload.value`) and ntopng (at `rawEvent.cli.ip`).
-      // See `extractGroupValue` in `lib/security/rule-engine.ts` for the
-      // source-path probe order.
+      // Wazuh, and ELK — each source surfaces the attacker IP at a different
+      // JSON path. See `extractGroupValue` in `lib/security/rule-engine.ts`.
+      //
+      // Scoped to network-source security tools (crowdsec, wazuh, elk) —
+      // host_agent SSH failures are covered by the narrower host.ssh_brute_force
+      // rule. Without a sourceFilter, Docker lifecycle events from host_agent
+      // (container.dead, container.restarted) were bucketed under attackerKey=unknown
+      // and triggered false brute-force incidents on every correlator run.
       field: 'attackerKey',
       op: 'gte' as const,
       value: 5,
       window: 300, // 5 minutes
       groupBy: ['attackerKey'],
+      sourceFilter: ['crowdsec', 'wazuh', 'elk'],
     },
     severity: 70,
     window: 300,
@@ -71,9 +74,10 @@ const DEFAULT_RULES = [
   // ── Host-agent rules (from gigly-sniffing-parasol.md, PR3) ─────────────────
 
   // host.ssh_brute_force — ≥5 SSH failed-password events from same IP in 5min.
-  // This is a narrower variant of the generic brute_force rule that fires
-  // specifically on host_agent source SSH failures (which have structured
-  // metadata from the Vector shipper).
+  // Narrower variant of brute_force, targeting host_agent source specifically.
+  // typeFilter restricts to SSH/auth failures — without it, Docker lifecycle
+  // events (container.dead, container.restarted) from the same host_agent source
+  // are counted as brute-force attempts, which they are not.
   {
     name: 'host.ssh_brute_force',
     ruleType: 'threshold',
@@ -84,9 +88,15 @@ const DEFAULT_RULES = [
       value: 5,
       window: 300, // 5 minutes
       groupBy: ['attackerKey'],
-      // Only match events from the host_agent source — the generic
-      // brute_force rule already handles CrowdSec/Wazuh SSH failures.
       sourceFilter: ['host_agent'],
+      typeFilter: [
+        'auth.ssh.failed_password',
+        'auth.ssh.invalid_user',
+        'auth.ssh.invalid_password',
+        'auth.sudo.failed',
+        'auth.pam.failure',
+        'auth.generic',
+      ],
     },
     severity: 70,
     window: 300,

--- a/apps/web/src/workers/security-correlator.ts
+++ b/apps/web/src/workers/security-correlator.ts
@@ -50,6 +50,19 @@ const LOOKBACK_WINDOW_SEC = 600
 /** Max incidents to create per run (guard against spam). */
 const MAX_INCIDENTS_PER_RUN = 10
 
+/**
+ * Minimum incident severity required to wake Warden. Incidents below this
+ * threshold still get a system-notice in the room (audit trail) but Warden's
+ * agentic loop is not triggered. Default 40 — above operational Docker noise
+ * (10-40) but below real auth/security signals (70+).
+ *
+ * Override with WARDEN_MIN_SEVERITY env var.
+ */
+const WARDEN_MIN_SEVERITY = (() => {
+  const v = Number(process.env.WARDEN_MIN_SEVERITY)
+  return Number.isFinite(v) && v > 0 ? v : 40
+})()
+
 /** How often to update source health staleness check (ms). */
 const STALENESS_CHECK_INTERVAL = 5 * 60 * 1000
 
@@ -333,17 +346,16 @@ async function correlateEnvironment(
           },
         })
 
-        // BUG-2 fix: trigger room agents so Warden actually wakes up on a new
-        // incident. The HTTP message-create paths
-        // (api/chatrooms/[id]/messages/route.ts and api/chatrooms/route.ts)
-        // both call triggerRoomAgentReplies after writing a ChatMessage; the
-        // correlator was skipping this call, so Warden's agent never received
-        // the new-incident notice. Fire-and-forget so a slow agent never
-        // blocks correlation.
-        triggerRoomAgentReplies(securityRoomId, noticeBody).catch((e: unknown) => {
-          // eslint-disable-next-line no-console
-          console.error(`[warden-wakeup] Failed to trigger room agent replies for incident ${incident.id ?? 'unknown'}: ${e instanceof Error ? e.message : e}`)
-        })
+        // Only wake Warden for incidents that meet the minimum severity threshold.
+        // Below-threshold incidents still get the system-notice above (audit trail)
+        // but don't trigger an agentic loop — prevents operational noise (Docker
+        // restarts, stale-source events) from burning tokens on every correlator tick.
+        if (incident.severity >= WARDEN_MIN_SEVERITY) {
+          triggerRoomAgentReplies(securityRoomId, noticeBody).catch((e: unknown) => {
+            // eslint-disable-next-line no-console
+            console.error(`[warden-wakeup] Failed to trigger room agent replies for incident ${incident.id ?? 'unknown'}: ${e instanceof Error ? e.message : e}`)
+          })
+        }
       }
 
       // Update events to reference the new incident

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -599,6 +599,12 @@ services:
     restart: unless-stopped
     privileged: true
     pid: host
+    # modern_ebpf ring buffers need locked memory beyond the Docker default (8 MB).
+    # Without this, scap_init fails even in a privileged container.
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
       - /var/run/docker.sock:/host/var/run/docker.sock:ro
       - /dev:/host/dev:ro


### PR DESCRIPTION
## Summary

- **typeFilter implemented** in correlation rule engine (`threshold` + `pattern` runners) — the field already existed in 4 seed rules but was silently ignored for all of them
- **`brute_force` rule scoped** to `sourceFilter: ['crowdsec', 'wazuh', 'elk']` — Docker lifecycle events from `host_agent` were bucketing under `attackerKey=unknown`, crossing the 5-event threshold on every correlator run
- **`host.ssh_brute_force`** gets a `typeFilter` for the 6 SSH/auth event types as a second layer of defense (same `host_agent` source also emits Docker events)
- **Severity count-boost gated on known attacker** — `min(100, maxSeverity + (count - threshold) * 5)` no longer applies the count multiplier when the group key is `unknown`/empty
- **Warden wakeup gated on `WARDEN_MIN_SEVERITY`** (default 40, env var override) — below-threshold incidents still write a system-notice to the security room but do not trigger an agentic loop

## Root cause chain

Falco crash-loop (fixed in PR #661) → 52+ Docker lifecycle events in the 10-min lookback window → `brute_force` rule (no source or type filter) grouped all events under `attackerKey=unknown` → `(52-5)*5 = 235` boost → capped to severity 100 → cross-run dedup skipped for `unknown` attackerKey → new severity-100 incident on every correlator tick (~every 10s) → `triggerRoomAgentReplies` called unconditionally → 86 Warden wakeups → 1M+ tokens in 24h.

## Layered defense after this PR

| Layer | Before | After |
|-------|--------|-------|
| Rule engine `typeFilter` | Silently ignored | Enforced in DB query |
| `brute_force` scope | All sources | crowdsec / wazuh / elk only |
| `host.ssh_brute_force` scope | All host_agent types | SSH/auth types only |
| Severity boost | Applied for `unknown` key | Only for known attacker keys |
| Warden wakeup | Every incident | Severity ≥ 40 only |

## Cleanup required after merge + deploy

Run this against the production DB to close the 86 storm incidents:

```sql
-- Dry-run first:
SELECT count(*) FROM "Incident"
WHERE status = 'open'
  AND severity = 100
  AND "attackerKey" = 'unknown'
  AND "rootCauseSummary" LIKE '%attackerKey events%'
  AND "openedAt" > '2026-06-13';

-- Then close them:
UPDATE "Incident"
SET status = 'closed', "closedAt" = now()
WHERE status = 'open'
  AND severity = 100
  AND "attackerKey" = 'unknown'
  AND "rootCauseSummary" LIKE '%attackerKey events%'
  AND "openedAt" > '2026-06-13';
```

## Deferred (separate PR)

- Add `ruleName` column to `Incident` for proper cross-run dedup on unknown-attacker incidents (Opus recommendation — schema migration required)
- Make per-rule rate limiter restart-safe (currently in-memory Map, cleared on worker restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)