### PR TITLE
feat: vulnerability assessment — CVE dashboard, scan tracking, accept-risk workflow

### DIFF
--- a/apps/web/prisma/migrations/20260615_vuln_assessment_ui/migration.sql
+++ b/apps/web/prisma/migrations/20260615_vuln_assessment_ui/migration.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "VulnerabilityScan" (
+    "id" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+    "driver" TEXT NOT NULL DEFAULT 'trivy',
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "triggeredBy" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "errorMessage" TEXT,
+    "findingsCreated" INTEGER NOT NULL DEFAULT 0,
+    "findingsEscalated" INTEGER NOT NULL DEFAULT 0,
+    "findingsFixed" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "VulnerabilityScan_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "VulnerabilityScan_environmentId_startedAt_idx" ON "VulnerabilityScan"("environmentId", "startedAt");
+CREATE INDEX "VulnerabilityScan_status_idx" ON "VulnerabilityScan"("status");
+
+ALTER TABLE "VulnerabilityScan" ADD CONSTRAINT "VulnerabilityScan_environmentId_fkey"
+    FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "VulnerabilityFinding"
+    ADD COLUMN "title" TEXT,
+    ADD COLUMN "description" TEXT,
+    ADD COLUMN "fixAvailable" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "taskId" TEXT,
+    ADD COLUMN "acceptedRiskJustification" TEXT,
+    ADD COLUMN "acceptedRiskExpiresAt" TIMESTAMP(3),
+    ADD COLUMN "scanId" TEXT;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -160,6 +160,7 @@ model Environment {
   sourceHealths            SourceHealth[]
   environmentSourceHealths EnvironmentSourceHealth[]
   vulnerabilityFindings    VulnerabilityFinding[]
+  vulnerabilityScans       VulnerabilityScan[]
   suppressions             Suppression[]
   toolExecutions           ToolExecution[]
   driftReports             DriftReport[]
@@ -1209,12 +1210,37 @@ model VulnerabilityFinding {
 
   rawTrivy Json // full Trivy vulnerability object (for forensics)
 
+  title                     String?
+  description               String?   @db.Text
+  fixAvailable              Boolean   @default(false)
+  taskId                    String?
+  acceptedRiskJustification String?   @db.Text
+  acceptedRiskExpiresAt     DateTime?
+  scanId                    String?
+
   @@unique([environmentId, target, cveId, packageName])
   @@index([environmentId])
   @@index([cveId])
   @@index([isKev])
   @@index([status])
   @@index([severity])
+}
+
+model VulnerabilityScan {
+  id            String      @id @default(cuid())
+  environmentId String
+  environment   Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  driver        String      @default("trivy")
+  status        String      @default("pending")
+  triggeredBy   String?
+  startedAt     DateTime    @default(now())
+  completedAt   DateTime?
+  errorMessage  String?     @db.Text
+  findingsCreated   Int     @default(0)
+  findingsEscalated Int     @default(0)
+  findingsFixed     Int     @default(0)
+  @@index([environmentId, startedAt])
+  @@index([status])
 }
 
 // ── Security: Event suppressions ──────────────────────────────────────────────

--- a/apps/web/src/app/(app)/security/vulnerabilities/page.tsx
+++ b/apps/web/src/app/(app)/security/vulnerabilities/page.tsx
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic'
+import { requireAuth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import VulnerabilityDashboard from '@/components/security/VulnerabilityDashboard'
+
+export default async function VulnerabilitiesPage() {
+  try { await requireAuth() } catch { redirect('/login') }
+  return <VulnerabilityDashboard />
+}

--- a/apps/web/src/app/api/vulnerabilities/findings/[id]/route.ts
+++ b/apps/web/src/app/api/vulnerabilities/findings/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAuth } from '@/lib/auth'
+import { logAudit } from '@/lib/audit'
+import { z } from 'zod'
+
+const PatchSchema = z.object({
+  status: z.enum(['open', 'fixed', 'accepted', 'false_positive']),
+  acceptedRiskJustification: z.string().min(10).max(2000).optional(),
+  acceptedRiskExpiresAt: z.string().datetime().optional(),
+})
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let user
+  try { user = await requireAuth() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { id } = await params
+
+  let body: unknown
+  try { body = await req.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+  const parsed = PatchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 400 })
+  }
+  const { status, acceptedRiskJustification, acceptedRiskExpiresAt } = parsed.data
+
+  if (status === 'accepted' && !acceptedRiskJustification) {
+    return NextResponse.json({ error: 'Justification required when accepting risk' }, { status: 400 })
+  }
+
+  const finding = await prisma.vulnerabilityFinding.findUnique({ where: { id } })
+  if (!finding) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const updated = await prisma.vulnerabilityFinding.update({
+    where: { id },
+    data: {
+      status,
+      acceptedRiskJustification: status === 'accepted' ? acceptedRiskJustification : null,
+      acceptedRiskExpiresAt: status === 'accepted' && acceptedRiskExpiresAt
+        ? new Date(acceptedRiskExpiresAt) : null,
+    },
+  })
+
+  if (status === 'accepted') {
+    await logAudit({
+      userId: user.id,
+      action: 'cve_finding_accept_risk',
+      target: `vulnerability:${id}`,
+      detail: {
+        cveId: finding.cveId,
+        environmentId: finding.environmentId,
+        justification: acceptedRiskJustification,
+        expiresAt: acceptedRiskExpiresAt ?? null,
+      },
+    })
+  }
+
+  return NextResponse.json(updated)
+}

--- a/apps/web/src/app/api/vulnerabilities/findings/route.ts
+++ b/apps/web/src/app/api/vulnerabilities/findings/route.ts
@@ -1,0 +1,47 @@
+export const dynamic = 'force-dynamic'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAuth } from '@/lib/auth'
+
+export async function GET(req: NextRequest) {
+  try { await requireAuth() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const environmentId = searchParams.get('environmentId') ?? undefined
+  const statusFilter = searchParams.get('status') ?? undefined
+  const severityFilter = searchParams.get('severity') ?? undefined
+  const fixAvailable = searchParams.get('fixAvailable')
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '100', 10), 500)
+  const offset = parseInt(searchParams.get('offset') ?? '0', 10)
+
+  const severityRanges: Record<string, { gte?: number; lt?: number }> = {
+    critical: { gte: 90 },
+    high: { gte: 70, lt: 90 },
+    medium: { gte: 40, lt: 70 },
+    low: { lt: 40 },
+  }
+
+  const where: Record<string, unknown> = {}
+  if (environmentId) where.environmentId = environmentId
+  if (statusFilter) where.status = statusFilter
+  if (fixAvailable === 'true') where.fixAvailable = true
+  if (fixAvailable === 'false') where.fixAvailable = false
+  if (severityFilter && severityRanges[severityFilter]) {
+    where.severity = severityRanges[severityFilter]
+  }
+
+  const [total, findings] = await Promise.all([
+    prisma.vulnerabilityFinding.count({ where }),
+    prisma.vulnerabilityFinding.findMany({
+      where,
+      orderBy: [{ severity: 'desc' }, { firstSeenAt: 'asc' }],
+      take: limit,
+      skip: offset,
+      include: { environment: { select: { name: true } } },
+    }),
+  ])
+
+  return NextResponse.json({ total, findings })
+}

--- a/apps/web/src/app/api/vulnerabilities/scans/route.ts
+++ b/apps/web/src/app/api/vulnerabilities/scans/route.ts
@@ -1,0 +1,82 @@
+export const dynamic = 'force-dynamic'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAuth } from '@/lib/auth'
+import { z } from 'zod'
+import { runDailyScan } from '@/jobs/security-scan-vulns'
+
+const TriggerSchema = z.object({
+  environmentId: z.string().min(1).max(100),
+})
+
+export async function GET() {
+  try { await requireAuth() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const scans = await prisma.vulnerabilityScan.findMany({
+    orderBy: { startedAt: 'desc' },
+    take: 50,
+    include: { environment: { select: { name: true } } },
+  })
+  return NextResponse.json(scans)
+}
+
+export async function POST(req: NextRequest) {
+  try { await requireAuth() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try { body = await req.json() } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+  const parsed = TriggerSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', issues: parsed.error.issues }, { status: 400 })
+  }
+
+  const env = await prisma.environment.findUnique({
+    where: { id: parsed.data.environmentId },
+    select: { id: true, name: true },
+  })
+  if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 })
+
+  const scan = await prisma.vulnerabilityScan.create({
+    data: {
+      environmentId: parsed.data.environmentId,
+      driver: 'trivy',
+      status: 'pending',
+      triggeredBy: 'user',
+    },
+  })
+
+  // Fire and forget — update scan status in background
+  ;(async () => {
+    try {
+      await prisma.vulnerabilityScan.update({
+        where: { id: scan.id },
+        data: { status: 'running', startedAt: new Date() },
+      })
+      const results = await runDailyScan()
+      const totals = results.reduce(
+        (acc, r) => ({
+          findingsCreated: acc.findingsCreated + r.findingsCreated,
+          findingsEscalated: acc.findingsEscalated + r.findingsEscalated,
+          findingsFixed: acc.findingsFixed + r.findingsFixed,
+        }),
+        { findingsCreated: 0, findingsEscalated: 0, findingsFixed: 0 }
+      )
+      await prisma.vulnerabilityScan.update({
+        where: { id: scan.id },
+        data: { status: 'completed', completedAt: new Date(), ...totals },
+      })
+    } catch (e) {
+      await prisma.vulnerabilityScan.update({
+        where: { id: scan.id },
+        data: { status: 'failed', completedAt: new Date(), errorMessage: String(e) },
+      }).catch(() => {})
+    }
+  })()
+
+  return NextResponse.json(scan, { status: 202 })
+}

--- a/apps/web/src/app/api/vulnerabilities/summary/route.ts
+++ b/apps/web/src/app/api/vulnerabilities/summary/route.ts
@@ -1,0 +1,48 @@
+export const dynamic = 'force-dynamic'
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { requireAuth } from '@/lib/auth'
+
+export async function GET() {
+  try { await requireAuth() } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const [critical, high, medium, low, byEnv, recentScans] = await Promise.all([
+    prisma.vulnerabilityFinding.count({ where: { status: 'open', severity: { gte: 90 } } }),
+    prisma.vulnerabilityFinding.count({ where: { status: 'open', severity: { gte: 70, lt: 90 } } }),
+    prisma.vulnerabilityFinding.count({ where: { status: 'open', severity: { gte: 40, lt: 70 } } }),
+    prisma.vulnerabilityFinding.count({ where: { status: 'open', severity: { lt: 40 } } }),
+    prisma.vulnerabilityFinding.groupBy({
+      by: ['environmentId'],
+      where: { status: 'open' },
+      _count: { id: true },
+      _max: { severity: true },
+    }),
+    prisma.vulnerabilityScan.findMany({
+      orderBy: { startedAt: 'desc' },
+      take: 10,
+      include: { environment: { select: { name: true } } },
+    }),
+  ])
+
+  const envIds = byEnv.map(r => r.environmentId)
+  const envs = await prisma.environment.findMany({
+    where: { id: { in: envIds } },
+    select: { id: true, name: true },
+  })
+  const envMap = Object.fromEntries(envs.map(e => [e.id, e.name]))
+
+  return NextResponse.json({
+    critical, high, medium, low,
+    total: critical + high + medium + low,
+    envsAffected: byEnv.length,
+    byEnvironment: byEnv.map(r => ({
+      environmentId: r.environmentId,
+      environmentName: envMap[r.environmentId] ?? r.environmentId,
+      openCount: r._count.id,
+      maxSeverity: r._max.severity,
+    })),
+    recentScans,
+  })
+}

--- a/apps/web/src/components/security/VulnerabilityDashboard.tsx
+++ b/apps/web/src/components/security/VulnerabilityDashboard.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+
+type Severity = 'critical' | 'high' | 'medium' | 'low'
+
+interface Summary {
+  critical: number
+  high: number
+  medium: number
+  low: number
+  total: number
+  envsAffected: number
+  byEnvironment: Array<{
+    environmentId: string
+    environmentName: string
+    openCount: number
+    maxSeverity: number | null
+  }>
+  recentScans: Array<{
+    id: string
+    environmentId: string
+    status: string
+    driver: string
+    startedAt: string
+    completedAt: string | null
+    findingsCreated: number
+    environment: { name: string }
+  }>
+}
+
+interface Finding {
+  id: string
+  environmentId: string
+  cveId: string
+  severity: number
+  packageName: string
+  packageVersion: string
+  fixedVersion: string | null
+  fixAvailable: boolean
+  status: string
+  title: string | null
+  acceptedRiskJustification: string | null
+  acceptedRiskExpiresAt: string | null
+  firstSeenAt: string
+  isKev: boolean
+  cvssScore: number | null
+  environment: { name: string }
+}
+
+const SEVERITY_LABEL: Record<string, string> = { critical: 'Critical', high: 'High', medium: 'Medium', low: 'Low' }
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: 'bg-red-900/30 text-red-400 border border-red-700/30',
+  high: 'bg-orange-900/30 text-orange-400 border border-orange-700/30',
+  medium: 'bg-yellow-900/30 text-yellow-400 border border-yellow-700/30',
+  low: 'bg-blue-900/30 text-blue-400 border border-blue-700/30',
+}
+const STATUS_BADGE: Record<string, string> = {
+  open: 'bg-red-500/10 text-red-400',
+  fixed: 'bg-emerald-500/10 text-emerald-400',
+  accepted: 'bg-yellow-500/10 text-yellow-400',
+  false_positive: 'bg-bg-raised text-text-muted',
+}
+
+function severityLabel(score: number): Severity {
+  if (score >= 90) return 'critical'
+  if (score >= 70) return 'high'
+  if (score >= 40) return 'medium'
+  return 'low'
+}
+
+export default function VulnerabilityDashboard() {
+  const [summary, setSummary] = useState<Summary | null>(null)
+  const [findings, setFindings] = useState<Finding[]>([])
+  const [total, setTotal] = useState(0)
+  const [severityFilter, setSeverityFilter] = useState('')
+  const [statusFilter, setStatusFilter] = useState('open')
+  const [envFilter, setEnvFilter] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [acceptModal, setAcceptModal] = useState<Finding | null>(null)
+  const [justification, setJustification] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [scanning, setScanning] = useState<string | null>(null)
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [summRes, findRes] = await Promise.all([
+        fetch('/api/vulnerabilities/summary'),
+        fetch(`/api/vulnerabilities/findings?status=${statusFilter}&severity=${severityFilter}&environmentId=${envFilter}&limit=100`),
+      ])
+      if (summRes.ok) setSummary(await summRes.json())
+      if (findRes.ok) {
+        const data = await findRes.json()
+        setFindings(data.findings)
+        setTotal(data.total)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter, severityFilter, envFilter])
+
+  useEffect(() => { loadData() }, [loadData])
+
+  async function updateStatus(findingId: string, status: string, opts?: { justification?: string; expiresAt?: string }) {
+    const res = await fetch(`/api/vulnerabilities/findings/${findingId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status, acceptedRiskJustification: opts?.justification, acceptedRiskExpiresAt: opts?.expiresAt }),
+    })
+    if (res.ok) loadData()
+  }
+
+  async function triggerScan(environmentId: string) {
+    setScanning(environmentId)
+    try {
+      await fetch('/api/vulnerabilities/scans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ environmentId }),
+      })
+      setTimeout(loadData, 2000)
+    } finally {
+      setScanning(null)
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-7xl">
+      <div>
+        <h1 className="text-lg font-semibold text-text-primary">Vulnerability Assessment</h1>
+        <p className="text-sm text-text-muted mt-0.5">CVE findings from Trivy scans across all environments</p>
+      </div>
+
+      {/* Summary cards */}
+      {summary && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {(['critical', 'high', 'medium', 'low'] as Severity[]).map(s => (
+            <button
+              key={s}
+              onClick={() => setSeverityFilter(severityFilter === s ? '' : s)}
+              className={`rounded-xl border p-4 text-left transition-colors ${severityFilter === s ? 'border-accent bg-accent/5' : 'border-border-subtle bg-bg-card hover:border-border-default'}`}
+            >
+              <div className={`text-2xl font-bold ${s === 'critical' ? 'text-red-400' : s === 'high' ? 'text-orange-400' : s === 'medium' ? 'text-yellow-400' : 'text-blue-400'}`}>
+                {summary[s]}
+              </div>
+              <div className="text-xs text-text-muted mt-1 capitalize">{s} open</div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Per-environment table */}
+      {summary && summary.byEnvironment.length > 0 && (
+        <div className="rounded-lg border border-border-subtle bg-bg-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-border-subtle bg-bg-raised">
+            <span className="text-sm font-medium text-text-primary">Environments</span>
+          </div>
+          <table className="w-full text-sm">
+            <thead className="border-b border-border-subtle">
+              <tr>
+                {['Environment', 'Open CVEs', 'Max Severity', 'Last Scan', ''].map(h => (
+                  <th key={h} className="text-left px-4 py-2 text-xs font-semibold text-text-muted">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-subtle">
+              {summary.byEnvironment.map(env => {
+                const lastScan = summary.recentScans.find(s => s.environmentId === env.environmentId)
+                return (
+                  <tr key={env.environmentId} className="hover:bg-bg-raised transition-colors">
+                    <td className="px-4 py-2.5 text-text-primary text-xs">{env.environmentName}</td>
+                    <td className="px-4 py-2.5 text-text-secondary text-xs">{env.openCount}</td>
+                    <td className="px-4 py-2.5">
+                      {env.maxSeverity != null && (
+                        <span className={`text-xs px-2 py-0.5 rounded ${SEVERITY_BADGE[severityLabel(env.maxSeverity)]}`}>
+                          {SEVERITY_LABEL[severityLabel(env.maxSeverity)]}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 text-text-muted text-xs">
+                      {lastScan ? new Date(lastScan.startedAt).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <button
+                        onClick={() => triggerScan(env.environmentId)}
+                        disabled={scanning === env.environmentId}
+                        className="text-xs px-2 py-1 rounded border border-border-subtle bg-bg-raised text-text-primary hover:border-accent hover:text-accent transition-colors disabled:opacity-50"
+                      >
+                        {scanning === env.environmentId ? 'Scanning…' : 'Scan Now'}
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Findings table */}
+      <div className="rounded-lg border border-border-subtle bg-bg-card overflow-hidden">
+        <div className="px-4 py-3 border-b border-border-subtle bg-bg-raised flex items-center gap-3 flex-wrap">
+          <span className="text-sm font-medium text-text-primary">Findings ({total})</span>
+          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}
+            className="text-xs px-2 py-1 rounded border border-border-subtle bg-bg-raised text-text-primary">
+            <option value="">All statuses</option>
+            <option value="open">Open</option>
+            <option value="fixed">Fixed</option>
+            <option value="accepted">Accepted risk</option>
+            <option value="false_positive">False positive</option>
+          </select>
+          <select value={severityFilter} onChange={e => setSeverityFilter(e.target.value)}
+            className="text-xs px-2 py-1 rounded border border-border-subtle bg-bg-raised text-text-primary">
+            <option value="">All severities</option>
+            <option value="critical">Critical</option>
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+          <button onClick={loadData} className="text-xs px-2 py-1 rounded border border-border-subtle bg-bg-raised text-text-primary hover:border-accent">
+            Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="px-4 py-10 text-center text-sm text-text-muted">Loading…</div>
+        ) : findings.length === 0 ? (
+          <div className="px-4 py-10 text-center text-sm text-text-muted">No findings match the current filter.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[900px]">
+              <thead className="border-b border-border-subtle">
+                <tr>
+                  {['CVE', 'Severity', 'Package', 'Installed', 'Fix', 'Environment', 'Status', 'Actions'].map(h => (
+                    <th key={h} className="text-left px-4 py-2 text-xs font-semibold text-text-muted whitespace-nowrap">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-subtle">
+                {findings.map(f => {
+                  const sev = severityLabel(f.severity)
+                  return (
+                    <tr key={f.id} className="hover:bg-bg-raised transition-colors">
+                      <td className="px-4 py-2.5 font-mono text-xs text-accent whitespace-nowrap">
+                        {f.cveId}
+                        {f.isKev && <span className="ml-1 text-[10px] bg-red-900/40 text-red-300 px-1 rounded">KEV</span>}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <span className={`text-xs px-2 py-0.5 rounded ${SEVERITY_BADGE[sev]}`}>
+                          {SEVERITY_LABEL[sev]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-xs text-text-secondary truncate max-w-[140px]">{f.packageName}</td>
+                      <td className="px-4 py-2.5 font-mono text-xs text-text-muted">{f.packageVersion}</td>
+                      <td className="px-4 py-2.5 font-mono text-xs">
+                        {f.fixedVersion
+                          ? <span className="text-emerald-400">{f.fixedVersion}</span>
+                          : <span className="text-text-muted">No fix</span>}
+                      </td>
+                      <td className="px-4 py-2.5 text-xs text-text-muted">{f.environment.name}</td>
+                      <td className="px-4 py-2.5">
+                        <span className={`text-xs px-2 py-0.5 rounded ${STATUS_BADGE[f.status] ?? ''}`}>
+                          {f.status.replace('_', ' ')}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <div className="flex items-center gap-1">
+                          {f.status === 'open' && (
+                            <>
+                              <button onClick={() => updateStatus(f.id, 'fixed')}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-900/20 text-emerald-400 hover:bg-emerald-900/40 transition-colors">
+                                Mark Fixed
+                              </button>
+                              <button onClick={() => { setAcceptModal(f); setJustification(''); setExpiresAt('') }}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-900/20 text-yellow-400 hover:bg-yellow-900/40 transition-colors">
+                                Accept Risk
+                              </button>
+                              <button onClick={() => updateStatus(f.id, 'false_positive')}
+                                className="text-[10px] px-1.5 py-0.5 rounded bg-bg-raised text-text-muted hover:text-text-primary transition-colors">
+                                FP
+                              </button>
+                            </>
+                          )}
+                          {f.status !== 'open' && (
+                            <button onClick={() => updateStatus(f.id, 'open')}
+                              className="text-[10px] px-1.5 py-0.5 rounded bg-bg-raised text-text-muted hover:text-text-primary transition-colors">
+                              Reopen
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Accept-risk modal */}
+      {acceptModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="bg-bg-card border border-border-subtle rounded-xl p-6 w-full max-w-md shadow-2xl">
+            <h2 className="text-base font-semibold text-text-primary mb-1">Accept Risk</h2>
+            <p className="text-xs text-text-muted mb-4">{acceptModal.cveId} — {acceptModal.packageName}</p>
+            <div className="space-y-3">
+              <div>
+                <label className="text-xs font-medium text-text-secondary block mb-1">Justification (required)</label>
+                <textarea
+                  value={justification}
+                  onChange={e => setJustification(e.target.value)}
+                  rows={4}
+                  placeholder="Explain why this risk is accepted…"
+                  className="w-full text-xs px-3 py-2 rounded border border-border-subtle bg-bg-raised text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent resize-none"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-text-secondary block mb-1">Expires (optional)</label>
+                <input
+                  type="date"
+                  value={expiresAt}
+                  onChange={e => setExpiresAt(e.target.value)}
+                  className="w-full text-xs px-3 py-2 rounded border border-border-subtle bg-bg-raised text-text-primary focus:outline-none focus:border-accent"
+                />
+              </div>
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={() => {
+                    if (justification.length < 10) return
+                    updateStatus(acceptModal.id, 'accepted', {
+                      justification,
+                      expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+                    })
+                    setAcceptModal(null)
+                  }}
+                  disabled={justification.length < 10}
+                  className="flex-1 text-xs py-2 rounded bg-accent text-bg-base font-medium hover:bg-accent/90 disabled:opacity-50 transition-colors"
+                >
+                  Accept Risk
+                </button>
+                <button onClick={() => setAcceptModal(null)}
+                  className="flex-1 text-xs py-2 rounded border border-border-subtle text-text-muted hover:text-text-primary transition-colors">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/lib/audit.ts
+++ b/apps/web/src/lib/audit.ts
@@ -62,6 +62,8 @@ export type AuditAction =
   | 'cleanup_requested_with_export'
   | 'cleanup_failed'
   | 'AUDIT_LOG_CLEANUP'
+  | 'vulnerability_scan_trigger'
+  | 'cve_finding_accept_risk'
 
 /**
  * Compute a SHA-256 hash of an audit entry's content for the hash chain.

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -464,6 +464,15 @@ export async function getCurrentUser(): Promise<AppUser | null> {
 
 /**
  * SOC2: Require a logged-in user with write access (any role except readonly).
+ * Require an authenticated user (any role). Throws if not logged in.
+ */
+export async function requireAuth(): Promise<AppUser> {
+  const user = await getCurrentUser()
+  if (!user) throw new Error('Unauthorized')
+  return user
+}
+
+/**
  * Use this for POST/PUT/DELETE handlers to block readonly users.
  */
 export async function requireWriteAccess(): Promise<AppUser> {


### PR DESCRIPTION
## Summary

- **New `VulnerabilityScan` model** to track each scan run (driver, status, timing, finding counts) — builds on the existing `VulnerabilityFinding` model and Trivy scanner job which were already in place
- **Extended `VulnerabilityFinding`** with 7 new fields: `title`, `description`, `fixAvailable`, `taskId`, `acceptedRiskJustification`, `acceptedRiskExpiresAt`, `scanId`
- **4 new API routes** under `/api/vulnerabilities/`: `summary` (aggregate counts), `findings` (filterable list), `findings/[id]` (PATCH status/accept-risk), `scans` (list + on-demand trigger)
- **Vulnerability dashboard** at `/security/vulnerabilities` — severity summary cards, per-environment table with "Scan Now" button, filterable CVE findings table, accept-risk modal with justification + expiry

## Features

- Severity breakdown (Critical/High/Medium/Low) based on existing 0-100 score formula
- Filter findings by severity, status, and environment
- Mark findings as Fixed, False Positive, or Accept Risk (requires written justification)
- Accept-risk expiry date support
- On-demand scan trigger per environment (fire-and-forget with status tracking)
- KEV badge on findings in the CISA Known Exploited Vulnerabilities catalog
- ACAS/Tenable-ready via `driver` field on `VulnerabilityScan`

## Test plan

- [ ] Migration applies cleanly: `prisma migrate deploy`
- [ ] `/security/vulnerabilities` page loads with summary cards
- [ ] Severity filter cards toggle the findings table
- [ ] "Scan Now" button creates a scan record and shows status
- [ ] Accept Risk modal requires ≥10 char justification before saving
- [ ] PATCH `/api/vulnerabilities/findings/:id` with `status: accepted` without justification returns 400
- [ ] Reopening an accepted/fixed finding clears justification fields

https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPxi6zY3g16PMA2W4k7wzV)_