### PR TITLE
fix(argocd): add ArgoCD hub to compose, fix namespace crash-loop

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -658,6 +658,81 @@ services:
           cpus: '0.25'
           memory: 128M
 
+  # ── ArgoCD (hub) ──────────────────────────────────────────────────────────────
+  # Runs on the Docker host as the central GitOps hub managing all cluster
+  # spokes (Talos + any future environments) via kubeconfig.
+  # Orion calls the API at http://host.docker.internal:8083.
+  #
+  # --namespace argocd is required: kubeconfig defaults to `namespace: default`
+  # but ArgoCD's ConfigMap and CRDs live in the `argocd` namespace on the cluster.
+  # KUBECONFIG=/kubeconfig/config maps /root/.kube/config from the host.
+
+  argocd-redis:
+    image: redis:7.4-alpine
+    restart: unless-stopped
+    command: redis-server --save "" --appendonly no
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 64M
+
+  argocd-repo-server:
+    image: quay.io/argoproj/argocd:v3.3.8
+    restart: unless-stopped
+    command: argocd-repo-server
+    environment:
+      KUBECONFIG: /kubeconfig/config
+    volumes:
+      - argocd-data:/shared
+      - /root/.kube:/kubeconfig:ro
+    depends_on:
+      - argocd-redis
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+
+  argocd-server:
+    image: quay.io/argoproj/argocd:v3.3.8
+    restart: unless-stopped
+    command: argocd-server --insecure --namespace argocd
+    environment:
+      KUBECONFIG: /kubeconfig/config
+      ARGOCD_SERVER_INSECURE: "true"
+    volumes:
+      - argocd-data:/home/argocd
+      - /root/.kube:/kubeconfig:ro
+    ports:
+      - "8083:8080"
+    depends_on:
+      - argocd-redis
+      - argocd-repo-server
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+
+  argocd-application-controller:
+    image: quay.io/argoproj/argocd:v3.3.8
+    restart: unless-stopped
+    command: argocd-application-controller --redis argocd-redis:6379 --namespace argocd
+    environment:
+      KUBECONFIG: /kubeconfig/config
+    volumes:
+      - argocd-data:/shared
+      - /root/.kube:/kubeconfig:ro
+    depends_on:
+      - argocd-redis
+      - argocd-repo-server
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+
   # orion-executor — contained localhost execution service with Warden gating.
   # Receives tool calls from gateway, classifies risk, gates on Warden approval,
   # executes in this container (limited mounts + resource caps), logs to Orion.
@@ -708,3 +783,4 @@ volumes:
   redis-sentinel-3-data:
   traefik-letsencrypt:
   vault-audit:
+  argocd-data:


### PR DESCRIPTION
## Problem

All four ArgoCD containers (`argocd-server`, `argocd-application-controller`, `argocd-repo-server`, `argocd-redis`) were running as **orphaned** Docker Compose services — not defined in `docker-compose.yml` — and the server + controller were crash-looping every 60s with:

```
{"level":"fatal","msg":"configmap \"argocd-cm\" not found"}
```

**Root cause**: the kubeconfig context has `namespace: default`, but `argocd-cm` (and all ArgoCD CRDs) live in the `argocd` namespace on the Talos cluster. Without `--namespace argocd` the containers look in `default`, find nothing, and exit fatal.

## Architecture decision

ArgoCD belongs on the **Docker host** as a GitOps hub managing all cluster spokes via kubeconfig — not inside any cluster it manages (circular dependency: rebuild the cluster → lose the deployment engine). Orion already calls `http://host.docker.internal:8083` for cluster registration and app provisioning.

## Fix

- Add all four ArgoCD services to `docker-compose.yml` with correct config
- Pin to `v3.3.8` (matches current in-cluster version — avoids CRD/schema skew during cutover)
- Add `--namespace argocd` to `argocd-server` and `argocd-application-controller`
- Mount `/root/.kube → /kubeconfig` with `KUBECONFIG=/kubeconfig/config`
- Add `argocd-data` named volume for shared repo-server data

## After merging

Once deployed, the in-cluster ArgoCD application-controller should be scaled to 0 to prevent two controllers competing over the `argocd` namespace:

```bash
kubectl scale statefulset argocd-application-controller -n argocd --replicas=0
kubectl scale deployment argocd-server -n argocd --replicas=0
```

The `argocd` namespace, its ConfigMaps, and the `talos-cluster` Application CRD all remain — the host ArgoCD takes over managing them.

## Test plan
- [ ] `docker compose up argocd-server` starts without crash
- [ ] `argocd-application-controller` starts without crash  
- [ ] `argocd login localhost:8083` succeeds
- [ ] `argocd app list` shows `talos-cluster` application
- [ ] Scale down in-cluster controller, verify host controller takes over sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)