### PR TITLE
feat(security): add Acknowledge All to clear the alert badge

### DIFF
--- a/apps/web/src/app/api/monitoring/security/alerts/ack-all/route.ts
+++ b/apps/web/src/app/api/monitoring/security/alerts/ack-all/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/monitoring/security/alerts/ack-all
+ *
+ * Acknowledges all unacknowledged SecurityEvent rows. Optionally scoped to
+ * events within a time window via `?minutes=N` (default: all time).
+ *
+ * Returns { acknowledged: number } — the count of rows updated.
+ */
+export async function POST(req: NextRequest) {
+  try { await requireAdmin() } catch { return NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+
+  const { searchParams } = new URL(req.url)
+  const minutes = searchParams.get('minutes') ? parseInt(searchParams.get('minutes')!) : null
+
+  const where = {
+    acknowledged: false,
+    ...(minutes != null && minutes > 0
+      ? { createdAt: { gte: new Date(Date.now() - minutes * 60 * 1000) } }
+      : {}),
+  }
+
+  const { count } = await prisma.securityEvent.updateMany({
+    where,
+    data: { acknowledged: true, acknowledgedAt: new Date() },
+  })
+
+  return NextResponse.json({ acknowledged: count })
+}

--- a/apps/web/src/components/security/AlertFeed.tsx
+++ b/apps/web/src/components/security/AlertFeed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { AlertTriangle, CheckCircle2, XCircle, Loader2, Shield, Globe, Database } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { AlertTriangle, CheckCircle2, XCircle, Loader2, Shield, Globe, Database, CheckCheck } from 'lucide-react'
 import Link from 'next/link'
 import { type NotifyMessage } from '@/lib/security/stream-utils'
 
@@ -49,6 +49,7 @@ function SeverityBadge({ severity }: { severity: number }) {
 export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: any[]; compact?: boolean }) {
   const [alerts, setAlerts] = useState(initialAlerts || [])
   const [selected, setSelected] = useState<string[]>([])
+  const [ackingAll, setAckingAll] = useState(false)
   const mountedRef = useRef(true)
 
   useEffect(() => {
@@ -94,6 +95,17 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
     setSelected([])
   }
 
+  const ackAll = useCallback(async () => {
+    setAckingAll(true)
+    try {
+      await fetch('/api/monitoring/security/alerts/ack-all', { method: 'POST' })
+      setAlerts(prev => prev.map((a: any) => ({ ...a, acknowledged: true })))
+      setSelected([])
+    } finally {
+      setAckingAll(false)
+    }
+  }, [])
+
   if (alerts.length === 0 && !initialAlerts) {
     return (
       <div className="p-8 text-center text-text-muted text-sm">
@@ -116,16 +128,34 @@ export default function AlertFeed({ initialAlerts, compact }: { initialAlerts?: 
     )
   }
 
+  const hasUnacked = alerts.some((a: any) => !a.acknowledged)
+
   return (
     <div>
-      {selected.length > 0 && (
-        <div className="px-4 py-2 border-b border-border-subtle flex items-center justify-between bg-bg-raised">
-          <span className="text-xs text-text-muted">{selected.length} selected</span>
-          <button onClick={ackSelected} className="text-xs text-accent hover:underline">
-            Acknowledge selected
-          </button>
-        </div>
-      )}
+      <div className="px-4 py-2 border-b border-border-subtle flex items-center justify-between bg-bg-raised min-h-[36px]">
+        {selected.length > 0 ? (
+          <>
+            <span className="text-xs text-text-muted">{selected.length} selected</span>
+            <button onClick={ackSelected} className="text-xs text-accent hover:underline">
+              Acknowledge selected
+            </button>
+          </>
+        ) : (
+          <>
+            <span className="text-xs text-text-muted">{alerts.filter((a: any) => !a.acknowledged).length} unacknowledged</span>
+            {hasUnacked && (
+              <button
+                onClick={ackAll}
+                disabled={ackingAll}
+                className="flex items-center gap-1.5 text-xs text-text-secondary border border-border-subtle rounded px-2 py-1 hover:text-accent hover:border-accent/40 transition-colors disabled:opacity-50"
+              >
+                <CheckCheck size={11} />
+                {ackingAll ? 'Clearing…' : 'Acknowledge All'}
+              </button>
+            )}
+          </>
+        )}
+      </div>
 
       <div className="divide-y divide-border-subtle">
         {alerts.map((alert: any) => {

--- a/apps/web/src/hooks/useSecurityAlerts.ts
+++ b/apps/web/src/hooks/useSecurityAlerts.ts
@@ -6,10 +6,15 @@ export function useUnackAlertCount() {
   const [count, setCount] = useState(0)
 
   useEffect(() => {
-    fetch('/api/monitoring/security/alerts?acknowledged=false&minutes=60&limit=1')
-      .then(r => r.json())
-      .then(d => { setCount(d.pagination?.total ?? 0) })
-      .catch(() => {})
+    const fetch_ = () =>
+      fetch('/api/monitoring/security/alerts?acknowledged=false&minutes=60&limit=1')
+        .then(r => r.json())
+        .then(d => { setCount(d.pagination?.total ?? 0) })
+        .catch(() => {})
+
+    fetch_()
+    const timer = setInterval(fetch_, 30_000)
+    return () => clearInterval(timer)
   }, [])
 
   return count


### PR DESCRIPTION
## Problem

The Security sidebar badge was at **715 and climbing** with no way to bulk-clear it. The only existing path was per-item checkbox selection (max 500 IDs per POST), which would require manual multi-step work to clear hundreds of alerts.

## Changes

**`POST /api/monitoring/security/alerts/ack-all`** — new endpoint. Marks all unacknowledged `SecurityEvent` rows as acknowledged in a single `updateMany`. Optional `?minutes=N` query param to scope to a time window (default: all time). Requires admin auth.

**`AlertFeed.tsx`** — always-visible toolbar row above the alert list:
- Shows count of unacknowledged alerts
- Shows "Acknowledge All" button (with double-check icon) when any unacked alerts exist
- Clicking calls `ack-all`, immediately dims all alerts in the in-memory list
- When checkboxes are in use, reverts to the existing "N selected / Acknowledge selected" bar

**`useUnackAlertCount`** — was fetch-once on mount. Now polls every 30s so the sidebar badge zeroes out automatically after a bulk ack without requiring a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)