### PR TITLE
fix(falco): upgrade to 0.40.0 to fix modern_ebpf crash on Ubuntu 6.8

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -594,8 +594,14 @@ services:
   # falcoctl installs modern_ebpf by default; falco.yaml is now aligned.
   # privileged: true is still required for Falco's syscall capture even
   # with eBPF — see https://falco.org/docs/getting-started/running/#docker.
+  #
+  # 0.38.x crash-loop root cause: Ubuntu 6.8 kernel vmlinux BTF omits the
+  # btf_trace_page_fault_kernel type, so the tp_btf/page_fault_kernel BPF
+  # program (named "pf_kernel") fails PROG_LOAD with EINVAL and scap_init
+  # fails. 0.40.0 makes pf_kernel optional — it is skipped when BTF type
+  # is absent rather than aborting startup.
   falco:
-    image: falcosecurity/falco:0.38.2
+    image: falcosecurity/falco:0.40.0
     restart: unless-stopped
     privileged: true
     pid: host

--- a/deploy/host-agent/falco/falco.yaml
+++ b/deploy/host-agent/falco/falco.yaml
@@ -18,11 +18,10 @@ rules_file:
 # ── Engine / driver ─────────────────────────────────────────────────────────
 # modern_ebpf (CO-RE) — no probe file needed; BTF is available on this host
 # at /sys/kernel/btf/vmlinux (kernel 6.8.0-124-generic, PREEMPT_DYNAMIC).
-# The falco:0.38.x image's entrypoint runs `falcoctl driver install` which
-# defaults to modern_ebpf; aligning this config removes the mismatch that
-# caused the crash-loop ("need to provide a path to the bpf object file").
-# Previous note about modern_ebpf segfaulting was on an earlier 6.8 build;
-# verified BTF present before switching.
+# Requires falco >= 0.40.0: Ubuntu 6.8 kernel vmlinux BTF omits the
+# btf_trace_page_fault_kernel type, causing pf_kernel (tp_btf/page_fault_kernel)
+# PROG_LOAD to fail EINVAL and scap_init to abort. 0.40.0 treats pf_kernel
+# as optional — skipped when the BTF type is absent rather than crashing.
 engine:
   kind: modern_ebpf
   modern_ebpf:


### PR DESCRIPTION
## Summary

- Upgrades Falco from `0.38.2` → `0.40.0`
- Root cause identified: Ubuntu 6.8 kernel vmlinux BTF omits `btf_trace_page_fault_kernel`, causing Falco's `tp_btf/page_fault_kernel` BPF program to fail `PROG_LOAD` with `EINVAL`, which aborts `scap_init`
- Falco 0.40.0 makes `pf_kernel` optional — it is skipped when the BTF type is absent rather than crashing

## Diagnosis path

1. Built a custom ptrace BPF tracer inside the container → found `BPF_PROG_TYPE_TRACING(26)` PROG_LOAD failing with `EINVAL` on programs `#2`, `#338`, `#339` (named `pf_kernel`)
2. `strings`/`objdump` of `/usr/bin/falco` confirmed `tp_btf/page_fault_kernel` is the attach target
3. `strings /sys/kernel/btf/vmlinux` confirmed `btf_trace_page_fault_kernel` is absent while `btf_trace_page_fault_user` is present — Ubuntu kernel intentionally omits this BTF type
4. Live test of `falco:0.40.0` confirmed it starts successfully and detects real events (pg_isready reading `/etc/shadow`, etc.)

Previous PRs (#661, #663) were correct about memlock and memory limits being prerequisites, but the actual fatal failure was the missing BTF type — a 0.38.x bug fixed in 0.40.0.

## Test plan

- [ ] Merge and wait for CI/CD deploy to `/opt/orion`
- [ ] Confirm `docker logs deploy-falco-1` shows Falco running (no scap_init error, shows event detections)
- [ ] Confirm Falco status shows healthy in Orion monitoring dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)