### PR TITLE
fix(ui): missing res.ok checks and stuck loading states in components

### DIFF
--- a/apps/web/src/components/ingress/IngressPage.tsx
+++ b/apps/web/src/components/ingress/IngressPage.tsx
@@ -1524,6 +1524,7 @@ function DnsBootstrapPanel({ domain, environments, onDone }: {
     })
     try {
       const res = await fetch(`/api/ingress/domains/${domain.id}/dns/bootstrap`, { method: 'POST' })
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`)
       if (!res.body) throw new Error('No response body')
       const reader = res.body.pipeThrough(new TextDecoderStream()).getReader()
       while (true) {

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
 
   useEffect(() => {
     fetch('/api/admin/settings')
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`Request failed: ${r.status}`); return r.json() })
       .then(d => { if (d['app.name']) setAppName(d['app.name'] as string) })
       .catch((e) => console.error("[fetch]", e))
   }, [])
@@ -44,7 +44,7 @@ export function Header() {
           <button
             onClick={() => setOpen(o => !o)}
             className="w-8 h-8 rounded-full bg-accent/20 border border-accent/30 flex items-center justify-center text-xs font-semibold text-accent hover:bg-accent/30 transition-colors"
-            title={session.user?.name ?? session.user?.email ?? ''}
+            title={(session.user?.name ?? session.user?.email ?? '').replace(/"/g, '&quot;')}
           >
             {initials}
           </button>

--- a/apps/web/src/components/layout/StatusBar.tsx
+++ b/apps/web/src/components/layout/StatusBar.tsx
@@ -33,7 +33,7 @@ export function StatusBar() {
 
   useEffect(() => {
     fetch('/api/setup/status')
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error(`Request failed: ${r.status}`); return r.json() })
       .then(d => { if (d.internalDomain) setDomain(d.internalDomain) })
       .catch((e) => console.error("[fetch]", e))
   }, [])
@@ -41,8 +41,8 @@ export function StatusBar() {
   useEffect(() => {
     const check = () =>
       Promise.all([
-        fetch('/api/health').then(r => r.json()).catch(() => null),
-        fetch('/api/models').then(r => r.json()).catch(() => []),
+        fetch('/api/health').then(r => { if (!r.ok) throw new Error(`Request failed: ${r.status}`); return r.json() }).catch(() => null),
+        fetch('/api/models').then(r => { if (!r.ok) throw new Error(`Request failed: ${r.status}`); return r.json() }).catch(() => []),
       ]).then(([h, m]) => {
         setHealth(h)
         setModels(Array.isArray(m) ? m : [])

--- a/apps/web/src/components/messages/RoomChat.tsx
+++ b/apps/web/src/components/messages/RoomChat.tsx
@@ -161,6 +161,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
   const loadRoom = useCallback(async (limit?: number) => {
     try {
       const res = await fetch(`/api/chatrooms/${roomId}?messages=${limit ?? messageLimit}`)
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`)
       const detail = await res.json()
       setRoom(detail)
       setTokenState({ count: detail.tokenCount ?? 0, limit: detail.tokenLimit ?? null })
@@ -314,11 +315,12 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
               : taskId    ? `/api/tasks/${taskId}`
               : null
     if (!url) return
-    await fetch(url, {
+    const undoRes = await fetch(url, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ plan: planToast.prevPlan }),
     })
+    if (!undoRes.ok) return
     setPlanToast(null)
     setSavedPlanMsgId(null)
   }, [room, planToast])
@@ -337,8 +339,7 @@ export function RoomChat({ roomId, onMobileBack, onLeave }: Props) {
       // Messages will arrive via SSE in real-time, no need to poll
       // Just reload room once for metadata/counts
       await loadRoom()
-    } catch { /* ignore */ }
-    setSending(false)
+    } catch { /* ignore */ } finally { setSending(false) }
   }
 
   const loadInviteOptions = useCallback(async () => {

--- a/apps/web/src/components/notifications/BudgetPausedTasks.tsx
+++ b/apps/web/src/components/notifications/BudgetPausedTasks.tsx
@@ -24,7 +24,9 @@ export function BudgetPausedTasks() {
 
   const fetchPending = useCallback(async () => {
     try {
-      const data: PendingTask[] = await fetch('/api/tasks?status=pending_validation').then(r => r.json())
+      const res = await fetch('/api/tasks?status=pending_validation')
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`)
+      const data: PendingTask[] = await res.json()
       setTasks(
         (Array.isArray(data) ? data : []).filter(t => {
           const meta = (t.metadata ?? {}) as Record<string, unknown>

--- a/apps/web/src/components/notifications/PendingPlanApprovals.tsx
+++ b/apps/web/src/components/notifications/PendingPlanApprovals.tsx
@@ -43,7 +43,9 @@ export function PendingPlanApprovals() {
 
   const fetchPending = useCallback(async () => {
     try {
-      const data: PendingTask[] = await fetch('/api/tasks?status=pending_validation').then(r => r.json())
+      const res = await fetch('/api/tasks?status=pending_validation')
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`)
+      const data: PendingTask[] = await res.json()
       setTasks(
         (Array.isArray(data) ? data : []).filter(t => {
           const meta = (t.metadata ?? {}) as Record<string, unknown>


### PR DESCRIPTION
## Summary

- **Header**: Add `res.ok` check before parsing admin settings JSON; encode user name in `title` attribute to prevent quote-breaking
- **StatusBar**: Add `res.ok` checks in both `/api/health` and `/api/models` fetches so failed requests correctly propagate as `null`/`[]` rather than throwing on `.json()`
- **RoomChat**: Add `res.ok` check in `loadRoom`; move `setSending(false)` into a `finally` block to prevent stuck sending state; add `res.ok` guard in `undoPlan` before clearing toast state
- **IngressPage**: Add `res.ok` check before reading bootstrap SSE body — prevents `running` staying `true` indefinitely on non-2xx responses
- **BudgetPausedTasks / PendingPlanApprovals**: Add `res.ok` check in `fetchPending` so error responses don't get parsed as task arrays, leaving stale state on screen

## Test plan

- [ ] Header loads app name correctly; on API failure, falls back to "ORION" without console errors about JSON parsing
- [ ] StatusBar health dots show grey (unknown) rather than crashing when health/models endpoints fail
- [ ] RoomChat send button un-sticks after a failed send (no spinner freeze)
- [ ] RoomChat undo plan does nothing visible when the PATCH fails
- [ ] IngressPage bootstrap shows an error message and re-enables the button when the POST returns non-2xx
- [ ] BudgetPausedTasks and PendingPlanApprovals don't clear existing tasks on a failed poll

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_