### PR TITLE
fix(falco): raise memory limit and halve ring buffer count for 32-CPU host

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -621,7 +621,11 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 512M
+          # modern_ebpf allocates 1 ring buffer per CPU × 8 MB each by default.
+          # On a 32-CPU host that's 256 MB just for ring buffers + ~200 MB for
+          # Falco itself → OOM at 512 MB → scap_init fails. 1.5 GB gives ample
+          # headroom. Ring buffer count halved via falco.yaml (cpus_for_each_syscall_buffer: 2).
+          memory: 1536M
 
   # Falcosidekick — forwards Falco alerts to the /webhooks/falco endpoint
   # with an HMAC-signed body. CUSTOMFIELDS injects environmentId="host" so

--- a/deploy/host-agent/falco/falco.yaml
+++ b/deploy/host-agent/falco/falco.yaml
@@ -25,6 +25,13 @@ rules_file:
 # verified BTF present before switching.
 engine:
   kind: modern_ebpf
+  modern_ebpf:
+    # Default is 1 ring buffer per CPU × 8 MB. On a 32-CPU host that's 256 MB
+    # locked in kernel BPF memory before Falco even starts. Setting this to 2
+    # allocates 1 buffer per 2 CPUs = 16 buffers × 8 MB = 128 MB total.
+    # Halves locked-memory usage while keeping per-CPU coverage adequate for
+    # a lightly-loaded homelab host.
+    cpus_for_each_syscall_buffer: 2
 
 # ── Output channels ─────────────────────────────────────────────────────────
 # http_output: Falco POSTs each alert to Falcosidekick which handles retries,


### PR DESCRIPTION
## Root cause

`modern_ebpf` allocates **1 BPF ring buffer per CPU × 8 MB** by default. On the 32-CPU homelab host:

- Ring buffers: 32 × 8 MB = **256 MB**
- Falco process RSS: ~150–200 MB
- **Total: ~450 MB** — hits the 512 MB cgroup memory limit during `scap_init`

The `memlock` ulimit was already set to unlimited (PR #661), but `memlock` and cgroup memory are separate limits. `memlock` controls how much memory can be locked in RAM (preventing it from being swapped); the cgroup memory limit is a hard cap on total virtual memory usage regardless of locking. Setting `memlock: -1` doesn't override the cgroup cap.

Evidence: `docker inspect deploy-falco-1 --format '{{json .HostConfig.Ulimits}}'` returns `[{"Name":"memlock","Hard":-1,"Soft":-1}]` — ulimit is correct — yet `scap_init` still fails every restart.

## Fix

| Change | Before | After |
|--------|--------|-------|
| Container memory limit | 512 M | 1536 M |
| `cpus_for_each_syscall_buffer` | 1 (default) | 2 |
| Ring buffer total | 32 × 8 MB = 256 MB | 16 × 8 MB = **128 MB** |
| Estimated headroom | ~60 MB (tight) | ~1.2 GB |

`cpus_for_each_syscall_buffer: 2` means 1 ring buffer per 2 CPUs = 16 buffers. Coverage is still complete (each CPU shares a buffer with one neighbour); for a lightly-loaded homelab this has no observable impact on event capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)