### PR TITLE
fix(cost): filter per-agent usage sparkline by agent

### DIFF
--- a/apps/web/src/app/(app)/cost/page.tsx
+++ b/apps/web/src/app/(app)/cost/page.tsx
@@ -12,6 +12,7 @@ interface AgentRow {
   costUsd: number
   savingsUsd: number
   tasks: number
+  last7: number[]
 }
 
 interface DayRow {
@@ -55,17 +56,7 @@ function fmtUsd(n: number): string {
   return `$${n.toFixed(2)}`
 }
 
-function Sparkline({ agentId, days }: { agentId: string; days: Days }) {
-  const [data, setData] = useState<number[]>([])
-  useEffect(() => {
-    fetch(`/api/cost/summary?days=${days}`)
-      .then(r => r.json())
-      .then((s: Summary) => {
-        setData(s.byDay.slice(-7).map(d => d.inputTokens + d.outputTokens))
-      })
-      .catch(() => {})
-  }, [agentId, days])
-
+function Sparkline({ data }: { data: number[] }) {
   if (!data.length) return <div className="w-16 h-5" />
   const max = Math.max(...data, 1)
   return (
@@ -288,7 +279,7 @@ export default function CostPage() {
                             {hasCost    && <td className="py-2 text-right text-status-error">{fmtUsd(a.costUsd)}</td>}
                             {hasSavings && <td className="py-2 text-right text-status-healthy">{fmtUsd(a.savingsUsd)}</td>}
                             <td className="py-2 text-right text-text-secondary">{a.tasks}</td>
-                            <td className="py-2 pl-2"><Sparkline agentId={a.agentId} days={days} /></td>
+                            <td className="py-2 pl-2"><Sparkline data={a.last7} /></td>
                           </tr>
                         )
                       })}

--- a/apps/web/src/app/api/cost/summary/route.ts
+++ b/apps/web/src/app/api/cost/summary/route.ts
@@ -67,6 +67,7 @@ export async function GET(req: NextRequest) {
     inputTokens: number; outputTokens: number
     costUsd: number; savingsUsd: number
     tasks: Set<string>
+    byDay: Map<string, number>
   }>()
   const modelMap = new Map<string, {
     modelId: string; selfHosted: boolean
@@ -92,7 +93,7 @@ export async function GET(req: NextRequest) {
     const agentId   = r.agentId
     const agentName = r.agent?.name ?? agentId
     if (!agentMap.has(agentId)) {
-      agentMap.set(agentId, { agentId, agentName, inputTokens: 0, outputTokens: 0, costUsd: 0, savingsUsd: 0, tasks: new Set() })
+      agentMap.set(agentId, { agentId, agentName, inputTokens: 0, outputTokens: 0, costUsd: 0, savingsUsd: 0, tasks: new Set(), byDay: new Map() })
     }
     const ag = agentMap.get(agentId)!
     ag.inputTokens  += r.inputTokens
@@ -100,6 +101,8 @@ export async function GET(req: NextRequest) {
     ag.costUsd      += costUsd    ?? 0
     ag.savingsUsd   += savingsUsd ?? 0
     if (r.taskId) ag.tasks.add(r.taskId as string)
+    const agDateKey = r.recordedAt.toISOString().slice(0, 10)
+    ag.byDay.set(agDateKey, (ag.byDay.get(agDateKey) ?? 0) + r.inputTokens + r.outputTokens)
 
     // By model
     if (mId) {
@@ -131,6 +134,9 @@ export async function GET(req: NextRequest) {
     byDay.push({ date: key, ...entry })
   }
 
+  // The last 7 day-keys of the window, used for each agent's sparkline series
+  const last7Keys = byDay.slice(-7).map(d => d.date)
+
   const byAgent = Array.from(agentMap.values()).map(a => ({
     agentId:      a.agentId,
     agentName:    a.agentName,
@@ -139,6 +145,7 @@ export async function GET(req: NextRequest) {
     costUsd:      a.costUsd,
     savingsUsd:   a.savingsUsd,
     tasks:        a.tasks.size,
+    last7:        last7Keys.map(k => a.byDay.get(k) ?? 0),
   })).sort((a, b) => (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens))
 
   const byModel = Array.from(modelMap.values())


### PR DESCRIPTION
## Bug

The sparkline in the Per-Agent Breakdown table showed identical data for every agent row. The `Sparkline` component accepted an `agentId` prop but **ignored it entirely** — on mount it refetched `/api/cost/summary?days=N` and rendered `s.byDay` (the **global** aggregate daily series). Every row was showing the same chart.

## Fix

**API** (`route.ts`): Added a per-agent `byDay` accumulator. Emits a `last7` array on each `byAgent` row — the token counts for the last 7 days of the window, aligned to the same day-keys as the global `byDay`.

**Frontend** (`page.tsx`): Rewrote `Sparkline` to accept a `data: number[]` prop and render it directly. Removed the `useState`/`useEffect` + redundant network round-trip. Pass `a.last7` at the call site.

Each agent's sparkline now shows only that agent's usage pattern, not the system-wide total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)